### PR TITLE
JBAS-9136

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
@@ -858,7 +858,7 @@ public class ThreadsExtension implements Extension {
             writer.writeStartElement(Element.QUEUELESS_THREAD_POOL.getLocalName());
 
             if (node.hasDefined(NAME)) {
-                writeAttribute(writer, Attribute.BLOCKING, node.get(NAME));
+                writeAttribute(writer, Attribute.NAME, node.get(NAME));
             }
             if (node.hasDefined(BLOCKING)) {
                 writeAttribute(writer, Attribute.BLOCKING, node.get(BLOCKING));


### PR DESCRIPTION
JBAS-9136 Thread subsystem writer outputting queueless-thread-pool name attribute as blocking
