### PR TITLE
AS7-1091 Update to Arquillian Core + Arquillian Container OSGi 1.0.0.CR1

### DIFF
--- a/arquillian/common/pom.xml
+++ b/arquillian/common/pom.xml
@@ -38,10 +38,6 @@
             <artifactId>arquillian-container-osgi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-jmx</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.testenricher</groupId>
             <artifactId>arquillian-testenricher-cdi</artifactId>
         </dependency>

--- a/arquillian/container-managed/pom.xml
+++ b/arquillian/container-managed/pom.xml
@@ -55,10 +55,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerExtension.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerExtension.java
@@ -17,9 +17,7 @@
 package org.jboss.as.arquillian.container.managed;
 
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
-import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
 import org.jboss.as.arquillian.container.CommonContainerExtension;
-import org.jboss.as.arquillian.protocol.jmx.JMXProtocolAS7;
 
 /**
  * The extensions used by the managed container.
@@ -33,7 +31,6 @@ public class ManagedContainerExtension extends CommonContainerExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         super.register(builder);
-        builder.service(Protocol.class, JMXProtocolAS7.class);
         builder.service(DeployableContainer.class, ManagedDeployableContainer.class);
     }
 }

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientTestCase.java
@@ -22,7 +22,6 @@ import java.net.URL;
 import javax.management.MBeanServerConnection;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.container.MBeanServerConnectionProvider;
 import org.jboss.as.arquillian.container.managed.archive.ConfigService;
@@ -37,10 +36,9 @@ import org.junit.runner.RunWith;
  * @author Thomas.Diesler@jboss.com
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ManagedAsClientTestCase extends AbstractContainerTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static JavaArchive createDeployment() throws Exception {
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "sar-example.sar");
         archive.addPackage(ConfigService.class.getPackage());

--- a/arquillian/container-managed/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed/src/test/resources/arquillian.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
 	<container qualifier="jboss" default="true">
 		<configuration>
@@ -11,9 +11,7 @@
             Make executionType configurable
          -->
         <protocol type="jmx-as7">
-            <configuration>
                 <property name="executionType">REMOTE</property>
-            </configuration>
         </protocol>
 	</container>
 </arquillian>

--- a/arquillian/protocol-jmx/pom.xml
+++ b/arquillian/protocol-jmx/pom.xml
@@ -1,36 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ JBoss, Home of Professional Open Source. ~ Copyright 2010, Red Hat, 
-    Inc., and individual contributors ~ as indicated by the @author tags. See 
-    the copyright.txt file in the ~ distribution for a full listing of individual 
-    contributors. ~ ~ This is free software; you can redistribute it and/or modify 
-    it ~ under the terms of the GNU Lesser General Public License as ~ published 
-    by the Free Software Foundation; either version 2.1 of ~ the License, or 
-    (at your option) any later version. ~ ~ This software is distributed in the 
-    hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the 
-    implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-    See the GNU ~ Lesser General Public License for more details. ~ ~ You should 
-    have received a copy of the GNU Lesser General Public ~ License along with 
-    this software; if not, write to the Free ~ Software Foundation, Inc., 51 
-    Franklin St, Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site: 
-    http://www.fsf.org. -->
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian</artifactId>
-        <version>7.0.0.Beta4-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.jboss.as</groupId>
+		<artifactId>jboss-as-arquillian</artifactId>
+		<version>7.0.0.Beta4-SNAPSHOT</version>
+	</parent>
 
-    <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-arquillian-protocol-jmx</artifactId>
-    <version>7.0.0.Beta4-SNAPSHOT</version>
+	<groupId>org.jboss.as</groupId>
+	<artifactId>jboss-as-arquillian-protocol-jmx</artifactId>
+	<version>7.0.0.Beta4-SNAPSHOT</version>
 
-    <name>JBoss Application Server: Arquillian Protocol JMX</name>
+	<name>JBoss Application Server: Arquillian Protocol JMX</name>
 
-    <packaging>jar</packaging>
+	<packaging>jar</packaging>
 
     <dependencies>
         <dependency>
@@ -63,5 +70,4 @@
           <scope>provided</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolAS7.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolAS7.java
@@ -20,7 +20,7 @@ package org.jboss.as.arquillian.protocol.jmx;
 import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.protocol.jmx.JMXProtocol;
+import org.jboss.arquillian.protocol.jmx.AbstractJMXProtocol;
 import org.jboss.arquillian.test.spi.annotation.SuiteScoped;
 import org.jboss.shrinkwrap.api.Archive;
 
@@ -30,7 +30,7 @@ import org.jboss.shrinkwrap.api.Archive;
  * @author thomas.diesler@jboss.com
  * @since 31-May-2011
  */
-public class JMXProtocolAS7 extends JMXProtocol {
+public class JMXProtocolAS7 extends AbstractJMXProtocol {
 
     @Inject
     @SuiteScoped

--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolPackager.java
@@ -31,11 +31,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.TestDeployment;
 import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
 import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
-import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.protocol.jmx.JMXProtocol;
+import org.jboss.arquillian.protocol.jmx.AbstractJMXProtocol;
 import org.jboss.as.arquillian.protocol.jmx.JMXProtocolAS7.ServiceArchiveHolder;
 import org.jboss.as.arquillian.service.ArquillianService;
 import org.jboss.as.arquillian.service.JMXProtocolEndpointExtension;
@@ -90,11 +90,11 @@ public class JMXProtocolPackager implements DeploymentPackager {
         log.debugf("Generating: %s", archive.getName());
 
         archive.addPackage(ArquillianService.class.getPackage());
-        archive.addPackage(JMXProtocol.class.getPackage());
+        archive.addPackage(AbstractJMXProtocol.class.getPackage());
 
         // Merge the auxilliary archives and collect the loadable extensions
         final Set<String> loadableExtensions = new HashSet<String>();
-        final String loadableExtentionsPath = "META-INF/services/" + LoadableExtension.class.getName();
+        final String loadableExtentionsPath = "META-INF/services/" + RemoteLoadableExtension.class.getName();
         for (Archive<?> aux : auxArchives) {
             Node node = aux.get(loadableExtentionsPath);
             if (node != null) {

--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/JMXProtocolEndpointExtension.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/JMXProtocolEndpointExtension.java
@@ -17,9 +17,7 @@
  */
 package org.jboss.as.arquillian.service;
 
-import org.jboss.arquillian.container.test.spi.command.CommandService;
-import org.jboss.arquillian.core.spi.LoadableExtension;
-import org.jboss.arquillian.protocol.jmx.JMXCommandService;
+import org.jboss.arquillian.protocol.jmx.JMXExtension;
 
 /**
  * JMXProtocolEndpointExtension
@@ -27,10 +25,10 @@ import org.jboss.arquillian.protocol.jmx.JMXCommandService;
  * @author thomas.diesler@jboss.com
  * @since 31-May-2011
  */
-public class JMXProtocolEndpointExtension implements LoadableExtension {
+public class JMXProtocolEndpointExtension extends JMXExtension {
 
     @Override
     public void register(ExtensionBuilder builder) {
-        builder.service(CommandService.class, JMXCommandService.class);
+        super.register(builder);
     }
 }

--- a/arquillian/testenricher-msc/src/main/java/org/jboss/arquillian/testenricher/msc/MSCAuxiliaryArchiveAppender.java
+++ b/arquillian/testenricher-msc/src/main/java/org/jboss/arquillian/testenricher/msc/MSCAuxiliaryArchiveAppender.java
@@ -17,8 +17,8 @@
  */
 package org.jboss.arquillian.testenricher.msc;
 
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
-import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -35,7 +35,7 @@ public class MSCAuxiliaryArchiveAppender implements AuxiliaryArchiveAppender {
     @Override
     public Archive<?> createAuxiliaryArchive() {
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "arquillian-testenricher-msc.jar");
-        archive.addAsServiceProvider(LoadableExtension.class, MSCEnricherExtension.class);
+        archive.addAsServiceProvider(RemoteLoadableExtension.class, MSCEnricherRemoteExtension.class);
         archive.addPackage(MSCTestEnricher.class.getPackage());
         return archive;
     }

--- a/arquillian/testenricher-msc/src/main/java/org/jboss/arquillian/testenricher/msc/MSCEnricherRemoteExtension.java
+++ b/arquillian/testenricher-msc/src/main/java/org/jboss/arquillian/testenricher/msc/MSCEnricherRemoteExtension.java
@@ -17,8 +17,8 @@
  */
 package org.jboss.arquillian.testenricher.msc;
 
-import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
-import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
 
 /**
  * MSCEnricherExtension
@@ -26,10 +26,10 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  * @author Thomas.Diesler@jboss.com
  * @since 07-Jun-2011
  */
-public class MSCEnricherExtension implements LoadableExtension {
+public class MSCEnricherRemoteExtension implements RemoteLoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
-        builder.service(AuxiliaryArchiveAppender.class, MSCAuxiliaryArchiveAppender.class);
+        builder.service(TestEnricher.class, MSCTestEnricher.class);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
         <version.org.hornetq.hornetq-jms>2.2.6.Final</version.org.hornetq.hornetq-jms>
         <version.org.infinispan>5.0.0.CR6</version.org.infinispan>
         <version.org.javassist>3.12.1.GA</version.org.javassist>
-        <version.org.jboss.arquillian.core>1.0.0.Beta2</version.org.jboss.arquillian.core>
-        <version.org.jboss.arquillian.osgi>1.0.0.Beta2</version.org.jboss.arquillian.osgi>
+        <version.org.jboss.arquillian.core>1.0.0.CR1</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.osgi>1.0.0.CR1</version.org.jboss.arquillian.osgi>
         <version.org.jboss.classfilewriter>1.0.0.Alpha7</version.org.jboss.classfilewriter>
         <version.org.jboss.com.sun.httpserver>1.0.0.Beta1</version.org.jboss.com.sun.httpserver>
         <version.org.jboss.ejb3>2.0.0-beta-1</version.org.jboss.ejb3>

--- a/testsuite/integration/src/test/resources/arquillian.xml
+++ b/testsuite/integration/src/test/resources/arquillian.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
 	<container qualifier="jboss" default="true">
 		<configuration>
 			<property name="jbossHome">target/jbossas</property>
 		</configuration>
-        <!-- 
-            [ARQ-425] config parser code not in sync with schema
-            Make executionType configurable
-         -->
         <protocol type="jmx-as7">
-            <configuration>
-                <property name="executionType">REMOTE</property>
-            </configuration>
+            <property name="executionType">REMOTE</property>
         </protocol>
 	</container>
 </arquillian>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
            <groupId>org.jboss.arquillian.junit</groupId>
-           <artifactId>arquillian-junit-core</artifactId>
+           <artifactId>arquillian-junit-container</artifactId>
            <scope>test</scope>
         </dependency>
         <dependency>
@@ -146,7 +146,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                   <failIfNoTests>false</failIfNoTests>
+                    <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                     <systemProperties>

--- a/testsuite/smoke/src/test/resources/arquillian.xml
+++ b/testsuite/smoke/src/test/resources/arquillian.xml
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
 	<container qualifier="jboss" default="true">
 		<configuration>
 			<property name="jbossHome">target/jbossas</property>
 		</configuration>
-        <!-- 
-            [ARQ-425] config parser code not in sync with schema
-            Make executionType configurable
-         -->
         <protocol type="jmx-as7">
-            <configuration>
-                <property name="executionType">REMOTE</property>
-            </configuration>
+            <property name="executionType">REMOTE</property>
         </protocol>
 	</container>
 </arquillian>

--- a/testsuite/spec/src/test/resources/arquillian.xml
+++ b/testsuite/spec/src/test/resources/arquillian.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
 	<container qualifier="jboss" default="true">
 		<configuration>
 			<property name="jbossHome">target/jbossas</property>
 		</configuration>
         <protocol type="jmx-as7">
-            <configuration>
-                <property name="executionType">REMOTE</property>
-            </configuration>
+            <property name="executionType">REMOTE</property>
         </protocol>
 	</container>
 </arquillian>


### PR DESCRIPTION
- Sync with new Arquillian XML schema
- Update to match new Abstract JMX Protocol. Protocols should be self contained and does not need to be included in the container extension it self.
- Replace @RunAsClient with Deployment.testable=false, @RunAsClient does not effect packaging. For pure 100% client tests, the packaging does not need to be enriched.
- Update TestEnricher-MSC to use RemoteLoadableExtension to match Arquillian Core CR1
