### PR TITLE
AS7-928 integrate hibernate-envers

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -396,6 +396,9 @@
             <maven-resource group="org.hibernate" artifact="hibernate-infinispan" />
         </module-def>
 
+        <module-def name="org.hibernate.envers">
+            <maven-resource group="org.hibernate" artifact="hibernate-envers"/>
+        </module-def>
         <module-def name="org.hibernate.validator">
             <maven-resource group="org.hibernate" artifact="hibernate-validator"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -553,6 +553,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
             <artifactId>hibernate-jpa-2.0-api</artifactId>
         </dependency>

--- a/build/src/main/resources/modules/org/hibernate/envers/main/module.xml
+++ b/build/src/main/resources/modules/org/hibernate/envers/main/module.xml
@@ -21,27 +21,19 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<!-- Represents the Hibernate 4.0.x module--> 
-<module xmlns="urn:jboss:module:1.0" name="org.hibernate">
+
+<module xmlns="urn:jboss:module:1.0" name="org.hibernate.envers">
     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
-        <module name="asm.asm"/>
+        <module name="org.hibernate"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.dom4j"/>
         <module name="javax.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
-        <module name="javax.validation.api"/>
-        <module name="org.antlr"/>
-        <module name="org.apache.ant"/>
-        <module name="org.apache.commons.collections"/>
-        <module name="org.dom4j"/>
-        <module name="org.infinispan"/>
         <module name="org.javassist"/>
-        <module name="org.jboss.as.jpa.hibernate"  slot="4"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.slf4j"/>
-        <module name="org.hibernate.envers" services="import" optional = "true" export="true"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/org/hibernate/main/module.xml
+++ b/build/src/main/resources/modules/org/hibernate/main/module.xml
@@ -42,6 +42,6 @@
         <module name="org.jboss.as.jpa.hibernate"  slot="4"/>
         <module name="org.jboss.logging"/>
         <module name="org.slf4j"/>
-        <module name="org.hibernate.envers" services="import" optional = "true" export="true"/>
+        <module name="org.hibernate.envers" services="import" optional = "true"/>
     </dependencies>
 </module>

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
@@ -68,7 +68,6 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
 
     private static final ModuleIdentifier HIBERNATE_3_PROVIDER = ModuleIdentifier.create("org.jboss.as.jpa.hibernate","3");
     private static final String HIBERNATE3_PROVIDER_ADAPTOR = "org.jboss.as.jpa.hibernate3.HibernatePersistenceProviderAdaptor";
-
     // module dependencies for hibernate3
     private static final ModuleIdentifier JBOSS_AS_NAMING_ID = ModuleIdentifier.create("org.jboss.as.naming");
     private static final ModuleIdentifier JBOSS_JANDEX_ID = ModuleIdentifier.create("org.jboss.jandex");
@@ -90,7 +89,6 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
         addDependency(moduleSpecification, moduleLoader, JBOSS_AS_JPA_ID);
         addDependency(moduleSpecification, moduleLoader, JBOSS_AS_JPA_SPI_ID);  // cover when adapter jar is in app
         addDependency(moduleSpecification, moduleLoader, JAVASSIST_ID);
-
         log.infof("added javax.persistence.api, javaee.api, org.jboss.as.jpa, org.javassist dependencies to %s", deploymentUnit.getName());
         addPersistenceProviderModuleDependencies(phaseContext, moduleSpecification, moduleLoader);
     }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
@@ -68,6 +68,7 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
 
     private static final ModuleIdentifier HIBERNATE_3_PROVIDER = ModuleIdentifier.create("org.jboss.as.jpa.hibernate","3");
     private static final String HIBERNATE3_PROVIDER_ADAPTOR = "org.jboss.as.jpa.hibernate3.HibernatePersistenceProviderAdaptor";
+    private static final ModuleIdentifier HIBERNATE_ENVERS_ID = ModuleIdentifier.create( "org.hibernate.envers" );
     // module dependencies for hibernate3
     private static final ModuleIdentifier JBOSS_AS_NAMING_ID = ModuleIdentifier.create("org.jboss.as.naming");
     private static final ModuleIdentifier JBOSS_JANDEX_ID = ModuleIdentifier.create("org.jboss.jandex");
@@ -119,6 +120,8 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
             moduleDependencies.add(Configuration.PROVIDER_MODULE_DEFAULT);
             log.info("added (default provider) " + Configuration.PROVIDER_MODULE_DEFAULT +
                     " dependency to application deployment (since " + defaultProviderCount + " PU(s) didn't specify " + Configuration.PROVIDER_MODULE + ")");
+            //only inject envers module as long as org.hibernate is injected.
+            addDependency( moduleSpecification, moduleLoader, HIBERNATE_ENVERS_ID );
         }
 
         // add persistence provider dependency

--- a/pom.xml
+++ b/pom.xml
@@ -2721,6 +2721,50 @@
             </dependency>
 
             <dependency>
+              <groupId>org.hibernate</groupId>
+              <artifactId>hibernate-envers</artifactId>
+              <version>${version.org.hibernate}</version>
+                 <exclusions>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>ejb3-persistence</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.transaction</groupId>
+                        <artifactId>jta</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-tools</artifactId>
+                    </exclusion>
+                     <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-entitymanager</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>cglib</groupId>
+                        <artifactId>cglib</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.hibernate.javax.persistence</groupId>
+                        <artifactId>hibernate-jpa-2.0-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                <groupId>org.hibernate</groupId>
                <artifactId>hibernate-commons-annotations</artifactId>
                <version>${version.org.hibernate.commons.annotations}</version>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -34,7 +34,9 @@
 
     <artifactId>jboss-as-testsuite-integration-compat</artifactId>
     <name>JBoss Application Server Test Suite: Compatibility Tests</name>
-
+    <properties>
+            <version.org.hibernate3>3.6.6.Final</version.org.hibernate3>
+    </properties>
    <!--
    Compile-time dependencies upon anything  in the AS7 runtime
    are allowed in this section
@@ -44,19 +46,25 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>3.6.5.Final</version>
+            <version>${version.org.hibernate3}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>3.6.5.Final</version>
+            <version>${version.org.hibernate3}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-infinispan</artifactId>
-            <version>3.6.5.Final</version>
+            <version>${version.org.hibernate3}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+            <version>${version.org.hibernate3}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/Address.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/Address.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Strong Liu
+ */
+@Entity
+@Audited
+public class Address {
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String streetName;
+
+    private Integer houseNumber;
+
+
+    @OneToMany(mappedBy = "address")
+    private Set<Person> persons = new HashSet<Person>(  );
+
+	public Integer getHouseNumber() {
+		return houseNumber;
+	}
+
+	public void setHouseNumber(Integer houseNumber) {
+		this.houseNumber = houseNumber;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public Set<Person> getPersons() {
+		return persons;
+	}
+
+	public void setPersons(Set<Person> persons) {
+		this.persons = persons;
+	}
+
+	public String getStreetName() {
+		return streetName;
+	}
+
+	public void setStreetName(String streetName) {
+		this.streetName = streetName;
+	}
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/HibernateEnvers3EmbeddedProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/HibernateEnvers3EmbeddedProviderTestCase.java
@@ -1,0 +1,203 @@
+package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import java.io.File;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Strong Liu
+ */
+@RunWith(Arquillian.class)
+public class HibernateEnvers3EmbeddedProviderTestCase {
+    private static final String ARCHIVE_NAME = "hibernate3_test";
+
+    private static final String persistence_xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+            "  <persistence-unit name=\"mypc\">" +
+            "    <description>Persistence Unit." +
+            "    </description>" +
+            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+            "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+            "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
+            "<property name=\"jboss.as.jpa.providerModule\" value=\"hibernate3-bundled\"/>" +
+            "<property name=\"hibernate.ejb.event.post-insert\" value=\"org.hibernate.ejb.event.EJB3PostInsertEventListener,org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.post-update\" value=\"org.hibernate.ejb.event.EJB3PostUpdateEventListener,org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.post-delete\" value=\"org.hibernate.ejb.event.EJB3PostDeleteEventListener,org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.pre-collection-update\" value=\"org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.pre-collection-remove\" value=\"org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.post-collection-recreate\" value=\"org.hibernate.envers.event.AuditEventListener\"/>"+
+            "</properties>" +
+            "  </persistence-unit>" +
+            "</persistence>";
+
+    private static final String web_persistence_xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+            "  <persistence-unit name=\"web_mypc\">" +
+            "    <description>Persistence Unit." +
+            "    </description>" +
+            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+            "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+            "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
+            "<property name=\"jboss.as.jpa.providerModule\" value=\"hibernate3-bundled\"/>" +
+            "<property name=\"hibernate.ejb.event.post-insert\" value=\"org.hibernate.ejb.event.EJB3PostInsertEventListener,org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.post-update\" value=\"org.hibernate.ejb.event.EJB3PostUpdateEventListener,org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.post-delete\" value=\"org.hibernate.ejb.event.EJB3PostDeleteEventListener,org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.pre-collection-update\" value=\"org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.pre-collection-remove\" value=\"org.hibernate.envers.event.AuditEventListener\"/>"+
+            "<property name=\"hibernate.ejb.event.post-collection-recreate\" value=\"org.hibernate.envers.event.AuditEventListener\"/>"+
+            "</properties>" +
+            "  </persistence-unit>" +
+            "</persistence>";
+
+    private static InitialContext iniCtx;
+
+    @BeforeClass
+    public static void beforeClass() throws NamingException {
+        iniCtx = new InitialContext();
+    }
+
+    private static void addHibernate3JarsToEar(EnterpriseArchive ear) {
+        final String basedir = System.getProperty("basedir");
+        final String testdir = basedir + File.separatorChar + "target" + File.separatorChar + "test-libs";
+        File hibernatecore = new File(testdir, "hibernate3-core.jar");
+        File hibernateannotations = new File(testdir, "hibernate3-commons-annotations.jar");
+        File hibernateentitymanager = new File(testdir, "hibernate3-entitymanager.jar");
+        File hibernateenvers = new File(testdir, "hibernate3-envers.jar");
+        File dom4j = new File(testdir, "dom4j.jar");
+        File slf4j = new File(testdir, "slf4j.jar");
+        File slf4jApi = new File(testdir, "slf4j-api.jar");
+        File commonCollections = new File(testdir, "commons-collections.jar");
+        File antlr = new File(testdir, "antlr.jar");
+        ear.addAsLibraries(
+            hibernatecore,
+            hibernateannotations,
+            hibernateentitymanager,
+            hibernateenvers,
+            dom4j,
+            slf4j,
+            slf4jApi,
+            commonCollections,
+            antlr
+        );
+
+    }
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+
+        EnterpriseArchive ear = ShrinkWrap.create( EnterpriseArchive.class, ARCHIVE_NAME + ".ear" );
+        addHibernate3JarsToEar(ear);
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
+        lib.addClasses(SLSBPU.class, HttpRequest.class);
+        ear.addAsModule(lib);
+
+        lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
+        lib.addClasses(Address.class, Person.class);
+        lib.addAsManifestResource(new StringAsset(persistence_xml), "persistence.xml");
+        ear.addAsLibraries(lib);
+
+        final WebArchive main = ShrinkWrap.create(WebArchive.class, "main.war");
+        main.addClasses(HibernateEnvers3EmbeddedProviderTestCase.class);
+        ear.addAsModule(main);
+
+        // add war that contains its own pu
+        WebArchive war = ShrinkWrap.create(WebArchive.class, ARCHIVE_NAME + ".war");
+        war.addClasses(SimpleServlet.class, Person.class, Address.class);
+        war.addAsResource(new StringAsset(web_persistence_xml), "META-INF/persistence.xml");
+
+        war.addAsWebInfResource(
+            new StringAsset("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<web-app version=\"3.0\"\n" +
+                "         xmlns=\"http://java.sun.com/xml/ns/javaee\"\n" +
+                "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n" +
+                "         metadata-complete=\"false\">\n" +
+                "<servlet-mapping>\n" +
+                "        <servlet-name>SimpleServlet</servlet-name>\n" +
+                "        <url-pattern>/simple/*</url-pattern>\n" +
+                "    </servlet-mapping>\n" +
+                "</web-app>"),
+            "web.xml");
+
+        ear.addAsModule(war);
+
+        return ear;
+    }
+
+    protected static <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        try {
+            return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + "beans/" + beanName + "!" + interfaceType.getName()));
+        } catch (NamingException e) {
+            dumpJndi("");
+            throw e;
+        }
+    }
+
+    // TODO: move this logic to a common base class (might be helpful for writing new tests)
+    private static void dumpJndi(String s) {
+        try {
+            dumpTreeEntry(iniCtx.list(s), s);
+        } catch (NamingException ignore) {
+        }
+    }
+
+    private static void dumpTreeEntry(NamingEnumeration<NameClassPair> list, String s) throws NamingException {
+        System.out.println("\ndump " + s);
+        while (list.hasMore()) {
+            NameClassPair ncp = list.next();
+            System.out.println(ncp.toString());
+            if (s.length() == 0) {
+                dumpJndi(ncp.getName());
+            } else {
+                dumpJndi(s + "/" + ncp.getName());
+            }
+        }
+    }
+
+    @Test
+    public void testSimpleEnversOperation() throws Exception {
+        SLSBPU slsbpu = lookup("SLSBPU",SLSBPU.class);
+		Person p1= slsbpu.createPerson( "Strong","Liu","kexueyuan source road",307 );
+		Person p2= slsbpu.createPerson( "tom","cat","apache",34 );
+		Address a1 =p1.getAddress();
+		a1.setHouseNumber( 5 );
+
+		p2.setAddress( a1 );
+		slsbpu.updateAddress( a1 );
+		slsbpu.updatePerson( p2 );
+
+		int size = slsbpu.retrieveOldPersonVersionFromAddress( a1.getId() );
+		Assert.assertEquals( 1, size );
+    }
+
+    @Test
+    public void testServletSubDeploymentRead() throws Exception {
+        String result = HttpRequest.get("http://localhost:8080/hibernate3_test/simple?type=query", 10, SECONDS);
+        assertEquals("2", result);
+
+        result = HttpRequest.get("http://localhost:8080/hibernate3_test/simple?type=revision", 10, SECONDS);
+        assertEquals("1", result);
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/HibernateEnvers3EmbeddedProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/HibernateEnvers3EmbeddedProviderTestCase.java
@@ -2,6 +2,7 @@ package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -68,7 +69,7 @@ public class HibernateEnvers3EmbeddedProviderTestCase {
             "</properties>" +
             "  </persistence-unit>" +
             "</persistence>";
-
+    @ArquillianResource
     private static InitialContext iniCtx;
 
     @BeforeClass

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/HttpRequest.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/HttpRequest.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
+ */
+public class HttpRequest {
+    private static String execute(final Callable<String> task, final long timeout, final TimeUnit unit) throws TimeoutException, ExecutionException {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Future<String> result = executor.submit(task);
+        try {
+            return result.get(timeout, unit);
+        } catch (TimeoutException e) {
+            result.cancel(true);
+            throw e;
+        } catch (InterruptedException e) {
+            // should not happen
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw e;
+        } finally {
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(timeout, unit);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+    }
+
+    public static String get(final String spec, final long timeout, final TimeUnit unit) throws MalformedURLException, ExecutionException, TimeoutException {
+        final URL url = new URL(spec);
+        Callable<String> task = new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setDoInput(true);
+                return processResponse(conn);
+            }
+        };
+        return execute(task, timeout, unit);
+    }
+
+    private static String read(final InputStream in) throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        int b;
+        while((b = in.read()) != -1) {
+            out.write(b);
+        }
+        return out.toString();
+    }
+
+    private static String processResponse(HttpURLConnection conn) throws IOException {
+        int responseCode = conn.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            final InputStream err = conn.getErrorStream();
+            try {
+                throw new IOException(read(err));
+            }
+            finally {
+                err.close();
+            }
+        }
+        final InputStream in = conn.getInputStream();
+        try {
+            return read(in);
+        }
+        finally {
+            in.close();
+        }
+    }
+
+    public static String put(final String spec, final String message, final long timeout, final TimeUnit unit) throws MalformedURLException, ExecutionException, TimeoutException {
+        final URL url = new URL(spec);
+        Callable<String> task = new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setDoInput(true);
+                conn.setDoOutput(true);
+                final OutputStream out = conn.getOutputStream();
+                try {
+                    write(out, message);
+                    return processResponse(conn);
+                }
+                finally {
+                    out.close();
+                }
+            }
+        };
+        return execute(task, timeout, unit);
+    }
+
+    private static void write(OutputStream out, String message) throws IOException {
+        final OutputStreamWriter writer = new OutputStreamWriter(out);
+        writer.write(message);
+        writer.flush();
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/Person.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/Person.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Strong Liu
+ */
+@Entity
+@Audited // that's the important part :)
+public class Person {
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String name;
+
+    private String surname;
+
+    @ManyToOne
+    private Address address;
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getSurname() {
+		return surname;
+	}
+
+	public void setSurname(String surname) {
+		this.surname = surname;
+	}
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/SLSBPU.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/SLSBPU.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
+
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+
+/**
+ * @author Strong Liu
+ */
+@Stateless
+public class SLSBPU {
+	@PersistenceContext(unitName = "mypc")
+	EntityManager em;
+
+	public Person createPerson(String firstName, String secondName, String streetName, int houseNumber) {
+		Address address = new Address();
+		address.setHouseNumber( houseNumber );
+		address.setStreetName( streetName );
+		Person person = new Person();
+		person.setName( firstName );
+		person.setSurname( secondName );
+		person.setAddress( address );
+		address.getPersons().add( person );
+
+		em.persist( address );
+		em.persist( person );
+		return person;
+	}
+
+	public Person updatePerson(Person p) {
+		return em.merge( p );
+	}
+
+	public Address updateAddress(Address a) {
+		return em.merge( a );
+	}
+
+	public int retrieveOldPersonVersionFromAddress(int id) {
+		AuditReader reader = AuditReaderFactory.get( em );
+		Address address1_rev = reader.find( Address.class, id, 1 );
+		return address1_rev.getPersons().size();
+	}
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/SimpleServlet.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/envers/SimpleServlet.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.compat.jpa.hibernate.envers;
+
+import java.io.IOException;
+import java.io.Writer;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceUnit;
+import javax.persistence.Query;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+
+/**
+ * @author Scott Marlow
+ *
+ * Exercise the code paths reached when a container managed entity manager is injected into a servlet
+ */
+
+@WebServlet(name="SimpleServlet", urlPatterns={"/simple"})
+public class SimpleServlet extends HttpServlet {
+    @PersistenceUnit(unitName = "web_mypc")
+    EntityManagerFactory emf;   // servlet is in control of when obtained entity managers are closed
+
+    @PersistenceContext(unitName = "web_mypc", name="persistence/em")
+    EntityManager em;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String type = req.getParameter("type");
+
+        Writer writer = resp.getWriter();
+        Long count = 0L;
+        if ( type.equals( "query" ) ) {
+            // This is how a servlet could get an entity manager from a entity manager factory
+            EntityManager localEntityManager = emf.createEntityManager();
+            Query query = localEntityManager.createQuery( "select count(*) from Person" );
+            Long count1 = (Long) query.getSingleResult();
+            localEntityManager.close();
+
+            // a new underlying entity manager will be obtained to handle creating query
+            // the em will stay open until the container closes it.
+            query = em.createQuery( "select count(*) from Person" );
+            Long count2 = (Long) query.getSingleResult();
+            if(count1!=count2){
+                throw new RuntimeException( "Local EntityManager and Injected EntityManager get different result" );
+            }
+            else {
+                count = count1;
+            }
+        }
+        else if ( type.equals( "revision" ) ) {
+            EntityManager localEntityManager = emf.createEntityManager();
+            AuditReader reader = AuditReaderFactory.get( localEntityManager );
+            Address address1_rev = reader.find( Address.class, 1, 1 );
+            count = Long.valueOf( address1_rev.getPersons().size() );
+        }
+        writer.write( count.toString() );
+    }
+}

--- a/testsuite/compat/src/test/scripts/build-jars.xml
+++ b/testsuite/compat/src/test/scripts/build-jars.xml
@@ -25,6 +25,7 @@
 <project>
     <target name="build-jars" description="Build the deployments.">
     <copy file="${org.hibernate:hibernate-core:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-core.jar"/>
+    <copy file="${org.hibernate:hibernate-envers:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-envers.jar"/>
     <copy file="${org.hibernate:hibernate-commons-annotations:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-commons-annotations.jar"/>
     <copy file="${org.hibernate:hibernate-entitymanager:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-entitymanager.jar"/>
     <copy file="${dom4j:dom4j:jar}" tofile="${tests.output.dir}/test-libs/dom4j.jar"/>

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/Address.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/Address.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.jpa.hibernate.envers;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Strong Liu
+ */
+@Entity
+@Audited
+public class Address {
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String streetName;
+
+    private Integer houseNumber;
+
+
+    @OneToMany(mappedBy = "address")
+    private Set<Person> persons = new HashSet<Person>(  );
+
+	public Integer getHouseNumber() {
+		return houseNumber;
+	}
+
+	public void setHouseNumber(Integer houseNumber) {
+		this.houseNumber = houseNumber;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public Set<Person> getPersons() {
+		return persons;
+	}
+
+	public void setPersons(Set<Person> persons) {
+		this.persons = persons;
+	}
+
+	public String getStreetName() {
+		return streetName;
+	}
+
+	public void setStreetName(String streetName) {
+		this.streetName = streetName;
+	}
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/BasicEnversTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/BasicEnversTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.testsuite.integration.jpa.hibernate.envers;
 import javax.ejb.EJB;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -69,7 +70,8 @@ public class BasicEnversTestCase {
 					"    </properties>" +
 					"  </persistence-unit>" +
 					"</persistence>";
-			  private static InitialContext iniCtx;
+    @ArquillianResource
+    private static InitialContext iniCtx;
 
     @BeforeClass
     public static void beforeClass() throws NamingException {

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/BasicEnversTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/BasicEnversTestCase.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.integration.jpa.hibernate.envers;
+
+import javax.ejb.EJB;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * @author Strong Liu
+ */
+@RunWith(Arquillian.class)
+public class BasicEnversTestCase {
+	private static final String ARCHIVE_NAME = "jpa_BasicEnversTestCase";
+
+	private static final String persistence_xml =
+			"<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+					"<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+					"  <persistence-unit name=\"mypc\">" +
+					"    <description>Persistence Unit." +
+					"    </description>" +
+					"    <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+					"    <properties> " +
+					"      <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+					"    </properties>" +
+					"  </persistence-unit>" +
+					"</persistence>";
+			  private static InitialContext iniCtx;
+
+    @BeforeClass
+    public static void beforeClass() throws NamingException {
+        iniCtx = new InitialContext();
+    }
+	@Deployment
+	public static Archive<?> deploy() {
+		JavaArchive jar = ShrinkWrap.create( JavaArchive.class, ARCHIVE_NAME + ".jar" );
+		jar.addClasses(
+				Person.class,
+				Address.class,
+				SLSBPU.class
+		);
+		jar.add( new StringAsset( persistence_xml ), "META-INF/persistence.xml" );
+		return jar;
+	}
+	
+	protected static <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + beanName + "!" + interfaceType.getName()));
+    }
+
+	@Test
+	public void testSimpleEnversOperation() throws Exception {
+        SLSBPU slsbpu = lookup("SLSBPU",SLSBPU.class);
+		Person p1= slsbpu.createPerson( "Strong","Liu","kexueyuan source road",307 );
+		Person p2= slsbpu.createPerson( "tom","cat","apache",34 );
+		Address a1 =p1.getAddress();
+		a1.setHouseNumber( 5 );
+
+		p2.setAddress( a1 );
+		slsbpu.updateAddress( a1 );
+		slsbpu.updatePerson( p2 );
+
+		int size = slsbpu.retrieveOldPersonVersionFromAddress( a1.getId() );
+		Assert.assertEquals( 1, size );
+	}
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/Person.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/Person.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.jpa.hibernate.envers;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.envers.Audited;
+
+/**
+ * @author Strong Liu
+ */
+@Entity
+@Audited // that's the important part :)
+public class Person {
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String name;
+
+    private String surname;
+
+    @ManyToOne
+    private Address address;
+
+	public Address getAddress() {
+		return address;
+	}
+
+	public void setAddress(Address address) {
+		this.address = address;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getSurname() {
+		return surname;
+	}
+
+	public void setSurname(String surname) {
+		this.surname = surname;
+	}
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/SLSBPU.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/hibernate/envers/SLSBPU.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.integration.jpa.hibernate.envers;
+
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+
+/**
+ * @author Strong Liu
+ */
+@Stateless
+public class SLSBPU {
+	@PersistenceContext(unitName = "mypc")
+	EntityManager em;
+
+	public Person createPerson(String firstName, String secondName, String streetName, int houseNumber) {
+		Address address = new Address();
+		address.setHouseNumber( houseNumber );
+		address.setStreetName( streetName );
+		Person person = new Person();
+		person.setName( firstName );
+		person.setSurname( secondName );
+		person.setAddress( address );
+		address.getPersons().add( person );
+
+		em.persist( address );
+		em.persist( person );
+		return person;
+	}
+
+	public Person updatePerson(Person p) {
+		return em.merge( p );
+	}
+
+	public Address updateAddress(Address a) {
+		return em.merge( a );
+	}
+
+	public int retrieveOldPersonVersionFromAddress(int id) {
+		AuditReader reader = AuditReaderFactory.get( em );
+		Address address1_rev = reader.find( Address.class, id, 1 );
+		return address1_rev.getPersons().size();
+	}
+}


### PR DESCRIPTION
this commit ingetrates hibernate-envers into AS7
with this fix, now users have two options to use hibernate envers:
1. using envers along with bundled org.hibernate:main:4 module.
   I add a org.hibernate.envers:main module, and this module will be injected into app as long as org.hibernate:main:4 is there.
   so, for users who use default hibernate 4 module, they don't need to do anything special to use hibernate envers 4
2. for users who want to use hibernate core 3 , and choose bundle hibernate core 3 jars into there app (e.g.  jboss.as.jpa.providerModule=bundled-hibernate), they can just bundle hibernate-envers 3 jar along with hibernate-core 3 jars in there app
3. for users who want to use shared hibernate 3 module  (e.g.  jboss.as.jpa.providerModule=org.hibernate:3), they need also create a org.hibernate.envers:main:3 module (but this option has not been tested yet)
