### PR TITLE
AS7-1740 fix for .sh scripts when path contains spaces

### DIFF
--- a/build/src/main/resources/bin/domain.sh
+++ b/build/src/main/resources/bin/domain.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DIRNAME=`dirname $0`
-PROGNAME=`basename $0`
+DIRNAME=`dirname "$0"`
+PROGNAME=`basename "$0"`
 GREP="grep"
 
 # Use the maximum available, or set MAX_FD != -1 to use that
@@ -61,7 +61,7 @@ fi
 # Setup JBOSS_HOME
 if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=`cd $DIRNAME/..; pwd`
+    JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
 fi
 export JBOSS_HOME
 

--- a/build/src/main/resources/bin/jboss-admin.sh
+++ b/build/src/main/resources/bin/jboss-admin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DIRNAME=`dirname $0`
+DIRNAME=`dirname "$0"`
 
 # OS specific support (must be 'true' or 'false').
 cygwin=false;
@@ -33,7 +33,7 @@ fi
 # Setup JBOSS_HOME
 if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=`cd $DIRNAME/..; pwd`
+    JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
 fi
 export JBOSS_HOME
 

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-DIRNAME=`dirname $0`
-PROGNAME=`basename $0`
+DIRNAME=`dirname "$0"`
+PROGNAME=`basename "$0"`
 GREP="grep"
 
 # Use the maximum available, or set MAX_FD != -1 to use that
@@ -61,7 +61,7 @@ fi
 # Setup JBOSS_HOME
 if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=`cd $DIRNAME/..; pwd`
+    JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
 fi
 export JBOSS_HOME
 

--- a/build/src/main/resources/bin/wsconsume.sh
+++ b/build/src/main/resources/bin/wsconsume.sh
@@ -34,7 +34,7 @@ fi
 # Setup JBOSS_HOME
 if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=`cd $DIRNAME/..; pwd`
+    JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
 fi
 export JBOSS_HOME
 

--- a/build/src/main/resources/bin/wsprovide.sh
+++ b/build/src/main/resources/bin/wsprovide.sh
@@ -34,7 +34,7 @@ fi
 # Setup JBOSS_HOME
 if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=`cd $DIRNAME/..; pwd`
+    JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
 fi
 export JBOSS_HOME
 


### PR DESCRIPTION
Fix for AS7-1740 - Launch of *.sh scripts from path with space does not work
