### PR TITLE
Remove reference to outdated and confusing EJB3 project versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,9 +119,7 @@
         <version.org.jboss.arquillian.osgi>1.0.0.CR4</version.org.jboss.arquillian.osgi>
         <version.org.jboss.classfilewriter>1.0.0.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.com.sun.httpserver>1.0.0.Beta2</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb3>2.0.0-beta-2</version.org.jboss.ejb3>
         <version.org.jboss.ejb3.ext-api>2.0.0-beta-1</version.org.jboss.ejb3.ext-api>
-        <version.org.jboss.ejb3.timerservice>2.0.0-beta-3</version.org.jboss.ejb3.timerservice>
         <version.org.jboss.integration.jboss-jca-spi>6.0.0.CR1</version.org.jboss.integration.jboss-jca-spi>
         <version.org.jboss.interceptor>2.0.0.Alpha3</version.org.jboss.interceptor>
         <version.org.jboss.invocation>1.1.0.Final</version.org.jboss.invocation>


### PR DESCRIPTION
Minor change to remove references in pom.xml to outdated EJB3 project versions. The EJB3 code is mostly based in AS7 codebase after one of the recent refactors, so these EJB3 project versions are no longer relevant.
