### PR TITLE
Jboss vs jboss-as

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -24,7 +24,7 @@
 
     <import file="lib.xml"/>
 
-    <property name="output.dir" value="target/jbossas-${jboss.as.release.version}"/>
+    <property name="output.dir" value="target/jboss-as-${jboss.as.release.version}"/>
     <target name="copy-files">
         <copy todir="${output.dir}">
             <fileset dir="src/main/resources">

--- a/build/build.xml
+++ b/build/build.xml
@@ -24,7 +24,7 @@
 
     <import file="lib.xml"/>
 
-    <property name="output.dir" value="target/jboss-${jboss.as.release.version}"/>
+    <property name="output.dir" value="target/jbossas-${jboss.as.release.version}"/>
     <target name="copy-files">
         <copy todir="${output.dir}">
             <fileset dir="src/main/resources">

--- a/build/lib.xml
+++ b/build/lib.xml
@@ -24,7 +24,7 @@
 
     <property name="src.dir" value="src"/>
     <property name="module.repo.src.dir" value="${src.dir}/main/resources/modules"/>
-    <property name="output.dir" value="target/jboss-${jboss.as.release.version}"/>
+    <property name="output.dir" value="target/jbossas-${jboss.as.release.version}"/>
     <property name="module.repo.output.dir" value="${output.dir}/modules"/>
     <property name="module.xml" value="module.xml"/>
 

--- a/build/lib.xml
+++ b/build/lib.xml
@@ -24,7 +24,7 @@
 
     <property name="src.dir" value="src"/>
     <property name="module.repo.src.dir" value="${src.dir}/main/resources/modules"/>
-    <property name="output.dir" value="target/jbossas-${jboss.as.release.version}"/>
+    <property name="output.dir" value="target/jboss-as-${jboss.as.release.version}"/>
     <property name="module.repo.output.dir" value="${output.dir}/modules"/>
     <property name="module.xml" value="module.xml"/>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -74,7 +74,7 @@
                                     <descriptors>
                                         <descriptor>assembly.xml</descriptor>
                                     </descriptors>
-                                    <finalName>jboss-${project.version}</finalName>
+                                    <finalName>jboss-as-${project.version}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <outputDirectory>target/</outputDirectory>
                                     <workDirectory>target/assembly/work</workDirectory>


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-996

current build script generates a distro named jboss-\* where it should be jboss-as-*
