### PR TITLE
[AS7-1483] Threads leaking when DeploymentScannerService stopped as Sched

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerService.java
@@ -170,6 +170,7 @@ public class DeploymentScannerService implements Service<DeploymentScanner> {
         final DeploymentScanner scanner = this.scanner;
         this.scanner = null;
         scanner.stopScanner();
+        scheduledExecutorValue.getValue().shutdown();
     }
 
     /**

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -269,6 +269,7 @@ class FileSystemDeploymentService implements DeploymentScanner {
     public synchronized void stopScanner() {
         this.scanEnabled = false;
         cancelScan();
+        safeClose(controllerClient);
     }
 
     /** Hook solely for unit test to control how long deployments with no progress can exist without failing */


### PR DESCRIPTION
[AS7-1483] Threads leaking when DeploymentScannerService stopped as ScheduledExecutor not shutdown.
