### PR TITLE
Make CDI class loading failures show up in the logs

### DIFF
--- a/build/src/main/resources/domain/configuration/domain-preview.xml
+++ b/build/src/main/resources/domain/configuration/domain-preview.xml
@@ -78,6 +78,10 @@
                 <logger category="org.apache.tomcat.util.modeler">
                     <level name="WARN"/>
                 </logger>
+                <!-- This makes CDI class loading problems visible-->
+                <logger category="org.jboss.weld.ClassLoading">
+                    <level name="DEBUG"/>
+                </logger>
                 <logger category="sun.rmi">
                     <level name="WARN"/>
                 </logger>

--- a/build/src/main/resources/domain/configuration/domain.xml
+++ b/build/src/main/resources/domain/configuration/domain.xml
@@ -74,6 +74,10 @@
                 <logger category="org.apache.tomcat.util.modeler">
                     <level name="WARN"/>
                 </logger>
+                <!-- This makes CDI class loading problems visible-->
+                <logger category="org.jboss.weld.ClassLoading">
+                    <level name="DEBUG"/>
+                </logger>
                 <logger category="sun.rmi">
                     <level name="WARN"/>
                 </logger>

--- a/build/src/main/resources/standalone/configuration/standalone-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-ha.xml
@@ -83,6 +83,10 @@
             <logger category="org.apache.tomcat.util.modeler">
                 <level name="WARN"/>
             </logger>
+            <!-- This makes CDI class loading problems visible-->
+            <logger category="org.jboss.weld.ClassLoading">
+                <level name="DEBUG"/>
+            </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>

--- a/build/src/main/resources/standalone/configuration/standalone-preview-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-preview-ha.xml
@@ -86,6 +86,10 @@
             <logger category="org.apache.tomcat.util.modeler">
                 <level name="WARN"/>
             </logger>
+            <!-- This makes CDI class loading problems visible-->
+            <logger category="org.jboss.weld.ClassLoading">
+                <level name="DEBUG"/>
+            </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>

--- a/build/src/main/resources/standalone/configuration/standalone-preview.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-preview.xml
@@ -85,6 +85,10 @@
             <logger category="org.apache.tomcat.util.modeler">
                 <level name="WARN"/>
             </logger>
+            <!-- This makes CDI class loading problems visible-->
+            <logger category="org.jboss.weld.ClassLoading">
+                <level name="DEBUG"/>
+            </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>

--- a/build/src/main/resources/standalone/configuration/standalone-xts.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-xts.xml
@@ -85,6 +85,10 @@
             <logger category="org.apache.tomcat.util.modeler">
                 <level name="WARN"/>
             </logger>
+            <!-- This makes CDI class loading problems visible-->
+            <logger category="org.jboss.weld.ClassLoading">
+                <level name="DEBUG"/>
+            </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -82,6 +82,10 @@
             <logger category="org.apache.tomcat.util.modeler">
                 <level name="WARN"/>
             </logger>
+            <!-- This makes CDI class loading problems visible-->
+            <logger category="org.jboss.weld.ClassLoading">
+                <level name="DEBUG"/>
+            </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>


### PR DESCRIPTION
These have their own logging category in weld, so this will not show any other weld debug information
