### PR TITLE
[AS7-1992] Enable verification of element names used.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
@@ -304,7 +304,10 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
+            final Element element = Element.forName(reader.getLocalName());
+            if (element != Element.EXTENSION) {
+                throw unexpectedElement(reader);
+            }
 
             // Attribute && require no content
             final String moduleName = readStringAttributeElement(reader, Attribute.MODULE.getLocalName());
@@ -995,11 +998,10 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
-            //final Element element = Element.forName(reader.getLocalName());
-            //if (element != Element.PROPERTY) {
-            //    throw unexpectedElement(reader);
-            //}
+            final Element element = Element.forName(reader.getLocalName());
+            if (element != Element.PROPERTY) {
+                throw unexpectedElement(reader);
+            }
 
             String name = null;
             String value = null;
@@ -1807,11 +1809,10 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
-            //Element element = Element.forName(reader.getLocalName());
-            //if (Element.INTERFACE != element) {
-            //    throw unexpectedElement(reader);
-            //}
+            Element element = Element.forName(reader.getLocalName());
+            if (Element.INTERFACE != element) {
+                throw unexpectedElement(reader);
+            }
 
             // Attributes
             requireSingleAttribute(reader, Attribute.NAME.getLocalName());
@@ -1982,11 +1983,10 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
-            //Element deployment = Element.forName(reader.getLocalName());
-            // if (Element.DEPLOYMENT != deployment) {
-            //    throw unexpectedElement(reader);
-            //}
+            Element deployment = Element.forName(reader.getLocalName());
+            if (Element.DEPLOYMENT != deployment) {
+                throw unexpectedElement(reader);
+            }
 
             // Handle attributes
             String uniqueName = null;

--- a/controller/src/main/java/org/jboss/as/controller/parsing/DomainXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/DomainXml.java
@@ -87,10 +87,9 @@ public class DomainXml extends CommonXml {
 
     @Override
     public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> nodes) throws XMLStreamException {
-        // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
-        //if (Element.forName(reader.getLocalName()) != Element.DOMAIN) {
-        //    throw unexpectedElement(reader);
-        //}
+        if (Element.forName(reader.getLocalName()) != Element.DOMAIN) {
+            throw unexpectedElement(reader);
+        }
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
         switch (readerNS) {
             case DOMAIN_1_0:
@@ -319,11 +318,10 @@ public class DomainXml extends CommonXml {
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
-            //Element serverGroup = Element.forName(reader.getLocalName());
-            //if (Element.SERVER_GROUP != serverGroup) {
-            //    throw unexpectedElement(reader);
-            //}
+            Element serverGroup = Element.forName(reader.getLocalName());
+            if (Element.SERVER_GROUP != serverGroup) {
+                throw unexpectedElement(reader);
+            }
 
             String name = null;
             String profile = null;
@@ -418,11 +416,10 @@ public class DomainXml extends CommonXml {
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
-            // TODO - We should be checking the name of the element, however this would cause previously accepted configurations to fail.
-            //Element element = Element.forName(reader.getLocalName());
-            //if (Element.PROFILE != element) {
-            //    throw unexpectedElement(reader);
-            //}
+            Element element = Element.forName(reader.getLocalName());
+            if (Element.PROFILE != element) {
+                throw unexpectedElement(reader);
+            }
 
             // Attributes
             requireSingleAttribute(reader, Attribute.NAME.getLocalName());


### PR DESCRIPTION
Follow on from AS7-1923, in a couple of locations we were not checking the name of the element used within the configuration.
