### PR TITLE
Add /f option to taskkill command on Windows. Stops respawn test from fai

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnTestCase.java
@@ -396,7 +396,7 @@ public class RespawnTestCase {
 
         @Override
         String getKillCommand(RunningProcess process) {
-            return "taskkill /pid " + process.getProcessId();
+            return "taskkill /f /pid " + process.getProcessId();
         }
     }
 


### PR DESCRIPTION
Add /f option to taskkill command on Windows. Stops respawn test from failing.
