### PR TITLE
[AS7-1137] Enable demos to prompt for a username and password if running 

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -100,16 +100,6 @@ public interface ModelControllerClient extends Closeable {
     AsyncFuture<ModelNode> executeAsync(Operation operation, OperationMessageHandler messageHandler);
 
     class Factory {
-//        /**
-//         * Create a client instance for an existing channel. It is the client's responsibility to close this channel
-//         *
-//         * @param channel The channel to use
-//         * @return A model controller client
-//         * @throws UnknownHostException if the host cannot be found
-//         */
-//        public static ModelControllerClient create(final ManagementChannel channel) {
-//            return new NewExistingChannelModelControllerClient(channel);
-//        }
 
         /**
          * Create a client instance for a remote address and port.
@@ -120,11 +110,28 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final InetAddress address, final int port){
-//            return new NewEstablishChannelModelControllerClient(address, port);
             return new AbstractModelControllerClient() {
                 @Override
                 protected ManagementClientChannelStrategy getClientChannelStrategy() throws URISyntaxException, IOException {
                     return ManagementClientChannelStrategy.create(address.getHostName(), port, executor, this, null);
+                }
+            };
+        }
+
+        /**
+         * Create a client instance for a remote address and port.
+         *
+         * @param address the address of the remote host
+         * @param port the port
+         * @param handler  CallbackHandler to obtain authentication information for the call.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler){
+            return new AbstractModelControllerClient() {
+                @Override
+                protected ManagementClientChannelStrategy getClientChannelStrategy() throws URISyntaxException, IOException {
+                    return ManagementClientChannelStrategy.create(address.getHostName(), port, executor, this, handler);
                 }
             };
         }
@@ -138,7 +145,6 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port) throws UnknownHostException {
-//            return new NewEstablishChannelModelControllerClient(hostName, port);
             return new AbstractModelControllerClient() {
                 @Override
                 protected ManagementClientChannelStrategy getClientChannelStrategy() throws URISyntaxException, IOException {
@@ -157,7 +163,6 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-            //return new ModelControllerClient(hostName, port, handler);
             return new AbstractModelControllerClient() {
                 @Override
                 protected ManagementClientChannelStrategy getClientChannelStrategy() throws URISyntaxException, IOException {

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/DomainClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/DomainClient.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller.client.helpers.domain;
 
+import javax.security.auth.callback.CallbackHandler;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.util.List;
@@ -126,5 +127,19 @@ public interface DomainClient extends ModelControllerClient {
         public static DomainClient create(final InetAddress address, int port) {
             return new DomainClientImpl(address, port);
         }
+
+
+        /**
+         * Create an {@link org.jboss.as.controller.client.helpers.domain.DomainClient} instance for a remote address and port.
+         *
+         * @param address The remote address to connect to
+         * @param port The remote port
+         * @param handler CallbackHandler to prompt for authentication requirements.
+         * @return A domain client
+         */
+        public static DomainClient create(final InetAddress address, int port, CallbackHandler handler) {
+            return new DomainClientImpl(address, port, handler);
+        }
+
     }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DomainClientImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DomainClientImpl.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller.client.helpers.domain.impl;
 
+import javax.security.auth.callback.CallbackHandler;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -56,6 +57,10 @@ public class DomainClientImpl implements DomainClient {
 
     public DomainClientImpl(InetAddress address, int port) {
         this.delegate = ModelControllerClient.Factory.create(address, port);
+    }
+
+    public DomainClientImpl(InetAddress address, int port, CallbackHandler handler) {
+        this.delegate = ModelControllerClient.Factory.create(address, port, handler);
     }
 
     @Override

--- a/demos/legacy/src/main/java/org/jboss/as/demos/DemoAuthentication.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/DemoAuthentication.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.demos;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+import javax.security.sasl.RealmChoiceCallback;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+/**
+ * This class provides both a CallbackHandler and an Authenticator to handle the client side authentication
+ * requirements for the demos.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class DemoAuthentication {
+
+    private static final DemoAuthentication INSTANCE = new DemoAuthentication();
+
+    private final CallbackHandler CALLBACK_HANDLER = new DemoCallbackHandler();
+    private final Authenticator AUTHENTICATOR = new DemoAuthenticator();
+
+    // After the demo has connected the physical connection may be re-established numerous times.
+    // for this reason we cache the entered values to allow for re-use without pestering the end
+    // user.
+    private boolean promptShown = false;
+    private String userName = null;
+    private char[] password = null;
+
+    private DemoAuthentication() {
+    }
+
+    public static CallbackHandler getCallbackHandler() {
+        return INSTANCE.CALLBACK_HANDLER;
+    }
+
+    public static Authenticator getAuthenticator() {
+        return INSTANCE.AUTHENTICATOR;
+    }
+
+    void prompt(final String realm) {
+        if (promptShown == false) {
+            promptShown = true;
+            System.out.println("Authenticating against security realm: " + realm);
+        }
+    }
+
+    String obtainUsername(final String prompt) {
+        if (userName == null) {
+            userName = System.console().readLine(prompt);
+        }
+        return userName;
+    }
+
+    char[] obtainPassword(final String prompt) {
+        if (password == null) {
+            password = System.console().readPassword(prompt);
+        }
+
+        return password;
+    }
+
+    class DemoCallbackHandler implements CallbackHandler {
+
+        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+
+            // Special case for anonymous authentication to avoid prompting user for their name.
+            if (callbacks.length == 1 && callbacks[0] instanceof NameCallback) {
+                ((NameCallback) callbacks[0]).setName("anonymous demo user");
+                return;
+            }
+
+            for (Callback current : callbacks) {
+                if (current instanceof RealmCallback) {
+                    RealmCallback rcb = (RealmCallback) current;
+                    String defaultText = rcb.getDefaultText();
+                    rcb.setText(defaultText); // For now just use the realm suggested.
+
+                    prompt(defaultText);
+                } else if (current instanceof RealmChoiceCallback) {
+                    throw new UnsupportedCallbackException(current, "Realm choice not currently supported.");
+                } else if (current instanceof NameCallback) {
+                    NameCallback ncb = (NameCallback) current;
+                    String userName = obtainUsername("Username:");
+
+                    ncb.setName(userName);
+                } else if (current instanceof PasswordCallback) {
+                    PasswordCallback pcb = (PasswordCallback) current;
+                    char[] password = obtainPassword("Password:");
+
+                    pcb.setPassword(password);
+                } else {
+                    throw new UnsupportedCallbackException(current);
+                }
+
+            }
+        }
+
+    }
+
+    class DemoAuthenticator extends Authenticator {
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            prompt(getRequestingPrompt());
+            String userName = obtainUsername("Username:");
+            char[] password = obtainPassword("Password:");
+
+            return new PasswordAuthentication(userName, password);
+        }
+    }
+
+}

--- a/demos/legacy/src/main/java/org/jboss/as/demos/DeploymentUtils.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/DeploymentUtils.java
@@ -72,7 +72,7 @@ public class DeploymentUtils implements Closeable {
     private long timeout = DEFAULT_TIMEOUT;
 
     public DeploymentUtils() throws UnknownHostException {
-        client = ModelControllerClient.Factory.create("localhost", 9999);
+        this.client = ModelControllerClient.Factory.create("localhost", 9999, DemoAuthentication.getCallbackHandler());
         manager = ServerDeploymentManager.Factory.create(client);
     }
 
@@ -83,7 +83,7 @@ public class DeploymentUtils implements Closeable {
 
     public DeploymentUtils(Archive<?> archive) throws UnknownHostException {
         this();
-        deployments.add(new ArbitraryDeployment(archive,false));
+        deployments.add(new ArbitraryDeployment(archive, false));
     }
 
     public DeploymentUtils(String archiveName, boolean show, Package... pkgs) throws UnknownHostException {
@@ -152,6 +152,10 @@ public class DeploymentUtils implements Closeable {
 
     public void setTimeout(long timeout) {
         this.timeout = timeout;
+    }
+
+    public ModelControllerClient getClient() {
+        return client;
     }
 
     @Override

--- a/demos/legacy/src/main/java/org/jboss/as/demos/DomainDeploymentUtils.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/DomainDeploymentUtils.java
@@ -70,7 +70,7 @@ public class DomainDeploymentUtils implements Closeable {
     private boolean injectedClient = true;
 
     public DomainDeploymentUtils() throws UnknownHostException {
-        this(ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999));
+        this(ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler()));
         this.injectedClient = false;
     }
 

--- a/demos/legacy/src/main/java/org/jboss/as/demos/client/jms/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/client/jms/runner/ExampleRunner.java
@@ -40,7 +40,6 @@ import javax.jms.TextMessage;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import java.io.IOException;
-import java.net.InetAddress;
 
 import static org.jboss.as.protocol.old.StreamUtils.safeClose;
 
@@ -56,12 +55,13 @@ public class ExampleRunner {
     public static void main(String[] args) throws Exception {
         QueueConnection conn = null;
         QueueSession session = null;
-        ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
         //TODO Don't do this FakeJndi stuff once we have remote JNDI working
         DeploymentUtils utils = null;
+        ModelControllerClient client = null;
         boolean actionsApplied = false;
         try {
             utils = new DeploymentUtils("fakejndi.sar", FakeJndi.class.getPackage());
+            client = utils.getClient();
             utils.deploy();
 
             ModelNode op = new ModelNode();
@@ -103,7 +103,6 @@ public class ExampleRunner {
             }
 
             Thread.sleep(1000);
-
         } finally {
             try {
                 conn.stop();
@@ -121,7 +120,6 @@ public class ExampleRunner {
             if(utils != null) {
                 utils.undeploy();
             }
-            safeClose(utils);
             if(actionsApplied) {
                 // Remove the queue using the management API
                 ModelNode op = new ModelNode();
@@ -130,7 +128,7 @@ public class ExampleRunner {
                 op.get("address").add("jms-queue", QUEUE_NAME);
                 applyUpdate(op, client);
             }
-            safeClose(client);
+            safeClose(utils);
         }
     }
 

--- a/demos/legacy/src/main/java/org/jboss/as/demos/client/messaging/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/client/messaging/runner/ExampleRunner.java
@@ -42,6 +42,7 @@ import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.core.remoting.impl.netty.NettyConnectorFactory;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -56,7 +57,7 @@ public class ExampleRunner {
         final String queueName = "queue.standalone";
 
         final ClientSessionFactory sf = createClientSessionFactory("localhost", 5445);
-        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler());
 
         try {
             // Check that the queue does not exist

--- a/demos/legacy/src/main/java/org/jboss/as/demos/description/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/description/runner/ExampleRunner.java
@@ -25,6 +25,7 @@ package org.jboss.as.demos.description.runner;
 import java.net.InetAddress;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -41,7 +42,7 @@ public class ExampleRunner {
         ModelControllerClient client = null;
         try {
             System.out.println("Connecting");
-            client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+            client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler());
             System.out.println("Connected");
 
             System.out.println("Dumping resource tree\n");

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/configs/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/configs/runner/ExampleRunner.java
@@ -33,6 +33,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -46,7 +47,7 @@ public class ExampleRunner {
 
     public static void main(String[] args) throws Exception {
 
-        final ModelControllerClient client = ModelControllerClient.Factory.create("localhost", 9999);
+        final ModelControllerClient client = ModelControllerClient.Factory.create("localhost", 9999, DemoAuthentication.getCallbackHandler());
         try {
             final ModelNode domainOp = new ModelNode();
             domainOp.get(OP).set(READ_RESOURCE_OPERATION);

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/description/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/description/runner/ExampleRunner.java
@@ -25,6 +25,7 @@ package org.jboss.as.demos.domain.description.runner;
 import java.net.InetAddress;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -43,7 +44,7 @@ public class ExampleRunner {
         ModelControllerClient client = null;
         try {
             System.out.println("Connecting");
-            client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+            client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler());
             System.out.println("Connected");
 
             System.out.println("Dumping resource tree\n");

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/host/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/host/runner/ExampleRunner.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -51,7 +52,7 @@ import org.jboss.dmr.ModelNode;
  */
 public class ExampleRunner {
     public static void main(String[] args) throws Exception {
-        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler());
         try {
             new ExampleRunner().run(client);
         } finally {

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/http/deploy/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/http/deploy/runner/ExampleRunner.java
@@ -8,11 +8,13 @@ import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.demos.war.archive.SimpleServlet;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ArchivePath;
@@ -33,6 +35,7 @@ public class ExampleRunner {
      * @param args
      */
     public static void main(String[] args) {
+        Authenticator.setDefault(DemoAuthentication.getAuthenticator());
 
         BufferedOutputStream os = null;
         BufferedInputStream is = null;

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/interactive/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/interactive/runner/ExampleRunner.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.client.helpers.domain.ServerIdentity;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.controller.client.helpers.domain.UndeployDeploymentPlanBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.demos.DomainDeploymentUtils;
 import org.jboss.as.demos.fakejndi.FakeJndi;
 import org.jboss.dmr.ModelNode;
@@ -116,7 +117,7 @@ public class ExampleRunner implements Runnable {
 
 
     private ExampleRunner(InetAddress address, int port) {
-        this.client = DomainClient.Factory.create(address, port);
+        this.client = DomainClient.Factory.create(address, port, DemoAuthentication.getCallbackHandler());
         this.stdin = new InputStreamReader(System.in);
     }
 

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/servers/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/servers/runner/ExampleRunner.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -58,7 +59,7 @@ public class ExampleRunner {
 
     public static void main(String[] args) throws Exception {
 
-        final ModelControllerClient client = ModelControllerClient.Factory.create("localhost", 9999);
+        final ModelControllerClient client = ModelControllerClient.Factory.create("localhost", 9999, DemoAuthentication.getCallbackHandler());
         try {
 
             final ModelNode hostNamesOp = new ModelNode();

--- a/demos/legacy/src/main/java/org/jboss/as/demos/domain/subsystem/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/domain/subsystem/runner/ExampleRunner.java
@@ -47,6 +47,7 @@ import java.net.URL;
 import java.net.URLConnection;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -71,7 +72,7 @@ public class ExampleRunner {
     }
 
     public static void main(String[] args) throws Exception {
-        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler());
         try {
             new ExampleRunner().run(client);
         } finally {

--- a/demos/legacy/src/main/java/org/jboss/as/demos/ejb3/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/ejb3/runner/ExampleRunner.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.demos.ejb3.runner;
 
-import java.util.concurrent.Future;
 import org.jboss.as.demos.DeploymentUtils;
 import org.jboss.as.demos.ejb3.archive.AsyncLocal;
 import org.jboss.as.demos.ejb3.archive.SimpleSingletonLocal;

--- a/demos/legacy/src/main/java/org/jboss/as/demos/http/deploy/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/http/deploy/runner/ExampleRunner.java
@@ -8,11 +8,13 @@ import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.net.Authenticator;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.demos.war.archive.SimpleServlet;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ArchivePath;
@@ -33,6 +35,7 @@ public class ExampleRunner {
      * @param args
      */
     public static void main(String[] args) {
+        Authenticator.setDefault(DemoAuthentication.getAuthenticator());
 
         BufferedOutputStream os = null;
         BufferedInputStream is = null;

--- a/demos/legacy/src/main/java/org/jboss/as/demos/jms/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/jms/runner/ExampleRunner.java
@@ -23,10 +23,9 @@ package org.jboss.as.demos.jms.runner;
 
 import static org.jboss.as.protocol.old.StreamUtils.safeClose;
 
-import java.util.List;
-
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import java.util.List;
 
 import org.jboss.as.demos.DeploymentUtils;
 import org.jboss.as.demos.jms.mbean.Test;

--- a/demos/legacy/src/main/java/org/jboss/as/demos/web/connector/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/web/connector/runner/ExampleRunner.java
@@ -46,9 +46,9 @@ public class ExampleRunner {
 
     public static void main(String[] args) throws Exception {
         DeploymentUtils utils = null;
-        final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
         try {
             utils = new DeploymentUtils();
+            ModelControllerClient client = utils.getClient();
             utils.addWarDeployment("war-example.war", true, SimpleServlet.class.getPackage());
             utils.deploy();
 
@@ -80,7 +80,6 @@ public class ExampleRunner {
         } finally {
             utils.undeploy();
             safeClose(utils);
-            safeClose(client);
         }
 
     }

--- a/demos/legacy/src/main/java/org/jboss/as/demos/xmlconfig/runner/ExampleRunner.java
+++ b/demos/legacy/src/main/java/org/jboss/as/demos/xmlconfig/runner/ExampleRunner.java
@@ -25,6 +25,7 @@ package org.jboss.as.demos.xmlconfig.runner;
 import java.net.InetAddress;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.demos.DemoAuthentication;
 import org.jboss.as.protocol.old.StreamUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -41,7 +42,7 @@ public class ExampleRunner {
         ModelControllerClient client = null;
         try {
             System.out.println("Connecting");
-            client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999);
+            client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, DemoAuthentication.getCallbackHandler());
             System.out.println("Connected");
 
             System.out.println("Dumping config as xml\n");


### PR DESCRIPTION
[AS7-1137] Enable demos to prompt for a username and password if running against a secured management interface.

Both the native and http interfaces are supported.
