### PR TITLE
Small Arquillian Container Configuration clean up

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -32,12 +32,10 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     private InetAddress managementAddress;
     private int managementPort;
-    private long startupTimeout;
 
     public CommonContainerConfiguration() {
         managementAddress = getInetAddress("127.0.0.1");
         managementPort = 9999;
-        startupTimeout = 30000;
     }
 
     public InetAddress getManagementAddress() {
@@ -54,14 +52,6 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public void setManagementPort(int managementPort) {
         this.managementPort = managementPort;
-    }
-
-    public long getStartupTimeout() {
-        return startupTimeout;
-    }
-
-    public void setStartupTimeout(long startupTimeout) {
-        this.startupTimeout = startupTimeout;
     }
 
     private InetAddress getInetAddress(String name) {

--- a/arquillian/container-managed-clustering/src/main/java/org/jboss/as/arquillian/container/managed/clustering/ManagedDeployableContainer.java
+++ b/arquillian/container-managed-clustering/src/main/java/org/jboss/as/arquillian/container/managed/clustering/ManagedDeployableContainer.java
@@ -26,8 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
@@ -210,15 +208,8 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
         public void run() {
             final InputStream stream = process.getInputStream();
             final InputStreamReader reader = new InputStreamReader(stream);
-            final boolean writeOutput = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
 
-                @Override
-                public Boolean run() {
-                    // this needs a better name
-                    String val = System.getProperty("org.jboss.as.writeconsole");
-                    return val != null && "true".equals(val);
-                }
-            });
             final char[] data = new char[100];
             try {
                 for (int read = 0; read != -1; read = reader.read(data)) {

--- a/arquillian/container-managed-clustering/src/main/java/org/jboss/as/arquillian/container/managed/clustering/ManagedDeployableContainer.java
+++ b/arquillian/container-managed-clustering/src/main/java/org/jboss/as/arquillian/container/managed/clustering/ManagedDeployableContainer.java
@@ -26,9 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.UnknownHostException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -36,14 +33,8 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
-import javax.management.MBeanServerConnection;
-
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
-import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
-import org.jboss.arquillian.core.api.InstanceProducer;
-import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.as.arquillian.container.CommonDeployableContainer;
-import org.jboss.as.arquillian.container.MBeanServerConnectionProvider;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
@@ -170,7 +161,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             }
             if (!serverAvailable) {
                 destroyProcess();
-                throw new TimeoutException(String.format("Managed server was not started within [%d] ms", getContainerConfiguration().getStartupTimeout()));
+                throw new TimeoutException(String.format("Managed server was not started within [%d] s", getContainerConfiguration().getStartupTimeoutInSeconds()));
             }
 
         } catch (Exception e) {

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -210,15 +210,8 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
         public void run() {
             final InputStream stream = process.getInputStream();
             final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-            final boolean writeOutput = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+            final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
 
-                @Override
-                public Boolean run() {
-                    // By default, redirect to stdout unless disabled by this property
-                    String val = System.getProperty("org.jboss.as.writeconsole");
-                    return val == null || !"false".equals(val);
-                }
-            });
             String line = null;
             try {
                 while ((line = reader.readLine()) != null) {

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -136,7 +136,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             }
             if (!serverAvailable) {
                 destroyProcess();
-                throw new TimeoutException(String.format("Managed server was not started within [%d] ms", getContainerConfiguration().getStartupTimeout()));
+                throw new TimeoutException(String.format("Managed server was not started within [%d] s", getContainerConfiguration().getStartupTimeoutInSeconds()));
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
AS7-1469 AS7-1468
- Removed duplicate startupTimeout from CommonContainerConfiguration
- use ManagedContainerConfiguration.outputToConsole (not 'secret' System Property)
