### PR TITLE
Fix for AS7-2056

### DIFF
--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/Echo.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/Echo.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.ejb.jndi;
+
+/**
+ * User: jpai
+ */
+public interface Echo {
+
+    String echo(String msg);
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/EchoBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/EchoBean.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.ejb.jndi;
+
+import javax.ejb.Local;
+import javax.ejb.LocalBean;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * User: jpai
+ */
+@Stateless
+@LocalBean
+@Remote(RemoteEcho.class)
+@Local(Echo.class)
+public class EchoBean implements Echo {
+
+    public String echo(String msg) {
+        return msg;
+    }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/OverriddenAppNameTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/OverriddenAppNameTestCase.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.ejb.jndi;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+/**
+ * Test that the deployment(s) with an overridden application-name and module-name have the correct EJB
+ * jndi bindings
+ * <p/>
+ * User: Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class OverriddenAppNameTestCase {
+
+    private static final Logger logger = Logger.getLogger(OverriddenAppNameTestCase.class);
+
+    /**
+     * The app name of the deployment
+     */
+    private static final String APP_NAME = "application-name-in-application.xml";
+
+    /**
+     * Complete ear file name including the .ear file extension
+     */
+    private static final String EAR_NAME = "overridden-application-name.ear";
+
+    /**
+     * The module name of the deployment
+     */
+    private static final String MODULE_NAME = "module-name-in-ejb-jar.xml";
+
+    /**
+     * Complete jar file name including the .jar file extension
+     */
+    private static final String JAR_NAME = "ejb.jar";
+
+    /**
+     * java:global/ namespace
+     */
+    private static final String JAVA_GLOBAL_NAMESPACE_PREFIX = "java:global/";
+
+    /**
+     * java:app/ namespace
+     */
+    private static final String JAVA_APP_NAMESPACE_PREFIX = "java:app/";
+
+    /**
+     * java:module/ namespace
+     */
+    private static final String JAVA_MODULE_NAMESPACE_PREFIX = "java:module/";
+
+    /**
+     * Create the deployment
+     *
+     * @return
+     */
+    @Deployment
+    public static EnterpriseArchive createEar() {
+        // create the top level ear
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_NAME);
+        // add application.xml
+        ear.addAsManifestResource("ejb/jndi/application.xml", "application.xml");
+
+        // create the jar containing the EJBs
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JAR_NAME);
+        // add ejb-jar.xml
+        jar.addAsManifestResource("ejb/jndi/ejb-jar.xml", "ejb-jar.xml");
+        // add the entire package
+        jar.addPackage(EchoBean.class.getPackage());
+        logger.info(jar.toString(true));
+
+        // add the jar to the .ear
+        ear.add(jar, "/", ZipExporter.class);
+        logger.info(ear.toString(true));
+
+        // return the .ear
+        return ear;
+    }
+
+    /**
+     * Tests that all possible local view bindings of a Stateless bean are available, when deployed through a .ear
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLocalBindingsOnSLSB() throws Exception {
+        Context ctx = new InitialContext();
+        String ejbName = EchoBean.class.getSimpleName();
+        // global bindings
+        // 1. local business interface
+        Echo localBusinessInterface = (Echo) ctx.lookup(JAVA_GLOBAL_NAMESPACE_PREFIX + APP_NAME + "/" + MODULE_NAME + "/" + ejbName + "!" + Echo.class.getName());
+        Assert.assertNotNull("Null object returned for local business interface lookup in java:global namespace", localBusinessInterface);
+        // 2. no-interface view
+        EchoBean noInterfaceView = (EchoBean) ctx.lookup(JAVA_GLOBAL_NAMESPACE_PREFIX + APP_NAME + "/" + MODULE_NAME + "/" + ejbName + "!" + EchoBean.class.getName());
+        Assert.assertNotNull("Null object returned for no-interface view lookup in java:global namespace", noInterfaceView);
+
+
+        // app bindings
+        // 1. local business interface
+        Echo localBusinessInterfaceInAppNamespace = (Echo) ctx.lookup(JAVA_APP_NAMESPACE_PREFIX + MODULE_NAME + "/" + ejbName + "!" + Echo.class.getName());
+        Assert.assertNotNull("Null object returned for local business interface lookup in java:app namespace", localBusinessInterfaceInAppNamespace);
+        // 2. no-interface view
+        EchoBean noInterfaceViewInAppNamespace = (EchoBean) ctx.lookup(JAVA_APP_NAMESPACE_PREFIX + MODULE_NAME + "/" + ejbName + "!" + EchoBean.class.getName());
+        Assert.assertNotNull("Null object returned for no-interface view lookup in java:app namespace", noInterfaceViewInAppNamespace);
+
+        // module bindings
+        // 1. local business interface
+        Echo localBusinessInterfaceInModuleNamespace = (Echo) ctx.lookup(JAVA_MODULE_NAMESPACE_PREFIX + ejbName + "!" + Echo.class.getName());
+        Assert.assertNotNull("Null object returned for local business interface lookup in java:module namespace", localBusinessInterfaceInModuleNamespace);
+        // 2. no-interface view
+        EchoBean noInterfaceViewInModuleNamespace = (EchoBean) ctx.lookup(JAVA_MODULE_NAMESPACE_PREFIX + ejbName + "!" + EchoBean.class.getName());
+        Assert.assertNotNull("Null object returned for no-interface view lookup in java:module namespace", noInterfaceViewInModuleNamespace);
+
+    }
+
+    /**
+     * Tests that all possible remote view bindings of a Stateless bean are available, when deployed through a .ear
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRemoteBindingsOnSLSB() throws Exception {
+        Context ctx = new InitialContext();
+        String ejbName = EchoBean.class.getSimpleName();
+        // global bindings
+        // 1. remote business interface
+        RemoteEcho remoteBusinessInterface = (RemoteEcho) ctx.lookup(JAVA_GLOBAL_NAMESPACE_PREFIX + APP_NAME + "/" + MODULE_NAME + "/" + ejbName + "!" + RemoteEcho.class.getName());
+        Assert.assertNotNull("Null object returned for remote business interface lookup in java:global namespace", remoteBusinessInterface);
+
+        // app bindings
+        // 1. remote business interface
+        RemoteEcho remoteBusinessInterfaceInAppNamespace = (RemoteEcho) ctx.lookup(JAVA_APP_NAMESPACE_PREFIX + MODULE_NAME + "/" + ejbName + "!" + RemoteEcho.class.getName());
+        Assert.assertNotNull("Null object returned for remote business interface lookup in java:app namespace", remoteBusinessInterfaceInAppNamespace);
+
+        // module bindings
+        // 1. remote business interface
+        RemoteEcho remoteBusinessInterfaceInModuleNamespace = (RemoteEcho) ctx.lookup(JAVA_MODULE_NAMESPACE_PREFIX + ejbName + "!" + RemoteEcho.class.getName());
+        Assert.assertNotNull("Null object returned for remote business interface lookup in java:module namespace", remoteBusinessInterfaceInModuleNamespace);
+
+    }
+
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/RemoteEcho.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/testsuite/integration/ejb/jndi/RemoteEcho.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.ejb.jndi;
+
+/**
+ * User: jpai
+ */
+public interface RemoteEcho extends Echo {
+}

--- a/testsuite/integration/src/test/resources/ejb/jndi/application.xml
+++ b/testsuite/integration/src/test/resources/ejb/jndi/application.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+      	http://java.sun.com/xml/ns/javaee/application_6.xsd"
+      version="6">
+
+    <application-name>application-name-in-application.xml</application-name>
+
+</application>

--- a/testsuite/integration/src/test/resources/ejb/jndi/ejb-jar.xml
+++ b/testsuite/integration/src/test/resources/ejb/jndi/ejb-jar.xml
@@ -1,0 +1,31 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+         version="3.1">
+    <module-name>module-name-in-ejb-jar.xml</module-name>
+</ejb-jar>
+
+


### PR DESCRIPTION
This commit fixes the issue reported in https://issues.jboss.org/browse/AS7-2056 where the EJB jndi bindings weren't taking into account the overridden application-name from application.xml.
