### PR TITLE
Fixes for 7.0.2: AS7-1719 & AS7-1750

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/clustering/web/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/clustering/web/infinispan/main/module.xml
@@ -41,5 +41,6 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.metadata"/>
         <module name="org.jboss.msc"/>
+        <!-- module name="org.jgroups"/-->
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/org/jboss/as/clustering/web/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/clustering/web/infinispan/main/module.xml
@@ -41,6 +41,6 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.metadata"/>
         <module name="org.jboss.msc"/>
-        <!-- module name="org.jgroups"/-->
+        <module name="org.jgroups"/>
     </dependencies>
 </module>

--- a/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/JvmRouteCacheSource.java
+++ b/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/JvmRouteCacheSource.java
@@ -22,6 +22,8 @@
 package org.jboss.as.clustering.web.infinispan;
 
 import org.infinispan.Cache;
+import org.infinispan.config.Configuration;
+import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.as.clustering.web.LocalDistributableSessionManager;
 import org.jboss.msc.service.ServiceRegistry;
@@ -43,6 +45,10 @@ public class JvmRouteCacheSource implements CacheSource {
     @Override
     public <K, V> Cache<K, V> getCache(ServiceRegistry registry, LocalDistributableSessionManager manager) {
         EmbeddedCacheManager container = (EmbeddedCacheManager) registry.getRequiredService(this.provider.getServiceName(manager.getReplicationConfig())).getValue();
+        String cacheName = manager.getEngineName();
+        if (!container.cacheExists(cacheName)) {
+            container.defineConfiguration(manager.getEngineName(), CacheContainer.DEFAULT_CACHE_NAME, new Configuration());
+        }
         return container.getCache(manager.getEngineName());
     }
 }

--- a/clustering/web-infinispan/src/test/java/org/jboss/as/clustering/web/infinispan/JvmRouteCacheSourceTest.java
+++ b/clustering/web-infinispan/src/test/java/org/jboss/as/clustering/web/infinispan/JvmRouteCacheSourceTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.when;
 import static org.junit.Assert.*;
 
 import org.infinispan.Cache;
+import org.infinispan.config.Configuration;
+import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.as.clustering.web.LocalDistributableSessionManager;
 import org.jboss.metadata.web.jboss.ReplicationConfig;
@@ -62,8 +64,11 @@ public class JvmRouteCacheSourceTest {
         when((ServiceController<EmbeddedCacheManager>) registry.getRequiredService(name)).thenReturn(controller);
         when(controller.getValue()).thenReturn(container);
         when(manager.getEngineName()).thenReturn(engine);
+        when(container.cacheExists(engine)).thenReturn(false, true);
         when(container.getCache(engine)).thenReturn(cache);
+        when(container.defineConfiguration(engine, CacheContainer.DEFAULT_CACHE_NAME, new Configuration())).thenReturn(new Configuration()).thenThrow(new AssertionError());
 
+        assertSame(cache, source.getCache(registry, manager));
         assertSame(cache, source.getCache(registry, manager));
     }
 }


### PR DESCRIPTION
AS7-1719 Add org.jgroups dependency to org.jboss.as.clustering.web.infinispan module, to avoid sporadic CNFEs since the org.jgroups module is an optional dependency of the org.infinispan module
AS7-1750 Invocation batching not enabled errors when using DIST mode for web sessions
