### PR TITLE
AS7-1352 AS7-1164 AS7-1258

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AttributeDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AttributeDefinition.java
@@ -70,7 +70,7 @@ public enum AttributeDefinition {
             ModelType.STRING, false), RECOVERY_SECURITY_DOMAIN(Constants.RECOVERY_SECURITY_DOMAIN, ModelType.STRING, false), RECOVERLUGIN_CLASSNAME(
             Constants.RECOVERLUGIN_CLASSNAME, ModelType.STRING, false), RECOVERLUGIN_PROPERTIES(
             Constants.RECOVERLUGIN_PROPERTIES, ModelType.OBJECT, false), NO_RECOVERY(Constants.NO_RECOVERY, ModelType.BOOLEAN,
-            false);
+            false), XADATASOURCE_PROPERTIES(Constants.XADATASOURCEPROPERTIES, ModelType.OBJECT, true);
 
     private final String propertyName;
     private final ModelType modelType;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemProviders.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemProviders.java
@@ -22,21 +22,20 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
-import java.util.Locale;
-import java.util.ResourceBundle;
-
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATA_SOURCE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DEPLOYMENT_NAME;
-import static org.jboss.as.connector.subsystems.datasources.Constants.*;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_CLASS_NAME;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_MAJOR_VERSION;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_MINOR_VERSION;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_MODULE_NAME;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_NAME;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_XA_DATASOURCE_CLASS_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.INSTALLED_DRIVERS;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_COMPLIANT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_DRIVER;
 import static org.jboss.as.connector.subsystems.datasources.Constants.MODULE_SLOT;
+import static org.jboss.as.connector.subsystems.datasources.Constants.XADATASOURCECLASS;
 import static org.jboss.as.connector.subsystems.datasources.Constants.XA_DATA_SOURCE;
-
-import org.jboss.as.connector.pool.PoolConfigurationRWHandler;
-import org.jboss.as.connector.pool.PoolMetrics;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
@@ -56,6 +55,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TAI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
 
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.connector.pool.PoolMetrics;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.jca.adapters.jdbc.statistics.JdbcStatisticsPlugin;
@@ -113,7 +117,8 @@ class DataSourcesSubsystemProviders {
             AttributeDefinition.SPY, AttributeDefinition.USE_CCM, AttributeDefinition.REAUTHPLUGIN_PROPERTIES,
             AttributeDefinition.RECOVERY_USERNAME, AttributeDefinition.RECOVERY_PASSWORD,
             AttributeDefinition.RECOVERY_SECURITY_DOMAIN, AttributeDefinition.RECOVERLUGIN_CLASSNAME,
-            AttributeDefinition.RECOVERLUGIN_PROPERTIES, AttributeDefinition.NO_RECOVERY };
+            AttributeDefinition.RECOVERLUGIN_PROPERTIES, AttributeDefinition.NO_RECOVERY,
+            AttributeDefinition.XADATASOURCE_PROPERTIES };
 
     static final String RESOURCE_NAME = DataSourcesSubsystemProviders.class.getPackage().getName() + ".LocalDescriptions";
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemProviders.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemProviders.java
@@ -360,6 +360,7 @@ class DataSourcesSubsystemProviders {
             operation.get(ATTRIBUTES, DEPLOYMENT_NAME, TYPE).set(ModelType.STRING);
             operation.get(ATTRIBUTES, DRIVER_MODULE_NAME, DESCRIPTION).set(bundle.getString("installed-drivers.module-name"));
             operation.get(ATTRIBUTES, DRIVER_MODULE_NAME, TYPE).set(ModelType.STRING);
+            operation.get(ATTRIBUTES, DRIVER_MODULE_NAME, REQUIRED).set(true);
             operation.get(ATTRIBUTES, MODULE_SLOT, DESCRIPTION).set(bundle.getString("installed-drivers.module-slot"));
             operation.get(ATTRIBUTES, MODULE_SLOT, TYPE).set(ModelType.STRING);
             operation.get(ATTRIBUTES, DRIVER_CLASS_NAME, DESCRIPTION).set(bundle.getString("installed-drivers.driver-class"));

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
@@ -44,20 +44,22 @@ import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.requireSingleAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.threads.CommonAttributes.BLOCKING;
 import static org.jboss.as.threads.ThreadsDescriptionUtil.addBoundedQueueThreadPool;
 import static org.jboss.as.threads.ThreadsSubsystemProviders.BOUNDED_QUEUE_THREAD_POOL_DESC;
 
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SubsystemRegistration;
@@ -337,6 +339,12 @@ public class JcaExtension implements Extension {
                         throw unexpectedElement(reader);
                 }
 
+            }
+            //AS7-1352 The "blocking" attribute for the JCA thread pools should be ignored as it should always be true.
+            for (ModelNode op : list) {
+                if (op.hasDefined(BLOCKING)) {
+                    op.get(BLOCKING).set(Boolean.TRUE);
+                }
             }
             // Handle elements
             requireNoContent(reader);


### PR DESCRIPTION
Hi,

Please help to review and merge the patch for
    [AS7-1352] The 'blocking' attribute for the JCA thread pools should be ignored as it should always be true
    [AS7-1164] add jdbc-driver : documentation incomplete or misleading
    [AS7-1258] required xa-data-source-properties is missing from add operation description

Thanks
Jeff
