### PR TITLE
Use the new connector integration API to get the ServiceName for a RA

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.ejb3.component.messagedriven;
 
+import org.jboss.as.connector.ConnectorServices;
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ejb3.component.EJBComponentCreateService;
@@ -36,6 +37,7 @@ import org.jboss.msc.value.InjectedValue;
 import javax.resource.ResourceException;
 import javax.resource.spi.ActivationSpec;
 import javax.resource.spi.ResourceAdapter;
+import java.util.Collection;
 import java.util.Properties;
 
 /**
@@ -124,8 +126,11 @@ public class MessageDrivenComponentCreateService extends EJBComponentCreateServi
     }
 
     ServiceName getResourceAdapterServiceName() {
-        // See ResourceAdapterDeploymentService
-        return ServiceName.JBOSS.append("ra").append(this.resourceAdapterName);
+        final Collection<ServiceName> serviceNames = ConnectorServices.getResourceAdapteServiceName(this.resourceAdapterName);
+        if (serviceNames == null || serviceNames.isEmpty()) {
+            throw new IllegalStateException("Cannot find any resource adapter service for resource adapter " + this.resourceAdapterName);
+        }
+        return serviceNames.iterator().next();
     }
 
     private String stripDotRarSuffix(final String raName) {


### PR DESCRIPTION
Now that https://issues.jboss.org/browse/AS7-1691 has been fixed, this commit ensures that the EJB MDB integration layer uses the correct API exposed by the connector module in AS7, to get hold of the RA service name for adding a dependency.
