### PR TITLE
AS7-1439 use module slots to refer to different versions of a persistence

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -523,11 +523,11 @@
             <maven-resource group="org.jboss.as" artifact="jboss-as-jpa"/>
         </module-def>
 
-        <module-def name="org.jboss.as.jpa.hibernate3">
+        <module-def name="org.jboss.as.jpa.hibernate" slot="3">
             <maven-resource group="org.jboss.as" artifact="jboss-as-jpa-hibernate3"/>
         </module-def>
 
-        <module-def name="org.jboss.as.jpa.hibernate4">
+        <module-def name="org.jboss.as.jpa.hibernate" slot="4">
             <maven-resource group="org.jboss.as" artifact="jboss-as-jpa-hibernate4"/>
         </module-def>
 

--- a/build/src/main/resources/modules/org/hibernate/main/module.xml
+++ b/build/src/main/resources/modules/org/hibernate/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
+<!-- Represents the Hibernate 4.0.x module--> 
 <module xmlns="urn:jboss:module:1.0" name="org.hibernate">
     <resources>
         <!-- Insert resources here -->
@@ -39,7 +39,7 @@
         <module name="org.dom4j"/>
         <module name="org.infinispan"/>
         <module name="org.javassist"/>
-        <module name="org.jboss.as.jpa.hibernate4"/>
+        <module name="org.jboss.as.jpa.hibernate"  slot="4"/>
         <module name="org.jboss.logging"/>
         <module name="org.slf4j"/>
     </dependencies>

--- a/build/src/main/resources/modules/org/jboss/as/jpa/hibernate/3/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jpa/hibernate/3/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.jpa.hibernate3">
+<!-- contains the JPA integration classes for Hibernate 3.x --> 
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.jpa.hibernate" slot="3">
 
     <resources>
         <!-- Insert resources here -->
@@ -32,7 +33,7 @@
         <module name="javax.annotation.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
-        <module name="org.hibernate3" optional="true"/>  <!-- org.hibernate3 must be manually populated with hibernate3 jars -->
+        <module name="org.hibernate" slot="3" optional="true"/>  <!-- org.hibernate:3 must be created manually with Hibernate 3 jars -->
         <module name="org.hibernate.validator"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.as.naming"/>

--- a/build/src/main/resources/modules/org/jboss/as/jpa/hibernate/4/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jpa/hibernate/4/module.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.jpa.hibernate4">
+<!-- contains the JPA integration classes for Hibernate 4.x --> 
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.jpa.hibernate" slot="4">
 
     <resources>
         <!-- Insert resources here -->

--- a/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -57,12 +57,12 @@ public class Configuration {
     /**
      * Hibernate 3 persistence provider, if this provider is chosen. ADAPTER_MODULE_HIBERNATE3 will be enabled
      */
-    public static final String PROVIDER_MODULE_HIBERNATE3 = "org.hibernate3";
+    public static final String PROVIDER_MODULE_HIBERNATE3 = "org.hibernate:3";
 
     /**
      * Hibernate 3 persistence provider adaptor
      */
-    public static final String ADAPTER_MODULE_HIBERNATE3 = "org.jboss.as.jpa.hibernate3";
+    public static final String ADAPTER_MODULE_HIBERNATE3 = "org.jboss.as.jpa.hibernate:3";
 
     /**
      * name of the AS module that contains the persistence provider adapter
@@ -72,7 +72,7 @@ public class Configuration {
     /**
      * default if no ADAPTER_MODULE is specified.
      */
-    public static final String ADAPTER_MODULE_DEFAULT = "org.jboss.as.jpa.hibernate4";
+    public static final String ADAPTER_MODULE_DEFAULT = "org.jboss.as.jpa.hibernate:4";
 
     /**
      * name of the persistence provider adapter class

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
@@ -66,12 +66,13 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
     private static final ModuleIdentifier JBOSS_AS_JPA_SPI_ID = ModuleIdentifier.create("org.jboss.as.jpa.spi");
     private static final ModuleIdentifier JAVASSIST_ID = ModuleIdentifier.create("org.javassist");
 
-    private static final ModuleIdentifier HIBERNATE_3_PROVIDER = ModuleIdentifier.create("org.jboss.as.jpa.hibernate3");
+    private static final ModuleIdentifier HIBERNATE_3_PROVIDER = ModuleIdentifier.create("org.jboss.as.jpa.hibernate","3");
     private static final String HIBERNATE3_PROVIDER_ADAPTOR = "org.jboss.as.jpa.hibernate3.HibernatePersistenceProviderAdaptor";
 
     // module dependencies for hibernate3
     private static final ModuleIdentifier JBOSS_AS_NAMING_ID = ModuleIdentifier.create("org.jboss.as.naming");
     private static final ModuleIdentifier JBOSS_JANDEX_ID = ModuleIdentifier.create("org.jboss.jandex");
+
     /**
      * Add dependencies for modules required for JPA deployments
      */
@@ -104,12 +105,10 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
 
     }
 
-
     private void addPersistenceProviderModuleDependencies(DeploymentPhaseContext phaseContext, ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) throws
             DeploymentUnitProcessingException {
 
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        final ResourceRoot deploymentRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
 
         int defaultProviderCount = 0;
         Set<String> moduleDependencies = new HashSet<String>();
@@ -126,7 +125,8 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
 
         // add persistence provider dependency
         for (String dependency : moduleDependencies) {
-            addDependency(moduleSpecification, moduleLoader, ModuleIdentifier.create(dependency));
+
+            addDependency(moduleSpecification, moduleLoader, ModuleIdentifier.fromString(dependency));
             log.info("added " + dependency + " dependency to application deployment");
         }
     }

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/Hibernate3SharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/Hibernate3SharedModuleProviderTestCase.java
@@ -58,11 +58,11 @@ public class Hibernate3SharedModuleProviderTestCase {
             "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
             "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
             "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
-// set the providerModule to the AS org.hibernate3 module (should be in as/modules/org/hibernate3/main folder
+// set the providerModule to the AS org.hibernate3 module (should be in as/modules/org/hibernate/3 folder
 // Hibernate 3 jars will need to be in the module folder and each jar name
 // should be added to module.xml in same folder.
-// not configuring the org.hibernate3 module will give errors like this: http://pastie.org/2280769
-            "<property name=\"jboss.as.jpa.providerModule\" value=\"org.hibernate3\"/>" +
+// not configuring the org.hibernate:3 module will give errors like this: http://pastie.org/2280769
+            "<property name=\"jboss.as.jpa.providerModule\" value=\"org.hibernate:3\"/>" +
             "</properties>" +
             "  </persistence-unit>" +
             "</persistence>";


### PR DESCRIPTION
AS7-1439 use module slots to refer to different versions of a persistence provider.  Note that doc on https://docs.jboss.org/author/display/AS7/JPA+Reference+Guide needs to be updated after this is merged in.  
