### PR TITLE
Make org.jboss.vfs module visible by default

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ServerDependenciesProcessor.java
@@ -40,6 +40,7 @@ public class ServerDependenciesProcessor implements DeploymentUnitProcessor {
     private static ModuleIdentifier SUN_JDK = ModuleIdentifier.create("sun.jdk");
     private static ModuleIdentifier JAVAX_API = ModuleIdentifier.create("javax.api");
     private static ModuleIdentifier JBOSS_LOGGING = ModuleIdentifier.create("org.jboss.logging");
+    private static ModuleIdentifier JBOSS_VFS = ModuleIdentifier.create("org.jboss.vfs");
 
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
@@ -49,6 +50,7 @@ public class ServerDependenciesProcessor implements DeploymentUnitProcessor {
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, SUN_JDK, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JAVAX_API, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JBOSS_LOGGING, false, false, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JBOSS_VFS, false, false, false));
     }
 
     @Override


### PR DESCRIPTION
It would be a good idea to do this, as Spring applications need it to properly interact to VFS.
