### PR TITLE
Make JMSQueueService public like JMSTopicService.

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
@@ -45,7 +45,7 @@ import java.util.Map;
  *
  * @author Emanuel Muckenhuber
  */
-class JMSQueueService implements Service<Void> {
+public class JMSQueueService implements Service<Void> {
 
     private final InjectedValue<JMSServerManager> jmsServer = new InjectedValue<JMSServerManager>();
 
@@ -100,7 +100,7 @@ class JMSQueueService implements Service<Void> {
         return null;
     }
 
-    InjectedValue<JMSServerManager> getJmsServer() {
+    public InjectedValue<JMSServerManager> getJmsServer() {
         return jmsServer;
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServices.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServices.java
@@ -62,7 +62,7 @@ import org.jboss.msc.service.ServiceName;
 /**
  * @author Emanuel Muckenhuber
  */
-class JMSServices {
+public class JMSServices {
 
     public static final ServiceName JMS = MessagingServices.JBOSS_MESSAGING.append("jms");
     public static final ServiceName JMS_MANAGER = JMS.append("manager");

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicService.java
@@ -96,7 +96,7 @@ public class JMSTopicService implements Service<Void> {
         return null;
     }
 
-    InjectedValue<JMSServerManager> getJmsServer() {
+    public InjectedValue<JMSServerManager> getJmsServer() {
         return jmsServer;
     }
 


### PR DESCRIPTION
AS7-798: "JMSTopicService and JMSQueueService made public for use outside of jboss-as-messaging"

https://issues.jboss.org/browse/AS7-798

Make the JmsServer injector public for users of JMSQueueService and JMSTopicService to be able to inject.
Make JMSServices public for name-creation for those trying to use JMSQueue/JMSTopic and create injections.
