### PR TITLE
AS7-1663 An extended persistence context should not be propagated if there is no JTA transaction 

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -82,7 +82,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
      * @param scopedPuName      the fully scoped reference to the persistence.xml
      * @param injectionTypeName is normally "javax.persistence.EntityManager" but could be a different target class
 *                          for example "org.hibernate.Session" in which case, EntityManager.unwrap(org.hibernate.Session.class is called)
-     * @param sfsbxpcMap
+     * @param sfsbxpcMap        TODO: refactor to only pass in for type == PersistenceContextType.EXTENDED
      * @param pu
      */
     public PersistenceContextInjectionSource(final PersistenceContextType type, final Map properties, final ServiceName puServiceName, final DeploymentUnit deploymentUnit, final String scopedPuName, final String injectionTypeName, final SFSBXPCMap sfsbxpcMap, final PersistenceUnitMetadata pu) {
@@ -154,7 +154,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
             boolean isExtended;
             if (type.equals(PersistenceContextType.TRANSACTION)) {
                 isExtended = false;
-                entityManager = new TransactionScopedEntityManager(unitName, properties, emf, sfsbxpcMap);
+                entityManager = new TransactionScopedEntityManager(unitName, properties, emf);
                 if (log.isDebugEnabled())
                     log.debug("created new TransactionScopedEntityManager for unit name=" + unitName);
             } else {

--- a/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -94,19 +94,6 @@ public class TransactionUtil {
     }
 
     /**
-     * Register the specified entity manager (persistence context) with the current transaction.
-     * Precondition:  Only call while a transaction is active in the current thread.
-     *
-     * @param scopedPuName is the fully (application deployment) scoped name of persistence unit
-     * @param xpc          is the entity manager (a org.jboss.as.jpa class) to register
-     */
-    public void registerExtendedWithTransaction(String scopedPuName, EntityManager xpc) {
-        registerSynchronization(xpc, scopedPuName, false);
-        putEntityManagerInTransactionRegistry(scopedPuName, xpc);
-        xpc.joinTransaction();
-    }
-
-    /**
      * Get current persistence context.  Only call while a transaction is active in the current thread.
      *
      * @param puScopedName

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/epcpropagation/EPCPropagationTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/jpa/epcpropagation/EPCPropagationTestCase.java
@@ -143,9 +143,8 @@ public class EPCPropagationTestCase {
     }
 
     /**
-     * 7.6.2.1 ensure that  NoTxEPCStatefulBean.em (extended persistence context entity manager) is inherited by
-     * StatelessBean.em (transactional scoped entity manager).  The test ensures that the modified entity (in XPC)
-     * is visible to the transactional scoped entity manager (modified entity is returned from em.find call).
+     * Ensure that AS7-1663 is fixed, extended persistence context should not be propagated if there is no JTA transaction.
+     *
      * @throws Exception
      */
     @Test
@@ -156,7 +155,7 @@ public class EPCPropagationTestCase {
         StatefulInterface stateful = lookup("NoTxEPCStatefulBean", StatefulInterface.class);
         boolean equal = stateful.execute(6, "EntityName");
 
-        assertTrue("Name changes should propagate", equal);
+        assertFalse("Name changes should not propagate (non-tx SFSB XPC shouldn't see SLSB PC changes)", equal);
     }
 
     @Test

--- a/weld/src/main/java/org/jboss/as/weld/services/bootstrap/WeldJpaInjectionServices.java
+++ b/weld/src/main/java/org/jboss/as/weld/services/bootstrap/WeldJpaInjectionServices.java
@@ -23,7 +23,6 @@ package org.jboss.as.weld.services.bootstrap;
 
 
 import org.jboss.as.jpa.container.PersistenceUnitSearch;
-import org.jboss.as.jpa.container.SFSBXPCMap;
 import org.jboss.as.jpa.container.TransactionScopedEntityManager;
 import org.jboss.as.jpa.service.PersistenceUnitService;
 import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
@@ -44,12 +43,10 @@ public class WeldJpaInjectionServices implements JpaInjectionServices {
 
     private final DeploymentUnit deploymentUnit;
     private final ServiceRegistry serviceRegistry;
-    private final SFSBXPCMap sfsbxpcMap;
 
     public WeldJpaInjectionServices(DeploymentUnit deploymentUnit, ServiceRegistry serviceRegistry) {
         this.deploymentUnit = deploymentUnit;
         this.serviceRegistry = serviceRegistry;
-        this.sfsbxpcMap = SFSBXPCMap.getXpcMap(deploymentUnit);
     }
 
     @Override
@@ -66,7 +63,7 @@ public class WeldJpaInjectionServices implements JpaInjectionServices {
         //now we have the service controller, as this method is only called at runtime the service should
         //always be up
         PersistenceUnitService persistenceUnitService = (PersistenceUnitService)serviceController.getValue();
-        return new TransactionScopedEntityManager(scopedPuName,new HashMap<Object,Object>(), persistenceUnitService.getEntityManagerFactory(), sfsbxpcMap);
+        return new TransactionScopedEntityManager(scopedPuName,new HashMap<Object,Object>(), persistenceUnitService.getEntityManagerFactory());
     }
 
     @Override


### PR DESCRIPTION
AS7-1663 An extended persistence context should not be propagated if there is no JTA transaction
