### PR TITLE
Enable webservice virtual host support

### DIFF
--- a/webservices/server-integration/src/main/resources/META-INF/stack-agnostic-deployment-aspects.xml
+++ b/webservices/server-integration/src/main/resources/META-INF/stack-agnostic-deployment-aspects.xml
@@ -69,7 +69,7 @@
 
   <deploymentAspect class="org.jboss.as.webservices.tomcat.WebMetaDataCreatingDeploymentAspect">
     <!--property name="requires" class="java.lang.String">VirtualHosts,URLPattern,EndpointAddress</property--><!-- TODO will AS7 provide virtual hosts feature? -->
-    <property name="requires" class="java.lang.String">URLPattern,EndpointAddress</property>
+    <property name="requires" class="java.lang.String">URLPattern,EndpointAddressm,VirtualHosts</property>
     <property name="provides" class="java.lang.String">WebMetaData</property>
   </deploymentAspect>
 
@@ -88,12 +88,14 @@
     <property name="provides" class="java.lang.String">InjectionAwareInstanceProvider</property>
   </deploymentAspect>
 
-  <!--
+
 
   <deploymentAspect class="org.jboss.ws.common.deployment.VirtualHostDeploymentAspect">
     <property name="requires" class="java.lang.String">ContainerMetaData</property>
     <property name="provides" class="java.lang.String">VirtualHosts</property>
   </deploymentAspect>
+
+  <!--
 
   <deploymentAspect class="org.jboss.as.webservices.weld.WeldDeploymentAspect">
     <property name="requires" class="java.lang.String">StackEndpointHandler</property>


### PR DESCRIPTION
This patch enables virtual host support for web-services.

now this will work 
```@WebContext( virtualHosts = {"my-virutal-host"},urlPattern = "/services/ServiceName")

```

the fix just enables (uncomments) one deployment aspect that provides support for virtual hosts.
```
