### PR TITLE
AS7-1210 Fix incorrect handling of jndi name during binding

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/AS7BindingRegistry.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/AS7BindingRegistry.java
@@ -80,7 +80,7 @@ public class AS7BindingRegistry implements BindingRegistry {
             throw new IllegalArgumentException("Binding to " + name + " isn't allowed, since it belongs to a unknown/unsupported jndi name context");
         }
         // create the binding service
-        final BinderService binderService = new BinderService(name);
+        final BinderService binderService = new BinderService(jndiBinding.relativeJndiName);
         container.addService(jndiBinding.jndiContextServiceName.append(jndiBinding.relativeJndiName), binderService)
                 .addDependency(jndiBinding.jndiContextServiceName, NamingStore.class, binderService.getNamingStoreInjector())
                 .addInjection(binderService.getManagedObjectInjector(), new ValueManagedReferenceFactory(Values.immediateValue(obj)))

--- a/testsuite/spec/src/main/java/org/jboss/as/test/spec/ejb3/mdb/ReplyingMDB.java
+++ b/testsuite/spec/src/main/java/org/jboss/as/test/spec/ejb3/mdb/ReplyingMDB.java
@@ -40,7 +40,7 @@ import javax.jms.TextMessage;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 @MessageDriven(activationConfig = {
-        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/queue/test")
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/jms/queue/test")
 })
 public class ReplyingMDB implements MessageListener {
     @Resource(lookup = "java:/JmsXA")

--- a/testsuite/spec/src/test/java/org/jboss/as/test/spec/ejb3/mdb/JMSMessageDrivenBeanTestCase.java
+++ b/testsuite/spec/src/test/java/org/jboss/as/test/spec/ejb3/mdb/JMSMessageDrivenBeanTestCase.java
@@ -71,7 +71,7 @@ public class JMSMessageDrivenBeanTestCase {
             final QueueReceiver receiver = session.createReceiver(replyDestination);
             final Message message = session.createTextMessage("Test");
             message.setJMSReplyTo(replyDestination);
-            final Destination destination = (Destination) ctx.lookup("java:jboss/queue/test");
+            final Destination destination = (Destination) ctx.lookup("java:jboss/jms/queue/test");
             final MessageProducer producer = session.createProducer(destination);
             producer.send(message);
             producer.close();


### PR DESCRIPTION
Please pull the commit from this branch to upstream. It contains a fix for binding the JMS objects into JNDI. A previous commit of mine had a typo in it, leading to incorrect JMS bindings in some specific cases.

-Jaikiran
