### PR TITLE
Additional runtime management for OSGi subsystem

### DIFF
--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/BundleRuntimeHandler.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/BundleRuntimeHandler.java
@@ -43,6 +43,7 @@ import org.jboss.osgi.framework.Services;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.startlevel.StartLevel;
 
@@ -54,7 +55,7 @@ public class BundleRuntimeHandler extends AbstractRuntimeOnlyHandler {
     static final BundleRuntimeHandler INSTANCE = new BundleRuntimeHandler();
 
     static final String [] ATTRIBUTES = { ModelConstants.ID, ModelConstants.STARTLEVEL,
-        ModelConstants.STATE, ModelConstants.SYMBOLIC_NAME, ModelConstants.VERSION };
+        ModelConstants.STATE, ModelConstants.SYMBOLIC_NAME, ModelConstants.TYPE, ModelConstants.VERSION };
 
     static final String START_OPERATION = "start";
     static final String STOP_OPERATION = "stop";
@@ -108,6 +109,12 @@ public class BundleRuntimeHandler extends AbstractRuntimeOnlyHandler {
             context.getResult().set(getBundleState(bundle));
         } else if (ModelConstants.SYMBOLIC_NAME.equals(name)) {
             context.getResult().set(bundle.getSymbolicName());
+        } else if (ModelConstants.TYPE.equals(name)) {
+            if (bundle.getHeaders().get(Constants.FRAGMENT_HOST) != null) {
+                context.getResult().set(ModelConstants.FRAGMENT);
+            } else {
+                context.getResult().set(ModelConstants.BUNDLE);
+            }
         } else if (ModelConstants.VERSION.equals(name)) {
             context.getResult().set(bundle.getVersion().toString());
         }

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/ModelConstants.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/ModelConstants.java
@@ -32,11 +32,13 @@ package org.jboss.as.osgi.parser;
  */
 public interface ModelConstants {
 
+    String ACTIVATE = "activate";
     String ACTIVATION = "activation";
     String BUNDLE = "bundle";
     String CAPABILITY = "capability";
     String CONFIGURATION = "configuration";
     String ENTRIES = "entries";
+    String FRAGMENT = "fragment";
     String ID = "id";
     String NAME = "name";
     String PID = "pid";
@@ -44,6 +46,7 @@ public interface ModelConstants {
     String STARTLEVEL = "startlevel";
     String STATE = "state";
     String SYMBOLIC_NAME = "symbolic-name";
+    String TYPE = "type";
     String VALUE = "value";
     String VERSION = "version";
 

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiExtension.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiExtension.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.osgi.parser;
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.PathElement;
@@ -55,6 +57,7 @@ public class OSGiExtension implements Extension {
         registration.registerOperationHandler(ModelDescriptionConstants.ADD, OSGiSubsystemAdd.INSTANCE, OSGiSubsystemAdd.DESCRIPTION, false);
         registration.registerReadWriteAttribute(ModelConstants.ACTIVATION, null, new ActivationAttributeHandler(), Storage.CONFIGURATION);
         registration.registerReadWriteAttribute(ModelConstants.STARTLEVEL, StartLevelHandler.READ_HANDLER, StartLevelHandler.WRITE_HANDLER, Storage.RUNTIME);
+        registration.registerOperationHandler(ModelConstants.ACTIVATE, ActivateOperationHandler.INSTANCE, ActivateOperationHandler.INSTANCE, EnumSet.of(OperationEntry.Flag.RESTART_NONE));
         registration.registerOperationHandler(ModelDescriptionConstants.DESCRIBE, OSGiSubsystemDescribeHandler.INSTANCE, OSGiSubsystemAdd.DESCRIPTION, false, OperationEntry.EntryType.PRIVATE);
 
         // Configuration Admin Setings

--- a/osgi/service/src/main/resources/org/jboss/as/osgi/parser/LocalDescriptions.properties
+++ b/osgi/service/src/main/resources/org/jboss/as/osgi/parser/LocalDescriptions.properties
@@ -1,4 +1,5 @@
 subsystem=The the OSGi subsystem configuration.
+subsystem.activate=Activate the OSGi subsystem.
 subsystem.activation=Activation flag for the OSGi subsystem. Possible values: lazy, eager.
 subsystem.startlevel=The current Start Level of the OSGi Framework. Changing this value will change the start level of the Framework accordingly. 
 

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivationWriteHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivationWriteHandlerTestCase.java
@@ -21,26 +21,15 @@
  */
 package org.jboss.as.osgi.parser;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationContext.Stage;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.osgi.parser.SubsystemState.Activation;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceController.Mode;
-import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.osgi.framework.Services;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * @author David Bosschaert
@@ -65,50 +54,5 @@ public class ActivationWriteHandlerTestCase {
         Mockito.verify(context).completeStep();
 
         Assert.assertEquals(Activation.LAZY.toString().toLowerCase(), targetNode.get(ModelConstants.ACTIVATION).asString());
-    }
-
-    @Test
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void testHandlerEagerActivate() throws Exception {
-        ModelNode targetNode = new ModelNode();
-        targetNode.get(ModelConstants.ACTIVATION).set("lazy");
-
-        OperationContext context = Mockito.mock(OperationContext.class);
-        Resource resource = Mockito.mock(Resource.class);
-        Mockito.when(resource.getModel()).thenReturn(targetNode);
-        Mockito.when(context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS)).thenReturn(resource);
-
-        final List<OperationStepHandler> addedSteps = new ArrayList<OperationStepHandler>();
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                addedSteps.add((OperationStepHandler) invocation.getArguments()[0]);
-                return null;
-            }
-        }).when(context).addStep((OperationStepHandler) Mockito.any(), Mockito.eq(Stage.RUNTIME));
-
-        ActivationAttributeHandler handler = new ActivationAttributeHandler();
-
-        ModelNode operation = new ModelNode();
-        operation.get(ModelDescriptionConstants.VALUE).set(Activation.EAGER.toString().toLowerCase());
-
-        Assert.assertEquals("Precondition", 0, addedSteps.size());
-        handler.execute(context, operation);
-        Mockito.verify(context).completeStep();
-        Assert.assertEquals(Activation.EAGER.toString().toLowerCase(), targetNode.get(ModelConstants.ACTIVATION).asString());
-
-        // Now test the runtime piece...
-        ServiceRegistry registry = Mockito.mock(ServiceRegistry.class);
-        ServiceController svcCtrl = Mockito.mock(ServiceController.class);
-        Mockito.when(registry.getRequiredService(Services.FRAMEWORK_ACTIVE)).thenReturn(svcCtrl);
-
-        OperationContext context2 = Mockito.mock(OperationContext.class);
-        Mockito.when(context2.getServiceRegistry(true)).thenReturn(registry);
-
-        Assert.assertEquals(1, addedSteps.size());
-        addedSteps.get(0).execute(context2, operation);
-
-        Mockito.verify(svcCtrl).setMode(Mode.ACTIVE);
-        Mockito.verify(context2).completeStep();
     }
 }

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/BundleRuntimeHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/BundleRuntimeHandlerTestCase.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.osgi.parser;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
+
 import junit.framework.Assert;
 
 import org.jboss.as.controller.OperationContext;
@@ -36,6 +39,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.Version;
 import org.osgi.service.startlevel.StartLevel;
@@ -124,6 +128,36 @@ public class BundleRuntimeHandlerTestCase {
 
         BundleRuntimeHandler.INSTANCE.executeRuntimeStep(operationContext, readOp);
         Assert.assertEquals("ACTIVE", contextResult.asString());
+    }
+
+    @Test
+    public void testTypeAttributeFragmen() throws Exception {
+        mockEnvironment();
+        ModelNode readOp = getReadOperation("1", ModelConstants.TYPE);
+
+        Dictionary<String, String> headers = new Hashtable<String, String>();
+        headers.put(Constants.FRAGMENT_HOST, "somebundle");
+        Bundle testBundle = Mockito.mock(Bundle.class);
+        Mockito.when(bundleContext.getBundle(1)).thenReturn(testBundle);
+        Mockito.when(testBundle.getHeaders()).thenReturn(headers);
+
+        BundleRuntimeHandler.INSTANCE.executeRuntimeStep(operationContext, readOp);
+        Assert.assertEquals(ModelConstants.FRAGMENT, contextResult.asString());
+    }
+
+    @Test
+    public void testTypeAttributeBundle() throws Exception {
+        mockEnvironment();
+        ModelNode readOp = getReadOperation("1", ModelConstants.TYPE);
+
+        Dictionary<String, String> headers = new Hashtable<String, String>();
+
+        Bundle testBundle = Mockito.mock(Bundle.class);
+        Mockito.when(bundleContext.getBundle(1)).thenReturn(testBundle);
+        Mockito.when(testBundle.getHeaders()).thenReturn(headers);
+
+        BundleRuntimeHandler.INSTANCE.executeRuntimeStep(operationContext, readOp);
+        Assert.assertEquals(ModelConstants.BUNDLE, contextResult.asString());
     }
 
     @Test


### PR DESCRIPTION
Add: activation operation to activate the OSGi subsystem.
This was previously hidden behind setting the activation mode to
'eager'. Now changing the activation mode configuration will have no
side-effect.

Add: bundle type attribute. Possible values: 'bundle' or 'fragment'.
