### PR TITLE
Minor fix to the jboss-as-ejb3_1_2.xsd

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_2.xsd
@@ -113,10 +113,13 @@
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:token">
+            <xs:enumeration value="DAYS"/>
             <xs:enumeration value="HOURS"/>
             <xs:enumeration value="MINUTES"/>
             <xs:enumeration value="SECONDS"/>
             <xs:enumeration value="MILLISECONDS"/>
+            <xs:enumeration value="MICROSECONDS"/>
+            <xs:enumeration value="NANOSECONDS"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
The commit introduces a fix to the jboss-as-ejb3_1_2.xsd to allow all possible timeunit(s) to be consistent with the rest of the elements. Just a xsd change, since the code already allows those timeunits.
