### PR TITLE
AS7-1583 allow Hibernate 3.3.x based applications to deploy with entity classes specified in persistence.xml

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -186,8 +186,9 @@ public class TransactionUtil {
             // so that we don't get this error on TransactionalEntityManager
             // (because the EntityManager is the underlying provider that
             // doesn't have the metadata.)
-        }
+        } catch (AbstractMethodError ignore) {          // JPA 1.0 provider won't have unwrap
 
+        }
 
         return result;
     }

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/Hibernate3SharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/Hibernate3SharedModuleProviderTestCase.java
@@ -57,6 +57,7 @@ public class Hibernate3SharedModuleProviderTestCase {
             "    <description>Persistence Unit." +
             "    </description>" +
             "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+            "<class>org.jboss.as.testsuite.compat.jpa.hibernate.Employee</class>" +  // currently hibernate 3.3.x cannot discover entities
             "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
             "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
 // set the providerModule to the AS org.hibernate3 module (should be in as/modules/org/hibernate/3 folder

--- a/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/SFSB1.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/testsuite/compat/jpa/hibernate/SFSB1.java
@@ -46,7 +46,7 @@ public class SFSB1 {
     }
 
     public Employee getEmployeeNoTX(int id) {
-        return em.find(Employee.class, id, LockModeType.NONE);
+        return em.find(Employee.class, id);
     }
 
 }


### PR DESCRIPTION
AS7-1583 allow Hibernate 3.3.x based applications to deploy.  They will see ClassNotFoundException (org.hibernate.ejb.packaging.Scanner) but that should be ignored.  Apps should also specify entity classes in the persistence.xml
