### PR TITLE
[AS7-1923] Support for both versions 1.0 and 1.1 of the domain schema.

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_0.xsd
@@ -106,7 +106,7 @@
                 <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management" type="managementType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management-interfaces" type="management-interfacesType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="profile" type="standalone-profileType"/>
+                <xs:element name="profile" type="standalone-profileType" minOccurs="0"/>
                 <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="deployments" type="mapped-deploymentsType" minOccurs="0" maxOccurs="1"/>

--- a/build/src/main/resources/docs/schema/jboss-as-config_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_1.xsd
@@ -108,7 +108,7 @@
                 <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management" type="managementType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management-interfaces" type="management-interfacesType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="profile" type="standalone-profileType"/>
+                <xs:element name="profile" type="standalone-profileType" minOccurs="0"/>
                 <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="deployments" type="mapped-deploymentsType" minOccurs="0" maxOccurs="1"/>

--- a/build/src/main/resources/domain/configuration/domain-osgi-only.xml
+++ b/build/src/main/resources/domain/configuration/domain-osgi-only.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.0">
+<domain xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/build/src/main/resources/domain/configuration/domain-preview.xml
+++ b/build/src/main/resources/domain/configuration/domain-preview.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.0">
+<domain xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/domain/configuration/domain.xml
+++ b/build/src/main/resources/domain/configuration/domain.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.0">
+<domain xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/domain/configuration/host.xml
+++ b/build/src/main/resources/domain/configuration/host.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.0"
+<host xmlns="urn:jboss:domain:1.1"
       name="master">
 
     <management>

--- a/build/src/main/resources/standalone/configuration/standalone-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-ha.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.0">
+<server xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/standalone/configuration/standalone-osgi-only.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-osgi-only.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.0">
+<server xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/build/src/main/resources/standalone/configuration/standalone-preview-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-preview-ha.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.0">
+<server xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/standalone/configuration/standalone-preview.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-preview.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.0">
+<server xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/standalone/configuration/standalone-xts.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-xts.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.0">
+<server xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.0">
+<server xmlns="urn:jboss:domain:1.1">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
@@ -303,8 +303,8 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
         final ExtensionParsingContextImpl context = new ExtensionParsingContextImpl(reader.getXMLMapper());
 
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
-            final Element element = Element.forName(reader.getLocalName());
             requireNamespace(reader, expectedNs);
+            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
 
             // Attribute && require no content
             final String moduleName = readStringAttributeElement(reader, Attribute.MODULE.getLocalName());
@@ -995,10 +995,11 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            final Element element = Element.forName(reader.getLocalName());
-            if (element != Element.PROPERTY) {
-                throw unexpectedElement(reader);
-            }
+            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+            //final Element element = Element.forName(reader.getLocalName());
+            //if (element != Element.PROPERTY) {
+            //    throw unexpectedElement(reader);
+            //}
 
             String name = null;
             String value = null;
@@ -1806,10 +1807,11 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            Element element = Element.forName(reader.getLocalName());
-            if (Element.INTERFACE != element) {
-                throw unexpectedElement(reader);
-            }
+            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+            //Element element = Element.forName(reader.getLocalName());
+            //if (Element.INTERFACE != element) {
+            //    throw unexpectedElement(reader);
+            //}
 
             // Attributes
             requireSingleAttribute(reader, Attribute.NAME.getLocalName());
@@ -1980,10 +1982,11 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            Element deployment = Element.forName(reader.getLocalName());
-            if (Element.DEPLOYMENT != deployment) {
-                throw unexpectedElement(reader);
-            }
+            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+            //Element deployment = Element.forName(reader.getLocalName());
+            // if (Element.DEPLOYMENT != deployment) {
+            //    throw unexpectedElement(reader);
+            //}
 
             // Handle attributes
             String uniqueName = null;

--- a/controller/src/main/java/org/jboss/as/controller/parsing/DomainXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/DomainXml.java
@@ -87,9 +87,10 @@ public class DomainXml extends CommonXml {
 
     @Override
     public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> nodes) throws XMLStreamException {
-        if (Element.forName(reader.getLocalName()) != Element.DOMAIN) {
-            throw unexpectedElement(reader);
-        }
+        // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+        //if (Element.forName(reader.getLocalName()) != Element.DOMAIN) {
+        //    throw unexpectedElement(reader);
+        //}
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
         switch (readerNS) {
             case DOMAIN_1_0:
@@ -318,10 +319,11 @@ public class DomainXml extends CommonXml {
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            Element serverGroup = Element.forName(reader.getLocalName());
-            if (Element.SERVER_GROUP != serverGroup) {
-                throw unexpectedElement(reader);
-            }
+            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+            //Element serverGroup = Element.forName(reader.getLocalName());
+            //if (Element.SERVER_GROUP != serverGroup) {
+            //    throw unexpectedElement(reader);
+            //}
 
             String name = null;
             String profile = null;
@@ -416,10 +418,11 @@ public class DomainXml extends CommonXml {
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            Element element = Element.forName(reader.getLocalName());
-            if (Element.PROFILE != element) {
-                throw unexpectedElement(reader);
-            }
+            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+            //Element element = Element.forName(reader.getLocalName());
+            //if (Element.PROFILE != element) {
+            //    throw unexpectedElement(reader);
+            //}
 
             // Attributes
             requireSingleAttribute(reader, Attribute.NAME.getLocalName());

--- a/controller/src/main/java/org/jboss/as/controller/parsing/DomainXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/DomainXml.java
@@ -22,27 +22,6 @@
 
 package org.jboss.as.controller.parsing;
 
-import org.jboss.as.controller.HashUtil;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
-import org.jboss.as.controller.persistence.ModelMarshallingContext;
-import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.jboss.modules.ModuleLoader;
-import org.jboss.staxmapper.XMLElementWriter;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
-
-import javax.xml.XMLConstants;
-import javax.xml.stream.XMLStreamException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
@@ -50,7 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEF
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HASH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
@@ -65,19 +44,40 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.parsing.ParseUtils.isNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.nextElement;
 import static org.jboss.as.controller.parsing.ParseUtils.parsePossibleExpression;
 import static org.jboss.as.controller.parsing.ParseUtils.readStringAttributeElement;
 import static org.jboss.as.controller.parsing.ParseUtils.requireAttributes;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNamespace;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.requireSingleAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
 
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
 /**
  * A mapper between an AS server's configuration model and XML representations, particularly  {@code domain.xml}.
  *
  * @author Emanuel Muckenhuber
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class DomainXml extends CommonXml {
 
@@ -87,7 +87,20 @@ public class DomainXml extends CommonXml {
 
     @Override
     public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> nodes) throws XMLStreamException {
-        readDomainElement(reader, new ModelNode(), nodes);
+        if (Element.forName(reader.getLocalName()) != Element.DOMAIN) {
+            throw unexpectedElement(reader);
+        }
+        Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
+        switch (readerNS) {
+            case DOMAIN_1_0:
+            case DOMAIN_1_1: {
+                readDomainElement(reader, new ModelNode(), readerNS, nodes);
+                break;
+            }
+            default: {
+                throw unexpectedElement(reader);
+            }
+        }
     }
 
     @Override
@@ -142,17 +155,15 @@ public class DomainXml extends CommonXml {
         writer.writeEndDocument();
     }
 
-    void readDomainElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list) throws XMLStreamException {
+    void readDomainElement(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
 
         parseNamespaces(reader, address, list);
 
         // attributes
         final int count = reader.getAttributeCount();
-        for (int i = 0; i < count; i ++) {
+        for (int i = 0; i < count; i++) {
             switch (Namespace.forUri(reader.getAttributeNamespace(i))) {
-                case DOMAIN_1_0: {
-                    throw unexpectedAttribute(reader, i);
-                } case XML_SCHEMA_INSTANCE: {
+                case XML_SCHEMA_INSTANCE: {
                     switch (Attribute.forName(reader.getAttributeLocalName(i))) {
                         case SCHEMA_LOCATION: {
                             parseSchemaLocations(reader, address, list, i);
@@ -168,50 +179,53 @@ public class DomainXml extends CommonXml {
                     }
                     break;
                 }
-                default: throw unexpectedAttribute(reader, i);
+                default:
+                    throw unexpectedAttribute(reader, i);
             }
         }
 
         // Content
         // Handle elements: sequence
 
-        Element element = nextElement(reader);
+        Element element = nextElement(reader, expectedNs);
         if (element == Element.EXTENSIONS) {
-            parseExtensions(reader, address, list);
-            element = nextElement(reader);
+            parseExtensions(reader, address, expectedNs, list);
+            element = nextElement(reader, expectedNs);
         }
         if (element == Element.SYSTEM_PROPERTIES) {
-            parseSystemProperties(reader, address, list, false);
-            element = nextElement(reader);
+            parseSystemProperties(reader, address, expectedNs, list, false);
+            element = nextElement(reader, expectedNs);
         }
         if (element == Element.PATHS) {
-            parsePaths(reader, address, list, false);
-            element = nextElement(reader);
+            parsePaths(reader, address, expectedNs, list, false);
+            element = nextElement(reader, expectedNs);
         }
         if (element == Element.PROFILES) {
-            parseProfiles(reader, address, list);
-            element = nextElement(reader);
+            parseProfiles(reader, address, expectedNs, list);
+            element = nextElement(reader, expectedNs);
         }
         final Set<String> interfaceNames = new HashSet<String>();
         if (element == Element.INTERFACES) {
-            parseInterfaces(reader, interfaceNames, address, list, false);
-            element = nextElement(reader);
+            parseInterfaces(reader, interfaceNames, address, expectedNs, list, false);
+            element = nextElement(reader, expectedNs);
         }
         if (element == Element.SOCKET_BINDING_GROUPS) {
-            parseDomainSocketBindingGroups(reader, address, list, interfaceNames);
-            element = nextElement(reader);
+            parseDomainSocketBindingGroups(reader, address, expectedNs, list, interfaceNames);
+            element = nextElement(reader, expectedNs);
         }
         if (element == Element.DEPLOYMENTS) {
-            parseDeployments(reader, address, list, false);
-            element = nextElement(reader);
+            parseDeployments(reader, address, expectedNs, list, false);
+            element = nextElement(reader, expectedNs);
         }
         if (element == Element.SERVER_GROUPS) {
-            parseServerGroups(reader, address, list);
-            element = nextElement(reader);
+            parseServerGroups(reader, address, expectedNs, list);
+            element = nextElement(reader, expectedNs);
         }
         if (element != null) {
             throw unexpectedElement(reader);
         }
+
+    }
 
 //        for (;;) {
 //            switch (reader.nextTag()) {
@@ -232,31 +246,26 @@ public class DomainXml extends CommonXml {
 //            }
 //        }
 
-    }
-
-    void parseDomainSocketBindingGroups(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> interfaces) throws XMLStreamException {
+    void parseDomainSocketBindingGroups(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs,
+                                        final List<ModelNode> list, final Set<String> interfaces) throws XMLStreamException {
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
-            switch (Namespace.forUri(reader.getNamespaceURI())) {
-                case DOMAIN_1_0: {
-                    final Element element = Element.forName(reader.getLocalName());
-                    switch (element) {
-                        case SOCKET_BINDING_GROUP: {
-                            // parse binding-group
-                            parseSocketBindingGroup(reader, interfaces, address, list);
-                            break;
-                        } default: {
-                            throw ParseUtils.unexpectedElement(reader);
-                        }
-                    }
+            requireNamespace(reader, expectedNs);
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case SOCKET_BINDING_GROUP: {
+                    // parse binding-group
+                    parseSocketBindingGroup(reader, interfaces, address, expectedNs, list);
                     break;
-                } default: {
-                    throw ParseUtils.unexpectedElement(reader);
+                }
+                default: {
+                    throw unexpectedElement(reader);
                 }
             }
         }
     }
 
-    void parseSocketBindingGroup(final XMLExtendedStreamReader reader, final Set<String> interfaces, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {
+    void parseSocketBindingGroup(final XMLExtendedStreamReader reader, final Set<String> interfaces, final ModelNode address,
+                                 final Namespace expectedNs, final List<ModelNode> updates) throws XMLStreamException {
         final Set<String> includedGroups = new HashSet<String>();
         final Set<String> socketBindings = new HashSet<String>();
 
@@ -278,27 +287,21 @@ public class DomainXml extends CommonXml {
 
         // Handle elements
         while (reader.nextTag() != END_ELEMENT) {
-            switch (Namespace.forUri(reader.getNamespaceURI())) {
-                case DOMAIN_1_0: {
-                    final Element element = Element.forName(reader.getLocalName());
-                    switch (element) {
-                        case INCLUDE: {
-                            final String includedGroup = readStringAttributeElement(reader, Attribute.SOCKET_BINDING_GROUP.getLocalName());
-                            if (!includedGroups.add(includedGroup)) {
-                                throw new XMLStreamException("Included socket-binding-group " + includedGroup + " already declared", reader.getLocation());
-                            }
-                            includes.add(includedGroup);
-                            break;
-                        }
-                        case SOCKET_BINDING: {
-                            final String bindingName = parseSocketBinding(reader, interfaces, groupAddress, updates);
-                            if (!socketBindings.add(bindingName)) {
-                                throw new XMLStreamException("socket-binding " + bindingName + " already declared", reader.getLocation());
-                            }
-                            break;
-                        }
-                        default:
-                            throw unexpectedElement(reader);
+            requireNamespace(reader, expectedNs);
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case INCLUDE: {
+                    final String includedGroup = readStringAttributeElement(reader, Attribute.SOCKET_BINDING_GROUP.getLocalName());
+                    if (!includedGroups.add(includedGroup)) {
+                        throw new XMLStreamException("Included socket-binding-group " + includedGroup + " already declared", reader.getLocation());
+                    }
+                    includes.add(includedGroup);
+                    break;
+                }
+                case SOCKET_BINDING: {
+                    final String bindingName = parseSocketBinding(reader, interfaces, groupAddress, updates);
+                    if (!socketBindings.add(bindingName)) {
+                        throw new XMLStreamException("socket-binding " + bindingName + " already declared", reader.getLocation());
                     }
                     break;
                 }
@@ -308,19 +311,24 @@ public class DomainXml extends CommonXml {
         }
     }
 
-    void parseServerGroups(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list) throws XMLStreamException {
+    void parseServerGroups(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
         requireNoAttributes(reader);
 
         final Set<String> names = new HashSet<String>();
 
         while (reader.nextTag() != END_ELEMENT) {
+            requireNamespace(reader, expectedNs);
+            Element serverGroup = Element.forName(reader.getLocalName());
+            if (Element.SERVER_GROUP != serverGroup) {
+                throw unexpectedElement(reader);
+            }
 
             String name = null;
             String profile = null;
 
             // Handle attributes
             final int count = reader.getAttributeCount();
-            for (int i = 0; i < count; i ++) {
+            for (int i = 0; i < count; i++) {
 
                 final String value = reader.getAttributeValue(i);
                 if (!isNoNamespaceAttribute(reader, i)) {
@@ -351,10 +359,10 @@ public class DomainXml extends CommonXml {
                 }
             }
             if (name == null) {
-                throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.NAME));
+                throw missingRequired(reader, Collections.singleton(Attribute.NAME));
             }
             if (profile == null) {
-                throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.PROFILE));
+                throw missingRequired(reader, Collections.singleton(Attribute.PROFILE));
             }
 
             final ModelNode groupAddress = new ModelNode().set(address);
@@ -370,48 +378,49 @@ public class DomainXml extends CommonXml {
 
             boolean sawDeployments = false;
             while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
-                switch (Namespace.forUri(reader.getNamespaceURI())) {
-                    case DOMAIN_1_0: {
-                        final Element element = Element.forName(reader.getLocalName());
-                        switch (element) {
-                            case JVM: {
-                                parseJvm(reader, groupAddress, list, new HashSet<String>());
-                                break;
-                            }
-                            case SOCKET_BINDING_GROUP: {
-                                parseSocketBindingGroupRef(reader, groupAddress, list);
-                                break;
-                            }
-                            case DEPLOYMENTS: {
-                                if (sawDeployments) {
-                                    throw new XMLStreamException(element.getLocalName() + " already defined", reader.getLocation());
-                                }
-                                sawDeployments = true;
-                                parseDeployments(reader, groupAddress, list, true);
-                                break;
-                            }
-                            case SYSTEM_PROPERTIES: {
-                                parseSystemProperties(reader, groupAddress, list, false);
-                                break;
-                            }
-                            default:
-                                throw ParseUtils.unexpectedElement(reader);
+                requireNamespace(reader, expectedNs);
+                final Element element = Element.forName(reader.getLocalName());
+                switch (element) {
+                    case JVM: {
+                        parseJvm(reader, groupAddress, expectedNs, list, new HashSet<String>());
+                        break;
+                    }
+                    case SOCKET_BINDING_GROUP: {
+                        parseSocketBindingGroupRef(reader, groupAddress, list);
+                        break;
+                    }
+                    case DEPLOYMENTS: {
+                        if (sawDeployments) {
+                            throw new XMLStreamException(element.getLocalName() + " already defined", reader.getLocation());
                         }
+                        sawDeployments = true;
+                        parseDeployments(reader, groupAddress, expectedNs, list, true);
+                        break;
+                    }
+                    case SYSTEM_PROPERTIES: {
+                        parseSystemProperties(reader, groupAddress, expectedNs, list, false);
                         break;
                     }
                     default:
                         throw ParseUtils.unexpectedElement(reader);
                 }
             }
+
         }
     }
 
-    void parseProfiles(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list) throws XMLStreamException {
+    void parseProfiles(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
         requireNoAttributes(reader);
 
         final Set<String> names = new HashSet<String>();
 
         while (reader.nextTag() != END_ELEMENT) {
+            requireNamespace(reader, expectedNs);
+            Element element = Element.forName(reader.getLocalName());
+            if (Element.PROFILE != element) {
+                throw unexpectedElement(reader);
+            }
+
             // Attributes
             requireSingleAttribute(reader, Attribute.NAME.getLocalName());
             final String name = reader.getAttributeValue(0);
@@ -440,7 +449,9 @@ public class DomainXml extends CommonXml {
 
                         break;
                     }
-                    case DOMAIN_1_0: {
+                    case DOMAIN_1_0:
+                    case DOMAIN_1_1: {
+                        requireNamespace(reader, expectedNs);
                         // include should come first
                         if (configuredSubsystemTypes.size() > 0) {
                             throw unexpectedElement(reader);

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
@@ -48,7 +48,7 @@ public enum Namespace {
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DOMAIN_1_0;
+    public static final Namespace CURRENT = DOMAIN_1_1;
 
     private final String name;
 

--- a/controller/src/main/java/org/jboss/as/controller/parsing/ParseUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/ParseUtils.java
@@ -50,11 +50,28 @@ public final class ParseUtils {
         if (reader.nextTag() == END_ELEMENT) {
             return null;
         }
-        Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
-        if ( !(readerNS == Namespace.DOMAIN_1_0 || readerNS == Namespace.DOMAIN_1_1 )) {
-            throw unexpectedElement(reader);
-        }
+
         return Element.forName(reader.getLocalName());
+    }
+
+    /**
+     * A variation of nextElement that verifies the nextElement is not in a different namespace.
+     *
+     * @param reader the XmlExtendedReader to read from.
+     * @param expectedNamespace the namespace expected.
+     * @return the element or null if the end is reached
+     * @throws XMLStreamException if the namespace is wrong or there is a problem accessing the reader
+     */
+    public static Element nextElement(XMLExtendedStreamReader reader, Namespace expectedNamespace) throws XMLStreamException {
+        Element element = nextElement(reader);
+
+        if (element == null) {
+            return element;
+        } else if (expectedNamespace.equals(Namespace.forUri(reader.getNamespaceURI()))) {
+            return element;
+        }
+
+        throw unexpectedElement(reader);
     }
 
     /**
@@ -158,6 +175,20 @@ public final class ParseUtils {
      */
     public static void requireNoContent(final XMLExtendedStreamReader reader) throws XMLStreamException {
         if (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            throw unexpectedElement(reader);
+        }
+    }
+
+    /**
+     * Require that the namespace of the current element matches the required namespace.
+     *
+     * @param reader the reader
+     * @param requiredNs the namespace required
+     * @throws XMLStreamException if the current namespace does not match the required namespace
+     */
+    public static void requireNamespace(final XMLExtendedStreamReader reader, final Namespace requiredNs) throws XMLStreamException {
+        Namespace actualNs = Namespace.forUri(reader.getNamespaceURI());
+        if (actualNs != requiredNs) {
             throw unexpectedElement(reader);
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/parsing/StandaloneXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/StandaloneXml.java
@@ -186,12 +186,10 @@ public class StandaloneXml extends CommonXml {
             element = nextElement(reader, DOMAIN_1_0);
         }
 
-        // Single profile - mandatory.
+        // Single profile
         if (element == Element.PROFILE) {
             parseServerProfile(reader, address, list);
             element = nextElement(reader, DOMAIN_1_0);
-        } else {
-            throw missingRequiredElement(reader, Collections.singleton(Element.PROFILE));
         }
 
         // Interfaces
@@ -294,12 +292,10 @@ public class StandaloneXml extends CommonXml {
             parseManagement(reader, address, DOMAIN_1_1, list, true);
             element = nextElement(reader, DOMAIN_1_1);
         }
-        // Single profile - mandatory.
+        // Single profile
         if (element == Element.PROFILE) {
             parseServerProfile(reader, address, list);
             element = nextElement(reader, DOMAIN_1_1);
-        } else {
-            throw missingRequiredElement(reader, Collections.singleton(Element.PROFILE));
         }
 
         // Interfaces

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -51,7 +51,9 @@ public class ConfigurationPersisterFactory {
 
     public static ExtensibleConfigurationPersister createDomainXmlConfigurationPersister(final File configDir, final ConfigurationFile file) {
         DomainXml domainXml = new DomainXml(Module.getBootModuleLoader());
-        return new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "domain"), domainXml, domainXml);
+        BackupXmlConfigurationPersister persister = new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "domain"), domainXml, domainXml);
+        persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "domain"), domainXml);
+        return persister;
     }
 
     public static ExtensibleConfigurationPersister createCachedRemoteDomainXmlConfigurationPersister(final File configDir) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -45,7 +45,7 @@ public class ConfigurationPersisterFactory {
     public static ExtensibleConfigurationPersister createHostXmlConfigurationPersister(final File configDir, final ConfigurationFile file) {
         HostXml hostXml = new HostXml(Module.getBootModuleLoader());
         BackupXmlConfigurationPersister persister =  new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "host"), hostXml, hostXml);
-        persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_1.getUriString(), "host"), hostXml);
+        persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "host"), hostXml);
         return persister;
     }
 

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -138,7 +138,7 @@ public interface Bootstrap {
                     QName rootElement = new QName(Namespace.CURRENT.getUriString(), "server");
                     StandaloneXml parser = new StandaloneXml(Module.getBootModuleLoader());
                     BackupXmlConfigurationPersister persister = new BackupXmlConfigurationPersister(serverEnvironment.getServerConfigurationFile(), rootElement, parser, parser);
-                    persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_1.getUriString(), "server"), parser);
+                    persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "server"), parser);
                     configurationPersister = persister;
                 }
             }


### PR DESCRIPTION
I would suggest these needs to be passed by Brian first to ensure we are happy to use this approach going forward.

The first notable change is regarding the actual handling of namespace validation, the namespace in the root node is now passed along with the calls, by having distinct schemas we do not support mixing and matching elements from different versions of the schema so this passed namespace is used to verify that no change has occurred.

At this point in time the only type definitions that have been changed in version 1.1 of the schema affect the server and the host element - this means that only the code of methods related to their parsing has diverged - the remainder is still common.

As I have worked through the parsing to verify consistency I am happy to offer to review pull requests related to the domain schema so that I can verify consistency is being maintained.

From this point on I would suggest the following checks when accepting updates to these parse methods: -

1 - Unless there is a very good reason where the methods have been versioned updates should only be accepted to the version 1_1 methods. 
2 - Where updates are made to the rest of the model if a versioned method does not exist then the unversioned method should be renamed by adding a 1_0 suffix, the method should then be duplicated and the duplicate have the suffix renamed 1_1 - the AS 7.1 changes should then be made to the 1_1 method.  The callee of the method can then switch on the namespace to identify which of the two methods to call.

As the parsing of the root node validated the namespace was correct and all subsequent parsing validated that the namespace is unchanged for the switch statements lower down we may just want to make the selection of the latest versioned parse method the default - that way when we add even newer schema versions we will not need to re-visit every switch statement to make it supported.

Note - The namespace of the root node should still be respected, this switch is only for the code to diverge at the point where the schema is updated, it is not to allow a multi namespace configuration.

The final commit in this pull request contains a number of commented out checks, in a few locations we have not been verifying the name of the element we are currently parsing - I would suggest once those methods become versioned we enable the checks on the latest version but we can probably not enable them earlier without breaking previously working but bad configurations.
