### PR TITLE
Critical fixes for 7.0.1: AS7-1507, AS7-1518

### DIFF
--- a/clustering/api/src/main/java/org/jboss/as/clustering/ClassLoaderProvider.java
+++ b/clustering/api/src/main/java/org/jboss/as/clustering/ClassLoaderProvider.java
@@ -1,5 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.clustering;
 
+/**
+ * Provides a class loader.
+ * @author Paul Ferraro
+ */
 public interface ClassLoaderProvider {
     ClassLoader getClassLoader();
 }

--- a/clustering/api/src/main/java/org/jboss/as/clustering/ClassLoaderProvider.java
+++ b/clustering/api/src/main/java/org/jboss/as/clustering/ClassLoaderProvider.java
@@ -1,0 +1,5 @@
+package org.jboss.as.clustering;
+
+public interface ClassLoaderProvider {
+    ClassLoader getClassLoader();
+}

--- a/clustering/api/src/main/java/org/jboss/as/clustering/MarshallingContext.java
+++ b/clustering/api/src/main/java/org/jboss/as/clustering/MarshallingContext.java
@@ -35,10 +35,16 @@ import org.jboss.marshalling.Unmarshaller;
 public class MarshallingContext {
     private final MarshallerFactory factory;
     private final MarshallingConfiguration configuration;
+    private final ClassLoaderProvider provider;
 
-    public MarshallingContext(MarshallerFactory factory, MarshallingConfiguration configuration) {
+    public MarshallingContext(MarshallerFactory factory, MarshallingConfiguration configuration, ClassLoaderProvider provider) {
         this.factory = factory;
         this.configuration = configuration;
+        this.provider = provider;
+    }
+
+    public ClassLoader getClassLoader() {
+        return this.provider.getClassLoader();
     }
 
     public Unmarshaller createUnmarshaller() throws IOException {

--- a/clustering/api/src/test/java/org/jboss/as/clustering/SimpleMarshalledValueFactoryTestCase.java
+++ b/clustering/api/src/test/java/org/jboss/as/clustering/SimpleMarshalledValueFactoryTestCase.java
@@ -39,15 +39,20 @@ import org.junit.Test;
  * 
  * @author Brian Stansberry
  */
-public class SimpleMarshalledValueFactoryTestCase {
+public class SimpleMarshalledValueFactoryTestCase implements ClassLoaderProvider {
     private final MarshallingContext context;
     private final SimpleMarshalledValueFactory factory;
     
     public SimpleMarshalledValueFactoryTestCase() {
-        this.context = new MarshallingContext(Marshalling.getMarshallerFactory("river"), new MarshallingConfiguration());
+        this.context = new MarshallingContext(Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader()), new MarshallingConfiguration(), this);
         this.factory = this.createFactory(this.context);
     }
     
+    @Override
+    public ClassLoader getClassLoader() {
+        return Thread.currentThread().getContextClassLoader();
+    }
+
     SimpleMarshalledValueFactory createFactory(MarshallingContext context) {
         return new SimpleMarshalledValueFactory(context);
     }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
@@ -140,7 +140,7 @@ public class DefaultEmbeddedCacheManager implements EmbeddedCacheManager {
      */
     @Override
     public Configuration defineConfiguration(String cacheName, Configuration configurationOverride) {
-        return this.container.defineConfiguration(this.getCacheName(cacheName), configurationOverride);
+        return this.defineConfiguration(cacheName, this.defaultCache, configurationOverride);
     }
 
     /**
@@ -149,7 +149,7 @@ public class DefaultEmbeddedCacheManager implements EmbeddedCacheManager {
      */
     @Override
     public Configuration defineConfiguration(String cacheName, String templateCacheName, Configuration configurationOverride) {
-        return this.container.defineConfiguration(this.getCacheName(cacheName), templateCacheName, configurationOverride);
+        return this.container.defineConfiguration(this.getCacheName(cacheName), this.getCacheName(templateCacheName), configurationOverride);
     }
 
     /**

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManagerTest.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManagerTest.java
@@ -152,8 +152,8 @@ public class DefaultEmbeddedCacheManagerTest {
         Configuration otherConfig = new Configuration();
         Configuration otherConfigOverride = new Configuration();
 
-        when(this.manager.defineConfiguration("default", defaultConfigOverride)).thenReturn(defaultConfig);
-        when(this.manager.defineConfiguration("other", otherConfigOverride)).thenReturn(otherConfig);
+        when(this.manager.defineConfiguration("default", "default", defaultConfigOverride)).thenReturn(defaultConfig);
+        when(this.manager.defineConfiguration("other", "default", otherConfigOverride)).thenReturn(otherConfig);
 
         Configuration result = this.subject.defineConfiguration("default", defaultConfigOverride);
 
@@ -179,22 +179,72 @@ public class DefaultEmbeddedCacheManagerTest {
         Configuration otherConfig = new Configuration();
         Configuration otherConfigOverride = new Configuration();
 
-        when(this.manager.defineConfiguration("default", "template", defaultConfigOverride)).thenReturn(defaultConfig);
-        when(this.manager.defineConfiguration("other", "template", otherConfigOverride)).thenReturn(otherConfig);
+        when(this.manager.defineConfiguration("default", "template", defaultConfigOverride)).thenReturn(defaultConfigOverride);
+        when(this.manager.defineConfiguration("default", "default", defaultConfigOverride)).thenReturn(defaultConfig);
+        when(this.manager.defineConfiguration("other", "template", otherConfigOverride)).thenReturn(otherConfigOverride);
+        when(this.manager.defineConfiguration("other", "default", otherConfigOverride)).thenReturn(otherConfig);
 
         Configuration result = this.subject.defineConfiguration("default", "template", defaultConfigOverride);
+
+        assertSame(defaultConfigOverride, result);
+
+        result = this.subject.defineConfiguration("default", "default", defaultConfigOverride);
+
+        assertSame(defaultConfig, result);
+
+        result = this.subject.defineConfiguration("default", CacheContainer.DEFAULT_CACHE_NAME, defaultConfigOverride);
+
+        assertSame(defaultConfig, result);
+
+        result = this.subject.defineConfiguration("default", null, defaultConfigOverride);
 
         assertSame(defaultConfig, result);
 
         result = this.subject.defineConfiguration("other", "template", otherConfigOverride);
 
+        assertSame(otherConfigOverride, result);
+
+        result = this.subject.defineConfiguration("other", "default", otherConfigOverride);
+
+        assertSame(otherConfig, result);
+
+        result = this.subject.defineConfiguration("other", CacheContainer.DEFAULT_CACHE_NAME, otherConfigOverride);
+
+        assertSame(otherConfig, result);
+
+        result = this.subject.defineConfiguration("other", null, otherConfigOverride);
+
         assertSame(otherConfig, result);
 
         result = this.subject.defineConfiguration(CacheContainer.DEFAULT_CACHE_NAME, "template", defaultConfigOverride);
 
+        assertSame(defaultConfigOverride, result);
+
+        result = this.subject.defineConfiguration(CacheContainer.DEFAULT_CACHE_NAME, "default", defaultConfigOverride);
+
+        assertSame(defaultConfig, result);
+
+        result = this.subject.defineConfiguration(CacheContainer.DEFAULT_CACHE_NAME, CacheContainer.DEFAULT_CACHE_NAME, defaultConfigOverride);
+
+        assertSame(defaultConfig, result);
+
+        result = this.subject.defineConfiguration(CacheContainer.DEFAULT_CACHE_NAME, null, defaultConfigOverride);
+
         assertSame(defaultConfig, result);
 
         result = this.subject.defineConfiguration(null, "template", defaultConfigOverride);
+
+        assertSame(defaultConfigOverride, result);
+
+        result = this.subject.defineConfiguration(null, "default", defaultConfigOverride);
+
+        assertSame(defaultConfig, result);
+
+        result = this.subject.defineConfiguration(null, CacheContainer.DEFAULT_CACHE_NAME, defaultConfigOverride);
+
+        assertSame(defaultConfig, result);
+
+        result = this.subject.defineConfiguration(null, null, defaultConfigOverride);
 
         assertSame(defaultConfig, result);
     }

--- a/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/impl/SessionAttributeMarshallerFactoryImpl.java
+++ b/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/impl/SessionAttributeMarshallerFactoryImpl.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.clustering.web.impl;
 
+import org.jboss.as.clustering.ClassLoaderProvider;
 import org.jboss.as.clustering.MarshallingContext;
 import org.jboss.as.clustering.web.LocalDistributableSessionManager;
 import org.jboss.as.clustering.web.SessionAttributeMarshaller;
@@ -61,6 +62,12 @@ public class SessionAttributeMarshallerFactoryImpl implements SessionAttributeMa
             }
         };
         configuration.setClassResolver(resolver);
-        return new SessionAttributeMarshallerImpl(new MarshallingContext(this.factory, configuration));
+        ClassLoaderProvider provider = new ClassLoaderProvider() {
+            @Override
+            public ClassLoader getClassLoader() {
+                return manager.getApplicationClassLoader();
+            }
+        };
+        return new SessionAttributeMarshallerImpl(new MarshallingContext(this.factory, configuration, provider));
     }
 }

--- a/clustering/web-spi/src/test/java/org/jboss/as/clustering/web/impl/SessionAttributeMarshallerTest.java
+++ b/clustering/web-spi/src/test/java/org/jboss/as/clustering/web/impl/SessionAttributeMarshallerTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
 
+import org.jboss.as.clustering.ClassLoaderProvider;
 import org.jboss.as.clustering.MarshallingContext;
 import org.jboss.as.clustering.web.SessionAttributeMarshaller;
 import org.jboss.marshalling.Marshalling;
@@ -37,8 +38,13 @@ import static org.junit.Assert.*;
  * @author Paul Ferraro
  *
  */
-public class SessionAttributeMarshallerTest {
-    private final SessionAttributeMarshaller marshaller = new SessionAttributeMarshallerImpl(new MarshallingContext(Marshalling.getMarshallerFactory("river"), new MarshallingConfiguration()));
+public class SessionAttributeMarshallerTest implements ClassLoaderProvider {
+    private final SessionAttributeMarshaller marshaller = new SessionAttributeMarshallerImpl(new MarshallingContext(Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader()), new MarshallingConfiguration(), this));
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return Thread.currentThread().getContextClassLoader();
+    }
 
     @Test
     public void test() throws IOException, ClassNotFoundException {


### PR DESCRIPTION
AS7-1507 Application classloader not being used to serialize session content when replication is triggered from replication queue.
AS7-1518 Cache configuration cloned from wrong template cache when using EmbeddedCacheManager.defineConfiguration(...)
