### PR TITLE
Fix for "timeout-unit" attribute model description in EJB3 subsystem

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDescriptions.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDescriptions.java
@@ -241,10 +241,10 @@ public class EJB3SubsystemDescriptions {
         description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, TYPE).set(ModelType.STRING);
         description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, REQUIRED).set(false);
         description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, DEFAULT).set(StrictMaxPoolConfig.DEFAULT_TIMEOUT_UNIT.name());
-        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).set(TimeUnit.HOURS.name());
-        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).set(TimeUnit.MINUTES.name());
-        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).set(TimeUnit.SECONDS.name());
-        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).set(TimeUnit.MILLISECONDS.name());
+        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).add(TimeUnit.HOURS.name());
+        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).add(TimeUnit.MINUTES.name());
+        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).add(TimeUnit.SECONDS.name());
+        description.get(ATTRIBUTES, INSTANCE_ACQUISITION_TIMEOUT_UNIT, ALLOWED).add(TimeUnit.MILLISECONDS.name());
 
         description.get(OPERATIONS); // placeholder
 


### PR DESCRIPTION
The commit contains a (minor) fix for setting right the model description of "timeout-unit" attribute in the EJB3 subsystem.
