### PR TITLE
Remove illegal file-name attrib

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -239,7 +239,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         // Attributes
         String name = null;
         boolean autoflush = true;
-        final EnumSet<Attribute> required = EnumSet.of(Attribute.FILE_NAME, Attribute.NAME);
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
             requireNoNamespaceAttribute(reader, i);


### PR DESCRIPTION
Fix asynch-logging config; it requires no file-name attrib.
