### PR TITLE
AS7-931 Expose OSGi subsystem configuration through management API

### DIFF
--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/ActivationWriteHandler.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/ActivationWriteHandler.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.parser;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.Stage;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.osgi.parser.SubsystemState.Activation;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.osgi.framework.Services;
+
+/**
+ * Handles changes to the activation attribute.
+ *
+ * @author David Bosschaert
+ */
+public class ActivationWriteHandler implements OperationStepHandler {
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        Activation val = Activation.valueOf(operation.require(ModelDescriptionConstants.VALUE).asString().toUpperCase());
+
+        ModelNode node = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel();
+        node.get(CommonAttributes.ACTIVATION).set(val.toString().toLowerCase());
+
+        if (val == Activation.EAGER) {
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                    ServiceController<?> svc = context.getServiceRegistry(true).getRequiredService(Services.AUTOINSTALL_PROVIDER);
+                    // This will kick off the OSGi subsystem...
+                    svc.setMode(Mode.ACTIVE);
+                    context.completeStep();
+                }
+            }, Stage.RUNTIME);
+        }
+        context.completeStep();
+    }
+}

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiExtension.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiExtension.java
@@ -62,6 +62,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.CommonDescriptions;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.as.controller.registry.AttributeAccess.Storage;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
@@ -95,6 +96,7 @@ public class OSGiExtension implements Extension {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(OSGiSubsystemProviders.SUBSYSTEM);
         registration.registerOperationHandler(ADD, OSGiSubsystemAdd.INSTANCE, OSGiSubsystemAdd.INSTANCE, false);
         registration.registerOperationHandler(DESCRIBE, OSGiSubsystemDescribeHandler.INSTANCE, OSGiSubsystemDescribeHandler.INSTANCE, false, OperationEntry.EntryType.PRIVATE);
+        registration.registerReadWriteAttribute(CommonAttributes.ACTIVATION, null, new ActivationWriteHandler(), Storage.CONFIGURATION);
 
         // Configuration Admin Setings
         ManagementResourceRegistration casConfigs = registration.registerSubModel(PathElement.pathElement(CONFIGURATION), OSGiSubsystemProviders.OSGI_CONFIGURATION_RESOURCE);

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/SubsystemState.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/SubsystemState.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Observable;
 import java.util.Set;
 
 import org.jboss.as.osgi.service.FrameworkBootstrapService;
@@ -54,7 +55,7 @@ import org.jboss.osgi.spi.util.UnmodifiableDictionary;
  * @author David Bosschaert
  * @since 13-Oct-2010
  */
-public final class SubsystemState implements Serializable, Service<SubsystemState> {
+public class SubsystemState  extends Observable implements Serializable, Service<SubsystemState> {
     private static final long serialVersionUID = 6268537612248019022L;
 
     public static final ServiceName SERVICE_NAME = FrameworkBootstrapService.FRAMEWORK_BASE_NAME.append("subsystemstate");
@@ -111,14 +112,22 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
     }
 
     public Dictionary<String, String> putConfiguration(String pid, Dictionary<String, String> props) {
-        synchronized (configurations) {
-            return configurations.put(pid, new UnmodifiableDictionary<String, String>(props));
+        try {
+            synchronized (configurations) {
+                return configurations.put(pid, new UnmodifiableDictionary<String, String>(props));
+            }
+        } finally {
+            notifyObservers(new ChangeEvent(ChangeType.CONFIG, false, pid));
         }
     }
 
     public Dictionary<String, String> removeConfiguration(String pid) {
-        synchronized (configurations) {
-            return configurations.remove(pid);
+        try {
+            synchronized (configurations) {
+                return configurations.remove(pid);
+            }
+        } finally {
+            notifyObservers(new ChangeEvent(ChangeType.CONFIG, true, pid));
         }
     }
 
@@ -131,10 +140,14 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
     }
 
     Object setProperty(String name, Object value) {
-        if (value == null)
-            return properties.remove(name);
-        else
-            return properties.put(name, value);
+        try {
+            if (value == null)
+                return properties.remove(name);
+            else
+                return properties.put(name, value);
+        } finally {
+            notifyObservers(new ChangeEvent(ChangeType.PROPERTY, value == null, name));
+        }
     }
 
     public List<OSGiModule> getModules() {
@@ -143,6 +156,7 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
 
     public void addModule(OSGiModule module) {
         modules.add(module);
+        notifyObservers(new ChangeEvent(ChangeType.MODULE, false, module.getIdentifier().toString()));
     }
 
     public OSGiModule removeModule(String id) {
@@ -152,6 +166,7 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
                 OSGiModule module = it.next();
                 if (module.getIdentifier().equals(identifier)) {
                     it.remove();
+                    notifyObservers(new ChangeEvent(ChangeType.MODULE, true, identifier.toString()));
                     return module;
                 }
             }
@@ -164,11 +179,20 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
     }
 
     void setActivation(Activation activation) {
-        this.activationPolicy = activation;
+        if (activationPolicy == activation)
+            return;
+
+        try {
+            activationPolicy = activation;
+        } finally {
+            notifyObservers(new ChangeEvent(ChangeType.ACTIVATION, false, activation.name()));
+        }
     }
 
-    boolean isEmpty() {
-        return properties.isEmpty() && modules.isEmpty() && configurations.isEmpty();
+    @Override
+    public void notifyObservers(Object arg) {
+        setChanged();
+        super.notifyObservers(arg);
     }
 
     public static class OSGiModule implements Serializable {
@@ -177,7 +201,7 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
         private final ModuleIdentifier identifier;
         private final Integer startlevel;
 
-        OSGiModule(ModuleIdentifier identifier, Integer startlevel) {
+        public OSGiModule(ModuleIdentifier identifier, Integer startlevel) {
             this.identifier = identifier;
             this.startlevel = startlevel;
         }
@@ -204,4 +228,30 @@ public final class SubsystemState implements Serializable, Service<SubsystemStat
             return identifier == null ? om.identifier == null : identifier.equals(om.identifier);
         }
     }
+
+    public static class ChangeEvent {
+        private final String id;
+        private final boolean isRemoved;
+        private final ChangeType type;
+
+        public ChangeEvent(ChangeType type, boolean isRemoved, String id) {
+            this.type = type;
+            this.isRemoved = isRemoved;
+            this.id = id;
+        }
+
+        public ChangeType getType() {
+            return type;
+        }
+
+        public boolean isRemoved() {
+            return isRemoved;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+
+    public enum ChangeType { ACTIVATION, CONFIG, PROPERTY, MODULE };
 }

--- a/osgi/service/src/main/java/org/jboss/as/osgi/service/AutoInstallIntegration.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/service/AutoInstallIntegration.java
@@ -29,14 +29,20 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.jboss.as.osgi.parser.SubsystemState;
+import org.jboss.as.osgi.parser.SubsystemState.ChangeEvent;
+import org.jboss.as.osgi.parser.SubsystemState.ChangeType;
 import org.jboss.as.osgi.parser.SubsystemState.OSGiModule;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
 import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.msc.service.AbstractService;
 import org.jboss.msc.service.ServiceBuilder;
@@ -66,15 +72,20 @@ import org.osgi.service.startlevel.StartLevel;
  * @author Thomas.Diesler@jboss.com
  * @since 11-Sep-2010
  */
-final class AutoInstallIntegration extends AbstractService<AutoInstallProvider> implements AutoInstallProvider {
+class AutoInstallIntegration extends AbstractService<AutoInstallProvider> implements AutoInstallProvider, Observer {
 
     private static final Logger log = Logger.getLogger("org.jboss.as.osgi");
 
-    private final InjectedValue<BundleManagerService> injectedBundleManager = new InjectedValue<BundleManagerService>();
+    final InjectedValue<BundleManagerService> injectedBundleManager = new InjectedValue<BundleManagerService>();
     private final InjectedValue<ServerEnvironment> injectedEnvironment = new InjectedValue<ServerEnvironment>();
     private final InjectedValue<Bundle> injectedSystemBundle = new InjectedValue<Bundle>();
     private final InjectedValue<StartLevel> injectedStartLevel = new InjectedValue<StartLevel>();
-    private final InjectedValue<SubsystemState> injectedSubsystemState = new InjectedValue<SubsystemState>();
+    final InjectedValue<SubsystemState> injectedSubsystemState = new InjectedValue<SubsystemState>();
+
+    private File bundlesDir;
+    ServiceController<?> serviceController;
+    private ServiceTarget serviceTarget;
+    private final AtomicLong updateServiceIdCounter = new AtomicLong();
 
     static ServiceController<?> addService(final ServiceTarget target) {
         AutoInstallIntegration service = new AutoInstallIntegration();
@@ -89,42 +100,30 @@ final class AutoInstallIntegration extends AbstractService<AutoInstallProvider> 
         return builder.install();
     }
 
-    private AutoInstallIntegration() {
+    AutoInstallIntegration() {
     }
 
     @Override
     public void start(StartContext context) throws StartException {
-        ServiceController<?> controller = context.getController();
-        log.debugf("Starting: %s in mode %s", controller.getName(), controller.getMode());
+        serviceController = context.getController();
+        log.debugf("Starting: %s in mode %s", serviceController.getName(), serviceController.getMode());
+
         final Map<ServiceName, OSGiModule> pendingServices = new LinkedHashMap<ServiceName, OSGiModule>();
         try {
             final BundleManagerService bundleManager = injectedBundleManager.getValue();
-            final ServiceContainer serviceContainer = context.getController().getServiceContainer();
-            final ServiceTarget serviceTarget = context.getChildTarget();
+            final ServiceContainer serviceContainer = serviceController.getServiceContainer();
+            serviceTarget = context.getChildTarget();
+
             final File modulesDir = injectedEnvironment.getValue().getModulesDir();
-            final File bundlesDir = new File(modulesDir.getPath() + "/../bundles").getCanonicalFile();
+            bundlesDir = new File(modulesDir.getPath() + "/../bundles").getCanonicalFile();
 
             if (bundlesDir.isDirectory() == false)
                 throw new IllegalStateException("Cannot find bundles directory: " + bundlesDir);
 
+            injectedSubsystemState.getValue().addObserver(this);
+
             for (OSGiModule moduleMetaData : injectedSubsystemState.getValue().getModules()) {
-                ServiceName serviceName;
-                ModuleIdentifier identifier = moduleMetaData.getIdentifier();
-                File bundleFile = getRepositoryEntry(bundlesDir, identifier);
-                if (bundleFile != null) {
-                    URL url = bundleFile.toURI().toURL();
-                    BundleInfo info = BundleInfo.createBundleInfo(url);
-                    Deployment dep = DeploymentFactory.createDeployment(info);
-                    Integer startLevel = moduleMetaData.getStartLevel();
-                    if (startLevel != null)
-                        dep.setStartLevel(startLevel.intValue());
-                    serviceName = bundleManager.installBundle(serviceTarget, dep);
-                } else {
-                    ModuleLoader moduleLoader = Module.getBootModuleLoader();
-                    Module module = moduleLoader.loadModule(identifier);
-                    OSGiMetaData metadata = getModuleMetadata(module);
-                    serviceName = bundleManager.registerModule(serviceTarget, module, metadata);
-                }
+                ServiceName serviceName = installModule(bundleManager, moduleMetaData);
                 pendingServices.put(serviceName, moduleMetaData);
             }
 
@@ -143,18 +142,7 @@ final class AutoInstallIntegration extends AbstractService<AutoInstallProvider> 
                 public void start(StartContext context) throws StartException {
                     for (ServiceName serviceName : pendingServices.keySet()) {
                         OSGiModule moduleMetaData = pendingServices.get(serviceName);
-                        if (moduleMetaData.getStartLevel() != null) {
-                            @SuppressWarnings("unchecked")
-                            ServiceController<Bundle> controller = (ServiceController<Bundle>) serviceContainer.getRequiredService(serviceName);
-                            Bundle bundle = controller.getValue();
-                            StartLevel startLevel = injectedStartLevel.getValue();
-                            startLevel.setBundleStartLevel(bundle, moduleMetaData.getStartLevel());
-                            try {
-                                bundle.start();
-                            } catch (BundleException ex) {
-                                log.errorf(ex, "Cannot start bundle: %s", bundle);
-                            }
-                        }
+                        startBundle(serviceContainer, serviceName, moduleMetaData);
                     }
                     log.debugf("Auto bundles bundles started");
                 }
@@ -164,6 +152,41 @@ final class AutoInstallIntegration extends AbstractService<AutoInstallProvider> 
 
         } catch (Exception ex) {
             throw new StartException("Failed to create auto install list", ex);
+        }
+    }
+
+    ServiceName installModule(BundleManagerService bundleManager, OSGiModule moduleMetaData)
+            throws IOException, BundleException, ModuleLoadException {
+        ModuleIdentifier identifier = moduleMetaData.getIdentifier();
+        File bundleFile = getRepositoryEntry(bundlesDir, identifier);
+        if (bundleFile != null) {
+            URL url = bundleFile.toURI().toURL();
+            BundleInfo info = BundleInfo.createBundleInfo(url);
+            Deployment dep = DeploymentFactory.createDeployment(info);
+            Integer startLevel = moduleMetaData.getStartLevel();
+            if (startLevel != null)
+                dep.setStartLevel(startLevel.intValue());
+            return bundleManager.installBundle(serviceTarget, dep);
+        } else {
+            ModuleLoader moduleLoader = Module.getBootModuleLoader();
+            Module module = moduleLoader.loadModule(identifier);
+            OSGiMetaData metadata = getModuleMetadata(module);
+            return bundleManager.registerModule(serviceTarget, module, metadata);
+        }
+    }
+
+    void startBundle(final ServiceContainer serviceContainer, ServiceName serviceName, OSGiModule moduleMetaData) {
+        if (moduleMetaData.getStartLevel() != null) {
+            @SuppressWarnings("unchecked")
+            ServiceController<Bundle> controller = (ServiceController<Bundle>) serviceContainer.getRequiredService(serviceName);
+            Bundle bundle = controller.getValue();
+            StartLevel startLevel = injectedStartLevel.getValue();
+            startLevel.setBundleStartLevel(bundle, moduleMetaData.getStartLevel());
+            try {
+                bundle.start();
+            } catch (BundleException ex) {
+                log.errorf(ex, "Cannot start bundle: %s", bundle);
+            }
         }
     }
 
@@ -223,6 +246,48 @@ final class AutoInstallIntegration extends AbstractService<AutoInstallProvider> 
             return OSGiMetaDataBuilder.load(input);
         } finally {
             input.close();
+        }
+    }
+
+    // Called when the SubsystemState changes.
+    @Override
+    public void update(Observable o, Object arg) {
+        if (arg instanceof SubsystemState.ChangeEvent == false)
+            return;
+
+        SubsystemState.ChangeEvent event = (ChangeEvent) arg;
+        if (event.getType() != ChangeType.MODULE)
+            return;
+
+        if (!event.isRemoved()) {
+            try {
+                for(final OSGiModule module : injectedSubsystemState.getValue().getModules()) {
+                    if (module.getIdentifier().toString().equals(event.getId())) {
+                        final ServiceName serviceName = installModule(injectedBundleManager.getValue(), module);
+
+                        ServiceBuilder<Void> builder = serviceController.getServiceContainer().addService(
+                            ServiceName.of(Services.AUTOINSTALL_PROVIDER, "ModuleUpdater", "" + updateServiceIdCounter.incrementAndGet()),
+                            new AbstractService<Void>() {
+                                @Override
+                                public void start(StartContext context) throws StartException {
+                                    try {
+                                        startBundle(serviceController.getServiceContainer(), serviceName, module);
+                                    } finally {
+                                        // Remove this temporary service
+                                        context.getController().setMode(Mode.REMOVE);
+                                    }
+                                }
+                        });
+                        builder.addDependency(serviceName);
+                        builder.install();
+                        return;
+                    }
+                }
+            } catch (Exception e) {
+                log.errorf(e, "Problem adding module: %s", event.getId());
+                return;
+            }
+            log.errorf("Cannot add module as it was not found: %s", event.getId());
         }
     }
 }

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivationWriteHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivationWriteHandlerTestCase.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.Stage;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.osgi.parser.SubsystemState.Activation;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.osgi.framework.Services;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * @author David Bosschaert
+ */
+public class ActivationWriteHandlerTestCase {
+    @Test
+    public void testHandlerLazy() throws Exception {
+        ModelNode targetNode = new ModelNode();
+        targetNode.get(CommonAttributes.ACTIVATION).set("eager");
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        Mockito.when(resource.getModel()).thenReturn(targetNode);
+        Mockito.when(context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS)).thenReturn(resource);
+
+        ActivationWriteHandler handler = new ActivationWriteHandler();
+
+        ModelNode operation = new ModelNode();
+        operation.get(ModelDescriptionConstants.VALUE).set(Activation.LAZY.toString().toLowerCase());
+        handler.execute(context, operation);
+
+        Mockito.verify(context).completeStep();
+
+        Assert.assertEquals(Activation.LAZY.toString().toLowerCase(), targetNode.get(CommonAttributes.ACTIVATION).asString());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testHandlerEagerActivate() throws Exception {
+        ModelNode targetNode = new ModelNode();
+        targetNode.get(CommonAttributes.ACTIVATION).set("lazy");
+
+        OperationContext context = Mockito.mock(OperationContext.class);
+        Resource resource = Mockito.mock(Resource.class);
+        Mockito.when(resource.getModel()).thenReturn(targetNode);
+        Mockito.when(context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS)).thenReturn(resource);
+
+        final List<OperationStepHandler> addedSteps = new ArrayList<OperationStepHandler>();
+        Mockito.doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                addedSteps.add((OperationStepHandler) invocation.getArguments()[0]);
+                return null;
+            }
+        }).when(context).addStep((OperationStepHandler) Mockito.any(), Mockito.eq(Stage.RUNTIME));
+
+        ActivationWriteHandler handler = new ActivationWriteHandler();
+
+        ModelNode operation = new ModelNode();
+        operation.get(ModelDescriptionConstants.VALUE).set(Activation.EAGER.toString().toLowerCase());
+
+        Assert.assertEquals("Precondition", 0, addedSteps.size());
+        handler.execute(context, operation);
+        Mockito.verify(context).completeStep();
+        Assert.assertEquals(Activation.EAGER.toString().toLowerCase(), targetNode.get(CommonAttributes.ACTIVATION).asString());
+
+        // Now test the runtime piece...
+        ServiceRegistry registry = Mockito.mock(ServiceRegistry.class);
+        ServiceController svcCtrl = Mockito.mock(ServiceController.class);
+        Mockito.when(registry.getRequiredService(Services.AUTOINSTALL_PROVIDER)).thenReturn(svcCtrl);
+
+        OperationContext context2 = Mockito.mock(OperationContext.class);
+        Mockito.when(context2.getServiceRegistry(true)).thenReturn(registry);
+
+        Assert.assertEquals(1, addedSteps.size());
+        addedSteps.get(0).execute(context2, operation);
+
+        Mockito.verify(svcCtrl).setMode(Mode.ACTIVE);
+        Mockito.verify(context2).completeStep();
+    }
+}

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/SubsystemStateTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/SubsystemStateTestCase.java
@@ -1,0 +1,219 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
+
+import org.jboss.modules.ModuleIdentifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author David Bosschaert
+ */
+public class SubsystemStateTestCase {
+    @Test
+    public void testConfiguration() {
+        String pid = "myPid";
+        SubsystemState state = new SubsystemState();
+
+        final List<Observable> observables = new ArrayList<Observable>();
+        final List<Object> arguments = new ArrayList<Object>();
+        Observer o = new Observer() {
+            @Override
+            public void update(Observable o, Object arg) {
+                observables.add(o);
+                arguments.add(arg);
+            }
+        };
+        state.addObserver(o);
+
+        Assert.assertFalse(state.hasConfiguration(pid));
+        Assert.assertNull(state.getConfiguration(pid));
+        Assert.assertEquals(0, state.getConfigurations().size());
+
+        Dictionary<String, String> d = new Hashtable<String, String>();
+
+        d.put("a", "b");
+        Assert.assertEquals("Precondition", 0, arguments.size());
+        state.putConfiguration(pid, d);
+        Assert.assertEquals(1, observables.size());
+        Assert.assertEquals(1, arguments.size());
+        Assert.assertSame(state, observables.get(0));
+
+        SubsystemState.ChangeEvent event = (SubsystemState.ChangeEvent) arguments.get(0);
+        assertEventEquals(pid, false, SubsystemState.ChangeType.CONFIG, event);
+
+        Assert.assertEquals(map(d), map(state.getConfiguration(pid)));
+        Assert.assertEquals(1, state.getConfigurations().size());
+        Assert.assertEquals(pid, state.getConfigurations().iterator().next());
+
+        Assert.assertEquals(map(d), map(state.removeConfiguration(pid)));
+        Assert.assertEquals(2, observables.size());
+        Assert.assertEquals(2, arguments.size());
+        Assert.assertSame(state, observables.get(1));
+
+        SubsystemState.ChangeEvent event2 = (SubsystemState.ChangeEvent) arguments.get(1);
+        assertEventEquals(pid, true, SubsystemState.ChangeType.CONFIG, event2);
+    }
+
+    @Test
+    public void testProperties() {
+        SubsystemState state = new SubsystemState();
+
+        final List<Observable> observables = new ArrayList<Observable>();
+        final List<Object> arguments = new ArrayList<Object>();
+        Observer o = new Observer() {
+            @Override
+            public void update(Observable o, Object arg) {
+                observables.add(o);
+                arguments.add(arg);
+            }
+        };
+        state.addObserver(o);
+
+        Assert.assertEquals("Precondition", Collections.emptyMap(), state.getProperties());
+
+        Assert.assertEquals("Precondition", 0, arguments.size());
+        Assert.assertNull(state.setProperty("a", "aaa"));
+        Assert.assertNull(state.setProperty("b", "bbb"));
+        Assert.assertEquals("bbb", state.setProperty("b", "ccc"));
+
+        Assert.assertEquals(3, observables.size());
+        Assert.assertEquals(Collections.nCopies(3, state), observables);
+        Assert.assertEquals(3, arguments.size());
+
+        SubsystemState.ChangeEvent event = (SubsystemState.ChangeEvent) arguments.get(0);
+        assertEventEquals("a", false, SubsystemState.ChangeType.PROPERTY, event);
+        SubsystemState.ChangeEvent event2 = (SubsystemState.ChangeEvent) arguments.get(1);
+        assertEventEquals("b", false, SubsystemState.ChangeType.PROPERTY, event2);
+        SubsystemState.ChangeEvent event3 = (SubsystemState.ChangeEvent) arguments.get(2);
+        assertEventEquals("b", false, SubsystemState.ChangeType.PROPERTY, event3);
+
+        Assert.assertEquals("aaa", state.getProperties().get("a"));
+        Assert.assertEquals("ccc", state.getProperties().get("b"));
+
+        Assert.assertEquals("aaa", state.setProperty("a", null));
+        Assert.assertEquals(4, observables.size());
+        Assert.assertEquals(Collections.nCopies(4, state), observables);
+        Assert.assertEquals(4, arguments.size());
+        SubsystemState.ChangeEvent event4 = (SubsystemState.ChangeEvent) arguments.get(3);
+        assertEventEquals("a", true, SubsystemState.ChangeType.PROPERTY, event4);
+
+        Assert.assertNull(state.getProperties().get("a"));
+        Assert.assertEquals("ccc", state.getProperties().get("b"));
+    }
+
+    @Test
+    public void testModules() {
+        SubsystemState state = new SubsystemState();
+
+        final List<Observable> observables = new ArrayList<Observable>();
+        final List<Object> arguments = new ArrayList<Object>();
+        Observer o = new Observer() {
+            @Override
+            public void update(Observable o, Object arg) {
+                observables.add(o);
+                arguments.add(arg);
+            }
+        };
+        state.addObserver(o);
+
+        Assert.assertEquals("Precondition", 0, state.getModules().size());
+
+        Assert.assertEquals("Precondition", 0, arguments.size());
+        ModuleIdentifier id = ModuleIdentifier.fromString("hi");
+        SubsystemState.OSGiModule m = new SubsystemState.OSGiModule(id, 3);
+        state.addModule(m);
+
+        Assert.assertEquals(1, arguments.size());
+        SubsystemState.ChangeEvent event = (SubsystemState.ChangeEvent) arguments.get(0);
+        assertEventEquals(id.toString(), false, SubsystemState.ChangeType.MODULE, event);
+
+        Assert.assertEquals(Collections.singletonList(m), state.getModules());
+
+        Assert.assertNull(state.removeModule("abc"));
+        Assert.assertEquals(Collections.singletonList(m), state.getModules());
+
+        Assert.assertEquals(m, state.removeModule("hi"));
+
+        Assert.assertEquals(2, arguments.size());
+        SubsystemState.ChangeEvent event2 = (SubsystemState.ChangeEvent) arguments.get(1);
+        assertEventEquals(id.toString(), true, SubsystemState.ChangeType.MODULE, event2);
+
+        Assert.assertEquals(0, state.getModules().size());
+    }
+
+    @Test
+    public void testActivation() {
+        SubsystemState state = new SubsystemState();
+
+        final List<Observable> observables = new ArrayList<Observable>();
+        final List<Object> arguments = new ArrayList<Object>();
+        Observer o = new Observer() {
+            @Override
+            public void update(Observable o, Object arg) {
+                observables.add(o);
+                arguments.add(arg);
+            }
+        };
+        state.addObserver(o);
+
+        Assert.assertEquals("Default", SubsystemState.Activation.LAZY, state.getActivationPolicy());
+
+        Assert.assertEquals("Precondition", 0, arguments.size());
+        state.setActivation(SubsystemState.Activation.LAZY);
+        Assert.assertEquals(0, arguments.size());
+
+        state.setActivation(SubsystemState.Activation.EAGER);
+        Assert.assertEquals(1, arguments.size());
+
+        SubsystemState.ChangeEvent event = (SubsystemState.ChangeEvent) arguments.get(0);
+        assertEventEquals(SubsystemState.Activation.EAGER.toString(), false, SubsystemState.ChangeType.ACTIVATION, event);
+    }
+
+    private void assertEventEquals(String id, boolean isRemoved, SubsystemState.ChangeType type, SubsystemState.ChangeEvent event) {
+        Assert.assertEquals(id, event.getId());
+        Assert.assertEquals(isRemoved, event.isRemoved());
+        Assert.assertEquals(type, event.getType());
+    }
+
+    private Map<String, String> map(Dictionary<String, String> d) {
+        Map<String, String> m = new HashMap<String, String>();
+
+        for (Enumeration<String> e = d.keys(); e.hasMoreElements(); ) {
+            String key = e.nextElement();
+            m.put(key, d.get(key));
+        }
+
+        return m;
+    }
+}

--- a/osgi/service/src/test/java/org/jboss/as/osgi/service/AutoInstallIntegrationTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/service/AutoInstallIntegrationTestCase.java
@@ -1,0 +1,225 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import org.jboss.as.osgi.parser.SubsystemState;
+import org.jboss.as.osgi.parser.SubsystemState.OSGiModule;
+import org.jboss.logmanager.Level;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.value.ImmediateValue;
+import org.jboss.osgi.framework.BundleManagerService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+/**
+ * @author David Bosschaert
+ */
+public class AutoInstallIntegrationTestCase {
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void testUpdateAddModule() throws Exception {
+        // This is a fairly involved unit test, but this is unavoidable as the relevant code is quite dependent
+        // on other infrastructure which is being mocked up here.
+
+        // What is being tested here is that the AutoInstallIntegration code correctly responds to new modules
+        // being added through the management console at runtime.
+
+        // First we create a test version of AutoInstallIntegration that intercepts the installModule and startBundle
+        // methods so that it can be checked that they are called.
+        final ServiceName dummyService = ServiceName.of("dummy");
+        final List<OSGiModule> installedModules = new ArrayList<SubsystemState.OSGiModule>();
+        final List<OSGiModule> startedBundles = new ArrayList<SubsystemState.OSGiModule>();
+        AutoInstallIntegration aii = new AutoInstallIntegration() {
+            @Override
+            ServiceName installModule(BundleManagerService bundleManager, OSGiModule moduleMetaData) {
+                installedModules.add(moduleMetaData);
+                return dummyService;
+            }
+
+            @Override
+            void startBundle(ServiceContainer serviceContainer, ServiceName serviceName, OSGiModule moduleMetaData) {
+                startedBundles.add(moduleMetaData);
+            }
+        };
+
+        // Now we set up the SubsystemState object.
+        List<OSGiModule> modules = new ArrayList<SubsystemState.OSGiModule>();
+        ModuleIdentifier id = ModuleIdentifier.fromString("abc");
+        OSGiModule module = new OSGiModule(id, null);
+        modules.add(module);
+        SubsystemState state = Mockito.mock(SubsystemState.class);
+        Mockito.when(state.getModules()).thenReturn(modules);
+
+        // Provide some mock injected services into AutoInstallIntegration
+        aii.injectedSubsystemState.setValue(new ImmediateValue<SubsystemState>(state));
+        aii.injectedBundleManager.setValue(Mockito.mock(BundleManagerService.class));
+
+        // Here we create a mock serviceController that allows us to catch the (temporary) service
+        // created by the update and start it later from inside this test.
+        final List<Service<?>> addedServices = new ArrayList<Service<?>>(); // the caught services
+        final ServiceBuilder<Void> builder = Mockito.mock(ServiceBuilder.class);
+        ServiceContainer container = Mockito.mock(ServiceContainer.class);
+        Mockito.when(container.addService((ServiceName) Mockito.any(), (Service<?>) Mockito.any())).thenAnswer(
+            new Answer<ServiceBuilder<Void>>() {
+                @Override
+                public ServiceBuilder<Void> answer(InvocationOnMock invocation) throws Throwable {
+                    addedServices.add((Service<?>) invocation.getArguments()[1]);
+                    return builder;
+                }
+        });
+        ServiceController<?> controller = Mockito.mock(ServiceController.class);
+        Mockito.when(controller.getServiceContainer()).thenReturn(container);
+        aii.serviceController = controller;
+
+        // Do the actual Observer invocation on the AutoInstallIntegration object.
+        SubsystemState.ChangeEvent event = new SubsystemState.ChangeEvent(SubsystemState.ChangeType.MODULE, false, id.toString());
+        aii.update(null, event);
+
+        Assert.assertEquals("The new module should have been installed in the system",
+            1, installedModules.size());
+        Assert.assertEquals(module, installedModules.get(0));
+        Assert.assertEquals("The new bundle is not yet started, this is done in a service instead",
+            0, startedBundles.size());
+        Mockito.verify(builder).addDependency(dummyService);
+        Mockito.verify(builder).install();
+
+        // Now we're going to check that the service that was created inside aii.update() works correctly...
+        // First, mock up a separate ServiceController, specific to the service created in aii.update()
+        ServiceController innerController = Mockito.mock(ServiceController.class);
+        StartContext context = Mockito.mock(StartContext.class);
+        Mockito.when(context.getController()).thenReturn(innerController);
+        Assert.assertEquals(1, addedServices.size());
+
+        // Call start() on the service, which should do its work...
+        addedServices.get(0).start(context);
+
+        Assert.assertEquals("The bundle should have been started", 1, startedBundles.size());
+        Assert.assertEquals(module, startedBundles.get(0));
+        // The service should have been removed again after doing its work.
+        Mockito.verify(innerController).setMode(Mode.REMOVE);
+    }
+
+    @Test
+    public void testUpdateNull() {
+        assertPreconditionForUpdateTest();
+
+        TestHandler testHandler = new TestHandler();
+        try {
+            AutoInstallIntegration aii = new AutoInstallIntegration();
+            aii.update(null, null);
+            Assert.assertEquals("There should not be any error logs", 0, testHandler.records.size());
+        } finally {
+            testHandler.remove();
+        }
+    }
+
+    @Test
+    public void testUpdateOther() {
+        assertPreconditionForUpdateTest();
+
+        TestHandler testHandler = new TestHandler();
+        try {
+            AutoInstallIntegration aii = new AutoInstallIntegration();
+            SubsystemState.ChangeEvent event = new SubsystemState.ChangeEvent(SubsystemState.ChangeType.PROPERTY, false, "testing");
+            aii.update(null, event);
+            Assert.assertEquals("There should not be any error logs", 0, testHandler.records.size());
+        } finally {
+            testHandler.remove();
+        }
+    }
+
+    @Test
+    public void testUpdateRemoveModule() {
+        // Removing a module has no effect at this point in this. This tests verifies that it has no effect
+        // but in the future it might be taken into effect at which point this test needs to be altered accordingly.
+        assertPreconditionForUpdateTest();
+
+        TestHandler testHandler = new TestHandler();
+        try {
+            AutoInstallIntegration aii = new AutoInstallIntegration();
+            ModuleIdentifier id = ModuleIdentifier.fromString("testing");
+            SubsystemState.ChangeEvent event = new SubsystemState.ChangeEvent(SubsystemState.ChangeType.MODULE, true, id.toString());
+            aii.update(null, event);
+            Assert.assertEquals("There should not be any error logs", 0, testHandler.records.size());
+        } finally {
+            testHandler.remove();
+        }
+    }
+
+    /**
+     * The tests that call this method rely on intercepting logging messages for their assertions. These tests generally
+     * expect no error log messages which means that all went well. To ensure that the actual error log messages do actually
+     * exist, this precondition message makes an invalid invocation and checks that the error gets logged.
+     */
+    public void assertPreconditionForUpdateTest() {
+        TestHandler testHandler = new TestHandler();
+
+        try {
+            AutoInstallIntegration aii = new AutoInstallIntegration();
+            ModuleIdentifier id = ModuleIdentifier.fromString("testing");
+            SubsystemState.ChangeEvent event = new SubsystemState.ChangeEvent(SubsystemState.ChangeType.MODULE, false, id.toString());
+            Assert.assertEquals("Precondition", 0, testHandler.records.size());
+
+            aii.update(null, event);
+            Assert.assertEquals("There should be an error log, because the update was called with insufficient services available",
+                1, testHandler.records.size());
+            Assert.assertEquals(Level.ERROR, testHandler.records.get(0).getLevel());
+        } finally {
+            testHandler.remove();
+        }
+    }
+
+    private static class TestHandler extends ConsoleHandler {
+        private final List<LogRecord> records = new ArrayList<LogRecord>();
+        private final Logger logger;
+
+        private TestHandler() {
+            logger = Logger.getLogger("org.jboss.as.osgi");
+            logger.addHandler(this);
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        public void remove() {
+            logger.removeHandler(this);
+        }
+    }
+}


### PR DESCRIPTION
Some of AS7-931 was already covered in the AS7-371 commit. This commit includes:
Make the OSGi Subsystem Activation attribute writeable.
Make the system dynamically react to additions in the modules configuration.
A bunch of new unit tests.
