### PR TITLE
[AS7-1737] If master already contains a host called the same as the slave

### DIFF
--- a/domain-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandler.java
+++ b/domain-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandler.java
@@ -125,8 +125,13 @@ public class ReadMasterDomainModelHandler implements OperationStepHandler, Descr
             ModelController.OperationTransaction tx = txRef.get();
             if (tx != null) {
                 if (resultAction == OperationContext.ResultAction.KEEP) {
-                    tx.commit();
-                    domainController.registerRemoteHost(proxy);
+                    try {
+                        domainController.registerRemoteHost(proxy);
+                        tx.commit();
+                    } catch (Exception e) {
+                        context.getFailureDescription().set(SlaveRegistrationError.formatHostAlreadyExists(e.getMessage()));
+                        tx.rollback();
+                    }
                 } else {
                     tx.rollback();
                 }

--- a/domain-controller/src/main/java/org/jboss/as/domain/controller/operations/SlaveRegistrationError.java
+++ b/domain-controller/src/main/java/org/jboss/as/domain/controller/operations/SlaveRegistrationError.java
@@ -1,0 +1,92 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.domain.controller.operations;
+
+/**
+ * Used to propogate error codes as part of the error message when an error occurs registering the a slave host controller.
+ * I do not want to modify the protocol at the moment to support error codes natively.
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class SlaveRegistrationError {
+
+    private static final String SEPARATOR = "-$-";
+
+    private final ErrorCode errorCode;
+    private final String errorMessage;
+
+    private SlaveRegistrationError(ErrorCode errorCode, String errorMessage) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public static SlaveRegistrationError parse(String raw) {
+        int index = raw.indexOf("-$-");
+        if (index == -1) {
+            return new SlaveRegistrationError(ErrorCode.NONE, raw);
+        }
+
+        ErrorCode code = ErrorCode.parseCode(Integer.valueOf(raw.substring(0, index)));
+        String msg = raw.substring(index + SEPARATOR.length());
+        return new SlaveRegistrationError(code, msg);
+    }
+
+    public static String formatHostAlreadyExists(String msg) {
+        return new SlaveRegistrationError(ErrorCode.HOST_ALREADY_EXISTS, msg).toString();
+    }
+
+    public String toString() {
+        return errorCode.getCode() + SEPARATOR + errorMessage;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public enum ErrorCode {
+        NONE(0),
+        HOST_ALREADY_EXISTS(1);
+
+        private final int code;
+
+        ErrorCode(int code){
+            this.code = code;
+        }
+
+        int getCode() {
+            return code;
+        }
+
+        static ErrorCode parseCode(int code) {
+            if (code == NONE.getCode()) {
+                return NONE;
+            } else if (code == HOST_ALREADY_EXISTS.getCode()) {
+                return HOST_ALREADY_EXISTS;
+            }
+            throw new IllegalArgumentException("Invalid code " + code);
+        }
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostAlreadyExistsException.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostAlreadyExistsException.java
@@ -1,0 +1,34 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.host.controller;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class HostAlreadyExistsException extends RuntimeException {
+
+    public HostAlreadyExistsException(String msg) {
+        super(msg);
+    }
+
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.as.process.CommandLineConstants;
+import org.jboss.as.process.ExitCodes;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.logging.MDC;
 import org.jboss.logmanager.Level;
@@ -128,7 +129,7 @@ public final class Main {
             } else {
                 // Inform the process controller that we are shutting down on purpose
                 // so it doesn't try to respawn us
-                exitCode = 99;
+                exitCode = ExitCodes.HOST_CONTROLLER_ABORT_EXIT_CODE;
             }
 
         } finally {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/MasterDomainControllerClient.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/MasterDomainControllerClient.java
@@ -1,9 +1,11 @@
 /**
  *
  */
-package org.jboss.as.domain.controller;
+package org.jboss.as.host.controller;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.domain.controller.DomainController;
+import org.jboss.as.domain.controller.FileRepository;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -20,6 +22,7 @@ public interface MasterDomainControllerClient extends ModelControllerClient {
      * Register with the remote domain controller
      *
      * @throws IllegalStateException if there was a problem talking to the remote host
+     * @throws HostAlreadyExistsException if the slave hc has the same name as an existing slave on the master
      */
     void register();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerImpl.java
@@ -44,6 +44,7 @@ import org.jboss.as.domain.controller.FileRepository;
 import org.jboss.as.domain.controller.UnregisteredHostChannelRegistry;
 import org.jboss.as.domain.controller.UnregisteredHostChannelRegistry.ProxyCreatedCallback;
 import org.jboss.as.domain.controller.operations.ReadMasterDomainModelHandler;
+import org.jboss.as.domain.controller.operations.SlaveRegistrationError;
 import org.jboss.as.protocol.mgmt.FlushableDataOutput;
 import org.jboss.as.protocol.mgmt.ManagementOperationHandler;
 import org.jboss.as.protocol.mgmt.ManagementRequestHandler;
@@ -145,7 +146,7 @@ public class MasterDomainControllerOperationHandlerImpl extends AbstractModelCon
         protected void writeResponse(final FlushableDataOutput output) throws IOException {
             if (error != null) {
                 output.write(DomainControllerProtocol.PARAM_ERROR);
-                output.writeUTF(error);
+                output.writeUTF(SlaveRegistrationError.parse(error).toString());
             } else {
                 output.write(DomainControllerProtocol.PARAM_OK);
             }

--- a/process-controller/src/main/java/org/jboss/as/process/ExitCodes.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ExitCodes.java
@@ -1,0 +1,31 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.process;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class ExitCodes {
+    /** Exit code from host controller which the process controller does not try to respawn */
+    public static final int HOST_CONTROLLER_ABORT_EXIT_CODE = 99;
+}

--- a/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
@@ -284,7 +284,7 @@ final class ManagedProcess {
 
                 if (shutdown) {
                     processController.removeProcess(processName);
-                } else if (isPrivileged() && exitCode == 99) {
+                } else if (isPrivileged() && exitCode == ExitCodes.HOST_CONTROLLER_ABORT_EXIT_CODE) {
                     // Host Controller abort
                     processController.removeProcess(processName);
                     new Thread(new Runnable() {


### PR DESCRIPTION
[AS7-1737] If master already contains a host called the same as the slave trying to register, abort startup of the slave

This only solves the issue trying to register a slave with the same name as the master HC. More comments in https://issues.jboss.org/browse/AS7-2101
