### PR TITLE
[AS7-1861] For requests passed over a proxy avoid connection specific cac

### DIFF
--- a/domain-http-api/src/main/java/org/jboss/as/domain/http/server/Constants.java
+++ b/domain-http-api/src/main/java/org/jboss/as/domain/http/server/Constants.java
@@ -46,6 +46,7 @@ public interface Constants {
     String CONTENT_DISPOSITION = "Content-Disposition";
     String CONTENT_TYPE = "Content-Type";
     String LOCATION = "Location";
+    String VIA = "Via";
     String WWW_AUTHENTICATE_HEADER = "WWW-Authenticate";
 
     /*

--- a/domain-http-api/src/main/java/org/jboss/as/domain/http/server/security/DigestAuthenticator.java
+++ b/domain-http-api/src/main/java/org/jboss/as/domain/http/server/security/DigestAuthenticator.java
@@ -23,9 +23,8 @@
 package org.jboss.as.domain.http.server.security;
 
 import static org.jboss.as.domain.http.server.Constants.AUTHORIZATION_HEADER;
-import static org.jboss.as.domain.http.server.Constants.FORBIDDEN;
-import static org.jboss.as.domain.http.server.Constants.GET;
 import static org.jboss.as.domain.http.server.Constants.UNAUTHORIZED;
+import static org.jboss.as.domain.http.server.Constants.VIA;
 import static org.jboss.as.domain.http.server.Constants.WWW_AUTHENTICATE_HEADER;
 
 import javax.security.auth.callback.Callback;
@@ -349,13 +348,20 @@ public class DigestAuthenticator extends Authenticator {
 
 
     private DigestContext getOrCreateNegotiationContext(HttpExchange httpExchange) {
-        DigestContext context = (DigestContext) httpExchange.getAttribute(DigestContext.KEY, HttpExchange.AttributeScope.CONNECTION);
-        if (context == null) {
-            context = new DigestContext();
-            httpExchange.setAttribute(DigestContext.KEY, context, HttpExchange.AttributeScope.CONNECTION);
+        Headers headers = httpExchange.getRequestHeaders();
+        boolean proxied = headers.containsKey(VIA);
+
+        if (proxied) {
+            return new DigestContext();
+        } else {
+            DigestContext context = (DigestContext) httpExchange.getAttribute(DigestContext.KEY, HttpExchange.AttributeScope.CONNECTION);
+            if (context == null) {
+                context = new DigestContext();
+                httpExchange.setAttribute(DigestContext.KEY, context, HttpExchange.AttributeScope.CONNECTION);
+            }
+            return context;
         }
 
-        return context;
     }
 
 


### PR DESCRIPTION
[AS7-1861] For requests passed over a proxy avoid connection specific caching as most likely proxy is maintaining a pool of connections independent of the actual clients.
