### PR TITLE
[AS7-1394] Log a WARN if either the Native interface or Http interface ar

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesCallbackHandler.java
@@ -36,6 +36,7 @@ import java.net.MalformedURLException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import org.jboss.logging.Logger;
 
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
@@ -76,6 +77,12 @@ public class PropertiesCallbackHandler implements Service<PropertiesCallbackHand
         File propertiesFile = new File(file);
         try {
             users.load(propertiesFile.toURI().toURL().openStream());
+
+            final String admin = "admin";
+            if (users.contains(admin) && admin.equals(users.get(admin))) {
+                Logger.getLogger("org.jboss.as.domain-management")
+                        .warn("Properties file defined with default user and password, this will be easy to guess.");
+            }
         } catch (MalformedURLException mue) {
             throw new StartException("Unable to load properties", mue);
         } catch (IOException ioe) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -332,7 +332,15 @@ public class DomainModelControllerService extends AbstractControllerService impl
         int securePort = hostControllerInfo.getHttpManagementSecurePort();
         String securityRealm = hostControllerInfo.getHttpManagementSecurityRealm();
 
-        Logger.getLogger("org.jboss.as").infof("creating http management service using network interface (%s) port (%s) securePort (%s)", interfaceName, port, securePort);
+        StringBuilder sb = new StringBuilder();
+        sb.append("creating http management service using network interface (").append(interfaceName).append(")");
+        if (port > -1) {
+            sb.append(" port (").append(port).append(")");
+        }
+        if (securePort > -1) {
+            sb.append(" securePort (").append(securePort).append(")");
+        }
+        Logger.getLogger("org.jboss.as").info(sb.toString());
 
         final ThreadFactory httpMgmtThreads = new JBossThreadFactory(new ThreadGroup("HttpManagementService-threads"),
                 Boolean.FALSE, null, "%G - %t", null, null, AccessController.getContext());
@@ -349,6 +357,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
         if (securityRealm != null) {
             builder.addDependency(SecurityRealmService.BASE_SERVICE_NAME.append(securityRealm), SecurityRealmService.class, service.getSecurityRealmInjector());
+        } else {
+            Logger.getLogger("org.jboss.as").warn("No security realm defined for http management service, all access will be unrestricted.");
         }
         builder.setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAttributeHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAttributeHandlers.java
@@ -113,7 +113,15 @@ public class HttpManagementAttributeHandlers {
         int securePort = hostControllerInfo.getHttpManagementSecurePort();
         String securityRealm = hostControllerInfo.getHttpManagementSecurityRealm();
 
-        Logger.getLogger("org.jboss.as").infof("creating http management service using network interface (%s) port (%s) securePort (%s)", interfaceName, port, securePort);
+        StringBuilder sb = new StringBuilder();
+        sb.append("creating http management service using network interface (").append(interfaceName).append(")");
+        if (port > -1) {
+            sb.append(" port (").append(port).append(")");
+        }
+        if (securePort > -1) {
+            sb.append(" securePort (").append(securePort).append(")");
+        }
+        Logger.getLogger("org.jboss.as").info(sb.toString());
 
         final ThreadFactory httpMgmtThreads = new JBossThreadFactory(new ThreadGroup("HttpManagementService-threads"),
                 Boolean.FALSE, null, "%G - %t", null, null, AccessController.getContext());
@@ -131,6 +139,8 @@ public class HttpManagementAttributeHandlers {
 
         if (securityRealm != null) {
             builder.addDependency(SecurityRealmService.BASE_SERVICE_NAME.append(securityRealm), SecurityRealmService.class, service.getSecurityRealmInjector());
+        } else {
+            Logger.getLogger("org.jboss.as").warn("No security realm defined for http management service, all access will be unrestricted.");
         }
         builder.setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.remote.AbstractModelControllerOperationHandlerFac
 import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.as.network.NetworkInterfaceBinding;
+import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
@@ -293,6 +294,8 @@ public final class RemotingServices {
         ServiceBuilder<?> builder = serviceTarget.addService(AUTHENTICATION_PROVIDER, raps);
         if (securityRealmName != null) {
             builder.addDependency(securityRealmName, SecurityRealm.class, raps.getSecurityRealmInjectedValue());
+        } else {
+            Logger.getLogger("org.jboss.as").warn("No security realm defined for native management service, all access will be unrestricted.");
         }
         if (serverCallbackService != null) {
             builder.addDependency(serverCallbackService, CallbackHandler.class, raps.getServerCallbackValue());

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -85,7 +85,15 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler implements 
 
         final ServiceTarget serviceTarget = context.getServiceTarget();
 
-        Logger.getLogger("org.jboss.as").infof("creating http management service using network interface (%s) port (%s) securePort (%s)", interfaceName, port, securePort);
+        StringBuilder sb = new StringBuilder();
+        sb.append("creating http management service using network interface (").append(interfaceName).append(")");
+        if (port > -1) {
+            sb.append(" port (").append(port).append(")");
+        }
+        if (securePort > -1) {
+            sb.append(" securePort (").append(securePort).append(")");
+        }
+        Logger.getLogger("org.jboss.as").info(sb.toString());
 
         final HttpManagementService service = new HttpManagementService();
         ServiceBuilder builder = serviceTarget.addService(HttpManagementService.SERVICE_NAME, service)
@@ -100,6 +108,8 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler implements 
 
         if (securityRealm != null) {
             builder.addDependency(SecurityRealmService.BASE_SERVICE_NAME.append(securityRealm), SecurityRealmService.class, service.getSecurityRealmInjector());
+        } else {
+            Logger.getLogger("org.jboss.as").warn("No security realm defined for http management service, all access will be unrestricted.");
         }
 
         newControllers.add(builder.addListener(verificationHandler)

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAttributeHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAttributeHandlers.java
@@ -41,6 +41,7 @@ import org.jboss.as.server.mgmt.HttpManagementService;
 import org.jboss.as.server.services.net.NetworkInterfaceService;
 import org.jboss.as.server.services.path.AbstractPathService;
 import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
@@ -105,6 +106,8 @@ public class HttpManagementAttributeHandlers {
 
         if (securityRealm != null) {
             builder.addDependency(SecurityRealmService.BASE_SERVICE_NAME.append(securityRealm), SecurityRealmService.class, service.getSecurityRealmInjector());
+        } else {
+            Logger.getLogger("org.jboss.as").warn("No security realm defined for http management service, all access will be unrestricted.");
         }
         builder.setInitialMode(ServiceController.Mode.ACTIVE)
                .install();


### PR DESCRIPTION
[AS7-1394] Log a WARN if either the Native interface or Http interface are enabled without a security domain.

Also log a WARN if the default user admin=admin is defined.

Please review that these changes are acceptable as this will mean WARN messages logged out of the box but I wanted to add something to warn users they have not yet secured the management interfaces and to WARN users if they have the default user admin=admin defined.
