### PR TITLE
AS7-1242 Change to operate on a single instance of the ServiceArchiveHolder

### DIFF
--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolAS7.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolAS7.java
@@ -41,7 +41,9 @@ public class JMXProtocolAS7 extends AbstractJMXProtocol {
 
     @Override
     public DeploymentPackager getPackager() {
-        archiveHolderInst.set(new ServiceArchiveHolder());
+        if(archiveHolderInst.get() == null) {
+            archiveHolderInst.set(new ServiceArchiveHolder());
+        }
         return new JMXProtocolPackager(archiveHolderInst.get());
     }
 


### PR DESCRIPTION
AS7-1242 Change to operate on a single instance of the ServiceArchiveHolder across the whole Test Suite lifecycle. getPackager will be called pr Container, without a single instance the second container will overwrite the first containers state etc..
