### PR TITLE
Extend the ExtensionContext with Process Type information

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ExtensionContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExtensionContext.java
@@ -22,10 +22,12 @@
 
 package org.jboss.as.controller;
 
+
 /**
  * The context for registering a new extension.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author David Bosschaert
  */
 public interface ExtensionContext {
 
@@ -45,4 +47,38 @@ public interface ExtensionContext {
      * @throws IllegalArgumentException if the subsystem name has already been registered
      */
     SubsystemRegistration registerSubsystem(String name) throws IllegalArgumentException;
+
+    /**
+     * Provide the current Process Type.
+     * @return The current Process Type.
+     */
+    ProcessType getProcessType();
+
+    /**
+     * Holds the possible process types. This is used to identify what type of server we are running in.
+     * Extensions can use this information to decide whether certain resources, operations or attributes
+     * need to be present.
+     */
+    public enum ProcessType {
+        DOMAIN_SERVER,
+        EMBEDDED,
+        STANDALONE_SERVER,
+        MASTER_HOST_CONTROLLER,
+        SLAVE_HOST_CONTROLLER;
+
+        /**
+         * Returns true if the process is one of the 3 server variants.
+         *
+         * @return Returns <tt>true</tt> if the process is a server. Returns <tt>false</tt> otherwise.
+         */
+        public boolean isServer() {
+            switch (this) {
+            case DOMAIN_SERVER:
+            case EMBEDDED:
+            case STANDALONE_SERVER:
+                return true;
+            }
+            return false;
+        }
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/ExtensionContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExtensionContextImpl.java
@@ -42,6 +42,7 @@ import org.jboss.staxmapper.XMLElementWriter;
  */
 public final class ExtensionContextImpl implements ExtensionContext {
 
+    private final ProcessType processType;
     private final ManagementResourceRegistration profileRegistration;
     private final SubsystemXmlWriterRegistry writerRegistry;
     private final ManagementResourceRegistration subsystemDeploymentRegistration;
@@ -55,7 +56,7 @@ public final class ExtensionContextImpl implements ExtensionContext {
      */
     public ExtensionContextImpl(final ManagementResourceRegistration profileRegistration,
             final ManagementResourceRegistration deploymentOverrideRegistration,
-            final SubsystemXmlWriterRegistry writerRegistry) {
+            final SubsystemXmlWriterRegistry writerRegistry, ProcessType processType) {
         if (profileRegistration == null) {
             throw new IllegalArgumentException("profileRegistration is null");
         }
@@ -65,6 +66,7 @@ public final class ExtensionContextImpl implements ExtensionContext {
         if (writerRegistry == null) {
             throw new IllegalArgumentException("writerRegistry is null");
         }
+        this.processType = processType;
         this.profileRegistration = profileRegistration;
         this.writerRegistry = writerRegistry;
         if (deploymentOverrideRegistration != null) {
@@ -75,6 +77,11 @@ public final class ExtensionContextImpl implements ExtensionContext {
         } else {
             this.subsystemDeploymentRegistration = null;
         }
+    }
+
+    @Override
+    public ProcessType getProcessType() {
+        return processType;
     }
 
     /** {@inheritDoc} */

--- a/controller/src/test/java/org/jboss/as/controller/ExtensionContextProcessTypeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ExtensionContextProcessTypeTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.controller;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * @author David Bosschaert
+ */
+public class ExtensionContextProcessTypeTestCase {
+    @Test
+    public void testIsServer() {
+        Assert.assertTrue(ExtensionContext.ProcessType.DOMAIN_SERVER.isServer());
+        Assert.assertTrue(ExtensionContext.ProcessType.EMBEDDED.isServer());
+        Assert.assertTrue(ExtensionContext.ProcessType.STANDALONE_SERVER.isServer());
+        Assert.assertFalse(ExtensionContext.ProcessType.MASTER_HOST_CONTROLLER.isServer());
+        Assert.assertFalse(ExtensionContext.ProcessType.SLAVE_HOST_CONTROLLER.isServer());
+    }
+}

--- a/domain-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
+++ b/domain-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
@@ -52,9 +52,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.util.EnumSet;
 
+import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ExtensionContextImpl;
-import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.common.CommonProviders;
 import org.jboss.as.controller.operations.common.ExtensionAddHandler;
@@ -258,7 +258,8 @@ public class DomainModelUtil {
 
         // Extensions
         final ManagementResourceRegistration extensions = root.registerSubModel(PathElement.pathElement(EXTENSION), CommonProviders.EXTENSION_PROVIDER);
-        final ExtensionContext extensionContext = new ExtensionContextImpl(profile, deployments, configurationPersister);
+        final ExtensionContext extensionContext = new ExtensionContextImpl(profile, deployments, configurationPersister,
+                isMaster ? ExtensionContext.ProcessType.MASTER_HOST_CONTROLLER : ExtensionContext.ProcessType.SLAVE_HOST_CONTROLLER);
         final ExtensionAddHandler addExtensionHandler = new ExtensionAddHandler(extensionContext);
         extensions.registerOperationHandler(ExtensionAddHandler.OPERATION_NAME, addExtensionHandler, addExtensionHandler, false);
         extensions.registerOperationHandler(ExtensionRemoveHandler.OPERATION_NAME, ExtensionRemoveHandler.INSTANCE, ExtensionRemoveHandler.INSTANCE, false);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -59,12 +59,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRI
 
 import java.util.EnumSet;
 
-import org.jboss.as.controller.ExtensionContext;
-import org.jboss.as.controller.ExtensionContextImpl;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.common.CommonProviders;
-import org.jboss.as.controller.operations.common.ExtensionAddHandler;
-import org.jboss.as.controller.operations.common.ExtensionRemoveHandler;
 import org.jboss.as.controller.operations.common.InterfaceAddHandler;
 import org.jboss.as.controller.operations.common.InterfaceCriteriaWriteHandler;
 import org.jboss.as.controller.operations.common.InterfaceRemoveHandler;
@@ -241,13 +237,6 @@ public class HostModelUtil {
         hostRegistration.registerOperationHandler(SnapshotListHandler.OPERATION_NAME, snapshotList, snapshotList, false);
         SnapshotTakeHandler snapshotTake = new SnapshotTakeHandler(configurationPersister.getHostPersister());
         hostRegistration.registerOperationHandler(SnapshotTakeHandler.OPERATION_NAME, snapshotTake, snapshotTake, false);
-
-        //Extensions
-        ManagementResourceRegistration extensions = hostRegistration.registerSubModel(PathElement.pathElement(EXTENSION), CommonProviders.EXTENSION_PROVIDER);
-        ExtensionContext extensionContext = new ExtensionContextImpl(hostRegistration, null, configurationPersister, ExtensionContext.ProcessType.SLAVE_HOST_CONTROLLER);
-        ExtensionAddHandler addExtensionHandler = new ExtensionAddHandler(extensionContext);
-        extensions.registerOperationHandler(ExtensionAddHandler.OPERATION_NAME, addExtensionHandler, addExtensionHandler, false);
-        extensions.registerOperationHandler(ExtensionRemoveHandler.OPERATION_NAME, ExtensionRemoveHandler.INSTANCE, ExtensionRemoveHandler.INSTANCE, false);
 
         // Jvms
         final ManagementResourceRegistration jvms = hostRegistration.registerSubModel(PathElement.pathElement(JVM), CommonProviders.JVM_PROVIDER);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -244,7 +244,7 @@ public class HostModelUtil {
 
         //Extensions
         ManagementResourceRegistration extensions = hostRegistration.registerSubModel(PathElement.pathElement(EXTENSION), CommonProviders.EXTENSION_PROVIDER);
-        ExtensionContext extensionContext = new ExtensionContextImpl(hostRegistration, null, configurationPersister);
+        ExtensionContext extensionContext = new ExtensionContextImpl(hostRegistration, null, configurationPersister, ExtensionContext.ProcessType.SLAVE_HOST_CONTROLLER);
         ExtensionAddHandler addExtensionHandler = new ExtensionAddHandler(extensionContext);
         extensions.registerOperationHandler(ExtensionAddHandler.OPERATION_NAME, addExtensionHandler, addExtensionHandler, false);
         extensions.registerOperationHandler(ExtensionRemoveHandler.OPERATION_NAME, ExtensionRemoveHandler.INSTANCE, ExtensionRemoveHandler.INSTANCE, false);

--- a/server/src/test/java/org/jboss/as/server/ServerControllerModelUtilTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/ServerControllerModelUtilTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.server;
+
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ExtensionContext.ProcessType;
+import org.jboss.as.server.ServerEnvironment.LaunchType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author David Bosschaert
+ */
+public class ServerControllerModelUtilTestCase {
+    @Test
+    public void testGetProcessType() {
+        testGetProcessType(ServerEnvironment.LaunchType.DOMAIN, ExtensionContext.ProcessType.DOMAIN_SERVER);
+        testGetProcessType(ServerEnvironment.LaunchType.EMBEDDED, ExtensionContext.ProcessType.EMBEDDED);
+        testGetProcessType(ServerEnvironment.LaunchType.STANDALONE, ExtensionContext.ProcessType.STANDALONE_SERVER);
+    }
+
+    private void testGetProcessType(LaunchType launchType, ProcessType processType) {
+        ServerEnvironment se = Mockito.mock(ServerEnvironment.class);
+        Mockito.when(se.getLaunchType()).thenReturn(launchType);
+
+        Assert.assertEquals(processType, ServerControllerModelUtil.getProcessType(se));
+    }
+
+    @Test
+    public void testGetProcessTypeNull() {
+        Assert.assertEquals(ExtensionContext.ProcessType.EMBEDDED, ServerControllerModelUtil.getProcessType(null));
+    }
+}

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -47,8 +47,16 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSParser;
+import org.w3c.dom.ls.LSSerializer;
+
 import junit.framework.Assert;
 import junit.framework.AssertionFailedError;
+
 import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ControlledProcessState;
@@ -103,12 +111,6 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.jboss.staxmapper.XMLMapper;
 import org.junit.After;
 import org.junit.Before;
-import org.w3c.dom.Document;
-import org.w3c.dom.bootstrap.DOMImplementationRegistry;
-import org.w3c.dom.ls.DOMImplementationLS;
-import org.w3c.dom.ls.LSInput;
-import org.w3c.dom.ls.LSParser;
-import org.w3c.dom.ls.LSSerializer;
 
 /**
  * The base class for parsing tests which does the work of setting up the environment for parsing
@@ -248,7 +250,7 @@ public abstract class AbstractSubsystemTest {
         StringConfigurationPersister persister = new StringConfigurationPersister(Collections.<ModelNode>emptyList(), testParser);
 
         Extension extension = mainExtension.getClass().newInstance();
-        extension.initialize(new ExtensionContextImpl(MOCK_RESOURCE_REG, MOCK_RESOURCE_REG, persister));
+        extension.initialize(new ExtensionContextImpl(MOCK_RESOURCE_REG, MOCK_RESOURCE_REG, persister, ExtensionContext.ProcessType.EMBEDDED));
 
         ConfigurationPersister.PersistenceResource resource = persister.store(model, Collections.<PathAddress>emptySet());
         resource.commit();
@@ -582,7 +584,7 @@ public abstract class AbstractSubsystemTest {
 
             controllerInitializer.initializeModel(rootResource, rootRegistration);
 
-            ExtensionContext context = new ExtensionContextImpl(rootRegistration, deployments, persister);
+            ExtensionContext context = new ExtensionContextImpl(rootRegistration, deployments, persister, ExtensionContext.ProcessType.EMBEDDED);
             additionalInit.initializeExtraSubystemsAndModel(context, rootResource, rootRegistration);
             mainExtension.initialize(context);
         }

--- a/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/smoke/src/test/java/org/jboss/as/test/embedded/parse/ParseAndMarshalModelsTestCase.java
@@ -140,7 +140,6 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.vfs.VirtualFile;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -424,7 +423,7 @@ public class ParseAndMarshalModelsTestCase {
 
                 //Extensions
                 ManagementResourceRegistration extensions = hostRegistration.registerSubModel(PathElement.pathElement(EXTENSION), CommonProviders.EXTENSION_PROVIDER);
-                ExtensionContext extensionContext = new ExtensionContextImpl(hostRegistration, null, persister);
+                ExtensionContext extensionContext = new ExtensionContextImpl(hostRegistration, null, persister, ExtensionContext.ProcessType.STANDALONE_SERVER);
                 ExtensionAddHandler addExtensionHandler = new ExtensionAddHandler(extensionContext);
                 extensions.registerOperationHandler(ExtensionAddHandler.OPERATION_NAME, addExtensionHandler, addExtensionHandler, false);
 

--- a/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemTestCase.java
+++ b/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemTestCase.java
@@ -92,6 +92,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import junit.framework.Assert;
+
 import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ExtensionContext;
@@ -797,6 +798,11 @@ public class ThreadsSubsystemTestCase {
 
         TestNewExtensionContext(ManagementResourceRegistration testProfileRegistration) {
             this.testProfileRegistration = testProfileRegistration;
+        }
+
+        @Override
+        public ProcessType getProcessType() {
+            return ProcessType.EMBEDDED;
         }
 
         @Override


### PR DESCRIPTION
This information is to allow management extensions to react to the type
of server they are running in.
