### PR TITLE
AS7-1473

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerRemove.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerRemove.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * Operation removing a {@link DeploymentScannerService}.
@@ -50,7 +51,11 @@ class DeploymentScannerRemove extends AbstractRemoveStepHandler implements Descr
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
-        context.removeService(DeploymentScannerService.getServiceName(name));
+        final ServiceName serviceName = DeploymentScannerService.getServiceName(name);
+        final ServiceName pathServiceName = serviceName.append("path");
+
+        context.removeService(serviceName);
+        context.removeService(pathServiceName);
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -987,7 +987,7 @@ class FileSystemDeploymentService implements DeploymentScanner {
             if (deployed.containsKey(deploymentName)) {
                 deployed.remove(deploymentName);
             }
-            deployed.put(deploymentName, new DeploymentMarker(deployedMarker.lastModified(), archive));
+            deployed.put(deploymentName, new DeploymentMarker(doDeployTimestamp, archive));
         }
     }
 

--- a/testsuite/smoke/src/test/java/org/jboss/as/test/surefire/servermodule/ServerInModuleDeploymentTestCase.java
+++ b/testsuite/smoke/src/test/java/org/jboss/as/test/surefire/servermodule/ServerInModuleDeploymentTestCase.java
@@ -157,14 +157,14 @@ public class ServerInModuleDeploymentTestCase  {
 
         ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
         final String scannerName = "dummy";
-        addDeploymentScanner(deployDir, client, scannerName);
+        addDeploymentScanner(deployDir, client, scannerName, false);
         removeDeploymentScanner(client, scannerName);
-        addDeploymentScanner(deployDir, client, scannerName);
+        addDeploymentScanner(deployDir, client, scannerName, false);
         removeDeploymentScanner(client, scannerName);
     }
 
     @Test
-    public void testFilesystemDeployment() throws Exception {
+    public void testFilesystemDeployment_Marker() throws Exception {
         final JavaArchive archive = ShrinkWrapUtils.createJavaArchive("servermodule/test-deployment.sar",
                 Simple.class.getPackage());
         final File dir = new File("target/archives");
@@ -172,11 +172,11 @@ public class ServerInModuleDeploymentTestCase  {
         final File file = new File(dir, "test-deployment.sar");
         archive.as(ZipExporter.class).exportTo(file, true);
 
-        final File deployDir = createDeploymentDir("deployments");
+        final File deployDir = createDeploymentDir("marker-deployments");
 
         ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
-        final String scannerName = "zips";
-        addDeploymentScanner(deployDir, client, scannerName);
+        final String scannerName = "markerZips";
+        addDeploymentScanner(deployDir, client, scannerName, false);
 
         try {
             final File target = new File(deployDir, "test-deployment.sar");
@@ -223,8 +223,9 @@ public class ServerInModuleDeploymentTestCase  {
                     // let that complete
                     // so we don't end up having our own file deleted
                     final File dodeploy = new File(deployDir, "test-deployment.sar.dodeploy");
+                    final File isdeploying = new File(deployDir, "test-deployment.sar.isdeploying");
                     for (int i = 0; i < 500; i++) {
-                        if (!dodeploy.exists()) {
+                        if (!dodeploy.exists() && !isdeploying.exists()) {
                             break;
                         }
                         // Wait for the last action to complete :(
@@ -247,8 +248,9 @@ public class ServerInModuleDeploymentTestCase  {
                 @Override
                 public void undeploy() {
                     final File dodeploy = new File(deployDir, "test-deployment.sar.dodeploy");
+                    final File isdeploying = new File(deployDir, "test-deployment.sar.isdeploying");
                     for (int i = 0; i < 500; i++) {
-                        if (!dodeploy.exists() && deployed.exists()) {
+                        if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
                         }
                         // Wait for the last action to complete :(
@@ -271,7 +273,119 @@ public class ServerInModuleDeploymentTestCase  {
             try {
                 removeDeploymentScanner(client, scannerName);
             } catch (Exception e) {
+            }
+            try {
                 client.close();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    @Test
+    public void testFilesystemDeployment_Auto() throws Exception {
+        final JavaArchive archive = ShrinkWrapUtils.createJavaArchive("servermodule/test-deployment.sar",
+                Simple.class.getPackage());
+        final File dir = new File("target/archives");
+        dir.mkdirs();
+        final File file = new File(dir, "test-deployment.sar");
+        archive.as(ZipExporter.class).exportTo(file, true);
+
+        final File deployDir = createDeploymentDir("auto-deployments");
+
+        ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+        final String scannerName = "autoZips";
+        addDeploymentScanner(deployDir, client, scannerName, true);
+
+        try {
+            final File target = new File(deployDir, "test-deployment.sar");
+            final File deployed = new File(deployDir, "test-deployment.sar.deployed");
+            Assert.assertFalse(target.exists());
+
+            testDeployments(new DeploymentExecutor() {
+                @Override
+                public void initialDeploy() throws IOException {
+                    // Copy file to deploy directory
+                    final InputStream in = new BufferedInputStream(new FileInputStream(file));
+                    try {
+                        final OutputStream out = new BufferedOutputStream(new FileOutputStream(target));
+                        try {
+                            int i = in.read();
+                            while (i != -1) {
+                                out.write(i);
+                                i = in.read();
+                            }
+                        } finally {
+                            StreamUtils.safeClose(out);
+                        }
+                    } finally {
+                        StreamUtils.safeClose(in);
+                    }
+
+                    Assert.assertTrue(file.exists());
+                }
+
+                @Override
+                public void fullReplace() throws IOException {
+                    // The test is going to call this as soon as the deployment
+                    // sends a notification
+                    // but often before the scanner has completed the process
+                    // and deleted the
+                    // .isdeploying put down by deployment scanner. So pause a bit to
+                    // let that complete
+                    // so we don't end up having our own file deleted
+                    final File isdeploying = new File(deployDir, "test-deployment.sar.isdeploying");
+                    for (int i = 0; i < 500; i++) {
+                        if (!isdeploying.exists()) {
+                            break;
+                        }
+                        // Wait for the last action to complete :(
+                        try {
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+
+                    if (isdeploying.exists()) {
+                        Assert.fail("initialDeploy step did not complete in a reasonably timely fashion");
+                    }
+
+                    // Copy file to deploy directory again
+                    initialDeploy();
+                }
+
+                @Override
+                public void undeploy() {
+                   final File isdeploying = new File(deployDir, "test-deployment.sar.isdeploying");
+                    for (int i = 0; i < 500; i++) {
+                        if (!isdeploying.exists() && deployed.exists()) {
+                            break;
+                        }
+                        // Wait for the last action to complete :(
+                        try {
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                    }
+                    if (!deployed.exists()) {
+                        Assert.fail("fullReplace step did not complete in a reasonably timely fashion");
+                    }
+
+                    // Delete file from deploy directory
+                    target.delete();
+                }
+            });
+        } finally {
+            try {
+                removeDeploymentScanner(client, scannerName);
+            } catch (Exception e) {
+            }
+            try {
+                client.close();
+            } catch (Exception e) {
             }
         }
     }
@@ -283,13 +397,12 @@ public class ServerInModuleDeploymentTestCase  {
 
         ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
         final String scannerName = "exploded";
-        addDeploymentScanner(deployDir, client, scannerName);
+        addDeploymentScanner(deployDir, client, scannerName, false);
 
         final JavaArchive archive = ShrinkWrapUtils.createJavaArchive("servermodule/test-deployment.sar",
                 Simple.class.getPackage());
         final File dir = new File("target/archives");
         dir.mkdirs();
-        final File file = new File(dir, "test-deployment.sar");
         archive.as(ExplodedExporter.class).exportExploded(deployDir);
 
         try {
@@ -321,8 +434,9 @@ public class ServerInModuleDeploymentTestCase  {
                     // let that complete
                     // so we don't end up having our own file deleted
                     final File dodeploy = new File(deployDir, "test-deployment.sar.dodeploy");
+                    final File isdeploying = new File(deployDir, "test-deployment.sar.isdeploying");
                     for (int i = 0; i < 500; i++) {
-                        if (!dodeploy.exists()) {
+                        if (!dodeploy.exists() && !isdeploying.exists()) {
                             break;
                         }
                         // Wait for the last action to complete :(
@@ -345,8 +459,9 @@ public class ServerInModuleDeploymentTestCase  {
                 @Override
                 public void undeploy() {
                     final File dodeploy = new File(deployDir, "test-deployment.sar.dodeploy");
+                    final File isdeploying = new File(deployDir, "test-deployment.sar.isdeploying");
                     for (int i = 0; i < 500; i++) {
-                        if (!dodeploy.exists() && deployed.exists()) {
+                        if (!dodeploy.exists() && !isdeploying.exists() && deployed.exists()) {
                             break;
                         }
                         // Wait for the last action to complete :(
@@ -369,12 +484,15 @@ public class ServerInModuleDeploymentTestCase  {
             try {
                 removeDeploymentScanner(client, scannerName);
             } catch (Exception e) {
+            }
+            try {
                 client.close();
+            } catch (Exception e) {
             }
         }
     }
 
-    private ModelNode addDeploymentScanner(final File deployDir, final ModelControllerClient client, final String scannerName)
+    private ModelNode addDeploymentScanner(final File deployDir, final ModelControllerClient client, final String scannerName, final boolean autoDeployZipped)
             throws IOException {
         ModelNode add = new ModelNode();
         add.get(OP).set(ADD);
@@ -385,6 +503,9 @@ public class ServerInModuleDeploymentTestCase  {
         add.get("path").set(deployDir.getAbsolutePath());
         add.get("scan-enabled").set(true);
         add.get("scan-interval").set(1000);
+        if (autoDeployZipped == false) {
+            add.get("auto-deploy-zipped").set(false);
+        }
 
         ModelNode result = client.execute(add);
         Assert.assertEquals(ModelDescriptionConstants.SUCCESS, result.require(ModelDescriptionConstants.OUTCOME).asString());

--- a/testsuite/smoke/src/test/java/org/jboss/as/test/surefire/servermodule/ServerInModuleDeploymentTestCase.java
+++ b/testsuite/smoke/src/test/java/org/jboss/as/test/surefire/servermodule/ServerInModuleDeploymentTestCase.java
@@ -152,6 +152,18 @@ public class ServerInModuleDeploymentTestCase  {
     }
 
     @Test
+    public void testFilesystemScannerRegistration() throws Exception {
+        final File deployDir = createDeploymentDir("dummy");
+
+        ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+        final String scannerName = "dummy";
+        addDeploymentScanner(deployDir, client, scannerName);
+        removeDeploymentScanner(client, scannerName);
+        addDeploymentScanner(deployDir, client, scannerName);
+        removeDeploymentScanner(client, scannerName);
+    }
+
+    @Test
     public void testFilesystemDeployment() throws Exception {
         final JavaArchive archive = ShrinkWrapUtils.createJavaArchive("servermodule/test-deployment.sar",
                 Simple.class.getPackage());


### PR DESCRIPTION
Fixes to correct the sporadic failures in the ServerInModuleDeploymentTestCase, most noticed is the testExplodedFilesystemDeployment failure although this was often caused by the previous testFilesystemDeployment test.

A couple of issues were identified within the FileSystemDeploymentService but in addition to this the test was also out of date as it had not been updated based on the added support for direct deployment of archives without the need for marker files.
