### PR TITLE
Export javax.xml.stream.api from javaee.api

### DIFF
--- a/build/src/main/resources/modules/javaee/api/main/module.xml
+++ b/build/src/main/resources/modules/javaee/api/main/module.xml
@@ -52,6 +52,7 @@
         <module name="javax.xml.bind.api" export="true"/>
         <module name="javax.xml.registry.api" export="true"/>
         <module name="javax.xml.soap.api" export="true"/>
+        <module name="javax.xml.stream.api" export="true"/>
         <module name="javax.xml.ws.api" export="true"/>
 
         <!-- This one always goes last. -->


### PR DESCRIPTION
This fairly straightforward WAR:

  http://markmc.fedorapeople.org/rhevm-api-mock.war

includes RESTEasy, Spring and uses JAX-B.

Test using:

  $> wget -O - --http-user=foo --http-password=bar --header='Accept: application/xml' http://localhost:8080/rhevm-api-mock/

resteasy-jaxb-provider pulls in stax-api, but we exclude it from the WAR
in order to avoid this error with EAP5:

  java.lang.LinkageError: loader constraint violation: when resolving field
      "DATETIME" the class loader (instance of org/jboss/classloader/spi/base/BaseClassLoader)
      of the referring class, javax/xml/datatype/DatatypeConstants, and the class loader
      (instance of <bootloader>) for the field's resolved type, javax/xml/namespace/QName,
      have different Class objects for that type

(A similar error is seen under AS7 if stax-api is included)

However, we see this error under AS7:

  Servlet.service() for servlet Resteasy threw exception: java.lang.ClassNotFoundException:
    javax.xml.stream.XMLStreamException from [Module "deployment.rhevm-api-mock.war:main" from Service Module Loader]
      at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:184) [:1.0.0.Beta17]
      at org.jboss.modules.ConcurrentClassLoader.performLoadClassChecked(ConcurrentClassLoader.java:357) [:1.0.0.Beta17]
      at org.jboss.modules.ConcurrentClassLoader.performLoadClassChecked(ConcurrentClassLoader.java:329) [:1.0.0.Beta17]
      at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:306) [:1.0.0.Beta17]
      at org.jboss.modules.ConcurrentClassLoader.loadClass(ConcurrentClassLoader.java:100) [:1.0.0.Beta17]
      at com.sun.xml.bind.v2.runtime.JAXBContextImpl.createMarshaller(JAXBContextImpl.java:768) [jaxb-impl-2.1.12.jar:]

Now, some of the packages in stax-api are already exported by the
javax.api module:

  <path name="javax/xml/datatype"/>
  <path name="javax/xml/namespace"/>

and re-exported to web apps via javaee.api.

This patch includes the rest of the stax-api packages in the javaee.api
exports by exporting javax.xml.stream.api from there.

An alternate apparoach would be to fold javax.xml.stream.api into
javax.api completely.
