### PR TITLE
AS7-1832

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -223,6 +223,7 @@ public class ModelDescriptionConstants {
     public static final String STEPS = "steps";
     /** The key for {@link AttributeAccess.Storage} fields. */
     public static final String STORAGE = "storage";
+    public static final String SUBDEPLOYMENT = "subdeployment";
     public static final String SUBSYSTEM = "subsystem";
     public static final String SUCCESS = "success";
     public static final String SYSTEM_PROPERTY = "system-property";

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/common/DeploymentDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/common/DeploymentDescription.java
@@ -169,6 +169,25 @@ public class DeploymentDescription {
         return root;
     }
 
+    public static ModelNode getSubDeploymentDescription(Locale locale) {
+        final ResourceBundle bundle = getResourceBundle(locale);
+        final ModelNode root = new ModelNode();
+        root.get(DESCRIPTION).set(bundle.getString("deployment.subdeployment"));
+
+        root.get(ATTRIBUTES).setEmptyObject();
+        root.get(OPERATIONS); // placeholder
+
+        root.get(CHILDREN, SUBSYSTEM, DESCRIPTION).set(bundle.getString("deployment.subsystem"));
+        root.get(CHILDREN, SUBSYSTEM, MIN_OCCURS).set(0);
+        root.get(CHILDREN, SUBSYSTEM, MODEL_DESCRIPTION);
+
+        root.get(CHILDREN, SUBDEPLOYMENT, DESCRIPTION).set(bundle.getString("deployment.subdeployment"));
+        root.get(CHILDREN, SUBDEPLOYMENT, MIN_OCCURS).set(0);
+        root.get(CHILDREN, SUBDEPLOYMENT, MODEL_DESCRIPTION);
+
+        return root;
+    }
+
     public static final ModelNode getUploadDeploymentBytesOperation(Locale locale) {
         final ResourceBundle bundle = getResourceBundle(locale);
         final ModelNode root = new ModelNode();

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/common/DeploymentDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/common/DeploymentDescription.java
@@ -39,7 +39,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HEA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INPUT_STREAM_INDEX;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_LENGTH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_LENGTH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_OCCURS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
@@ -54,6 +56,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQ
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATUS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TAIL_COMMENT_ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_REPLACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
@@ -76,7 +80,7 @@ public class DeploymentDescription {
     private DeploymentDescription() {
     }
 
-    public static final ModelNode getDeploymentDescription(Locale locale, boolean includeEnabled, boolean includeContent) {
+    public static final ModelNode getDeploymentDescription(Locale locale, boolean includeEnabled, boolean includeContent, boolean includeRuntime) {
         final ResourceBundle bundle = getResourceBundle(locale);
         final ModelNode root = new ModelNode();
         root.get(DESCRIPTION).set(bundle.getString("deployment"));
@@ -147,8 +151,21 @@ public class DeploymentDescription {
                 root.get(ATTRIBUTES, STATUS, REQUIRED).set(false);
             }
         }
-        root.get(OPERATIONS);
-        root.get(CHILDREN).setEmptyObject();
+
+        root.get(OPERATIONS);  // placeholder
+
+        if (includeRuntime) {
+            root.get(CHILDREN, SUBSYSTEM, DESCRIPTION).set(bundle.getString("deployment.subsystem"));
+            root.get(CHILDREN, SUBSYSTEM, MIN_OCCURS).set(0);
+            root.get(CHILDREN, SUBSYSTEM, MODEL_DESCRIPTION);
+
+            root.get(CHILDREN, SUBDEPLOYMENT, DESCRIPTION).set(bundle.getString("deployment.subdeployment"));
+            root.get(CHILDREN, SUBDEPLOYMENT, MIN_OCCURS).set(0);
+            root.get(CHILDREN, SUBDEPLOYMENT, MODEL_DESCRIPTION);
+        } else {
+            root.get(CHILDREN).setEmptyObject();
+        }
+
         return root;
     }
 
@@ -348,7 +365,7 @@ public class DeploymentDescription {
     }
 
     public static void main(String[] args) {
-        System.out.println(getDeploymentDescription(null, true, true));
+        System.out.println(getDeploymentDescription(null, true, true, false));
         System.out.println(getAddDeploymentOperation(null, true));
         System.out.println(getDeployDeploymentOperation(null));
         System.out.println(getFullReplaceDeploymentOperation(null));

--- a/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
@@ -79,9 +79,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param operationName the operation name
      * @return the operation entry flags or {@code null}
      *
-     * @deprecated may change in AS 7.1
      */
-    @Deprecated
     Set<OperationEntry.Flag> getOperationFlags(PathAddress address, String operationName);
 
     /**

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -139,6 +139,9 @@ deployment.full-replace=Add previously uploaded deployment content to the list o
 deployment.undeploy=Undeploy content from the runtime. The content remains in the list of content available for use.
 deployment.redeploy=Undeploy existing content from the runtime and deploy it again.
 deployment.status=The current runtime status of a deployment. Possible status modes are OK, FAILED, and STOPPED. FAILED indicates a dependency is missing or a service could not start. STOPPED indicates that the deployment was manually stopped.
+deployment.subsystem=Runtime resources created when the deployment is deployed, organized by the subsystem responsible for the runtime resource.
+deployment.subdeployment=Runtime resources associated with a child deployment packaged inside another deployment; for example a war packaged inside an ear.
+
 # Global operations
 global.read-attribute=Gets the value of an attribute for the selected resource
 global.read-attribute.name=The name of the attribute to get the value for under the selected resource

--- a/domain-controller/src/main/java/org/jboss/as/domain/controller/descriptions/DomainDescriptionProviders.java
+++ b/domain-controller/src/main/java/org/jboss/as/domain/controller/descriptions/DomainDescriptionProviders.java
@@ -93,7 +93,7 @@ public final class DomainDescriptionProviders {
 
         @Override
         public ModelNode getModelDescription(Locale locale) {
-            return DeploymentDescription.getDeploymentDescription(locale, false, true);
+            return DeploymentDescription.getDeploymentDescription(locale, false, true, false);
         }
     };
 
@@ -107,7 +107,7 @@ public final class DomainDescriptionProviders {
     public static final DescriptionProvider SERVER_GROUP_DEPLOYMENT = new DescriptionProvider() {
         @Override
         public ModelNode getModelDescription(Locale locale) {
-            return DeploymentDescription.getDeploymentDescription(locale, true, false);
+            return DeploymentDescription.getDeploymentDescription(locale, true, false, false);
         }
     };
 

--- a/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
+++ b/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
@@ -53,6 +53,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SEC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE_CONTAINER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
@@ -303,8 +304,7 @@ public class
         deployments.registerMetric(DeploymentStatusHandler.ATTRIBUTE_NAME, DeploymentStatusHandler.INSTANCE);
 
         // The sub-deployments registry
-        // TODO this does not look correct, as it implies all the ops available at "/deployment=x" are available at /deployment=x/subdeployment=y and that isn't the case
-        deployments.registerSubModel(PathElement.pathElement("subdeployment"), deployments);
+        deployments.registerSubModel(PathElement.pathElement(SUBDEPLOYMENT), ServerDescriptionProviders.SUBDEPLOYMENT_PROVIDER);
 
 
         // Extensions

--- a/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
+++ b/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
@@ -303,6 +303,7 @@ public class
         deployments.registerMetric(DeploymentStatusHandler.ATTRIBUTE_NAME, DeploymentStatusHandler.INSTANCE);
 
         // The sub-deployments registry
+        // TODO this does not look correct, as it implies all the ops available at "/deployment=x" are available at /deployment=x/subdeployment=y and that isn't the case
         deployments.registerSubModel(PathElement.pathElement("subdeployment"), deployments);
 
 

--- a/server/src/main/java/org/jboss/as/server/controller/descriptions/ServerDescriptionProviders.java
+++ b/server/src/main/java/org/jboss/as/server/controller/descriptions/ServerDescriptionProviders.java
@@ -23,10 +23,8 @@ package org.jboss.as.server.controller.descriptions;
 
 
 import java.util.Locale;
-import java.util.ResourceBundle;
 
 import org.jboss.as.controller.descriptions.DescriptionProvider;
-import org.jboss.as.controller.descriptions.common.CommonDescriptions;
 import org.jboss.as.controller.descriptions.common.DeploymentDescription;
 import org.jboss.as.controller.descriptions.common.SocketBindingGroupDescription;
 import org.jboss.dmr.ModelNode;
@@ -65,7 +63,7 @@ public final class ServerDescriptionProviders {
 
         @Override
         public ModelNode getModelDescription(Locale locale) {
-            return DeploymentDescription.getDeploymentDescription(locale, true, true);
+            return DeploymentDescription.getDeploymentDescription(locale, true, true, true);
         }
     };
 

--- a/server/src/main/java/org/jboss/as/server/controller/descriptions/ServerDescriptionProviders.java
+++ b/server/src/main/java/org/jboss/as/server/controller/descriptions/ServerDescriptionProviders.java
@@ -67,6 +67,14 @@ public final class ServerDescriptionProviders {
         }
     };
 
+    public static final DescriptionProvider SUBDEPLOYMENT_PROVIDER = new DescriptionProvider() {
+
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return DeploymentDescription.getSubDeploymentDescription(locale);
+        }
+    };
+
     public static final DescriptionProvider RELOAD_PROVIDER = new DescriptionProvider() {
 
         @Override

--- a/web/src/main/java/org/jboss/as/web/WebExtension.java
+++ b/web/src/main/java/org/jboss/as/web/WebExtension.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.web;
 
+import org.apache.catalina.servlets.WebdavServlet;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
@@ -75,14 +76,8 @@ public class WebExtension implements Extension {
         hosts.registerOperationHandler(ADD, WebVirtualHostAdd.INSTANCE, WebVirtualHostAdd.INSTANCE, false);
         hosts.registerOperationHandler(REMOVE, WebVirtualHostRemove.INSTANCE, WebVirtualHostRemove.INSTANCE, false);
 
-        DescriptionProvider NULL = new DescriptionProvider() {
-            @Override
-            public ModelNode getModelDescription(Locale locale) {
-                return new ModelNode();
-            }
-        };
-        final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(NULL);
-        final ManagementResourceRegistration servlets = deployments.registerSubModel(PathElement.pathElement("servlet"), NULL);
+        final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(WebSubsystemDescriptionProviders.DEPLOYMENT);
+        final ManagementResourceRegistration servlets = deployments.registerSubModel(PathElement.pathElement("servlet"), WebSubsystemDescriptionProviders.SERVLET);
         ServletDeploymentStats.register(servlets);
     }
 

--- a/web/src/main/java/org/jboss/as/web/WebSubsystemDescriptionProviders.java
+++ b/web/src/main/java/org/jboss/as/web/WebSubsystemDescriptionProviders.java
@@ -33,4 +33,18 @@ class WebSubsystemDescriptionProviders {
         }
     };
 
+    public static final DescriptionProvider DEPLOYMENT = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return WebSubsystemDescriptions.getDeploymentRuntimeDescription(locale);
+        }
+    };
+
+    public static final DescriptionProvider SERVLET = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return WebSubsystemDescriptions.getDeploymentServletDescription(locale);
+        }
+    };
+
 }

--- a/web/src/main/java/org/jboss/as/web/WebSubsystemDescriptions.java
+++ b/web/src/main/java/org/jboss/as/web/WebSubsystemDescriptions.java
@@ -29,8 +29,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEF
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HEAD_COMMENT_ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_OCCURS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_OCCURS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
@@ -638,10 +641,53 @@ class WebSubsystemDescriptions {
         return node;
     }
 
+    static ModelNode getDeploymentRuntimeDescription(Locale locale) {
+        final ResourceBundle bundle = getResourceBundle(locale);
+
+        final ModelNode node = new ModelNode();
+
+        node.get(DESCRIPTION).set(bundle.getString("web.deployment"));
+        node.get(ATTRIBUTES).setEmptyObject();
+        node.get(OPERATIONS); // placeholder
+
+        node.get(CHILDREN, "servlet", DESCRIPTION).set(bundle.getString("web.deployment.servlet"));
+        node.get(CHILDREN, "servlet", MIN_OCCURS).set(0);
+        node.get(CHILDREN, "servlet", MODEL_DESCRIPTION);
+
+        return node;
+    }
+
+    static ModelNode getDeploymentServletDescription(Locale locale) {
+        final ResourceBundle bundle = getResourceBundle(locale);
+
+        final ModelNode node = new ModelNode();
+
+        node.get(DESCRIPTION).set(bundle.getString("web.deployment.servlet"));
+
+        node.get(ATTRIBUTES, "load-time", DESCRIPTION).set(bundle.getString("web.deployment.servlet.load-time"));
+        node.get(ATTRIBUTES, "load-time", TYPE).set(ModelType.LONG);
+        node.get(ATTRIBUTES, "max-time", DESCRIPTION).set(bundle.getString("web.deployment.servlet.max-time"));
+        node.get(ATTRIBUTES, "max-time", TYPE).set(ModelType.LONG);
+        node.get(ATTRIBUTES, "min-time", DESCRIPTION).set(bundle.getString("web.deployment.servlet.min-time"));
+        node.get(ATTRIBUTES, "min-time", TYPE).set(ModelType.LONG);
+        node.get(ATTRIBUTES, "processing-time", DESCRIPTION).set(bundle.getString("web.deployment.servlet.processing-time"));
+        node.get(ATTRIBUTES, "processing-time", TYPE).set(ModelType.LONG);
+        node.get(ATTRIBUTES, "request-count", DESCRIPTION).set(bundle.getString("web.deployment.servlet.request-count"));
+        node.get(ATTRIBUTES, "request-count", TYPE).set(ModelType.INT);
+
+        node.get(OPERATIONS); // placeholder
+
+        node.get(CHILDREN).setEmptyObject();
+
+        return node;
+    }
+
     private static ResourceBundle getResourceBundle(Locale locale) {
         if (locale == null) {
             locale = Locale.getDefault();
         }
         return ResourceBundle.getBundle(RESOURCE_NAME, locale);
     }
+
+
 }

--- a/web/src/main/java/org/jboss/as/web/deployment/ServletDeploymentStats.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/ServletDeploymentStats.java
@@ -44,7 +44,7 @@ import java.util.Locale;
  */
 public class ServletDeploymentStats {
 
-    static final DescriptionProvider provider = new DescriptionProvider() {
+    public static final DescriptionProvider provider = new DescriptionProvider() {
         @Override
         public ModelNode getModelDescription(Locale locale) {
             return new ModelNode();
@@ -109,7 +109,9 @@ public class ServletDeploymentStats {
                         final String name = node.get("servlet-name").asString();
                         final Context webContext = Context.class.cast(controller.getValue());
                         final Wrapper wrapper = Wrapper.class.cast(webContext.findChild(name));
-                        handle(context.getResult(), address.getLastElement().getValue(), wrapper);
+                        final ModelNode response = new ModelNode();
+                        handle(response, address.getLastElement().getValue(), wrapper);
+                        context.getResult().set(response);
                     }
                     context.completeStep();
                 }

--- a/web/src/main/resources/org/jboss/as/web/LocalDescriptions.properties
+++ b/web/src/main/resources/org/jboss/as/web/LocalDescriptions.properties
@@ -64,7 +64,6 @@ web.connector.stats.error-count=Number of error that occurs when processing requ
 web.connector.stats.max-time=Max time spent to process a requests.
 web.connector.request-count=Number of the request processed by the connector.
 
-
 web.connector.ssl=The SSL configuration of the connector.
 web.connector.ssl.name=The configuration name.
 web.connector.ssl.key-alias=The key alias.
@@ -111,3 +110,11 @@ web.virtual-server.sso=The SSO configuration for this virtual server.
 web.virtual-server.sso.cache-container=Enables clustered SSO using the specified clustered cache container.
 web.virtual-server.sso.domain=The cookie domain that will be used.
 web.virtual-server.sso.reauthenticate=Enables reauthentication with the realm when using SSO.
+
+web.deployment=Runtime resources exposed by web components in the deployment.
+web.deployment.servlet=Runtime information about the servlets in the deployment.
+web.deployment.servlet.load-time=Load time
+web.deployment.servlet.max-time=Maximum processing time of a request
+web.deployment.servlet.min-time=Minimum processing time of a request
+web.deployment.servlet.processing-time=Total execution time of the servlet's service method
+web.deployment.servlet.request-count=Number of requests processed by this servlet

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
@@ -69,12 +69,7 @@ public final class WSExtension implements Extension {
         epConfigs.registerOperationHandler(REMOVE, EndpointConfigRemove.INSTANCE, WSSubsystemProviders.ENDPOINTCONFIG_REMOVE_DESCRIPTION, false);
 
 
-        final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(new DescriptionProvider() {
-            @Override
-            public ModelNode getModelDescription(Locale locale) {
-                return new ModelNode();
-            }
-        });
+        final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(WSSubsystemProviders.DEPLOYMENT_DESCRIPTION);
         // ws endpoint children
         final ManagementResourceRegistration endpoints = deployments.registerSubModel(PathElement.pathElement(ENDPOINT), WSSubsystemProviders.ENDPOINT_DESCRIPTION);
         for (final String attributeName : WSEndpointMetrics.ATTRIBUTES) {

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemProviders.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemProviders.java
@@ -26,8 +26,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HEAD_COMMENT_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_OCCURS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REPLY_PROPERTIES;
@@ -91,6 +94,12 @@ final class WSSubsystemProviders {
     static final DescriptionProvider SUBSYSTEM_DESCRIBE = new DescriptionProvider() {
         public ModelNode getModelDescription(final Locale locale) {
             return CommonDescriptions.getSubsystemDescribeOperation(locale);
+        }
+    };
+
+    static final DescriptionProvider DEPLOYMENT_DESCRIPTION = new DescriptionProvider() {
+        public ModelNode getModelDescription(final Locale locale) {
+            return Descriptions.getDeploymentDescription(locale);
         }
     };
 
@@ -215,6 +224,21 @@ final class WSSubsystemProviders {
             operation.get(REPLY_PROPERTIES).setEmptyObject();
 
             return operation;
+        }
+
+        static ModelNode getDeploymentDescription(Locale locale) {
+            final ResourceBundle bundle = getResourceBundle(locale);
+            final ModelNode node = new ModelNode();
+
+            node.get(DESCRIPTION).set(bundle.getString("deployment"));
+            node.get(ATTRIBUTES).setEmptyObject();
+            node.get(OPERATIONS); // placeholder
+
+            node.get(CHILDREN, ENDPOINT, DESCRIPTION).set(bundle.getString("endpoint"));
+            node.get(CHILDREN, ENDPOINT, MIN_OCCURS).set(0);
+            node.get(CHILDREN, ENDPOINT, MODEL_DESCRIPTION);
+
+            return node;
         }
 
         static ModelNode getEndpointDescription(final Locale locale) {
@@ -471,7 +495,6 @@ final class WSSubsystemProviders {
 
             return op;
         }
-
     }
 
 }

--- a/webservices/server-integration/src/main/resources/org/jboss/as/webservices/dmr/LocalDescriptions.properties
+++ b/webservices/server-integration/src/main/resources/org/jboss/as/webservices/dmr/LocalDescriptions.properties
@@ -1,5 +1,6 @@
 ws=The configuration of the web services subsystem.
 ws.add=Adds the web services subsystem.
+deployment=Runtime resources exposed by web service components in the deployment.
 endpoint=Webservice endpoint.
 endpoint.name=Webservice endpoint name.
 endpoint.context=Webservice endpoint context.
@@ -20,7 +21,7 @@ request.count=Count of requests the endpoint processed.
 response.count=Count of responses the endpoint generated.
 fault.count=Count of faults the endpoint generated.
 
-endpoint.config=Webservice Endpoint configuration 
+endpoint.config=Webservice Endpoint configuration
 endpoint.config.add=Add a new endpoint configuration
 endpoint.config.remove=Remove a endpoint configuration
 endpoint.config.name=Endpoint configuration name


### PR DESCRIPTION
Fixes AS7-1832 plus fixes the /deployment=8/subdeployment=\* runtime resource so it doesn't expose the attributes and operations of its non-runtime-only parent.
