### PR TITLE
AS7-893, use hasDefined(ALIAS) to avoid IllegalArgumentException error wh

### DIFF
--- a/web/src/main/java/org/jboss/as/web/WebVirtualHostAdd.java
+++ b/web/src/main/java/org/jboss/as/web/WebVirtualHostAdd.java
@@ -53,6 +53,7 @@ import java.util.Locale;
  * {@code OperationHandler} responsible for adding a virtual host.
  *
  * @author Emanuel Muckenhuber
+ * @author Scott stark (sstark@redhat.com) (C) 2011 Red Hat Inc.
  */
 class WebVirtualHostAdd implements ModelAddOperationHandler, DescriptionProvider {
 
@@ -134,7 +135,7 @@ class WebVirtualHostAdd implements ModelAddOperationHandler, DescriptionProvider
     }
 
     static String[] aliases(final ModelNode node) {
-        if(node.has(Constants.ALIAS)) {
+        if(node.hasDefined(Constants.ALIAS)) {
             final ModelNode aliases = node.require(Constants.ALIAS);
             final int size = aliases.asInt();
             final String[] array = new String[size];


### PR DESCRIPTION
AS7-893, use hasDefined(ALIAS) to avoid IllegalArgumentException error when
virtual-server does not have an alias subelement.
