### PR TITLE
AS7-932 OSGi Runtime Bundle Management through Detyped API

### DIFF
--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/BundleRuntimeHandler.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/BundleRuntimeHandler.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.parser;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.osgi.framework.Services;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author David Bosschaert
+ */
+public class BundleRuntimeHandler extends AbstractRuntimeOnlyHandler {
+
+    public static final BundleRuntimeHandler INSTANCE = new BundleRuntimeHandler();
+
+    public static final String [] ATTRIBUTES = { CommonAttributes.ID, CommonAttributes.SYMBOLIC_NAME, CommonAttributes.VERSION };
+
+    private BundleRuntimeHandler() {
+    }
+
+    public void register(ManagementResourceRegistration registry) {
+        for (String attr : ATTRIBUTES) {
+            registry.registerReadOnlyAttribute(attr, this, AttributeAccess.Storage.RUNTIME);
+        }
+    }
+
+    @Override
+    protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final String operationName = operation.require(OP).asString();
+        if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+            handleReadAttribute(context, operation);
+        }
+    }
+
+    private void handleReadAttribute(OperationContext context, ModelNode operation) {
+        String name = operation.require(ModelDescriptionConstants.NAME).asString();
+        Long id = Long.parseLong(PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue());
+        BundleContext bc = getBundleContext(context);
+
+        if (CommonAttributes.ID.equals(name)) {
+            context.getResult().set(id);
+        } else if (CommonAttributes.SYMBOLIC_NAME.equals(name)) {
+            Bundle b = bc.getBundle(id);
+            context.getResult().set(b.getSymbolicName());
+        } else if (CommonAttributes.VERSION.equals(name)) {
+            Bundle b = bc.getBundle(id);
+            context.getResult().set(b.getVersion().toString());
+        }
+
+        context.completeStep();
+    }
+
+    private BundleContext getBundleContext(OperationContext context) {
+        ServiceController<?> sbs = context.getServiceRegistry(false).getService(Services.SYSTEM_BUNDLE);
+        if (sbs == null) {
+            return null;
+        }
+
+        Bundle systemBundle = Bundle.class.cast(sbs.getValue());
+        return systemBundle.getBundleContext();
+    }
+}

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/CommonAttributes.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/CommonAttributes.java
@@ -28,11 +28,17 @@ package org.jboss.as.osgi.parser;
 interface CommonAttributes {
 
     String ACTIVATION = "activation";
+    String BUNDLE = "bundle";
     String CONFIGURATION = "configuration";
     String ENTRIES = "entries";
     String MODULE = "module";
     String PROPERTY = "property";
     String STARTLEVEL = "start";
     String VALUE = "value";
+
+    // Attributes on the Bundle resource
+    String ID = "id";
+    String SYMBOLIC_NAME = "symbolic-name";
+    String VERSION = "version";
 
 }

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiBundleResource.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiBundleResource.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.parser;
+
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * More or less copied from org.jboss.as.messaging.CoreAddressResource.
+ *
+ * @author David Bosschaert
+ */
+public class OSGiBundleResource implements Resource {
+    static OSGiBundleResource INSTANCE = new OSGiBundleResource();
+
+    private OSGiBundleResource() {
+    }
+
+    @Override
+    public ModelNode getModel() {
+        return new ModelNode();
+    }
+
+    @Override
+    public void writeModel(ModelNode newModel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isModelDefined() {
+        return false;
+    }
+
+    @Override
+    public boolean hasChild(PathElement element) {
+        return false;
+    }
+
+    @Override
+    public Resource getChild(PathElement element) {
+        return null;
+    }
+
+    @Override
+    public Resource requireChild(PathElement element) {
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public boolean hasChildren(String childType) {
+        return false;
+    }
+
+    @Override
+    public Resource navigate(PathAddress address) {
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public Set<String> getChildTypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getChildrenNames(String childType) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ResourceEntry> getChildren(String childType) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void registerChild(PathElement address, Resource resource) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Resource removeChild(PathElement address) {
+        return null;
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return true;
+    }
+
+    @Override
+    public boolean isProxy() {
+        return false;
+    }
+
+    @Override
+    public Resource clone()  {
+        return new OSGiBundleResource();
+    }
+
+    static class OSGiBundleResourceEntry extends OSGiBundleResource implements ResourceEntry {
+        final PathElement path;
+
+        public OSGiBundleResourceEntry(String name) {
+            path = PathElement.pathElement(CommonAttributes.BUNDLE, name);
+        }
+
+        @Override
+        public String getName() {
+            return path.getValue();
+        }
+
+        @Override
+        public PathElement getPathElement() {
+            return path;
+        }
+
+        @Override
+        public OSGiBundleResourceEntry clone() {
+            return new OSGiBundleResourceEntry(path.getValue());
+        }
+    }
+}

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiExtension.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiExtension.java
@@ -23,6 +23,7 @@ package org.jboss.as.osgi.parser;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
+import static org.jboss.as.osgi.parser.CommonAttributes.BUNDLE;
 import static org.jboss.as.osgi.parser.CommonAttributes.CONFIGURATION;
 import static org.jboss.as.osgi.parser.CommonAttributes.MODULE;
 import static org.jboss.as.osgi.parser.CommonAttributes.PROPERTY;
@@ -77,6 +78,10 @@ public class OSGiExtension implements Extension {
         ManagementResourceRegistration modules = registration.registerSubModel(PathElement.pathElement(MODULE), OSGiSubsystemProviders.OSGI_MODULE_RESOURCE);
         modules.registerOperationHandler(ModelDescriptionConstants.ADD, OSGiModuleAdd.INSTANCE, OSGiModuleAdd.INSTANCE, false);
         modules.registerOperationHandler(ModelDescriptionConstants.REMOVE, OSGiModuleRemove.INSTANCE, OSGiModuleRemove.INSTANCE, false);
+
+        // Bundles present at runtime
+        ManagementResourceRegistration bundles = registration.registerSubModel(PathElement.pathElement(BUNDLE), OSGiSubsystemProviders.OSGI_BUNDLE_RESOURCE);
+        BundleRuntimeHandler.INSTANCE.register(bundles);
 
         subsystem.registerXMLElementWriter(parser);
     }

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiRuntimeResource.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiRuntimeResource.java
@@ -1,0 +1,220 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.parser;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author David Bosschaert
+ */
+public class OSGiRuntimeResource implements Resource {
+    private final Resource delegate;
+    private SystemBundleControllerHolder systemBundleControllerHolder;
+
+    private static class SystemBundleControllerHolder {
+        ServiceController<Bundle> systemBundleController;
+    }
+
+    public OSGiRuntimeResource() {
+        this(Resource.Factory.create(), new SystemBundleControllerHolder());
+    }
+
+    public OSGiRuntimeResource(Resource delegate, SystemBundleControllerHolder holder) {
+        this.delegate = delegate;
+        this.systemBundleControllerHolder = holder;
+    }
+
+    public void setBundleContextServiceController(ServiceController<Bundle> serviceController) {
+        systemBundleControllerHolder.systemBundleController = serviceController;
+    }
+
+    @Override
+    public ModelNode getModel() {
+        return delegate.getModel();
+    }
+
+    @Override
+    public void writeModel(ModelNode newModel) {
+        delegate.writeModel(newModel);
+    }
+
+    @Override
+    public boolean isModelDefined() {
+        return delegate.isModelDefined();
+    }
+
+    @Override
+    public boolean hasChild(PathElement element) {
+        if (CommonAttributes.BUNDLE.equals(element.getKey()))
+            return hasBundle(element);
+        else
+            return delegate.hasChild(element);
+    }
+
+    @Override
+    public Resource getChild(PathElement element) {
+        if (CommonAttributes.BUNDLE.equals(element.getKey()))
+            return hasBundle(element) ? OSGiBundleResource.INSTANCE : null;
+        else
+            return delegate.getChild(element);
+    }
+
+    @Override
+    public Resource requireChild(PathElement element) {
+        if (CommonAttributes.BUNDLE.equals(element.getKey())) {
+            if (hasBundle(element))
+                return OSGiBundleResource.INSTANCE;
+            throw new NoSuchElementException(element.toString());
+        } else {
+            return delegate.requireChild(element);
+        }
+    }
+
+    @Override
+    public boolean hasChildren(String childType) {
+        if (CommonAttributes.BUNDLE.equals(childType))
+            return getChildrenNames(CommonAttributes.BUNDLE).size() > 0;
+        else
+            return delegate.hasChildren(childType);
+    }
+
+    @Override
+    public Resource navigate(PathAddress address) {
+        if (address.size() > 0 && CommonAttributes.BUNDLE.equals(address.getElement(0).getKey())) {
+            if (address.size() > 1) {
+                throw new NoSuchElementException(address.subAddress(1).toString());
+            }
+            return OSGiBundleResource.INSTANCE;
+        } else {
+            return delegate.navigate(address);
+        }
+    }
+
+    @Override
+    public Set<String> getChildTypes() {
+        Set<String> result = new HashSet<String>(delegate.getChildTypes());
+        result.add(CommonAttributes.BUNDLE);
+        return result;
+    }
+
+    @Override
+    public Set<String> getChildrenNames(String childType) {
+        if (CommonAttributes.BUNDLE.equals(childType))
+            return getBundleIDs();
+        else
+            return delegate.getChildrenNames(childType);
+    }
+
+    @Override
+    public Set<ResourceEntry> getChildren(String childType) {
+        if (CommonAttributes.BUNDLE.equals(childType)) {
+            Set<ResourceEntry> result = new HashSet<Resource.ResourceEntry>();
+            for (String id : getBundleIDs()) {
+                result.add(new OSGiBundleResource.OSGiBundleResourceEntry(id));
+            }
+            return result;
+        } else {
+            return delegate.getChildren(childType);
+        }
+    }
+
+    @Override
+    public void registerChild(PathElement address, Resource resource) {
+        if (CommonAttributes.BUNDLE.equals(address.getKey())) {
+            throw new UnsupportedOperationException();
+        } else {
+            delegate.registerChild(address, resource);
+        }
+    }
+
+    @Override
+    public Resource removeChild(PathElement address) {
+        if (CommonAttributes.BUNDLE.equals(address.getKey())) {
+            throw new UnsupportedOperationException();
+        } else {
+            return delegate.removeChild(address);
+        }
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return false;
+    }
+
+    @Override
+    public boolean isProxy() {
+        return false;
+    }
+
+    @Override
+    public Resource clone() {
+        return new OSGiRuntimeResource(delegate.clone(), systemBundleControllerHolder);
+    }
+
+    private boolean hasBundle(PathElement element) {
+        BundleContext ctx = getBundleContext();
+        if (ctx == null)
+            return false;
+
+        try {
+            long id = Long.parseLong(element.getValue());
+            return ctx.getBundle(id) != null;
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
+
+    private Set<String> getBundleIDs() {
+        BundleContext ctx = getBundleContext();
+
+        if (ctx == null) {
+            return Collections.emptySet();
+        } else {
+            Set<String> result = new TreeSet<String>();
+            for (Bundle b : ctx.getBundles()) {
+                result.add(Long.toString(b.getBundleId()));
+            }
+            return result;
+        }
+    }
+
+    private BundleContext getBundleContext() {
+        if (systemBundleControllerHolder.systemBundleController == null ||
+            systemBundleControllerHolder.systemBundleController.getState() != ServiceController.State.UP) {
+            return null;
+        } else {
+            return systemBundleControllerHolder.systemBundleController.getValue().getBundleContext();
+        }
+    }
+}

--- a/osgi/service/src/main/resources/org/jboss/as/osgi/parser/LocalDescriptions.properties
+++ b/osgi/service/src/main/resources/org/jboss/as/osgi/parser/LocalDescriptions.properties
@@ -3,6 +3,11 @@ osgi.add=Operation adding the OSGi subsystem
 
 activation=How the OSGi subsystem is activated. Possible values: lazy, eager.
 
+bundle=Runtime OSGi Bundle information.
+bundle.id=The bundle ID.
+bundle.bsn=The bundle symbolic name.
+bundle.version=The bundle version.
+
 config=OSGi Configuration Admin information. 
 config.add=Add OSGi Configuration Admin configuration, the primary key of the configuration represents the PID.
 config.remove=Remove OSGi Configuration Admin configuration.
@@ -17,3 +22,4 @@ module=Pre-loaded modules and bundles.
 module.add=Add pre-loaded module.
 module.remove=Remove a pre-loaded module.
 module.startlevel=Sets the startlevel of a pre-loaded module. Setting the start level causes the module to be started once the relevant framework startlevel has been reached. Specifying the start level only applies to modules which are OSGi bundles.
+


### PR DESCRIPTION
This commit add a baseline for this functionality. The bundle resource
under the osgi subsystem lists the bundles installed in the system.

This is modeled on a similar runtime resource that exist in the Messaging Subsystem.

Currently the bundle resources only have 3 attributes: id, bundle symbolic name and version.
Further details on what attributes the bundles should ultimately expose is tbd.
