### PR TITLE
Specification API Completion and Validation Mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,7 @@
         <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.0_spec>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.1_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.1_spec>
         <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
+        <version.org.jboss.spec.javax.management.j2eeorg.jboss.spec.javax.management.j2ee>1.0.0.Final</version.org.jboss.spec.javax.management.j2eeorg.jboss.spec.javax.management.j2ee>
         <version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>1.0.0.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>
         <version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>1.0.1.Final</version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.0_spec>
@@ -4453,6 +4454,12 @@
                 <groupId>org.jboss.spec.javax.jms</groupId>
                 <artifactId>jboss-jms-api_1.1_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec}</version>
+            </dependency>
+            
+            <dependency>
+              <groupId>org.jboss.spec.javax.management.j2ee</groupId>
+              <artifactId>jboss-j2eemgmt-api_1.1_spec</artifactId>
+              <version>${version.org.jboss.spec.javax.management.j2eeorg.jboss.spec.javax.management.j2ee}</version>
             </dependency>
 
             <dependency>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -144,6 +144,10 @@
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.management.j2ee</groupId>
+      <artifactId>jboss-j2eemgmt-api_1.1_spec</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -31,7 +31,6 @@
     <version>7.1.0.Alpha1-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.jboss.as</groupId>
   <artifactId>jboss-as-spec-api</artifactId>
   <name>JBoss Application Server: Exported Java EE Specification APIs</name>
   <description>Java EE Specification APIs exported by the Application Server</description>
@@ -136,6 +135,10 @@
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.annotation</groupId>
+      <artifactId>jboss-annotations-api_1.1_spec</artifactId>
     </dependency>
   </dependencies>
 

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -149,5 +149,10 @@
       <artifactId>jboss-j2eemgmt-api_1.1_spec</artifactId>
     </dependency>
   </dependencies>
+  
+  <!-- Modules -->
+  <modules>
+    <module>test</module>
+  </modules>
 
 </project>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -140,6 +140,10 @@
       <groupId>org.jboss.spec.javax.annotation</groupId>
       <artifactId>jboss-annotations-api_1.1_spec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/spec-api/test/pom.xml
+++ b/spec-api/test/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-spec-api</artifactId>
+    <version>7.1.0.Alpha1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>jboss-as-spec-api-test</artifactId>
+  <name>JBoss Application Server: Validation Tests for Exported Java EE Specification APIs</name>
+  <description>Validation Tests for Java EE Specification APIs exported by the Application Server</description>
+
+</project>

--- a/spec-api/test/src/test/java/org/jboss/as/spec/api/test/SpecApiDependencyCheck.java
+++ b/spec-api/test/src/test/java/org/jboss/as/spec/api/test/SpecApiDependencyCheck.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.spec.api.test;
+
+import javax.annotation.*;
+import javax.annotation.security.*;
+import javax.annotation.sql.*;
+import javax.decorator.*;
+import javax.ejb.*;
+import javax.ejb.embeddable.*;
+import javax.ejb.spi.*;
+import javax.el.*;
+import javax.enterprise.context.*;
+import javax.enterprise.context.spi.*;
+import javax.enterprise.deploy.model.*;
+import javax.enterprise.deploy.model.exceptions.*;
+import javax.enterprise.deploy.shared.*;
+import javax.enterprise.deploy.shared.factories.*;
+import javax.enterprise.deploy.spi.*;
+import javax.enterprise.deploy.spi.exceptions.*;
+import javax.enterprise.deploy.spi.factories.*;
+import javax.enterprise.deploy.spi.status.*;
+import javax.enterprise.event.*;
+import javax.enterprise.inject.*;
+import javax.enterprise.inject.spi.*;
+import javax.enterprise.util.*;
+import javax.faces.*;
+import javax.faces.application.*;
+import javax.faces.bean.*;
+import javax.faces.component.*;
+import javax.faces.component.behavior.*;
+import javax.faces.component.html.*;
+import javax.faces.component.visit.*;
+import javax.faces.context.*;
+import javax.faces.convert.*;
+import javax.faces.el.*;
+import javax.faces.event.*;
+import javax.faces.lifecycle.*;
+import javax.faces.model.*;
+import javax.faces.render.*;
+import javax.faces.validator.*;
+import javax.faces.view.*;
+import javax.faces.webapp.*;
+import javax.inject.*;
+import javax.interceptor.*;
+import javax.jms.*;
+import javax.jws.*;
+import javax.jws.soap.*;
+import javax.mail.*;
+import javax.mail.event.*;
+import javax.mail.internet.*;
+import javax.mail.search.*;
+import javax.mail.util.*;
+import javax.management.j2ee.*;
+import javax.management.j2ee.statistics.*;
+import javax.persistence.*;
+import javax.persistence.criteria.*;
+import javax.persistence.metamodel.*;
+import javax.persistence.spi.*;
+import javax.resource.*;
+import javax.resource.cci.*;
+import javax.resource.spi.*;
+import javax.resource.spi.endpoint.*;
+import javax.resource.spi.security.*;
+import javax.resource.spi.work.*;
+import javax.security.auth.message.*;
+import javax.security.auth.message.callback.*;
+import javax.security.auth.message.config.*;
+import javax.security.auth.message.module.*;
+import javax.security.jacc.*;
+import javax.servlet.*;
+import javax.servlet.annotation.*;
+import javax.servlet.descriptor.*;
+import javax.servlet.http.*;
+import javax.servlet.jsp.*;
+import javax.servlet.jsp.el.*;
+import javax.servlet.jsp.jstl.core.*;
+import javax.servlet.jsp.jstl.fmt.*;
+import javax.servlet.jsp.jstl.sql.*;
+import javax.servlet.jsp.jstl.tlv.*;
+import javax.servlet.jsp.tagext.*;
+import javax.transaction.*;
+import javax.transaction.xa.*;
+import javax.validation.*;
+import javax.validation.bootstrap.*;
+import javax.validation.constraints.*;
+import javax.validation.groups.*;
+import javax.validation.metadata.*;
+import javax.validation.spi.*;
+import javax.ws.rs.*;
+import javax.ws.rs.core.*;
+import javax.ws.rs.ext.*;
+import javax.xml.bind.*;
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.adapters.*;
+import javax.xml.bind.attachment.*;
+import javax.xml.bind.helpers.*;
+import javax.xml.bind.util.*;
+import javax.xml.registry.*;
+import javax.xml.registry.infomodel.*;
+import javax.xml.rpc.*;
+import javax.xml.rpc.encoding.*;
+import javax.xml.rpc.handler.*;
+import javax.xml.rpc.handler.soap.*;
+import javax.xml.rpc.holders.*;
+import javax.xml.rpc.server.*;
+import javax.xml.rpc.soap.*;
+import javax.xml.ws.*;
+import javax.xml.ws.handler.*;
+import javax.xml.ws.handler.soap.*;
+import javax.xml.ws.http.*;
+import javax.xml.ws.soap.*;
+import javax.xml.ws.spi.*;
+import javax.xml.ws.spi.http.*;
+import javax.xml.ws.wsaddressing.*;
+
+/**
+ * This class checks the dependencies as exported by the
+ * "spec-api" module to ensure that compilation of all Java EE
+ * 6 Specification Platform APIs are reachable.  As such, no runtime
+ * assertions are required here, only references.  If this class compiles, 
+ * all noted references are reachable within the spec-api dependency chain. 
+ * 
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ * @see http://download.oracle.com/javaee/6/api/
+ */
+@SuppressWarnings("unused")
+public class SpecApiDependencyCheck {
+
+    
+    
+}


### PR DESCRIPTION
This branch contains fixes for:

[AS7-1559] Export dependency upon javax.annotation.\* and javax.annotatio... 
[AS7-1620] Export dependency upon javax.validation and subpackages 
[AS7-1621] Export dependency upon javax.management.j2ee and subpackages 
[AS7-1619] Create a validation mechanism to assert that spec-api is comp... 

Thanks.
