### PR TITLE
Update for BoundedQueueThreadPoolService to use ExecutorService like the other ThreadPoolServices

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
@@ -22,7 +22,7 @@
 package org.jboss.as.threads;
 
 import java.util.Locale;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.OperationFailedException;
@@ -116,7 +116,7 @@ public class BoundedQueueThreadPoolAdd implements OperationStepHandler, Descript
 
                     //TODO add the handoffExceutor injection
 
-                    final ServiceBuilder<Executor> serviceBuilder = target.addService(serviceName, service);
+                    final ServiceBuilder<ExecutorService> serviceBuilder = target.addService(serviceName, service);
                     ThreadsSubsystemThreadPoolOperationUtils.addThreadFactoryDependency(params.getThreadFactory(), serviceName, serviceBuilder, service.getThreadFactoryInjector(), target, params.getName() + "-threads");
                     serviceBuilder.addListener(verificationHandler);
                     serviceBuilder.install();

--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolService.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolService.java
@@ -33,6 +33,7 @@ import org.jboss.threads.JBossExecutors;
 import org.jboss.threads.QueueExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -41,12 +42,12 @@ import java.util.concurrent.TimeUnit;
  *
  * @author John E. Bailey
  */
-public class BoundedQueueThreadPoolService implements Service<Executor> {
+public class BoundedQueueThreadPoolService implements Service<ExecutorService> {
     private final InjectedValue<ThreadFactory> threadFactoryValue = new InjectedValue<ThreadFactory>();
     private final InjectedValue<Executor> handoffExecutorValue = new InjectedValue<Executor>();
 
     private QueueExecutor executor;
-    private Executor value;
+    private ExecutorService value;
 
     private int coreThreads;
     private int maxThreads;
@@ -69,7 +70,7 @@ public class BoundedQueueThreadPoolService implements Service<Executor> {
         long keepAliveTime = keepAliveSpec == null ? Long.MAX_VALUE : keepAliveSpec.getUnit().toNanos(keepAliveSpec.getDuration());
         executor = new QueueExecutor(coreThreads, maxThreads, keepAliveTime, TimeUnit.NANOSECONDS, queueLength, threadFactoryValue.getValue(), blocking, handoffExecutorValue.getOptionalValue());
         executor.setAllowCoreThreadTimeout(allowCoreTimeout);
-        value = JBossExecutors.protectedBlockingExecutor(executor);
+        value = JBossExecutors.protectedBlockingExecutorService(executor);
     }
 
     public synchronized void stop(final StopContext context) {
@@ -88,8 +89,8 @@ public class BoundedQueueThreadPoolService implements Service<Executor> {
         value = null;
     }
 
-    public synchronized Executor getValue() throws IllegalStateException {
-        final Executor value = this.value;
+    public synchronized ExecutorService getValue() throws IllegalStateException {
+        final ExecutorService value = this.value;
         if (value == null) {
             throw new IllegalStateException();
         }


### PR DESCRIPTION
[AS7-608] Made BoundedQueueThreadPoolService use java.util.concurrent.ExecutorService instead of Executor
