### PR TITLE
AS7-2071 mutable managed executor services for thread pools

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
@@ -23,7 +23,6 @@ package org.jboss.as.threads;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;

--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
@@ -98,7 +98,7 @@ public class BoundedQueueThreadPoolAdd extends AbstractAddStepHandler implements
 
         //TODO add the handoffExceutor injection
 
-        final ServiceBuilder<ExecutorService> serviceBuilder = target.addService(serviceName, service);
+        final ServiceBuilder<ManagedQueueExecutorService> serviceBuilder = target.addService(serviceName, service);
         ThreadsSubsystemThreadPoolOperationUtils.addThreadFactoryDependency(params.getThreadFactory(), serviceName, serviceBuilder, service.getThreadFactoryInjector(), target, params.getName() + "-threads");
         serviceBuilder.addListener(verificationHandler);
         serviceBuilder.install();

--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolAdd.java
@@ -58,6 +58,10 @@ public class BoundedQueueThreadPoolAdd extends AbstractAddStepHandler implements
         PoolAttributeDefinitions.CORE_THREADS, PoolAttributeDefinitions.QUEUE_LENGTH, PoolAttributeDefinitions.HANDOFF_EXECUTOR,
         PoolAttributeDefinitions.ALLOW_CORE_TIMEOUT, PoolAttributeDefinitions.BLOCKING};
 
+    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
+        PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.CORE_THREADS, PoolAttributeDefinitions.QUEUE_LENGTH,
+        PoolAttributeDefinitions.ALLOW_CORE_TIMEOUT, PoolAttributeDefinitions.BLOCKING};
+
     @Override
     public ModelNode getModelDescription(Locale locale) {
         return ThreadsSubsystemProviders.ADD_BOUNDED_QUEUE_THREAD_POOL_DESC.getModelDescription(locale);

--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolWriteAttributeHandler.java
@@ -1,0 +1,131 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.threads.CommonAttributes.COUNT;
+import static org.jboss.as.threads.CommonAttributes.KEEPALIVE_TIME;
+import static org.jboss.as.threads.CommonAttributes.MAX_THREADS;
+import static org.jboss.as.threads.CommonAttributes.PER_CPU;
+import static org.jboss.as.threads.CommonAttributes.TIME;
+import static org.jboss.as.threads.CommonAttributes.UNIT;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
+
+    public static final BoundedQueueThreadPoolWriteAttributeHandler INSTANCE = new BoundedQueueThreadPoolWriteAttributeHandler();
+
+    private BoundedQueueThreadPoolWriteAttributeHandler() {
+        super(BoundedQueueThreadPoolAdd.ATTRIBUTES, BoundedQueueThreadPoolAdd.RW_ATTRIBUTES);
+    }
+
+    protected void applyOperation(ModelNode operation, String attributeName, ServiceController<?> service) {
+
+        final BoundedQueueThreadPoolService pool =  (BoundedQueueThreadPoolService) service.getService();
+        try {
+            final ModelNode value = operation.require(CommonAttributes.VALUE);
+            if (CommonAttributes.KEEPALIVE_TIME.equals(attributeName)) {
+                if (!value.hasDefined(TIME)) {
+                    throw new IllegalArgumentException("Missing '" + TIME + "' for '" + KEEPALIVE_TIME + "'");
+                }
+                if (!value.hasDefined(UNIT)) {
+                    throw new IllegalArgumentException("Missing '" + UNIT + "' for '" + KEEPALIVE_TIME + "'");
+                }
+                final TimeUnit unit;
+                try {
+                unit = Enum.valueOf(TimeUnit.class, value.get(UNIT).asString());
+                } catch(IllegalArgumentException e) {
+                    throw new OperationFailedException(new ModelNode().set("Failed to parse '" + UNIT + "', allowed values are: " + Arrays.asList(TimeUnit.values())));
+                }
+                final TimeSpec spec = new TimeSpec(unit, value.get(TIME).asLong());
+                pool.setKeepAlive(spec);
+            } else if(CommonAttributes.MAX_THREADS.equals(attributeName)) {
+                pool.setMaxThreads(getScaledCount(CommonAttributes.MAX_THREADS, value));
+            } else if(CommonAttributes.CORE_THREADS.equals(attributeName)) {
+                pool.setCoreThreads(getScaledCount(CommonAttributes.CORE_THREADS, value));
+            } else if(CommonAttributes.QUEUE_LENGTH.equals(attributeName)) {
+                pool.setQueueLength(getScaledCount(CommonAttributes.QUEUE_LENGTH, value));
+            } else if(CommonAttributes.ALLOW_CORE_TIMEOUT.equals(attributeName)) {
+                pool.setAllowCoreTimeout(value.asBoolean());
+            } else if(CommonAttributes.BLOCKING.equals(attributeName)) {
+                pool.setBlocking(value.asBoolean());
+            } else {
+                throw new IllegalArgumentException("Unexpected attribute '" + attributeName + "'");
+            }
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected int getScaledCount(String attributeName, final ModelNode value) {
+        if (!value.hasDefined(COUNT)) {
+            throw new IllegalArgumentException("Missing '" + COUNT + "' for '" + attributeName + "'");
+        }
+        if (!value.hasDefined(PER_CPU)) {
+            throw new IllegalArgumentException("Missing '" + PER_CPU + "' for '" + attributeName + "'");
+        }
+
+        final BigDecimal count;
+        try {
+            count = value.get(COUNT).asBigDecimal();
+        } catch(NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to parse '" + COUNT + "' as java.math.BigDecimal", e);
+        }
+        final BigDecimal perCpu;
+        try {
+            perCpu = value.get(PER_CPU).asBigDecimal();
+        } catch(NumberFormatException e) {
+            throw new IllegalArgumentException("Failed to parse '" + PER_CPU + "' as java.math.BigDecimal", e);
+        }
+
+        return new ScaledCount(count, perCpu).getScaledCount();
+    }
+
+    @Override
+    protected ServiceController<?> getService(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        final String name = Util.getNameFromAddress(operation.require(OP_ADDR));
+        final ServiceName serviceName = ThreadsServices.executorName(name);
+        ServiceController<?> controller = context.getServiceRegistry(true).getService(serviceName);
+        if(controller == null) {
+            throw new OperationFailedException(new ModelNode().set("Service " + serviceName + " not found."));
+        }
+        return controller;
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/ManagedExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedExecutorService.java
@@ -1,0 +1,174 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.threads.BlockingExecutorService;
+import org.jboss.threads.JBossExecutors;
+
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ManagedExecutorService implements ExecutorService {
+
+    private final ExecutorService executor;
+
+    public ManagedExecutorService(BlockingExecutorService executor) {
+        if(executor == null) {
+            throw new IllegalArgumentException("Executor is null.");
+        }
+        this.executor = JBossExecutors.protectedBlockingExecutorService(executor);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.Executor#execute(java.lang.Runnable)
+     */
+    @Override
+    public void execute(Runnable command) {
+        this.executor.execute(command);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#shutdown()
+     */
+    @Override
+    public void shutdown() {
+        // Don't shutdown managed executor
+    }
+
+    void internalShutdown() {
+        executor.shutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#shutdownNow()
+     */
+    @Override
+    public List<Runnable> shutdownNow() {
+        // Don't shutdown managed executor
+        return Collections.emptyList();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#isShutdown()
+     */
+    @Override
+    public boolean isShutdown() {
+        return this.executor.isShutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#isTerminated()
+     */
+    @Override
+    public boolean isTerminated() {
+        return this.executor.isTerminated();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#awaitTermination(long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return this.executor.isTerminated();
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#submit(java.util.concurrent.Callable)
+     */
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return this.executor.submit(task);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#submit(java.lang.Runnable, java.lang.Object)
+     */
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return this.executor.submit(task, result);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#submit(java.lang.Runnable)
+     */
+    @Override
+    public Future<?> submit(Runnable task) {
+        return this.executor.submit(task);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#invokeAll(java.util.Collection)
+     */
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return this.executor.invokeAll(tasks);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#invokeAll(java.util.Collection, long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return this.executor.invokeAll(tasks, timeout, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#invokeAny(java.util.Collection)
+     */
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return this.executor.invokeAny(tasks);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see java.util.concurrent.ExecutorService#invokeAny(java.util.Collection, long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return this.executor.invokeAny(tasks, timeout, unit);
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/ManagedJBossThreadPoolExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedJBossThreadPoolExecutorService.java
@@ -28,17 +28,17 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.threads.BlockingExecutor;
 import org.jboss.threads.EventListener;
 import org.jboss.threads.JBossExecutors;
-import org.jboss.threads.QueueExecutor;
+import org.jboss.threads.JBossThreadPoolExecutor;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-public class ManagedQueueExecutorService extends ManagedExecutorService implements BlockingExecutor {
+public class ManagedJBossThreadPoolExecutorService extends ManagedExecutorService implements BlockingExecutor {
 
-    private final QueueExecutor executor;
+    private final JBossThreadPoolExecutor executor;
 
-    public ManagedQueueExecutorService(QueueExecutor executor) {
+    public ManagedJBossThreadPoolExecutorService(JBossThreadPoolExecutor executor) {
         super(executor);
         this.executor = executor;
     }
@@ -94,12 +94,32 @@ public class ManagedQueueExecutorService extends ManagedExecutorService implemen
         executor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
     }
 
-    public int getCurrentThreadCount() {
-        return executor.getCurrentThreadCount();
+    public int getRejectedCount() {
+        return executor.getRejectedCount();
+    }
+
+    public long getTaskCount() {
+        return executor.getTaskCount();
     }
 
     public int getLargestThreadCount() {
         return executor.getLargestThreadCount();
+    }
+
+    public int getLargestPoolSize() {
+        return executor.getLargestPoolSize();
+    }
+
+    public int getCurrentThreadCount() {
+        return executor.getCurrentThreadCount();
+    }
+
+    public long getCompletedTaskCount() {
+        return executor.getCompletedTaskCount();
+    }
+
+    public int getActiveCount() {
+        return executor.getActiveCount();
     }
 
     <A> void addShutdownListener(final EventListener<A> shutdownListener, final A attachment) {

--- a/threads/src/main/java/org/jboss/as/threads/ManagedQueueExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedQueueExecutorService.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+import org.jboss.threads.EventListener;
+import org.jboss.threads.QueueExecutor;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ManagedQueueExecutorService extends ManagedExecutorService {
+
+    private final QueueExecutor executor;
+
+    public ManagedQueueExecutorService(QueueExecutor executor) {
+        super(executor);
+        this.executor = executor;
+    }
+
+    public int getCoreThreads() {
+        return executor.getCoreThreads();
+    }
+
+    // Package protected for subsys write-attribute handlers
+    void setCoreThreads(int coreThreads) {
+        executor.setCoreThreads(coreThreads);
+    }
+
+    public boolean isAllowCoreTimeout() {
+        return executor.isAllowCoreThreadTimeout();
+    }
+
+    void setAllowCoreTimeout(boolean allowCoreTimeout) {
+        executor.setAllowCoreThreadTimeout(allowCoreTimeout);
+    }
+
+    public boolean isBlocking() {
+        return executor.isBlocking();
+    }
+
+    void setBlocking(boolean blocking) {
+        executor.setBlocking(blocking);
+    }
+
+    public int getMaxThreads() {
+        return executor.getMaxThreads();
+    }
+
+    void setMaxThreads(int maxThreads) {
+        executor.setMaxThreads(maxThreads);
+    }
+
+    public long getKeepAlive() {
+        return executor.getKeepAliveTime();
+    }
+
+    void setKeepAlive(TimeSpec keepAlive) {
+        executor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
+    }
+
+    public int getCurrentThreadCount() {
+        return executor.getCurrentThreadCount();
+    }
+
+    public int getLargestThreadCount() {
+        return executor.getLargestThreadCount();
+    }
+
+    <A> void addShutdownListener(final EventListener<A> shutdownListener, final A attachment) {
+        executor.addShutdownListener(shutdownListener, attachment);
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/ManagedQueuelessExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedQueuelessExecutorService.java
@@ -28,17 +28,17 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.threads.BlockingExecutor;
 import org.jboss.threads.EventListener;
 import org.jboss.threads.JBossExecutors;
-import org.jboss.threads.QueueExecutor;
+import org.jboss.threads.QueuelessExecutor;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-public class ManagedQueueExecutorService extends ManagedExecutorService implements BlockingExecutor {
+public class ManagedQueuelessExecutorService extends ManagedExecutorService implements BlockingExecutor {
 
-    private final QueueExecutor executor;
+    private final QueuelessExecutor executor;
 
-    public ManagedQueueExecutorService(QueueExecutor executor) {
+    public ManagedQueuelessExecutorService(QueuelessExecutor executor) {
         super(executor);
         this.executor = executor;
     }
@@ -51,23 +51,6 @@ public class ManagedQueueExecutorService extends ManagedExecutorService implemen
     @Override
     void internalShutdown() {
         executor.shutdown();
-    }
-
-    public int getCoreThreads() {
-        return executor.getCoreThreads();
-    }
-
-    // Package protected for subsys write-attribute handlers
-    void setCoreThreads(int coreThreads) {
-        executor.setCoreThreads(coreThreads);
-    }
-
-    public boolean isAllowCoreTimeout() {
-        return executor.isAllowCoreThreadTimeout();
-    }
-
-    void setAllowCoreTimeout(boolean allowCoreTimeout) {
-        executor.setAllowCoreThreadTimeout(allowCoreTimeout);
     }
 
     public boolean isBlocking() {
@@ -90,8 +73,12 @@ public class ManagedQueueExecutorService extends ManagedExecutorService implemen
         return executor.getKeepAliveTime();
     }
 
-    void setKeepAlive(TimeSpec keepAlive) {
-        executor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
+    void setKeepAlive(long milliseconds) {
+        executor.setKeepAliveTime(milliseconds);
+    }
+
+    public int getRejectedCount() {
+        return executor.getRejectedCount();
     }
 
     public int getCurrentThreadCount() {

--- a/threads/src/main/java/org/jboss/as/threads/ManagedScheduledExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedScheduledExecutorService.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.threads;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import org.jboss.threads.JBossExecutors;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ManagedScheduledExecutorService extends ManagedExecutorService {
+
+    private final ScheduledThreadPoolExecutor executor;
+
+    public ManagedScheduledExecutorService(ScheduledThreadPoolExecutor executor) {
+        super(executor);
+        this.executor = executor;
+    }
+
+    @Override
+    protected ExecutorService protectExecutor(ExecutorService executor) {
+        return JBossExecutors.protectedScheduledExecutorService((ScheduledExecutorService) executor);
+    }
+
+    @Override
+    void internalShutdown() {
+        executor.shutdown();
+    }
+
+    public int getActiveCount() {
+        return executor.getActiveCount();
+    }
+
+    public long getCompletedTaskCount() {
+        return executor.getCompletedTaskCount();
+    }
+
+    public int getLargestPoolSize() {
+        return executor.getLargestPoolSize();
+    }
+
+    public long getTaskCount() {
+        return executor.getTaskCount();
+    }
+}

--- a/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolAdd.java
@@ -23,7 +23,6 @@ package org.jboss.as.threads;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -89,7 +88,7 @@ public class QueuelessThreadPoolAdd extends AbstractAddStepHandler implements De
 
         //TODO add the handoffExceutor injection
 
-        final ServiceBuilder<ExecutorService> serviceBuilder = target.addService(serviceName, service);
+        final ServiceBuilder<ManagedQueuelessExecutorService> serviceBuilder = target.addService(serviceName, service);
         ThreadsSubsystemThreadPoolOperationUtils.addThreadFactoryDependency(params.getThreadFactory(), serviceName, serviceBuilder, service.getThreadFactoryInjector(), target, params.getName() + "-threads");
         serviceBuilder.addListener(verificationHandler);
         serviceBuilder.install();

--- a/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolAdd.java
@@ -56,6 +56,9 @@ public class QueuelessThreadPoolAdd extends AbstractAddStepHandler implements De
         PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.PROPERTIES, PoolAttributeDefinitions.THREAD_FACTORY,
         PoolAttributeDefinitions.HANDOFF_EXECUTOR, PoolAttributeDefinitions.BLOCKING};
 
+    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
+        PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.BLOCKING};
+
     @Override
     public ModelNode getModelDescription(Locale locale) {
         return ThreadsSubsystemProviders.ADD_QUEUELESS_THREAD_POOL_DESC.getModelDescription(locale);

--- a/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolWriteAttributeHandler.java
@@ -45,17 +45,17 @@ import org.jboss.msc.service.ServiceName;
  *
  * @author Alexey Loubyansky
  */
-public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
+public class QueuelessThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
 
-    public static final BoundedQueueThreadPoolWriteAttributeHandler INSTANCE = new BoundedQueueThreadPoolWriteAttributeHandler();
+    public static final QueuelessThreadPoolWriteAttributeHandler INSTANCE = new QueuelessThreadPoolWriteAttributeHandler();
 
-    private BoundedQueueThreadPoolWriteAttributeHandler() {
-        super(BoundedQueueThreadPoolAdd.ATTRIBUTES, BoundedQueueThreadPoolAdd.RW_ATTRIBUTES);
+    private QueuelessThreadPoolWriteAttributeHandler() {
+        super(QueuelessThreadPoolAdd.ATTRIBUTES, QueuelessThreadPoolAdd.RW_ATTRIBUTES);
     }
 
     protected void applyOperation(ModelNode operation, String attributeName, ServiceController<?> service) {
 
-        final BoundedQueueThreadPoolService pool =  (BoundedQueueThreadPoolService) service.getService();
+        final QueuelessThreadPoolService pool =  (QueuelessThreadPoolService) service.getService();
         try {
             final ModelNode value = operation.require(CommonAttributes.VALUE);
             if (CommonAttributes.KEEPALIVE_TIME.equals(attributeName)) {
@@ -75,12 +75,6 @@ public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAtt
                 pool.setKeepAlive(spec);
             } else if(CommonAttributes.MAX_THREADS.equals(attributeName)) {
                 pool.setMaxThreads(getScaledCount(CommonAttributes.MAX_THREADS, value));
-            } else if(CommonAttributes.CORE_THREADS.equals(attributeName)) {
-                pool.setCoreThreads(getScaledCount(CommonAttributes.CORE_THREADS, value));
-            } else if(CommonAttributes.QUEUE_LENGTH.equals(attributeName)) {
-                pool.setQueueLength(getScaledCount(CommonAttributes.QUEUE_LENGTH, value));
-            } else if(CommonAttributes.ALLOW_CORE_TIMEOUT.equals(attributeName)) {
-                pool.setAllowCoreTimeout(value.asBoolean());
             } else if(CommonAttributes.BLOCKING.equals(attributeName)) {
                 pool.setBlocking(value.asBoolean());
             } else {

--- a/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolAdd.java
@@ -55,6 +55,8 @@ public class ScheduledThreadPoolAdd extends AbstractAddStepHandler implements De
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
         PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.PROPERTIES, PoolAttributeDefinitions.THREAD_FACTORY};
 
+    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[]{};
+
     @Override
     public ModelNode getModelDescription(Locale locale) {
         return ThreadsSubsystemProviders.ADD_SCHEDULED_THREAD_POOL_DESC.getModelDescription(locale);

--- a/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolAdd.java
@@ -23,7 +23,6 @@ package org.jboss.as.threads;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -85,7 +84,7 @@ public class ScheduledThreadPoolAdd extends AbstractAddStepHandler implements De
         ServiceTarget target = context.getServiceTarget();
         final ServiceName serviceName = ThreadsServices.executorName(params.getName());
         final ScheduledThreadPoolService service = new ScheduledThreadPoolService(params.getMaxThreads().getScaledCount(), params.getKeepAliveTime());
-        final ServiceBuilder<ScheduledExecutorService> serviceBuilder = target.addService(serviceName, service);
+        final ServiceBuilder<ManagedScheduledExecutorService> serviceBuilder = target.addService(serviceName, service);
         ThreadsSubsystemThreadPoolOperationUtils.addThreadFactoryDependency(params.getThreadFactory(), serviceName, serviceBuilder, service.getThreadFactoryInjector(), target, params.getName() + "-threads");
         serviceBuilder.addListener(verificationHandler);
         serviceBuilder.install();

--- a/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolService.java
@@ -28,9 +28,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.threads.JBossExecutors;
 
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 

--- a/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolService.java
@@ -39,12 +39,11 @@ import java.util.concurrent.ThreadFactory;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-public final class ScheduledThreadPoolService implements Service<ScheduledExecutorService> {
+public final class ScheduledThreadPoolService implements Service<ManagedScheduledExecutorService> {
 
     private final InjectedValue<ThreadFactory> threadFactoryValue = new InjectedValue<ThreadFactory>();
 
-    private ScheduledThreadPoolExecutor executor;
-    private ScheduledExecutorService value;
+    private ManagedScheduledExecutorService executor;
     private StopContext context;
 
     private final int maxThreads;
@@ -56,27 +55,26 @@ public final class ScheduledThreadPoolService implements Service<ScheduledExecut
     }
 
     public synchronized void start(final StartContext context) throws StartException {
-        executor = new ExecutorImpl(0, threadFactoryValue.getValue());
-        executor.setCorePoolSize(maxThreads);
+        ScheduledThreadPoolExecutor scheduledExecutor = new ExecutorImpl(0, threadFactoryValue.getValue());
+        scheduledExecutor.setCorePoolSize(maxThreads);
         if(keepAlive != null)
-            executor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
-        value = JBossExecutors.protectedScheduledExecutorService(executor);
+            scheduledExecutor.setKeepAliveTime(keepAlive.getDuration(), keepAlive.getUnit());
+        executor = new ManagedScheduledExecutorService(scheduledExecutor);
     }
 
     public synchronized void stop(final StopContext context) {
-        final ScheduledThreadPoolExecutor executor = this.executor;
+        final ManagedScheduledExecutorService executor = this.executor;
         if (executor == null) {
             throw new IllegalStateException();
         }
         this.context = context;
         context.asynchronous();
-        executor.shutdown();
+        executor.internalShutdown();
         this.executor = null;
-        value = null;
     }
 
-    public synchronized ScheduledExecutorService getValue() throws IllegalStateException {
-        final ScheduledExecutorService value = this.value;
+    public synchronized ManagedScheduledExecutorService getValue() throws IllegalStateException {
+        final ManagedScheduledExecutorService value = this.executor;
         if (value == null) {
             throw new IllegalStateException();
         }
@@ -88,18 +86,34 @@ public final class ScheduledThreadPoolService implements Service<ScheduledExecut
     }
 
     public int getActiveCount() {
+        final ManagedScheduledExecutorService executor = this.executor;
+        if(executor == null) {
+            throw new IllegalStateException("The exector service hasn't been initialized.");
+        }
         return executor.getActiveCount();
     }
 
     public long getCompletedTaskCount() {
+        final ManagedScheduledExecutorService executor = this.executor;
+        if(executor == null) {
+            throw new IllegalStateException("The exector service hasn't been initialized.");
+        }
         return executor.getCompletedTaskCount();
     }
 
     public int getLargestPoolSize() {
+        final ManagedScheduledExecutorService executor = this.executor;
+        if(executor == null) {
+            throw new IllegalStateException("The exector service hasn't been initialized.");
+        }
         return executor.getLargestPoolSize();
     }
 
     public long getTaskCount() {
+        final ManagedScheduledExecutorService executor = this.executor;
+        if(executor == null) {
+            throw new IllegalStateException("The exector service hasn't been initialized.");
+        }
         return executor.getTaskCount();
     }
 

--- a/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolWriteAttributeHandler.java
@@ -24,14 +24,9 @@ package org.jboss.as.threads;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.threads.CommonAttributes.COUNT;
-import static org.jboss.as.threads.CommonAttributes.KEEPALIVE_TIME;
 import static org.jboss.as.threads.CommonAttributes.PER_CPU;
-import static org.jboss.as.threads.CommonAttributes.TIME;
-import static org.jboss.as.threads.CommonAttributes.UNIT;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -45,55 +40,21 @@ import org.jboss.msc.service.ServiceName;
  *
  * @author Alexey Loubyansky
  */
-public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
+public class ScheduledThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
 
-    public static final BoundedQueueThreadPoolWriteAttributeHandler INSTANCE = new BoundedQueueThreadPoolWriteAttributeHandler();
+    public static final ScheduledThreadPoolWriteAttributeHandler INSTANCE = new ScheduledThreadPoolWriteAttributeHandler();
 
-    private BoundedQueueThreadPoolWriteAttributeHandler() {
-        super(BoundedQueueThreadPoolAdd.ATTRIBUTES, BoundedQueueThreadPoolAdd.RW_ATTRIBUTES);
+    private ScheduledThreadPoolWriteAttributeHandler() {
+        super(ScheduledThreadPoolAdd.ATTRIBUTES, ScheduledThreadPoolAdd.RW_ATTRIBUTES);
     }
 
     protected void applyOperation(ModelNode operation, String attributeName, ServiceController<?> service) {
 
-        final BoundedQueueThreadPoolService pool =  (BoundedQueueThreadPoolService) service.getService();
-        try {
-            final ModelNode value = operation.require(CommonAttributes.VALUE);
-            if (CommonAttributes.KEEPALIVE_TIME.equals(attributeName)) {
-                if (!value.hasDefined(TIME)) {
-                    throw new IllegalArgumentException("Missing '" + TIME + "' for '" + KEEPALIVE_TIME + "'");
-                }
-                if (!value.hasDefined(UNIT)) {
-                    throw new IllegalArgumentException("Missing '" + UNIT + "' for '" + KEEPALIVE_TIME + "'");
-                }
-                final TimeUnit unit;
-                try {
-                unit = Enum.valueOf(TimeUnit.class, value.get(UNIT).asString());
-                } catch(IllegalArgumentException e) {
-                    throw new OperationFailedException(new ModelNode().set("Failed to parse '" + UNIT + "', allowed values are: " + Arrays.asList(TimeUnit.values())));
-                }
-                final TimeSpec spec = new TimeSpec(unit, value.get(TIME).asLong());
-                pool.setKeepAlive(spec);
-            } else if(CommonAttributes.MAX_THREADS.equals(attributeName)) {
-                pool.setMaxThreads(getScaledCount(CommonAttributes.MAX_THREADS, value));
-            } else if(CommonAttributes.CORE_THREADS.equals(attributeName)) {
-                pool.setCoreThreads(getScaledCount(CommonAttributes.CORE_THREADS, value));
-            } else if(CommonAttributes.QUEUE_LENGTH.equals(attributeName)) {
-                pool.setQueueLength(getScaledCount(CommonAttributes.QUEUE_LENGTH, value));
-            } else if(CommonAttributes.ALLOW_CORE_TIMEOUT.equals(attributeName)) {
-                pool.setAllowCoreTimeout(value.asBoolean());
-            } else if(CommonAttributes.BLOCKING.equals(attributeName)) {
-                pool.setBlocking(value.asBoolean());
-            } else {
-                throw new IllegalArgumentException("Unexpected attribute '" + attributeName + "'");
-            }
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        throw new IllegalArgumentException("Unexpected attribute '" + attributeName + "'");
+        //final UnboundedQueueThreadPoolService pool =  (UnboundedQueueThreadPoolService) service.getService();
     }
 
-    protected int getScaledCount(String attributeName, final ModelNode value) {
+/*    protected int getScaledCount(String attributeName, final ModelNode value) {
         if (!value.hasDefined(COUNT)) {
             throw new IllegalArgumentException("Missing '" + COUNT + "' for '" + attributeName + "'");
         }
@@ -116,7 +77,7 @@ public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAtt
 
         return new ScaledCount(count, perCpu).getScaledCount();
     }
-
+*/
     @Override
     protected ServiceController<?> getService(final OperationContext context, final ModelNode operation) throws OperationFailedException {
         final String name = Util.getNameFromAddress(operation.require(OP_ADDR));

--- a/threads/src/main/java/org/jboss/as/threads/ThreadFactoryWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadFactoryWriteAttributeHandler.java
@@ -22,8 +22,14 @@
 package org.jboss.as.threads;
 
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 
 
 /**
@@ -38,6 +44,18 @@ public class ThreadFactoryWriteAttributeHandler extends ThreadsWriteAttributeOpe
         super(ThreadFactoryAdd.ATTRIBUTES, ThreadFactoryAdd.RW_ATTRIBUTES);
     }
 
+    @Override
+    protected ServiceController<?> getService(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        final String name = Util.getNameFromAddress(operation.require(OP_ADDR));
+        final ServiceName serviceName = ThreadsServices.threadFactoryName(name);
+        ServiceController<?> controller = context.getServiceRegistry(true).getService(serviceName);
+        if(controller == null) {
+            throw new OperationFailedException(new ModelNode().set("Service " + serviceName + " not found."));
+        }
+        return controller;
+    }
+
+    @Override
     protected void applyOperation(ModelNode operation, String attributeName, ServiceController<?> service) {
 
         final ThreadFactoryService tf = (ThreadFactoryService) service.getService();

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
@@ -110,6 +110,7 @@ public class ThreadsExtension implements Extension {
         unboundedQueueThreadPools.registerOperationHandler(REMOVE, UnboundedQueueThreadPoolRemove.INSTANCE,
                 UnboundedQueueThreadPoolRemove.INSTANCE, false);
         UnboundedQueueThreadPoolReadAttributeHandler.INSTANCE.registerAttributes(unboundedQueueThreadPools);
+        UnboundedQueueThreadPoolWriteAttributeHandler.INSTANCE.registerAttributes(unboundedQueueThreadPools);
 
         final ManagementResourceRegistration queuelessThreadPools = subsystem.registerSubModel(
                 PathElement.pathElement(QUEUELESS_THREAD_POOL), QUEUELESS_THREAD_POOL_DESC);
@@ -118,6 +119,7 @@ public class ThreadsExtension implements Extension {
         queuelessThreadPools.registerOperationHandler(REMOVE, QueuelessThreadPoolRemove.INSTANCE,
                 QueuelessThreadPoolRemove.INSTANCE, false);
         QueuelessThreadPoolReadAttributeHandler.INSTANCE.registerAttributes(queuelessThreadPools);
+        QueuelessThreadPoolWriteAttributeHandler.INSTANCE.registerAttributes(queuelessThreadPools);
 
         final ManagementResourceRegistration scheduledThreadPools = subsystem.registerSubModel(
                 PathElement.pathElement(SCHEDULED_THREAD_POOL), SCHEDULED_THREAD_POOL_DESC);
@@ -126,6 +128,7 @@ public class ThreadsExtension implements Extension {
         scheduledThreadPools.registerOperationHandler(REMOVE, ScheduledThreadPoolRemove.INSTANCE,
                 ScheduledThreadPoolRemove.INSTANCE, false);
         ScheduledThreadPoolReadAttributeHandler.INSTANCE.registerAttributes(scheduledThreadPools);
+        ScheduledThreadPoolWriteAttributeHandler.INSTANCE.registerAttributes(scheduledThreadPools);
     }
 
     @Override

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
@@ -101,6 +101,7 @@ public class ThreadsExtension implements Extension {
         boundedQueueThreadPools.registerOperationHandler(REMOVE, BoundedQueueThreadPoolRemove.INSTANCE,
                 BoundedQueueThreadPoolRemove.INSTANCE, false);
         BoundedQueueThreadPoolReadAttributeHandler.INSTANCE.registerAttributes(boundedQueueThreadPools);
+        BoundedQueueThreadPoolWriteAttributeHandler.INSTANCE.registerAttributes(boundedQueueThreadPools);
 
         final ManagementResourceRegistration unboundedQueueThreadPools = subsystem.registerSubModel(
                 PathElement.pathElement(UNBOUNDED_QUEUE_THREAD_POOL), UNBOUNDED_QUEUE_THREAD_POOL_DESC);

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsWriteAttributeOperationHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsWriteAttributeOperationHandler.java
@@ -33,14 +33,10 @@ import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.operations.global.WriteAttributeHandlers.WriteAttributeOperationHandler;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
@@ -52,7 +48,7 @@ import org.jboss.msc.service.ServiceName;
  */
 public abstract class ThreadsWriteAttributeOperationHandler extends AbstractWriteAttributeHandler<Boolean> {
 
-    private static final Logger log = Logger.getLogger("org.jboss.as.threads");
+//    private static final Logger log = Logger.getLogger("org.jboss.as.threads");
 
     private static final EnumSet<AttributeAccess.Flag> RESTART_NONE = EnumSet.of(AttributeAccess.Flag.RESTART_NONE);
     private static final EnumSet<AttributeAccess.Flag> RESTART_ALL = EnumSet.of(AttributeAccess.Flag.RESTART_ALL_SERVICES);
@@ -136,15 +132,7 @@ public abstract class ThreadsWriteAttributeOperationHandler extends AbstractWrit
         }
     }
 
-    protected ServiceController<?> getService(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-        final String name = Util.getNameFromAddress(operation.require(OP_ADDR));
-        final ServiceName serviceName = ThreadsServices.threadFactoryName(name);
-        ServiceController<?> controller = context.getServiceRegistry(true).getService(serviceName);
-        if(controller == null) {
-            throw new OperationFailedException(new ModelNode().set("Service " + serviceName + " not found."));
-        }
-        return controller;
-    }
+    protected abstract ServiceController<?> getService(final OperationContext context, final ModelNode operation) throws OperationFailedException;
 
     protected abstract void applyOperation(ModelNode operation, String attributeName, ServiceController<?> service);
 }

--- a/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolAdd.java
@@ -57,6 +57,9 @@ public class UnboundedQueueThreadPoolAdd extends AbstractAddStepHandler implemen
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
         PoolAttributeDefinitions.MAX_THREADS, PoolAttributeDefinitions.PROPERTIES, PoolAttributeDefinitions.THREAD_FACTORY};
 
+    static final AttributeDefinition[] RW_ATTRIBUTES = new AttributeDefinition[] {PoolAttributeDefinitions.KEEPALIVE_TIME,
+        PoolAttributeDefinitions.MAX_THREADS};
+
     @Override
     public ModelNode getModelDescription(Locale locale) {
         return ThreadsSubsystemProviders.ADD_UNBOUNDED_QUEUE_THREAD_POOL_DESC.getModelDescription(locale);

--- a/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolAdd.java
@@ -23,7 +23,6 @@ package org.jboss.as.threads;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -87,7 +86,7 @@ public class UnboundedQueueThreadPoolAdd extends AbstractAddStepHandler implemen
         ServiceTarget target = context.getServiceTarget();
         final ServiceName serviceName = ThreadsServices.executorName(params.getName());
         final UnboundedQueueThreadPoolService service = new UnboundedQueueThreadPoolService(params.getMaxThreads().getScaledCount(), params.getKeepAliveTime());
-        final ServiceBuilder<ExecutorService> serviceBuilder = target.addService(serviceName, service);
+        final ServiceBuilder<ManagedJBossThreadPoolExecutorService> serviceBuilder = target.addService(serviceName, service);
         ThreadsSubsystemThreadPoolOperationUtils.addThreadFactoryDependency(params.getThreadFactory(), serviceName, serviceBuilder, service.getThreadFactoryInjector(), target, params.getName() + "-threads");
         serviceBuilder.addListener(verificationHandler);
         serviceBuilder.install();

--- a/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolWriteAttributeHandler.java
+++ b/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolWriteAttributeHandler.java
@@ -45,17 +45,17 @@ import org.jboss.msc.service.ServiceName;
  *
  * @author Alexey Loubyansky
  */
-public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
+public class UnboundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAttributeOperationHandler {
 
-    public static final BoundedQueueThreadPoolWriteAttributeHandler INSTANCE = new BoundedQueueThreadPoolWriteAttributeHandler();
+    public static final UnboundedQueueThreadPoolWriteAttributeHandler INSTANCE = new UnboundedQueueThreadPoolWriteAttributeHandler();
 
-    private BoundedQueueThreadPoolWriteAttributeHandler() {
-        super(BoundedQueueThreadPoolAdd.ATTRIBUTES, BoundedQueueThreadPoolAdd.RW_ATTRIBUTES);
+    private UnboundedQueueThreadPoolWriteAttributeHandler() {
+        super(UnboundedQueueThreadPoolAdd.ATTRIBUTES, UnboundedQueueThreadPoolAdd.RW_ATTRIBUTES);
     }
 
     protected void applyOperation(ModelNode operation, String attributeName, ServiceController<?> service) {
 
-        final BoundedQueueThreadPoolService pool =  (BoundedQueueThreadPoolService) service.getService();
+        final UnboundedQueueThreadPoolService pool =  (UnboundedQueueThreadPoolService) service.getService();
         try {
             final ModelNode value = operation.require(CommonAttributes.VALUE);
             if (CommonAttributes.KEEPALIVE_TIME.equals(attributeName)) {
@@ -75,14 +75,6 @@ public class BoundedQueueThreadPoolWriteAttributeHandler extends ThreadsWriteAtt
                 pool.setKeepAlive(spec);
             } else if(CommonAttributes.MAX_THREADS.equals(attributeName)) {
                 pool.setMaxThreads(getScaledCount(CommonAttributes.MAX_THREADS, value));
-            } else if(CommonAttributes.CORE_THREADS.equals(attributeName)) {
-                pool.setCoreThreads(getScaledCount(CommonAttributes.CORE_THREADS, value));
-            } else if(CommonAttributes.QUEUE_LENGTH.equals(attributeName)) {
-                pool.setQueueLength(getScaledCount(CommonAttributes.QUEUE_LENGTH, value));
-            } else if(CommonAttributes.ALLOW_CORE_TIMEOUT.equals(attributeName)) {
-                pool.setAllowCoreTimeout(value.asBoolean());
-            } else if(CommonAttributes.BLOCKING.equals(attributeName)) {
-                pool.setBlocking(value.asBoolean());
             } else {
                 throw new IllegalArgumentException("Unexpected attribute '" + attributeName + "'");
             }


### PR DESCRIPTION
Makes thread pool services' attributes mutable w/o restart where possible.

A problem with those that require a restart is that, attribute values aren't validated. For example, max-threads in scheduled thread pool requires a restart. Correct new value would look like

/subsystem=threads/scheduled-thread-pool=my:write-attribute(name=max-threads,value={"count"=>"4","per-cpu"=>"2"})

but

/subsystem=threads/scheduled-thread-pool=my:write-attribute(name=max-threads,value={"count"=>"4"})

will succeed too although per-cpu is still currently required and the config will be missing it. So a restart will fail to initialize the service.

I'm gonna look into this next.
