### PR TITLE
JBAS-9177 added missing quotes where JBOSS_HOME is used

### DIFF
--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -85,8 +85,8 @@ echo.
 
 :RESTART
 "%JAVA%" %JAVA_OPTS% ^
- -Dorg.jboss.boot.log.file=%JBOSS_HOME%\process-controller\log\boot.log ^
- -Dlogging.configuration=file:%JBOSS_HOME%/domain/configuration/logging.properties ^
+ "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\process-controller\log\boot.log" ^
+ "-Dlogging.configuration=file:%JBOSS_HOME%/domain/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_HOME%\modules" ^
     -logmodule "org.jboss.logmanager" ^
@@ -94,8 +94,8 @@ echo.
     -jboss-home "%JBOSS_HOME%" ^
     -jvm "%JAVA%" ^
     -- ^
-    -Dorg.jboss.boot.log.file=%JBOSS_HOME%\domain\log\host-controller\boot.log ^
-    -Dlogging.configuration=file:%JBOSS_HOME%/domain/configuration/logging.properties ^
+    "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\domain\log\host-controller\boot.log" ^
+    "-Dlogging.configuration=file:%JBOSS_HOME%/domain/configuration/logging.properties" ^
     %JAVA_OPTS% ^
     -- ^
     -default-jvm "%JAVA%" ^

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -85,8 +85,8 @@ echo.
 
 :RESTART
 "%JAVA%" %JAVA_OPTS% ^
- -Dorg.jboss.boot.log.file=%JBOSS_HOME%\standalone\log\boot.log ^
- -Dlogging.configuration=file:%JBOSS_HOME%/standalone/configuration/logging.properties ^
+ "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\standalone\log\boot.log" ^
+ "-Dlogging.configuration=file:%JBOSS_HOME%/standalone/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_HOME%\modules" ^
     -logmodule "org.jboss.logmanager" ^


### PR DESCRIPTION
Turned out it was just a matter of adding quotes around two new lines in the bat files.
