### PR TITLE
Fix the default-stateful-access-timeout and default-singleton-access-time

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_2.xsd
@@ -43,20 +43,6 @@
             <xs:element name="session-bean" type="session-beanType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="pools" type="poolsType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="timer-service" type="timerServiceType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="default-stateful-access-timeout" type="xs:positiveInteger" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        The default access timeout for stateful session beans in milliseconds
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="default-singleton-access-timeout" type="xs:positiveInteger" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        The default access timeout for singleton session beans in milliseconds
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
             <xs:element name="thread-pools" type="threadPoolsType" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
@@ -80,6 +66,8 @@
     <xs:complexType name="session-beanType">
         <xs:all>
             <xs:element name="stateless" type="stateless-beanType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="stateful" type="stateful-beanType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="singleton" type="singleton-beanType" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
 
@@ -87,6 +75,26 @@
         <xs:all>
             <xs:element name="bean-instance-pool-ref" type="bean-instance-pool-refType" minOccurs="0" maxOccurs="1"/>
         </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="stateful-beanType">
+        <xs:attribute name="default-access-timeout" type="xs:positiveInteger" default="5000" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The default access timeout, for stateful session beans, in milliseconds
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="singleton-beanType">
+        <xs:attribute name="default-access-timeout" type="xs:positiveInteger" default="5000" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The default access timeout, for singleton beans, in milliseconds
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="resource-adapter-refType">

--- a/build/src/main/resources/domain/configuration/domain.xml
+++ b/build/src/main/resources/domain/configuration/domain.xml
@@ -147,11 +147,9 @@
                     <stateless>
                         <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
                     </stateless>
+                    <stateful default-access-timeout="5000"/>
+                    <singleton default-access-timeout="5000"/>
                 </session-bean>
-
-
-                <default-stateful-access-timeout>5000</default-stateful-access-timeout>
-                <default-singleton-access-timeout>5000</default-singleton-access-timeout>
 
                 <thread-pools>
                     <thread-pool name="default" max-threads="10" keepalive-time="100" />
@@ -482,11 +480,9 @@
                     <stateless>
                         <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
                     </stateless>
+                    <stateful default-access-timeout="5000"/>
+                    <singleton default-access-timeout="5000"/>
                 </session-bean>
-
-
-                <default-stateful-access-timeout>5000</default-stateful-access-timeout>
-                <default-singleton-access-timeout>5000</default-singleton-access-timeout>
 
                 <thread-pools>
                     <thread-pool name="default" max-threads="10" keepalive-time="100" />

--- a/build/src/main/resources/standalone/configuration/standalone-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-ha.xml
@@ -158,10 +158,10 @@
                 <stateless>
                     <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
                 </stateless>
-            </session-bean>
+                <stateful default-access-timeout="5000"/>
+                <singleton default-access-timeout="5000"/>
 
-            <default-stateful-access-timeout>5000</default-stateful-access-timeout>
-            <default-singleton-access-timeout>5000</default-singleton-access-timeout>
+            </session-bean>
 
             <thread-pools>
                 <thread-pool name="default" max-threads="10" keepalive-time="100" />

--- a/build/src/main/resources/standalone/configuration/standalone-xts.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-xts.xml
@@ -148,10 +148,10 @@
                 <stateless>
                     <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
                 </stateless>
-            </session-bean>
+                <stateful default-access-timeout="5000"/>
+                <singleton default-access-timeout="5000"/>
 
-            <default-stateful-access-timeout>5000</default-stateful-access-timeout>
-            <default-singleton-access-timeout>5000</default-singleton-access-timeout>
+            </session-bean>
 
             <thread-pools>
                 <thread-pool name="default" max-threads="10" keepalive-time="100" />

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -158,10 +158,9 @@
                 <stateless>
                     <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
                 </stateless>
+                <stateful default-access-timeout="5000"/>
+                <singleton default-access-timeout="5000"/>
             </session-bean>
-
-            <default-stateful-access-timeout>5000</default-stateful-access-timeout>
-            <default-singleton-access-timeout>5000</default-singleton-access-timeout>
 
             <thread-pools>
                 <thread-pool name="default" max-threads="10" keepalive-time="100" />

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponent.java
@@ -87,7 +87,7 @@ public class SingletonComponent extends SessionBeanComponent implements Lockable
         this.beanLevelLockType = singletonComponentCreateService.getBeanLockType();
         this.methodLockTypes = singletonComponentCreateService.getMethodApplicableLockTypes();
         this.methodAccessTimeouts = singletonComponentCreateService.getMethodApplicableAccessTimeouts();
-        this.defaultAccessTimeoutProvider = singletonComponentCreateService.getDefaultAccessTimeoutProvider();
+        this.defaultAccessTimeoutProvider = singletonComponentCreateService.getDefaultAccessTimeoutService();
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentCreateService.java
@@ -27,7 +27,9 @@ import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
 import org.jboss.as.ejb3.component.session.SessionBeanComponentCreateService;
 import org.jboss.as.ejb3.deployment.EjbJarConfiguration;
+import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.value.InjectedValue;
 
 import java.util.List;
 
@@ -38,13 +40,12 @@ public class SingletonComponentCreateService extends SessionBeanComponentCreateS
 
     private final boolean initOnStartup;
     private final List<ServiceName> dependsOn;
-    private final DefaultAccessTimeoutService defaultAccessTimeoutProvider;
+    private final InjectedValue<DefaultAccessTimeoutService> defaultAccessTimeoutService = new InjectedValue<DefaultAccessTimeoutService>();
 
     public SingletonComponentCreateService(final ComponentConfiguration componentConfiguration, final EjbJarConfiguration ejbJarConfiguration, final boolean initOnStartup, final List<ServiceName> dependsOn) {
         super(componentConfiguration, ejbJarConfiguration);
         this.initOnStartup = initOnStartup;
         this.dependsOn = dependsOn;
-        this.defaultAccessTimeoutProvider = ((SingletonComponentDescription)componentConfiguration.getComponentDescription()).getDefaultAccessTimeoutProvider();
     }
 
     @Override
@@ -56,7 +57,11 @@ public class SingletonComponentCreateService extends SessionBeanComponentCreateS
         return this.initOnStartup;
     }
 
-    public DefaultAccessTimeoutService getDefaultAccessTimeoutProvider() {
-        return defaultAccessTimeoutProvider;
+    public DefaultAccessTimeoutService getDefaultAccessTimeoutService() {
+        return defaultAccessTimeoutService.getValue();
+    }
+
+    Injector<DefaultAccessTimeoutService> getDefaultAccessTimeoutInjector() {
+        return this.defaultAccessTimeoutService;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentCreateServiceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentCreateServiceFactory.java
@@ -24,7 +24,11 @@ package org.jboss.as.ejb3.component.singleton;
 
 import org.jboss.as.ee.component.BasicComponentCreateService;
 import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ee.component.DependencyConfigurator;
+import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
 import org.jboss.as.ejb3.component.EJBComponentCreateServiceFactory;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 
 import java.util.List;
@@ -48,6 +52,14 @@ public class SingletonComponentCreateServiceFactory extends EJBComponentCreateSe
             throw new IllegalStateException("EjbJarConfiguration hasn't been set in " + this +
                     " .Cannot create component create service for EJB " + configuration.getComponentName());
         }
+        // setup a injection dependency to inject the DefaultAccessTimeoutService in the singleton bean
+        // component create service
+        configuration.getCreateDependencies().add(new DependencyConfigurator<SingletonComponentCreateService>() {
+            @Override
+            public void configureDependency(ServiceBuilder<?> serviceBuilder, SingletonComponentCreateService componentCreateService) throws DeploymentUnitProcessingException {
+                serviceBuilder.addDependency(DefaultAccessTimeoutService.SINGLETON_SERVICE_NAME, DefaultAccessTimeoutService.class, componentCreateService.getDefaultAccessTimeoutInjector());
+            }
+        });
         return new SingletonComponentCreateService(configuration, this.ejbJarConfiguration, this.initOnStartup, dependsOn);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -227,11 +227,4 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
         return true;
     }
 
-    public DefaultAccessTimeoutService getDefaultAccessTimeoutProvider() {
-        return defaultAccessTimeoutProvider;
-    }
-
-    public void setDefaultAccessTimeoutProvider(final DefaultAccessTimeoutService defaultAccessTimeoutProvider) {
-        this.defaultAccessTimeoutProvider = defaultAccessTimeoutProvider;
-    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentCreateServiceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentCreateServiceFactory.java
@@ -24,7 +24,12 @@ package org.jboss.as.ejb3.component.stateful;
 
 import org.jboss.as.ee.component.BasicComponentCreateService;
 import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ee.component.DependencyConfigurator;
+import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
 import org.jboss.as.ejb3.component.EJBComponentCreateServiceFactory;
+import org.jboss.as.ejb3.component.singleton.SingletonComponentCreateService;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.msc.service.ServiceBuilder;
 
 /**
  * User: jpai
@@ -36,6 +41,14 @@ public class StatefulComponentCreateServiceFactory extends EJBComponentCreateSer
             throw new IllegalStateException("EjbJarConfiguration hasn't been set in " + this +
                     " .Cannot create component create service for EJB " + configuration.getComponentName());
         }
+        // setup a injection dependency to inject the DefaultAccessTimeoutService in the stateful bean
+        // component create service
+        configuration.getCreateDependencies().add(new DependencyConfigurator<StatefulSessionComponentCreateService>() {
+            @Override
+            public void configureDependency(ServiceBuilder<?> serviceBuilder, StatefulSessionComponentCreateService componentCreateService) throws DeploymentUnitProcessingException {
+                serviceBuilder.addDependency(DefaultAccessTimeoutService.STATEFUL_SERVICE_NAME, DefaultAccessTimeoutService.class, componentCreateService.getDefaultAccessTimeoutInjector());
+            }
+        });
         return new StatefulSessionComponentCreateService(configuration, this.ejbJarConfiguration);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -345,11 +345,4 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
         return Collections.unmodifiableMap(initMethods);
     }
 
-    public DefaultAccessTimeoutService getDefaultAccessTimeoutProvider() {
-        return defaultAccessTimeoutProvider;
-    }
-
-    public void setDefaultAccessTimeoutProvider(final DefaultAccessTimeoutService defaultAccessTimeoutProvider) {
-        this.defaultAccessTimeoutProvider = defaultAccessTimeoutProvider;
-    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
@@ -92,7 +92,7 @@ public class StatefulSessionComponent extends SessionBeanComponent {
         this.afterCompletion = ejbComponentCreateService.getAfterCompletion();
         this.beforeCompletion = ejbComponentCreateService.getBeforeCompletion();
         this.methodAccessTimeouts = ejbComponentCreateService.getMethodApplicableAccessTimeouts();
-        this.defaultAccessTimeoutProvider = ejbComponentCreateService.getDefaultAccessTimeoutProvider();
+        this.defaultAccessTimeoutProvider = ejbComponentCreateService.getDefaultAccessTimeoutService();
 
         final StatefulTimeoutInfo statefulTimeout = ejbComponentCreateService.getStatefulTimeout();
         if (statefulTimeout != null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentCreateService.java
@@ -33,6 +33,8 @@ import org.jboss.as.ejb3.deployment.EjbJarConfiguration;
 import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.invocation.InterceptorFactory;
 import org.jboss.invocation.Interceptors;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.value.InjectedValue;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -45,7 +47,7 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
     private final InterceptorFactory afterCompletion;
     private final InterceptorFactory beforeCompletion;
     private final StatefulTimeoutInfo statefulTimeout;
-    private final DefaultAccessTimeoutService defaultAccessTimeoutProvider;
+    private final InjectedValue<DefaultAccessTimeoutService> defaultAccessTimeoutService = new InjectedValue<DefaultAccessTimeoutService>();
 
     /**
      * Construct a new instance.
@@ -63,7 +65,6 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
         this.afterCompletion = interceptorFactoryChain(tcclInterceptorFactory, namespaceContextInterceptorFactory, SessionInvocationContextInterceptor.FACTORY, invokeMethodOnTarget(beanClass, componentDescription.getAfterCompletion()));
         this.beforeCompletion = interceptorFactoryChain(tcclInterceptorFactory, namespaceContextInterceptorFactory, SessionInvocationContextInterceptor.FACTORY, invokeMethodOnTarget(beanClass, componentDescription.getBeforeCompletion()));
         this.statefulTimeout = componentDescription.getStatefulTimeout();
-        this.defaultAccessTimeoutProvider = componentDescription.getDefaultAccessTimeoutProvider();
     }
 
     private static InterceptorFactory invokeMethodOnTarget(Class<?> beanClass, MethodDescription methodDescription) {
@@ -134,7 +135,11 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
         return statefulTimeout;
     }
 
-    public DefaultAccessTimeoutService getDefaultAccessTimeoutProvider() {
-        return defaultAccessTimeoutProvider;
+    public DefaultAccessTimeoutService getDefaultAccessTimeoutService() {
+        return defaultAccessTimeoutService.getValue();
+    }
+
+    Injector<DefaultAccessTimeoutService> getDefaultAccessTimeoutInjector() {
+        return this.defaultAccessTimeoutService;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/EjbConcurrencyMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/EjbConcurrencyMergingProcessor.java
@@ -24,10 +24,7 @@ package org.jboss.as.ejb3.deployment.processors.merging;
 import org.jboss.as.ee.component.EEApplicationClasses;
 import org.jboss.as.ee.metadata.MethodAnnotationAggregator;
 import org.jboss.as.ee.metadata.RuntimeAnnotationInformation;
-import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
 import org.jboss.as.ejb3.component.session.SessionBeanComponentDescription;
-import org.jboss.as.ejb3.component.singleton.SingletonComponentDescription;
-import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.ejb3.concurrency.AccessTimeoutDetails;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -55,13 +52,8 @@ import java.util.Map;
  */
 public class EjbConcurrencyMergingProcessor extends AbstractMergingProcessor<SessionBeanComponentDescription> {
 
-    private final DefaultAccessTimeoutService singletonDefault;
-    private final DefaultAccessTimeoutService statefulDefault;
-
-    public EjbConcurrencyMergingProcessor(final DefaultAccessTimeoutService singletonDefault, final DefaultAccessTimeoutService statefulDefault) {
+    public EjbConcurrencyMergingProcessor() {
         super(SessionBeanComponentDescription.class);
-        this.singletonDefault = singletonDefault;
-        this.statefulDefault = statefulDefault;
     }
 
     protected void handleAnnotations(final DeploymentUnit deploymentUnit, final EEApplicationClasses applicationClasses, final DeploymentReflectionIndex deploymentReflectionIndex, final Class<?> componentClass, final SessionBeanComponentDescription componentConfiguration) {
@@ -96,12 +88,6 @@ public class EjbConcurrencyMergingProcessor extends AbstractMergingProcessor<Ses
 
     protected void handleDeploymentDescriptor(final DeploymentUnit deploymentUnit, final DeploymentReflectionIndex deploymentReflectionIndex, final Class<?> componentClass, final SessionBeanComponentDescription componentConfiguration) throws DeploymentUnitProcessingException {
 
-        if(componentConfiguration instanceof SingletonComponentDescription) {
-            ((SingletonComponentDescription) componentConfiguration).setDefaultAccessTimeoutProvider(singletonDefault);
-        } else if(componentConfiguration instanceof StatefulComponentDescription) {
-            ((StatefulComponentDescription) componentConfiguration).setDefaultAccessTimeoutProvider(singletonDefault);
-        }
-
         if (componentConfiguration.getDescriptorData() == null) {
             return;
         }
@@ -128,7 +114,7 @@ public class EjbConcurrencyMergingProcessor extends AbstractMergingProcessor<Ses
                         componentConfiguration.setLockType(method.getLockType(), methodIdentifier);
                     }
                     if (method.getAccessTimeout() != null) {
-                        componentConfiguration.setAccessTimeout( new AccessTimeoutDetails(method.getAccessTimeout().getTimeout(), method.getAccessTimeout().getUnit()), methodIdentifier);
+                        componentConfiguration.setAccessTimeout(new AccessTimeoutDetails(method.getAccessTimeout().getTimeout(), method.getAccessTimeout().getUnit()), methodIdentifier);
                     }
 
                 }
@@ -137,7 +123,6 @@ public class EjbConcurrencyMergingProcessor extends AbstractMergingProcessor<Ses
 
         }
     }
-
 
 
     private Method resolveMethod(final DeploymentReflectionIndex index, final Class<?> componentClass, final NamedMethodMetaData methodData) throws DeploymentUnitProcessingException {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/DefaultSingletonBeanAccessTimeoutWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/DefaultSingletonBeanAccessTimeoutWriteHandler.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
+import org.jboss.as.ejb3.component.messagedriven.DefaultResourceAdapterService;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+import java.util.List;
+
+/**
+ * User: jpai
+ */
+class DefaultSingletonBeanAccessTimeoutWriteHandler extends AbstractWriteAttributeHandler<Void> {
+
+    static final DefaultSingletonBeanAccessTimeoutWriteHandler INSTANCE = new DefaultSingletonBeanAccessTimeoutWriteHandler();
+
+    @Override
+    protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> voidHandbackHolder) throws OperationFailedException {
+        final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+        updateOrCreateDefaultSingletonBeanAccessTimeoutService(context, model, null);
+
+        return false;
+    }
+
+    @Override
+    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Void handback) throws OperationFailedException {
+        final ModelNode restored = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().clone();
+        restored.get(attributeName).set(valueToRestore);
+        updateOrCreateDefaultSingletonBeanAccessTimeoutService(context, restored, null);
+    }
+
+    void updateOrCreateDefaultSingletonBeanAccessTimeoutService(final OperationContext context, final ModelNode model, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        final long defaultAccessTimeout = EJB3SubsystemRootResourceDefinition.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT.validateResolvedOperation(model).asLong();
+        final ServiceName serviceName = DefaultAccessTimeoutService.SINGLETON_SERVICE_NAME;
+        final ServiceRegistry registry = context.getServiceRegistry(true);
+        final ServiceController sc = registry.getService(serviceName);
+        if (sc != null) {
+            final DefaultAccessTimeoutService defaultAccessTimeoutService = DefaultAccessTimeoutService.class.cast(sc.getValue());
+            defaultAccessTimeoutService.setDefaultAccessTimeout(defaultAccessTimeout);
+        } else {
+            // create and install the service
+            final DefaultAccessTimeoutService defaultAccessTimeoutService = new DefaultAccessTimeoutService(defaultAccessTimeout);
+            final ServiceController<?> newService = context.getServiceTarget().addService(serviceName, defaultAccessTimeoutService)
+                    .install();
+            if (newControllers != null) {
+                newControllers.add(newService);
+            }
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/DefaultStatefulBeanAccessTimeoutWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/DefaultStatefulBeanAccessTimeoutWriteHandler.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+import java.util.List;
+
+/**
+ * User: jpai
+ */
+class DefaultStatefulBeanAccessTimeoutWriteHandler extends AbstractWriteAttributeHandler<Void> {
+
+    static final DefaultStatefulBeanAccessTimeoutWriteHandler INSTANCE = new DefaultStatefulBeanAccessTimeoutWriteHandler();
+
+    @Override
+    protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> voidHandbackHolder) throws OperationFailedException {
+        final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+        updateOrCreateDefaultStatefulBeanAccessTimeoutService(context, model, null);
+
+        return false;
+    }
+
+    @Override
+    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Void handback) throws OperationFailedException {
+        final ModelNode restored = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().clone();
+        restored.get(attributeName).set(valueToRestore);
+        updateOrCreateDefaultStatefulBeanAccessTimeoutService(context, restored, null);
+    }
+
+    void updateOrCreateDefaultStatefulBeanAccessTimeoutService(final OperationContext context, final ModelNode model, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        final long defaultAccessTimeout = EJB3SubsystemRootResourceDefinition.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT.validateResolvedOperation(model).asLong();
+        final ServiceName serviceName = DefaultAccessTimeoutService.STATEFUL_SERVICE_NAME;
+        final ServiceRegistry registry = context.getServiceRegistry(true);
+        final ServiceController sc = registry.getService(serviceName);
+        if (sc != null) {
+            final DefaultAccessTimeoutService defaultAccessTimeoutService = DefaultAccessTimeoutService.class.cast(sc.getValue());
+            defaultAccessTimeoutService.setDefaultAccessTimeout(defaultAccessTimeout);
+        } else {
+            // create and install the service
+            final DefaultAccessTimeoutService defaultAccessTimeoutService = new DefaultAccessTimeoutService(defaultAccessTimeout);
+            final ServiceController<?> newService = context.getServiceTarget().addService(serviceName, defaultAccessTimeoutService)
+                    .install();
+            if (newControllers != null) {
+                newControllers.add(newService);
+            }
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
@@ -47,9 +47,9 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ejb3.subsystem.deployment.EntityBeanResourceDefinition;
 import org.jboss.as.ejb3.subsystem.deployment.MessageDrivenBeanResourceDefinition;
-import org.jboss.as.ejb3.subsystem.deployment.SingletonBeanResourceDefinition;
-import org.jboss.as.ejb3.subsystem.deployment.StatefulSessionBeanResourceDefinition;
-import org.jboss.as.ejb3.subsystem.deployment.StatelessSessionBeanResourceDefinition;
+import org.jboss.as.ejb3.subsystem.deployment.SingletonBeanDeploymentResourceDefinition;
+import org.jboss.as.ejb3.subsystem.deployment.StatefulSessionBeanDeploymentResourceDefinition;
+import org.jboss.as.ejb3.subsystem.deployment.StatelessSessionBeanDeploymentResourceDefinition;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -98,16 +98,16 @@ public class EJB3Extension implements Extension {
         subsystemRegistration.registerSubModel(TimerServiceResourceDefinition.INSTANCE);
 
         ResourceDefinition deploymentsDef = new SimpleResourceDefinition(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME),
-                                                                         getResourceDescriptionResolver("deployed"));
+                getResourceDescriptionResolver("deployed"));
         final ManagementResourceRegistration deploymentsRegistration = subsystem.registerDeploymentModel(deploymentsDef);
         deploymentsRegistration.registerSubModel(EntityBeanResourceDefinition.INSTANCE);
         deploymentsRegistration.registerSubModel(MessageDrivenBeanResourceDefinition.INSTANCE);
-        deploymentsRegistration.registerSubModel(SingletonBeanResourceDefinition.INSTANCE);
-        deploymentsRegistration.registerSubModel(StatelessSessionBeanResourceDefinition.INSTANCE);
-        deploymentsRegistration.registerSubModel(StatefulSessionBeanResourceDefinition.INSTANCE);
         // subsystem=ejb3/thread-pool=*
         subsystemRegistration.registerSubModel(EJB3ThreadPoolResourceDefinition.INSTANCE);
 
+        deploymentsRegistration.registerSubModel(SingletonBeanDeploymentResourceDefinition.INSTANCE);
+        deploymentsRegistration.registerSubModel(StatelessSessionBeanDeploymentResourceDefinition.INSTANCE);
+        deploymentsRegistration.registerSubModel(StatefulSessionBeanDeploymentResourceDefinition.INSTANCE);
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -22,25 +22,11 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.APPCLIENT;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_ACCESS_TIMEOUT;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_ACCESS_TIMEOUT;
-
-import java.util.List;
-
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-
 import org.jboss.as.connector.ConnectorServices;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
 import org.jboss.as.ejb3.component.EJBUtilities;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.processors.ApplicationExceptionAnnotationProcessor;
@@ -108,6 +94,18 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+import java.util.List;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.APPCLIENT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
+
 /**
  * Add operation handler for the EJB3 subsystem.
  *
@@ -130,8 +128,8 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         model.get(DEFAULT_MDB_INSTANCE_POOL).set(operation.get(DEFAULT_MDB_INSTANCE_POOL));
         model.get(DEFAULT_SLSB_INSTANCE_POOL).set(operation.get(DEFAULT_SLSB_INSTANCE_POOL));
         model.get(DEFAULT_RESOURCE_ADAPTER_NAME).set(operation.get(DEFAULT_RESOURCE_ADAPTER_NAME));
-        model.get(DEFAULT_STATEFUL_ACCESS_TIMEOUT).set(operation.get(DEFAULT_STATEFUL_ACCESS_TIMEOUT));
-        model.get(DEFAULT_SINGLETON_ACCESS_TIMEOUT).set(operation.get(DEFAULT_SINGLETON_ACCESS_TIMEOUT));
+        model.get(DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT).set(operation.get(DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT));
+        model.get(DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT).set(operation.get(DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT));
     }
 
     protected void performBoottime(final OperationContext context, ModelNode operation, final ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
@@ -141,11 +139,6 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         //TODO: this is a bit of a hack
         InitialContext.addUrlContextFactory("ejb", new ejbURLContextFactory());
         final boolean appclient = model.hasDefined(APPCLIENT) && model.get(APPCLIENT).asBoolean();
-
-        final DefaultAccessTimeoutService statefulTimeout = new DefaultAccessTimeoutService(EJB3SubsystemRootResourceDefinition.DEFAULT_STATEFUL_ACCESS_TIMEOUT.validateResolvedOperation(model).asLong());
-        newControllers.add(context.getServiceTarget().addService(DefaultAccessTimeoutService.STATEFUL_SERVICE_NAME, statefulTimeout).install());
-        final DefaultAccessTimeoutService singletonTimeout = new DefaultAccessTimeoutService(EJB3SubsystemRootResourceDefinition.DEFAULT_SINGLETON_ACCESS_TIMEOUT.validateResolvedOperation(model).asLong());
-        newControllers.add(context.getServiceTarget().addService(DefaultAccessTimeoutService.SINGLETON_SERVICE_NAME, singletonTimeout).install());
 
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
@@ -189,7 +182,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_DD_METHOD_RESOLUTION, new DeploymentDescriptorMethodProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_TRANSACTION_MANAGEMENT, new TransactionManagementMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_CONCURRENCY_MANAGEMENT_MERGE, new ConcurrencyManagementMergingProcessor());
-                    processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_CONCURRENCY_MERGE, new EjbConcurrencyMergingProcessor(singletonTimeout, statefulTimeout));
+                    processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_CONCURRENCY_MERGE, new EjbConcurrencyMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_TX_ATTR_MERGE, new TransactionAttributeMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_RUN_AS_MERGE, new RunAsMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_RESOURCE_ADAPTER_MERGE, new ResourceAdaptorMergingProcessor());
@@ -222,6 +215,14 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         if (model.hasDefined(DEFAULT_RESOURCE_ADAPTER_NAME)) {
             DefaultResourceAdapterWriteHandler.INSTANCE.updateDefaultAdapterService(context, model, newControllers);
+        }
+
+        if (model.hasDefined(DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT)) {
+            DefaultSingletonBeanAccessTimeoutWriteHandler.INSTANCE.updateOrCreateDefaultSingletonBeanAccessTimeoutService(context, model, newControllers);
+        }
+
+        if (model.hasDefined(DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT)) {
+            DefaultStatefulBeanAccessTimeoutWriteHandler.INSTANCE.updateOrCreateDefaultStatefulBeanAccessTimeoutService(context, model, newControllers);
         }
 
         final ServiceTarget serviceTarget = context.getServiceTarget();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -53,8 +53,8 @@ public interface EJB3SubsystemModel {
     String RELATIVE_TO = "relative-to";
     String PATH = "path";
 
-    String DEFAULT_STATEFUL_ACCESS_TIMEOUT = "default-stateful-access-timeout";
-    String DEFAULT_SINGLETON_ACCESS_TIMEOUT = "default-singleton-access-timeout";
+    String DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT = "default-singleton-bean-access-timeout";
+    String DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT = "default-stateful-bean-access-timeout";
 
     String REMOTE = "remote";
     String SERVICE = "service";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -27,11 +27,11 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.LongRangeValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.as.ejb3.component.DefaultAccessTimeoutService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -53,18 +53,24 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public static final SimpleAttributeDefinition DEFAULT_RESOURCE_ADAPTER_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME, ModelType.STRING, true)
                     .setAllowExpression(true).build();
-    public static final SimpleAttributeDefinition DEFAULT_STATEFUL_ACCESS_TIMEOUT =
-            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_STATEFUL_ACCESS_TIMEOUT, ModelType.LONG)
-                    .setDefaultValue(new ModelNode().set(5000L))
-                    .setAllowExpression(true)
-                    .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
+    public static final SimpleAttributeDefinition DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT, ModelType.LONG, true)
+                    .setXmlName(EJB3SubsystemXMLAttribute.DEFAULT_ACCESS_TIMEOUT.getLocalName())
+                    .setDefaultValue(new ModelNode().set(5000)) // TODO: this should come from component description
+                    .setAllowExpression(true) // we allow expression for setting a timeout value
+                    .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, false, false))
+                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
                     .build();
-    public static final SimpleAttributeDefinition DEFAULT_SINGLETON_ACCESS_TIMEOUT =
-            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_SINGLETON_ACCESS_TIMEOUT, ModelType.LONG)
-                    .setDefaultValue(new ModelNode().set(5000L))
-                    .setAllowExpression(true)
-                    .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
+
+    public static final SimpleAttributeDefinition DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT, ModelType.LONG, true)
+                    .setXmlName(EJB3SubsystemXMLAttribute.DEFAULT_ACCESS_TIMEOUT.getLocalName())
+                    .setDefaultValue(new ModelNode().set(5000)) // TODO: this should come from component description
+                    .setAllowExpression(true) // we allow expression for setting a timeout value
+                    .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, false, false))
+                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
                     .build();
+
 
     private EJB3SubsystemRootResourceDefinition() {
         super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME),
@@ -78,7 +84,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SLSB_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.SLSB_POOL);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_MDB_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.MDB_POOL);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_RESOURCE_ADAPTER_NAME, null, DefaultResourceAdapterWriteHandler.INSTANCE);
-        resourceRegistration.registerReadWriteAttribute(DEFAULT_STATEFUL_ACCESS_TIMEOUT, null, new DefaultSessionBeanAccessTimeoutWriteHandler(DEFAULT_STATEFUL_ACCESS_TIMEOUT, DefaultAccessTimeoutService.STATEFUL_SERVICE_NAME));
-        resourceRegistration.registerReadWriteAttribute(DEFAULT_SINGLETON_ACCESS_TIMEOUT, null, new DefaultSessionBeanAccessTimeoutWriteHandler(DEFAULT_SINGLETON_ACCESS_TIMEOUT, DefaultAccessTimeoutService.SINGLETON_SERVICE_NAME));
+        resourceRegistration.registerReadWriteAttribute(DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT, null, DefaultSingletonBeanAccessTimeoutWriteHandler.INSTANCE);
+        resourceRegistration.registerReadWriteAttribute(DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT, null, DefaultStatefulBeanAccessTimeoutWriteHandler.INSTANCE);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
@@ -33,6 +33,8 @@ public enum EJB3SubsystemXMLAttribute {
     CONNECTOR_REF("connector-ref"),
     CORE_THREADS("core-threads"),
 
+    DEFAULT_ACCESS_TIMEOUT("default-access-timeout"),
+
     INSTANCE_AQUISITION_TIMEOUT("instance-acquisition-timeout"),
     INSTANCE_AQUISITION_TIMEOUT_UNIT("instance-acquisition-timeout-unit"),
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
@@ -40,8 +40,6 @@ public enum EJB3SubsystemXMLElement {
     BEAN_INSTANCE_POOL_REF("bean-instance-pool-ref"),
 
     DATA_STORE("data-store"),
-    DEFAULT_STATEFUL_ACCESS_TIMEOUT("default-stateful-access-timeout"),
-    DEFAULT_SINGLETON_ACCESS_TIMEOUT("default-singleton-access-timeout"),
     MDB("mdb"),
 
     POOLS("pools"),
@@ -51,6 +49,8 @@ public enum EJB3SubsystemXMLElement {
     RESOURCE_ADAPTER_REF("resource-adapter-ref"),
 
     SESSION_BEAN("session-bean"),
+    SINGLETON("singleton"),
+    STATEFUL("stateful"),
     STATELESS("stateless"),
     STRICT_MAX_POOL("strict-max-pool"),
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/SingletonBeanDeploymentResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/SingletonBeanDeploymentResourceDefinition.java
@@ -23,19 +23,18 @@
 package org.jboss.as.ejb3.subsystem.deployment;
 
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.ejb3.component.entity.EntityBeanComponent;
+import org.jboss.as.ejb3.component.singleton.SingletonComponent;
 
 /**
- * {@link ResourceDefinition} for a {@link EntityBeanComponent}.
+ * {@link ResourceDefinition} for a {@link SingletonComponent}.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class StatelessSessionBeanResourceDefinition extends AbstractEJBComponentResourceDefinition {
+public class SingletonBeanDeploymentResourceDefinition extends AbstractEJBComponentResourceDefinition {
 
-    public static final StatelessSessionBeanResourceDefinition INSTANCE = new StatelessSessionBeanResourceDefinition();
+    public static final SingletonBeanDeploymentResourceDefinition INSTANCE = new SingletonBeanDeploymentResourceDefinition();
 
-    private StatelessSessionBeanResourceDefinition() {
-        super(EJBComponentType.STATELESS);
+    private SingletonBeanDeploymentResourceDefinition() {
+        super(EJBComponentType.SINGLETON);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/StatefulSessionBeanDeploymentResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/StatefulSessionBeanDeploymentResourceDefinition.java
@@ -23,8 +23,6 @@
 package org.jboss.as.ejb3.subsystem.deployment;
 
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.ejb3.component.entity.EntityBeanComponent;
 import org.jboss.as.ejb3.component.stateful.StatefulSessionComponent;
 
 /**
@@ -32,11 +30,11 @@ import org.jboss.as.ejb3.component.stateful.StatefulSessionComponent;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class StatefulSessionBeanResourceDefinition extends AbstractEJBComponentResourceDefinition {
+public class StatefulSessionBeanDeploymentResourceDefinition extends AbstractEJBComponentResourceDefinition {
 
-    public static final StatefulSessionBeanResourceDefinition INSTANCE = new StatefulSessionBeanResourceDefinition();
+    public static final StatefulSessionBeanDeploymentResourceDefinition INSTANCE = new StatefulSessionBeanDeploymentResourceDefinition();
 
-    private StatefulSessionBeanResourceDefinition() {
+    private StatefulSessionBeanDeploymentResourceDefinition() {
         super(EJBComponentType.STATEFUL);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/StatelessSessionBeanDeploymentResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/StatelessSessionBeanDeploymentResourceDefinition.java
@@ -23,18 +23,18 @@
 package org.jboss.as.ejb3.subsystem.deployment;
 
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.ejb3.component.singleton.SingletonComponent;
+import org.jboss.as.ejb3.component.entity.EntityBeanComponent;
 
 /**
- * {@link ResourceDefinition} for a {@link SingletonComponent}.
+ * {@link ResourceDefinition} for a {@link EntityBeanComponent}.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class SingletonBeanResourceDefinition extends AbstractEJBComponentResourceDefinition {
+public class StatelessSessionBeanDeploymentResourceDefinition extends AbstractEJBComponentResourceDefinition {
 
-    public static final SingletonBeanResourceDefinition INSTANCE = new SingletonBeanResourceDefinition();
+    public static final StatelessSessionBeanDeploymentResourceDefinition INSTANCE = new StatelessSessionBeanDeploymentResourceDefinition();
 
-    private SingletonBeanResourceDefinition() {
-        super(EJBComponentType.SINGLETON);
+    private StatelessSessionBeanDeploymentResourceDefinition() {
+        super(EJBComponentType.STATELESS);
     }
 }

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -5,8 +5,10 @@ ejb3.lite=Specifies whether the ejb3 container need only provide the "LITE" prof
 ejb3.default-mdb-instance-pool=Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level
 ejb3.default-resource-adapter-name=Name of the default resource adapter name that will be used by MDBs, unless overridden at the deployment or bean level
 ejb3.default-slsb-instance-pool=Name of the default stateless bean instance pool, which will be applicable to all stateless EJBs, unless overridden at the deployment or bean level
-ejb3.default-stateful-access-timeout=The default access timeout for stateful session bean instances
-ejb3.default-singleton-access-timeout=The default access timeout for singleton session bean instances
+ejb3.default-stateful-bean-access-timeout=The default access timeout for stateful beans
+ejb3.default-singleton-bean-access-timeout=The default access timeout for singleton beans
+
+
 
 service=Centrally configurable services that are part of the EJB3 subsystem.
 

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
@@ -20,10 +20,11 @@
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
         </stateless>
+        <stateful default-access-timeout="5000"/>
+        <singleton default-access-timeout="5000"/>
+
     </session-bean>
 
-    <default-stateful-access-timeout>5000</default-stateful-access-timeout>
-    <default-singleton-access-timeout>5000</default-singleton-access-timeout>
     <thread-pools>
         <thread-pool name="default" max-threads="10" keepalive-time="100" />
     </thread-pools>


### PR DESCRIPTION
This commit fixes the EJB3 subsytem XSD as well as the EJB3 subsystem model to align with the rest of the management model, so that:

```
<subsystem name="ejb3">
    ...
    <default-stateful-access-timeout>5000</default-stateful-access-timeout>
    <default-singleton-access-timeout>5000</default-singleton-access-timeout>
    ...
</subsystem>
```

can now be represented in XML as:

```
<subsystem xmlns="urn:jboss:domain:ejb3:1.2" lite="true">
        <!-- Session bean configurations -->
        <session-bean>
            <stateful default-access-timeout="5000"/>
            <singleton default-access-timeout="5000"/>
        </session-bean>
```

Furthermore, the subystem model will now consider these as attributes:

```
/subsystem=ejb3:read-attribute(name=default-stateful-bean-access-timeout)
```

This also taken into account the mail discussion about allowing expression for attributes.  
