### PR TITLE
JBWS-3366: Initial JAX-RPC support

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -621,7 +621,11 @@
         </module-def>
 
         <module-def name="org.jboss.as.webservices.server.integration">
-            <!-- this is just dependencies wrapper module - to support multiple JBossWS SOAP stacks -->
+            <!-- this is a dependencies only wrapper module - to support multiple JBossWS SOAP stacks -->
+        </module-def>
+
+        <module-def name="org.jboss.as.webservices.server.jaxrpc-integration">
+            <!-- this is a dependencies only module for JAXRPC functionalities provided by JBossWS Native stack -->
         </module-def>
 
         <module-def name="org.jboss.as.weld">
@@ -889,6 +893,18 @@
             <maven-resource group="org.jboss.ws.projects" artifact="jaxws-jboss-httpserver-httpspi"/>
         </module-def>
 
+        <module-def name="org.jboss.ws.native.jbossws-native-core">
+            <maven-resource group="org.jboss.ws.native" artifact="jbossws-native-core"/>
+        </module-def>
+
+        <module-def name="org.jboss.ws.native.jbossws-native-factories">
+            <maven-resource group="org.jboss.ws.native" artifact="jbossws-native-factories"/>
+        </module-def>
+
+        <module-def name="org.jboss.ws.native.jbossws-native-services">
+            <maven-resource group="org.jboss.ws.native" artifact="jbossws-native-services"/>
+        </module-def>
+
         <module-def name="org.jboss.ws.api">
             <maven-resource group="org.jboss.ws" artifact="jbossws-api"/>
         </module-def>
@@ -908,6 +924,10 @@
         </module-def>
 
         <module-def name="org.jboss.ws.tools.wsconsume">
+        </module-def>
+
+        <module-def name="org.jboss.xb">
+            <maven-resource group="org.jboss" artifact="jbossxb"/>
         </module-def>
 
         <module-def name="org.jboss.xnio">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1405,6 +1405,26 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.ws.native</groupId>
+            <artifactId>jbossws-native-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.ws.native</groupId>
+            <artifactId>jbossws-native-factories</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.ws.native</groupId>
+            <artifactId>jbossws-native-services</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jbossxb</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-api</artifactId>
         </dependency>

--- a/build/src/main/resources/modules/org/jboss/as/webservices/server/jaxrpc-integration/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/webservices/server/jaxrpc-integration/main/module.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.webservices.server.jaxrpc-integration">
+
+    <resources>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api" export="true"/>
+        <module name="javax.xml.rpc.api" export="true"/>
+        <module name="javax.wsdl4j.api" export="true"/>
+        <module name="com.sun.xml.bind" services="export" export="true"/>
+        <module name="org.jboss.ws.api" export="true"/>
+        <module name="org.jboss.ws.spi" export="true"/>
+        <module name="org.jboss.ws.common" services="import" export="true"/>
+        <module name="org.jboss.ws.native.jbossws-native-factories" services="export" export="true"/>
+        <module name="org.jboss.ws.native.jbossws-native-core" services="export" export="true">
+          <imports>
+            <include path="META-INF"/>
+            <include path="dtd"/>
+            <include path="schema"/>
+          </imports>
+          <exports>
+            <include path="META-INF"/>
+            <include path="dtd"/>
+            <include path="schema"/>
+          </exports>
+        </module>
+        <module name="org.jboss.ws.native.jbossws-native-services" services="export" export="true"/>
+        <module name="org.apache.xalan" services="export" export="true"/>
+        <module name="org.apache.xerces" services="export" export="true"/>
+        <module name="org.jboss.as.webservices" services="export" export="true"/>
+    </dependencies>
+</module>

--- a/build/src/main/resources/modules/org/jboss/ws/native/jbossws-native-core/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ws/native/jbossws-native-core/main/module.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.ws.native.jbossws-native-core">
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="com.sun.tools.ws" services="import" optional="true"/>
+        <module name="com.sun.xml.bind" services="import"/>
+        <module name="com.sun.xml.fastinfoset" optional="true"/>
+        <module name="javax.api" />
+        <module name="javax.servlet.api" />
+        <module name="javax.jws.api" />
+        <module name="javax.mail.api" />
+        <module name="javax.wsdl4j.api" />
+        <module name="javax.xml.bind.api" />
+        <module name="javax.xml.stream.api" />
+        <module name="javax.xml.rpc.api" />
+        <module name="javax.xml.ws.api" />
+        <module name="org.picketbox"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.apache.xmlsec" optional="true"/>
+        <module name="org.apache.ws.commons.policy" optional="true"/>
+        <module name="org.javassist" />
+        <module name="org.codehaus.jettison" optional="true"/>
+        <module name="org.jboss.netty" />
+        <module name="org.jboss.xb" />
+        <module name="org.jboss.ws.api" />
+        <module name="org.jboss.ws.spi" />
+        <module name="org.jboss.ws.common" />
+        <module name="org.jboss.ws.native.jbossws-native-factories" services="import"/>
+        <module name="org.jboss.ws.native.jbossws-native-services" services="import"/>
+        <module name="org.jboss.common-core" />
+        <module name="org.jboss.logging" />
+    </dependencies>
+</module>

--- a/build/src/main/resources/modules/org/jboss/ws/native/jbossws-native-factories/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ws/native/jbossws-native-factories/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.ws.native.jbossws-native-factories">
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+
+    </dependencies>
+</module>

--- a/build/src/main/resources/modules/org/jboss/ws/native/jbossws-native-services/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ws/native/jbossws-native-services/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.ws.native.jbossws-native-services">
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+
+    </dependencies>
+</module>

--- a/build/src/main/resources/modules/org/jboss/xb/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/xb/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.xb">
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.common-core"/>
+    </dependencies>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -195,11 +195,13 @@
         <version.org.jboss.weld.weld>1.1.2.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>1.1.Final</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.0.Beta2</version.org.jboss.ws.api>
-        <version.org.jboss.ws.common>2.0.0.Beta9</version.org.jboss.ws.common>
+        <version.org.jboss.ws.common>2.0.0.Beta10</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.0.0.Beta1</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.jbossws-cxf>4.0.0.Beta4</version.org.jboss.ws.jbossws-cxf>
-        <version.org.jboss.ws.spi>2.0.0.Beta9</version.org.jboss.ws.spi>
+        <version.org.jboss.ws.jbossws-cxf>4.0.0.Beta5</version.org.jboss.ws.jbossws-cxf>
+        <version.org.jboss.ws.jbossws-native>4.0.0.Beta2</version.org.jboss.ws.jbossws-native>
+        <version.org.jboss.ws.spi>2.0.0.Beta10</version.org.jboss.ws.spi>
         <version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>1.0.0.GA</version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>
+        <version.org.jboss.xb>2.0.3.GA</version.org.jboss.xb>
         <version.org.jboss.xnio.xnio-api>3.0.0.Beta3</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>3.0.0.Beta3</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>2.12.1.3.Final</version.org.jgroups>
@@ -4715,6 +4717,46 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss</groupId>
+                <artifactId>jbossxb</artifactId>
+                <version>${version.org.jboss.xb}</version>
+                <exclusions>
+                     <exclusion>
+                        <groupId>apache-xerces</groupId>
+                        <artifactId>xml-apis</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>apache-xerces</groupId>
+                        <artifactId>xercesImpl</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>jboss</groupId>
+                        <artifactId>jboss-common-core</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-spi</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-log4j</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>sun-jaxb</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>wutka-dtdparser</groupId>
+                        <artifactId>dtdparser121</artifactId>
+                     </exclusion>
+               </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.xnio</groupId>
                 <artifactId>xnio-api</artifactId>
                 <version>${version.org.jboss.xnio.xnio-api}</version>
@@ -5063,6 +5105,106 @@
                         <artifactId>juddi-service</artifactId>
                     </exclusion>
                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.ws.native</groupId>
+                <artifactId>jbossws-native-core</artifactId>
+                <version>${version.org.jboss.ws.jbossws-native}</version>
+                <exclusions>
+                     <exclusion>
+                        <groupId>com.sun.xml.ws</groupId>
+                        <artifactId>jaxws-rt</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>com.sun.xml.ws</groupId>
+                        <artifactId>jaxws-tools</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>woodstox</groupId>
+                        <artifactId>wstx-lgpl</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-impl</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-xjc</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>com.sun.xml.fastinfoset</groupId>
+                        <artifactId>FastInfoset</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>ws-commons</groupId>
+                        <artifactId>policy</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.codehaus.jettison</groupId>
+                        <artifactId>jettison</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.apache</groupId>
+                        <artifactId>xmlsec</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.spec.javax.xml.rpc</groupId>
+                        <artifactId>jboss-jaxrpc-api_1.1_spec</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.spec.javax.xml.soap</groupId>
+                        <artifactId>jboss-saaj-api_1.3_spec</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.spec.javax.xml.ws</groupId>
+                        <artifactId>jboss-jaxws-api_2.2_spec</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>javax.jws</groupId>
+                        <artifactId>jsr181-api</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.spec.javax.xml.bind</groupId>
+                        <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>javax.mail</groupId>
+                        <artifactId>mail</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>org.jboss.netty</groupId>
+                        <artifactId>netty</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>wsdl4j</groupId>
+                        <artifactId>wsdl4j</artifactId>
+                     </exclusion>
+                     <exclusion>
+                        <groupId>javassist</groupId>
+                        <artifactId>javassist</artifactId>
+                    </exclusion>
+               </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.ws.native</groupId>
+                <artifactId>jbossws-native-factories</artifactId>
+                <version>${version.org.jboss.ws.jbossws-native}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.ws.native</groupId>
+                <artifactId>jbossws-native-services</artifactId>
+                <version>${version.org.jboss.ws.jbossws-native}</version>
             </dependency>
 
             <dependency>

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/ServletDelegateFactoryImpl.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/ServletDelegateFactoryImpl.java
@@ -36,10 +36,11 @@ import org.jboss.wsf.spi.deployment.ServletDelegateFactory;
 public class ServletDelegateFactoryImpl implements ServletDelegateFactory {
 
     @Override
-    public ServletDelegate newServletDelegate(String servletClassName) {
+    public ServletDelegate newServletDelegate(final String servletClassName, final boolean isJaxWs) {
+        final ClassLoaderProvider provider = ClassLoaderProvider.getDefaultProvider();
+        final ClassLoader classLoader = isJaxWs ? provider.getServerIntegrationClassLoader() : provider.getServerJAXRPCIntegrationClassLoader();
         try {
-            ClassLoader classLoader = ClassLoaderProvider.getDefaultProvider().getServerIntegrationClassLoader();
-            Class<?> clazz = classLoader.loadClass(servletClassName);
+            final Class<?> clazz = classLoader.loadClass(servletClassName);
             return (ServletDelegate) clazz.newInstance();
         } catch (Exception e) {
             throw new RuntimeException("Could not create servlet delegate: " + servletClassName, e);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataModifier.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataModifier.java
@@ -97,6 +97,8 @@ final class WebMetaDataModifier {
                     final List<ParamValueMetaData> initParams = WebMetaDataHelper.getServletInitParams(servletMD);
                     // configure transport class name
                     WebMetaDataHelper.newParamValue(WSFServlet.STACK_SERVLET_DELEGATE_CLASS, transportClassName, initParams);
+                    // configure the integration classloader to be used (JAXRPC or JAXWS)
+                    WebMetaDataHelper.newParamValue(WSFServlet.INTEGRATION_CLASSLOADER, dep.getType().toString(), initParams);
                     // configure webservice endpoint
                     WebMetaDataHelper.newParamValue(Endpoint.SEPID_DOMAIN_ENDPOINT, endpointClassName, initParams);
                 }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/ASHelper.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/ASHelper.java
@@ -390,6 +390,8 @@ public final class ASHelper {
         final boolean hasWebservicesMD = unit.hasAttachment(WSAttachmentKeys.WEBSERVICES_METADATA_KEY);
         final boolean hasJBossWebMD = getJBossWebMetaData(unit) != null;
 
+        // TODO: at least also check for jaxrpc mapping file element in WebservicesMD as a JAXWS deployment is also allowed to
+        // have webservices.xml despite that being very uncommon.
         if (hasWebservicesMD && hasJBossWebMD) {
             return getJaxrpcServlets(unit).size() > 0;
         }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/ModuleClassLoaderProvider.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/ModuleClassLoaderProvider.java
@@ -38,6 +38,8 @@ public class ModuleClassLoaderProvider extends ClassLoaderProvider {
 
     private static final ModuleIdentifier ASIL = ModuleIdentifier.create("org.jboss.as.webservices.server.integration");
     private WeakReference<ClassLoader> integrationClassLoader;
+    private static final ModuleIdentifier JAXRPC_ASIL = ModuleIdentifier.create("org.jboss.as.webservices.server.jaxrpc-integration");
+    private WeakReference<ClassLoader> jaxrpcIntegrationClassLoader;
 
     @Override
     public ClassLoader getWebServiceSubsystemClassLoader() {
@@ -55,6 +57,19 @@ public class ModuleClassLoaderProvider extends ClassLoaderProvider {
             }
         }
         return integrationClassLoader.get();
+    }
+
+    @Override
+    public ClassLoader getServerJAXRPCIntegrationClassLoader() {
+        if (jaxrpcIntegrationClassLoader == null || jaxrpcIntegrationClassLoader.get() == null) {
+            try {
+                Module module = Module.getBootModuleLoader().loadModule(JAXRPC_ASIL);
+                jaxrpcIntegrationClassLoader = new WeakReference<ClassLoader>(module.getClassLoader());
+            } catch (ModuleLoadException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return jaxrpcIntegrationClassLoader.get();
     }
 
     public static void register() {


### PR DESCRIPTION
The changes basically restore the jbossws-native stack into the AS for serving JAX-RPC only requests.
Basic jaxrpc functionalities tested and properly working (no client support yet, due to missing appclient support)
- JBWS-3366: Initial JAX-RPC support - restoring dual ws stack configuration
