### PR TITLE
AS7-1152 Support Deployment introspection using ProtocolMetadata in the Arquillian Containers

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -110,7 +110,8 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
         ArchiveDeployer archiveDeployer = archiveDeployerInst.get();
         String runtimeName = archiveDeployer.deploy(archive);
         registry.put(archive, runtimeName);
-        return new ProtocolMetaData();
+
+        return new ProtocolMetaDataParser(modelControllerClient).parse(runtimeName);
     }
 
     @Override

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
 import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
 import org.jboss.arquillian.core.api.InstanceProducer;
@@ -111,7 +112,8 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
         String runtimeName = archiveDeployer.deploy(archive);
         registry.put(archive, runtimeName);
 
-        return new ProtocolMetaDataParser(modelControllerClient).parse(runtimeName);
+        HTTPContext ctx = new HTTPContext(containerConfig.getBindAddress().getHostName(), containerConfig.getHttpPort());
+        return new ProtocolMetaDataParser(modelControllerClient).parse(runtimeName, ctx);
     }
 
     @Override

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ProtocolMetaDataParser.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ProtocolMetaDataParser.java
@@ -1,0 +1,142 @@
+package org.jboss.as.arquillian.container;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+public class ProtocolMetaDataParser {
+
+    private ModelControllerClient client;
+
+    public ProtocolMetaDataParser(ModelControllerClient client) {
+        if (client == null) {
+            throw new IllegalArgumentException("Client must be specified");
+        }
+        this.client = client;
+    }
+
+    public ProtocolMetaData parse(String deploymentName) {
+        ProtocolMetaData protocol = new ProtocolMetaData();
+        HTTPContext context = new HTTPContext("localhost", 8080);
+        protocol.addContext(context);
+
+        if (isWebArchive(deploymentName)) {
+            extractWebArchiveContexts(context, deploymentName);
+        } else if (isEnterpriseArchive(deploymentName)) {
+            extractEnterpriseArchiveContexts(context, deploymentName);
+        }
+
+        return protocol;
+    }
+
+    private void extractEnterpriseArchiveContexts(HTTPContext context,
+            String deploymentName) {
+        ModelNode address = new ModelNode();
+        address.add(DEPLOYMENT, deploymentName);
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_CHILDREN_RESOURCES_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        operation.get(CHILD_TYPE).set("subdeployment");
+        try {
+            ModelNode result = executeForResult(operation);
+            for (String subDeploymentName : result.keys()) {
+                if (isWebArchive(subDeploymentName)) {
+                    extractEnterpriseWebArchiveContexts(context,
+                            deploymentName, subDeploymentName);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void extractWebArchiveContexts(HTTPContext context,
+            String webDeploymentName) {
+        ModelNode address = new ModelNode();
+        address.add(DEPLOYMENT, webDeploymentName);
+        address.add(SUBSYSTEM, "web");
+
+        extractWebContext(context, webDeploymentName, address);
+    }
+
+    private void extractEnterpriseWebArchiveContexts(HTTPContext context,
+            String enterpriseDeploymentName, String webDeploymentName) {
+        ModelNode address = new ModelNode();
+        address.add(DEPLOYMENT, enterpriseDeploymentName);
+        address.add("subdeployment", webDeploymentName);
+        address.add(SUBSYSTEM, "web");
+
+        extractWebContext(context, webDeploymentName, address);
+    }
+
+    private void extractWebContext(HTTPContext context, String deploymentName,
+            ModelNode address) {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+
+        try {
+            ModelNode result = executeForResult(operation);
+            for (ModelNode servletNode : result.get("servlet").asList()) {
+                for (String servletName : servletNode.keys()) {
+                    context.add(new Servlet(servletName,
+                            toContextName(deploymentName)));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private boolean isEnterpriseArchive(String deploymentName) {
+        return deploymentName.endsWith(".ear");
+    }
+
+    private boolean isWebArchive(String deploymentName) {
+        return deploymentName.endsWith(".war");
+    }
+
+    private String toContextName(String deploymentName) {
+        String correctedName = deploymentName;
+        if (correctedName.startsWith("/")) {
+            correctedName = correctedName.substring(1);
+        }
+        if (correctedName.indexOf(".") != -1) {
+            correctedName = correctedName.substring(0,
+                    correctedName.lastIndexOf("."));
+        }
+        return correctedName;
+    }
+
+    private ModelNode executeForResult(final ModelNode operation)
+            throws Exception {
+        final ModelNode result = client.execute(operation);
+        checkSuccessful(result, operation);
+        return result.get(RESULT);
+    }
+
+    static void checkSuccessful(final ModelNode result,
+            final ModelNode operation) throws UnSuccessfulOperationException {
+        if (!SUCCESS.equals(result.get(OUTCOME).asString())) {
+            throw new UnSuccessfulOperationException();
+        }
+    }
+
+    private static class UnSuccessfulOperationException extends Exception {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/HelloWorldServlet.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/HelloWorldServlet.java
@@ -1,0 +1,29 @@
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A basic "hello world" servlet for testing client-side invocation in an Arquillian test.
+ *
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@WebServlet(name = "HelloWorldServlet", urlPatterns = HelloWorldServlet.URL_PATTERN)
+public class HelloWorldServlet extends HttpServlet {
+    private static final long serialVersionUID = 2202174128107400113L;
+    
+    public static final String URL_PATTERN = "/greet";
+    
+    public static final String GREETING = "Hello, World";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        res.setContentType("text/plain");
+        res.getWriter().append(GREETING);
+    }
+}

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A client-side test case that verifies that the root deployment URL can be injected
+ * into the test case.
+ *
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@RunWith(Arquillian.class)
+public class ManagedAsClientEnterpriseArchiveServletTestCase {
+
+    @Deployment(testable = false)
+    public static EnterpriseArchive createDeployment() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class).addClass(HelloWorldServlet.class);
+        return ShrinkWrap.create(EnterpriseArchive.class).addAsModule(war);
+    }
+
+    @ArquillianResource
+    URL deploymentUrl;
+    
+    @Test
+    public void shouldBeAbleToInvokeServlet() throws Exception {
+        Assert.assertNotNull(deploymentUrl);
+        String result = getContent(new URL(deploymentUrl.toString() + HelloWorldServlet.URL_PATTERN.substring(1)));
+        Assert.assertEquals(HelloWorldServlet.GREETING, result);
+    }
+    
+    private String getContent(URL url) throws Exception {
+        InputStream is = url.openStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            int read;
+            while ((read = is.read()) != -1) {
+                out.write(read);
+            }
+        } finally {
+            try {
+                is.close();
+            } catch (Exception e) {
+            }
+        }
+        return out.toString();
+    }
+
+}

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A client-side test case that verifies that the root deployment URL can be injected
+ * into the test case.
+ *
+ * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
+ */
+@RunWith(Arquillian.class)
+public class ManagedAsClientWebArchiveServletTestCase {
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() throws Exception {
+        return ShrinkWrap.create(WebArchive.class).addClass(HelloWorldServlet.class);
+    }
+
+    @ArquillianResource
+    URL deploymentUrl;
+    
+    @Test
+    public void shouldBeAbleToInvokeServlet() throws Exception {
+        Assert.assertNotNull(deploymentUrl);
+        String result = getContent(new URL(deploymentUrl.toString() + HelloWorldServlet.URL_PATTERN.substring(1)));
+        Assert.assertEquals(HelloWorldServlet.GREETING, result);
+    }
+    
+    private String getContent(URL url) throws Exception {
+        InputStream is = url.openStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            int read;
+            while ((read = is.read()) != -1) {
+                out.write(read);
+            }
+        } finally {
+            try {
+                is.close();
+            } catch (Exception e) {
+            }
+        }
+        return out.toString();
+    }
+
+}

--- a/arquillian/container-remote/pom.xml
+++ b/arquillian/container-remote/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>javax.inject</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/arquillian/container-remote/src/test/java/org/jboss/as/arquillian/container/remote/ServletClientTestCase.java
+++ b/arquillian/container-remote/src/test/java/org/jboss/as/arquillian/container/remote/ServletClientTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.remote;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.remote.servlet.Servlet1;
+import org.jboss.as.arquillian.container.remote.servlet.Servlet2;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test to verify correct Protocol Metadata returned from Deployment
+ * 
+ * @author <a href="aslak@redhat.com">Aslak Knutsen</a>
+ */
+@RunWith(Arquillian.class)
+public class ServletClientTestCase {
+
+    @Deployment(name = "war", testable = false)
+    public static WebArchive createWarDeployment() throws Exception {
+        return ShrinkWrap.create(WebArchive.class).addClass(Servlet1.class);
+    }
+
+    @Deployment(name = "ear", testable = false)
+    public static EnterpriseArchive createDeployment() throws Exception {
+        return ShrinkWrap
+                .create(EnterpriseArchive.class)
+                .addAsModule(
+                        ShrinkWrap.create(WebArchive.class).addClass(
+                                Servlet1.class))
+                .addAsModule(
+                        ShrinkWrap.create(WebArchive.class).addClass(
+                                Servlet2.class));
+    }
+
+    @Test @OperateOnDeployment("war")
+    public void shouldBeAbleToLookupServletURLInAWar(@ArquillianResource URL baseURL) throws Exception {
+        Assert.assertNotNull("Should have injected Base URL for deployed WebContext",
+                baseURL);
+        
+        Assert.assertEquals(Servlet1.class.getName(), getContent(new URL(baseURL, Servlet1.PATTERN)));
+    }
+
+    @Test @OperateOnDeployment("ear")
+    public void shouldBeAbleToLookupServletURLInAEar(
+            @ArquillianResource(Servlet1.class) URL servlet1BaseURL, 
+            @ArquillianResource(Servlet2.class) URL servlet2BaseURL) throws Exception {
+        
+        Assert.assertNotNull("Should have injected Base URL for deployed WebContext",
+                servlet1BaseURL);
+        Assert.assertEquals(Servlet1.class.getName(), getContent(new URL(servlet1BaseURL, Servlet1.PATTERN)));
+
+        Assert.assertNotNull("Should have injected Base URL for deployed WebContext",
+                servlet2BaseURL);
+        Assert.assertEquals(Servlet2.class.getName(), getContent(new URL(servlet2BaseURL, Servlet2.PATTERN)));
+    }
+
+    private String getContent(URL url) throws Exception {
+        InputStream is = url.openStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            int read;
+            while ((read = is.read()) != -1) {
+                out.write(read);
+            }
+        } finally {
+            try {
+                is.close();
+            } catch (Exception e) {
+            }
+        }
+        return out.toString();
+    }
+
+}

--- a/arquillian/container-remote/src/test/java/org/jboss/as/arquillian/container/remote/servlet/Servlet1.java
+++ b/arquillian/container-remote/src/test/java/org/jboss/as/arquillian/container/remote/servlet/Servlet1.java
@@ -1,0 +1,23 @@
+package org.jboss.as.arquillian.container.remote.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = "/" + Servlet1.PATTERN)
+public class Servlet1 extends HttpServlet {
+
+    public static final String PATTERN = "Servlet1";
+            
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException 
+    {
+        resp.getWriter().append(this.getClass().getName());
+    }
+}

--- a/arquillian/container-remote/src/test/java/org/jboss/as/arquillian/container/remote/servlet/Servlet2.java
+++ b/arquillian/container-remote/src/test/java/org/jboss/as/arquillian/container/remote/servlet/Servlet2.java
@@ -1,0 +1,23 @@
+package org.jboss.as.arquillian.container.remote.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = "/" + Servlet2.PATTERN)
+public class Servlet2 extends HttpServlet {
+
+    public static final String PATTERN = "Servlet2";
+            
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException 
+    {
+        resp.getWriter().append(this.getClass().getName());
+    }
+}


### PR DESCRIPTION
The following patch combines the initial work done by Aslak to setup a ProtocolMetaData extractor and my additions to capture the bind address and host name, as well as optimize the read operations to extract servlet information from the web subsystem. I tests to ensure that the deployment URL can be injected into a client-side test case with @ArquillianResource for both a WebArchive and EnterpriseArchive deployment.

This patch is based off of the 7.0.0.Final tag, though should apply clean to master.
