### PR TITLE
AS7-1646, look first to MODULEPATH variable when determining -mp arg valu

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -70,6 +70,11 @@ rem Setup JBoss specific properties
 rem Setup the java endorsed dirs
 set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
 
+rem Set default module root paths
+if "x%MODULEPATH%" == "x" (
+  set  "MODULEPATH=%JBOSS_HOME%\modules"
+)
+
 echo ===============================================================================
 echo.
 echo   JBoss Bootstrap Environment
@@ -88,7 +93,7 @@ echo.
  "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\standalone\log\boot.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/standalone/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%JBOSS_HOME%\modules" ^
+    -mp "%MODULEPATH%" ^
     -logmodule "org.jboss.logmanager" ^
     -jaxpmodule "javax.xml.jaxp-provider" ^
      org.jboss.as.standalone ^

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -107,12 +107,17 @@ else
     JVM_OPTVERSION="-server $JVM_OPTVERSION"
 fi
 
+if [ "x$MODULEPATH" = "x" ]; then
+    MODULEPATH="$JBOSS_HOME/modules"
+fi
+
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
     JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
+    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
 fi
 
 # Display our environment
@@ -136,7 +141,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/standalone/log/boot.log\" \
          \"-Dlogging.configuration=file:$JBOSS_HOME/standalone/configuration/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"$JBOSS_HOME/modules\" \
+         -mp \"${MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          -jaxpmodule javax.xml.jaxp-provider \
          org.jboss.as.standalone \
@@ -149,7 +154,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/standalone/log/boot.log\" \
          \"-Dlogging.configuration=file:$JBOSS_HOME/standalone/configuration/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"$JBOSS_HOME/modules\" \
+         -mp \"${MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          -jaxpmodule javax.xml.jaxp-provider \
          org.jboss.as.standalone \


### PR DESCRIPTION
AS7-1646, look first to MODULEPATH variable when determining -mp arg value
