### PR TITLE
[AS7-1976] JSF version should be set/obtained from the deployment unit (WAR) and not from the parent (EAR)

### DIFF
--- a/web/src/main/java/org/jboss/as/web/deployment/WarClassloadingDependencyProcessor.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/WarClassloadingDependencyProcessor.java
@@ -68,11 +68,10 @@ public class WarClassloadingDependencyProcessor implements DeploymentUnitProcess
             return; // Skip non web deployments
         }
 
-        final DeploymentUnit topLevelDeployment = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         final ModuleLoader moduleLoader = Module.getBootModuleLoader();
 
-        final String jsfVersion = JsfVersionMarker.getVersion(topLevelDeployment);
+        final String jsfVersion = JsfVersionMarker.getVersion(deploymentUnit);
 
         addJSFAPI(jsfVersion, moduleSpecification, moduleLoader);
 

--- a/web/src/main/java/org/jboss/as/web/deployment/jsf/JsfVersionProcessor.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/jsf/JsfVersionProcessor.java
@@ -45,7 +45,6 @@ public class JsfVersionProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        final DeploymentUnit topLevelDeployment = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();
         final WarMetaData metaData = deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY);
 
         if (metaData == null) {
@@ -75,12 +74,12 @@ public class JsfVersionProcessor implements DeploymentUnitProcessor {
             if ((param.getParamName().equals(WAR_BUNDLES_JSF_IMPL_PARAM) &&
                     (param.getParamValue() != null) &&
                     (param.getParamValue().toLowerCase().equals("true")))) {
-                JsfVersionMarker.setVersion(topLevelDeployment, JsfVersionMarker.WAR_BUNDLES_JSF_IMPL);
+                JsfVersionMarker.setVersion(deploymentUnit, JsfVersionMarker.WAR_BUNDLES_JSF_IMPL);
                 break; // WAR_BUNDLES_JSF_IMPL always wins
             }
 
             if (param.getParamName().equals(JSF_CONFIG_NAME_PARAM)) {
-                JsfVersionMarker.setVersion(topLevelDeployment, param.getParamValue());
+                JsfVersionMarker.setVersion(deploymentUnit, param.getParamValue());
             }
         }
     }


### PR DESCRIPTION
EAR file containing a WAR file that bundles Myfaces 1.2.7 fails deployment (trying to load JSF 2 libraries although WAR_BUNDLES_JSF_IMPL is set)

15:27:59,585 ERROR [org.jboss.msc.service.fail](MSC service thread 1-4) MSC00001: Failed to start service jboss.deployment.subunit."MyFacesTest.ear"."myfacesTest.war".INSTALL: org
.jboss.msc.service.StartException in service jboss.deployment.subunit."MyFacesTest.ear"."myfacesTest.war".INSTALL: Failed to process phase INSTALL of subdeployment "myfacesTest.war
" of deployment "MyFacesTest.ear"
        at org.jboss.as.server.deployment.DeploymentUnitPhaseService.start(DeploymentUnitPhaseService.java:121) [jboss-as-server-7.0.2.Final.jar:7.0.2.Final]
        at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1824) [jboss-msc-1.0.1.GA.jar:1.0.1.GA]
        at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1759) [jboss-msc-1.0.1.GA.jar:1.0.1.GA]
        at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886) [:1.6.0_21]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908) [:1.6.0_21]
        at java.lang.Thread.run(Thread.java:619) [:1.6.0_21]
Caused by: java.lang.RuntimeException: Failed to load class com.sun.faces.config.ConfigureListener
        at org.jboss.as.ee.component.deployers.EEClassConfigurationProcessor$1.compute(EEClassConfigurationProcessor.java:141)
        at org.jboss.as.ee.component.deployers.EEClassConfigurationProcessor$1.compute(EEClassConfigurationProcessor.java:122)
        at org.jboss.as.ee.component.LazyValue.get(LazyValue.java:40)
        at org.jboss.as.ee.component.EEApplicationDescription.getClassConfiguration(EEApplicationDescription.java:183)
        at org.jboss.as.ee.component.ComponentDescription.createConfiguration(ComponentDescription.java:153)
        at org.jboss.as.ee.component.deployers.EEModuleConfigurationProcessor.deploy(EEModuleConfigurationProcessor.java:70)
        at org.jboss.as.server.deployment.DeploymentUnitPhaseService.start(DeploymentUnitPhaseService.java:115) [jboss-as-server-7.0.2.Final.jar:7.0.2.Final]
        ... 5 more
Caused by: java.lang.ClassNotFoundException: com.sun.faces.config.ConfigureListener from [Module "deployment.MyFacesTest.ear.myfacesTest.war:main" from Service Module Loader]
        at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:191)
        at org.jboss.modules.ConcurrentClassLoader.performLoadClassChecked(ConcurrentClassLoader.java:361)
        at org.jboss.modules.ConcurrentClassLoader.performLoadClassChecked(ConcurrentClassLoader.java:333)
        at org.jboss.modules.ConcurrentClassLoader.performLoadClass(ConcurrentClassLoader.java:310)
        at org.jboss.modules.ConcurrentClassLoader.loadClass(ConcurrentClassLoader.java:103)
        at java.lang.Class.forName0(Native Method) [:1.6.0_21]
        at java.lang.Class.forName(Class.java:247) [:1.6.0_21]
        at org.jboss.as.ee.component.deployers.EEClassConfigurationProcessor$1.compute(EEClassConfigurationProcessor.java:139)
        ... 11 more
