### PR TITLE
[AS7-1912] Fix or remove @Ignore in EnterpriseDeploymentTestCase

### DIFF
--- a/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/deployment/EnterpriseDeploymentTestCase.java
+++ b/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/deployment/EnterpriseDeploymentTestCase.java
@@ -113,7 +113,7 @@ public class EnterpriseDeploymentTestCase {
     }
 
     @Test
-    @Ignore
+    @Ignore("[AS7-1929] Invalid webapp deploys without error in management API")
     public void testDistributeBadWar() throws Exception {
         ProgressObject progress = jsr88Deploy(getBadWebArchive());
         TargetModuleID[] targetModules = progress.getResultTargetModuleIDs();

--- a/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/deployment/EnterpriseDeploymentTestCase.java
+++ b/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/deployment/EnterpriseDeploymentTestCase.java
@@ -52,7 +52,6 @@ import javax.enterprise.deploy.spi.status.ProgressEvent;
 import javax.enterprise.deploy.spi.status.ProgressListener;
 import javax.enterprise.deploy.spi.status.ProgressObject;
 
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.ee.deployment.spi.DeploymentManagerImpl;
@@ -76,9 +75,8 @@ import org.junit.runner.RunWith;
  * @author Thomas.Diesler@jboss.com
  * @since 02-Aug-2011
  */
-@RunWith(Arquillian.class)
 @RunAsClient
-@Ignore
+@RunWith(Arquillian.class)
 public class EnterpriseDeploymentTestCase {
 
     private static final String WAR_JBOSS_FILE = "WEB-INF/jboss-web.xml";
@@ -86,12 +84,6 @@ public class EnterpriseDeploymentTestCase {
     private static final String EAR_JBOSS_FILE = "META-INF/jboss-app.xml";
 
     private DeploymentManager deploymentManager;
-
-    @Deployment
-    public static Archive<?> createDeployment(){
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "deployment-test.jar");
-        return archive;
-    }
 
     @Test
     public void testDeploymentManager() throws Exception {

--- a/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/deployment/EnterpriseDeploymentTestCase.java
+++ b/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/deployment/EnterpriseDeploymentTestCase.java
@@ -227,6 +227,10 @@ public class EnterpriseDeploymentTestCase {
     }
 
     private void awaitCompletion(ProgressObject progress, long timeout) throws InterruptedException {
+        DeploymentStatus status = progress.getDeploymentStatus();
+        if (status.isCompleted())
+            return;
+
         final CountDownLatch latch = new CountDownLatch(1);
         progress.addProgressListener(new ProgressListener() {
             public void handleProgressEvent(ProgressEvent event) {
@@ -236,7 +240,8 @@ public class EnterpriseDeploymentTestCase {
                 }
             }
         });
-        if (latch.await(timeout, TimeUnit.MILLISECONDS) == false)
+
+        if (!status.isCompleted() && latch.await(timeout, TimeUnit.MILLISECONDS) == false)
             throw new IllegalStateException("Deployment not completed: " + progress);
     }
 


### PR DESCRIPTION
This functionality is critical for the TCK. Apparently there is a race condition somewhere. I cannot reproduce the failure.
