### PR TITLE
[AS7-1397] JPS should look in the JDK bin directory if not found in the J

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
@@ -354,8 +354,14 @@ public class RespawnTestCase {
     private static class UnixProcessUtil extends ProcessUtil {
         @Override
         String getJpsCommand() {
-            return System.getProperty("java.home") + "/bin/jps -vl";
-
+            final File jreHome = new File(System.getProperty("java.home"));
+            Assert.assertTrue("JRE home not found. File: " + jreHome.getAbsoluteFile(), jreHome.exists());
+            File jpsExe = new File(jreHome, "bin/jps");
+            if (!jpsExe.exists()) {
+                jpsExe = new File(jreHome, "../bin/jps");
+            }
+            Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
+            return String.format("%s -vl", jpsExe.getAbsolutePath());
         }
 
         @Override
@@ -373,7 +379,14 @@ public class RespawnTestCase {
 
         @Override
         String getJpsCommand() {
-            return System.getProperty("java.home") + "/bin/jps.exe -vl";
+            final File jreHome = new File(System.getProperty("java.home"));
+            Assert.assertTrue("JRE home not found. File: " + jreHome.getAbsoluteFile(), jreHome.exists());
+            File jpsExe = new File(jreHome, "bin/jps.exe");
+            if (!jpsExe.exists()) {
+                jpsExe = new File(jreHome, "../bin/jps.exe");
+            }
+            Assert.assertTrue("JPS executable not found. File: " + jpsExe, jpsExe.exists());
+            return String.format("%s -vl", jpsExe.getAbsolutePath());
         }
 
         @Override


### PR DESCRIPTION
[AS7-1397] JPS should look in the JDK bin directory if not found in the JRE bin directory.

Just fixes an integration tests. I've seen the error locally on the Jenkins builds.
