### PR TITLE
cli: generic jms commands and improvements in generic commands in general

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli;
+
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public interface ArgumentValueConverter {
+
+    abstract class DMRWithFallbackConverter implements ArgumentValueConverter {
+        @Override
+        public ModelNode fromString(String value) throws CommandFormatException {
+            if(value == null) {
+                return new ModelNode();
+            }
+            try {
+                return ModelNode.fromString(value);
+            } catch(Exception e) {
+                return fromNonDMRString(value);
+            }
+        }
+
+        protected abstract ModelNode fromNonDMRString(String value) throws CommandFormatException;
+    }
+
+    ArgumentValueConverter DEFAULT = new ArgumentValueConverter() {
+        @Override
+        public ModelNode fromString(String value) throws CommandFormatException {
+            if (value == null) {
+                return new ModelNode();
+            }
+            ModelNode toSet = null;
+            try {
+                toSet = ModelNode.fromString(value);
+            } catch (Exception e) {
+                // just use the string
+                toSet = new ModelNode().set(value);
+            }
+            return toSet;
+        }
+    };
+
+    ArgumentValueConverter LIST = new DMRWithFallbackConverter() {
+        @Override
+        protected ModelNode fromNonDMRString(String value)
+                throws CommandFormatException {
+            final ModelNode list = new ModelNode();
+            for (String item : value.split(",")) {
+                list.add(new ModelNode().set(item));
+            }
+            return list;
+        }
+    };
+
+    ArgumentValueConverter PROPERTIES = new DMRWithFallbackConverter() {
+        @Override
+        protected ModelNode fromNonDMRString(String value)
+                throws CommandFormatException {
+            final String[] props = value.split(",");
+            final ModelNode list = new ModelNode();
+            for (String prop : props) {
+                int equals = prop.indexOf('=');
+                if (equals == -1) {
+                    throw new CommandFormatException("Property '" + prop + "' in '" + value + "' is missing the equals sign.");
+                }
+                String propName = prop.substring(0, equals);
+                if (propName.isEmpty()) {
+                    throw new CommandFormatException("Property name is missing for '" + prop + "' in '" + value + "'");
+                }
+                list.add(propName, prop.substring(equals + 1));
+            }
+            return list;
+        }
+    };
+
+    ModelNode fromString(String value) throws CommandFormatException;
+}

--- a/cli/src/main/java/org/jboss/as/cli/CommandHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandHandler.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.cli;
 
-import java.util.List;
+import java.util.Collection;
 
 
 /**
@@ -64,5 +64,5 @@ public interface CommandHandler {
      */
     boolean hasArgument(int index);
 
-    List<CommandArgument> getArguments(CommandContext ctx);
+    Collection<CommandArgument> getArguments(CommandContext ctx);
 }

--- a/cli/src/main/java/org/jboss/as/cli/CommandLineMain.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandLineMain.java
@@ -127,15 +127,6 @@ public class CommandLineMain {
         cmdRegistry.registerHandler(new UndeployHandler(), "undeploy");
         cmdRegistry.registerHandler(new PrintWorkingNodeHandler(), "pwd", "pwn");
 
-        cmdRegistry.registerHandler(new JmsQueueAddHandler(), "add-jms-queue");
-        cmdRegistry.registerHandler(new JmsQueueRemoveHandler(), "remove-jms-queue");
-        cmdRegistry.registerHandler(new JmsTopicAddHandler(), "add-jms-topic");
-        cmdRegistry.registerHandler(new JmsTopicRemoveHandler(), "remove-jms-topic");
-        cmdRegistry.registerHandler(new JmsCFAddHandler(), "add-jms-cf");
-        cmdRegistry.registerHandler(new JmsCFRemoveHandler(), "remove-jms-cf");
-        cmdRegistry.registerHandler(new CreateJmsResourceHandler(), false, "create-jms-resource");
-        cmdRegistry.registerHandler(new DeleteJmsResourceHandler(), false, "delete-jms-resource");
-
         cmdRegistry.registerHandler(new BatchHandler(), "batch");
         cmdRegistry.registerHandler(new BatchDiscardHandler(), "discard-batch");
         cmdRegistry.registerHandler(new BatchListHandler(), "list-batch");
@@ -148,6 +139,12 @@ public class CommandLineMain {
 
         cmdRegistry.registerHandler(new VersionHandler(), "version");
 
+        cmdRegistry.registerHandler(new CommandCommandHandler(cmdRegistry), "command");
+
+        // data-source
+        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=datasources/data-source", "jndi-name"), "data-source");
+        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=datasources/xa-data-source", "jndi-name"), "xa-data-source");
+        // supported but hidden from the tab-completion
         cmdRegistry.registerHandler(new DataSourceAddHandler(), false, "add-data-source");
         cmdRegistry.registerHandler(new DataSourceModifyHandler(), false, "modify-data-source");
         cmdRegistry.registerHandler(new DataSourceRemoveHandler(), false, "remove-data-source");
@@ -155,11 +152,20 @@ public class CommandLineMain {
         cmdRegistry.registerHandler(new XADataSourceRemoveHandler(), false, "remove-xa-data-source");
         cmdRegistry.registerHandler(new XADataSourceModifyHandler(), false, "modify-xa-data-source");
 
-        cmdRegistry.registerHandler(new CommandCommandHandler(cmdRegistry), "command");
-
-        // data-source
-        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=datasources/data-source", "jndi-name"), "data-source");
-        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=datasources/xa-data-source", "jndi-name"), "xa-data-source");
+        // JMS
+        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=messaging/hornetq-server=default/jms-queue", "queue-address"), "jms-queue");
+        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=messaging/hornetq-server=default/jms-topic", "topic-address"), "jms-topic");
+        cmdRegistry.registerHandler(new GenericTypeOperationHandler("/subsystem=messaging/hornetq-server=default/connection-factory", null), "connection-factory");
+        // supported but hidden from the tab-completion
+        cmdRegistry.registerHandler(new JmsQueueAddHandler(), false, "add-jms-queue");
+        cmdRegistry.registerHandler(new JmsQueueRemoveHandler(), false, "remove-jms-queue");
+        cmdRegistry.registerHandler(new JmsTopicAddHandler(), false, "add-jms-topic");
+        cmdRegistry.registerHandler(new JmsTopicRemoveHandler(), false, "remove-jms-topic");
+        cmdRegistry.registerHandler(new JmsCFAddHandler(), false, "add-jms-cf");
+        cmdRegistry.registerHandler(new JmsCFRemoveHandler(), false, "remove-jms-cf");
+        // these are used for the cts setup
+        cmdRegistry.registerHandler(new CreateJmsResourceHandler(), false, "create-jms-resource");
+        cmdRegistry.registerHandler(new DeleteJmsResourceHandler(), false, "delete-jms-resource");
     }
 
     public static void main(String[] args) throws Exception {
@@ -564,7 +570,7 @@ public class CommandLineMain {
         /** current command line */
         private String cmdLine;
         /** parsed command arguments */
-        private DefaultCallbackHandler parsedCmd = new DefaultCallbackHandler();
+        private DefaultCallbackHandler parsedCmd = new DefaultCallbackHandler(true);
 
         /** domain or standalone mode*/
         private boolean domainMode;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
@@ -181,10 +181,10 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
                 if(actionStr == null) {
                     return false;
                 }
-                if("add".equals(actionStr)) {
+/*                if("add".equals(actionStr)) {
                     return idProperty.isValueComplete(args);
                 }
-                if("remove".equals(actionStr)) {
+*/                if("remove".equals(actionStr)) {
                     return true;
                 }
                 return false;
@@ -212,7 +212,7 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
 
         if(action.equals("add")) {
             final String nodePath = this.nodePath.getValue(args, true);
-            final String propName = this.idProperty.getValue(args, true);
+            final String propName = this.idProperty.getValue(args, false);
             final String cmdName = this.commandName.getValue(args, true);
 
             if(!validateInput(ctx, profile.getValue(args), nodePath, propName)) {
@@ -223,7 +223,7 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
                 ctx.printLine("Command '" + cmdName + "' already registered.");
                 return;
             }
-            cmdRegistry.registerHandler(new GenericTypeOperationHandler(nodePath, idProperty.getValue(args)), cmdName);
+            cmdRegistry.registerHandler(new GenericTypeOperationHandler(nodePath, propName), cmdName);
             return;
         }
 
@@ -391,14 +391,16 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
             return false;
         }
 
-        for(Property prop : result.get("attributes").asPropertyList()) {
-            if(prop.getName().equals(propertyName)) {
-                ModelNode value = prop.getValue();
-                if(value.has("access-type") && "read-only".equals(value.get("access-type").asString())) {
-                    return true;
+        if(propertyName != null) {
+            for(Property prop : result.get("attributes").asPropertyList()) {
+                if(prop.getName().equals(propertyName)) {
+                    ModelNode value = prop.getValue();
+                    if(value.has("access-type") && "read-only".equals(value.get("access-type").asString())) {
+                        return true;
+                    }
+                    ctx.printLine("Property " + propertyName + " is not read-only.");
+                    return false;
                 }
-                ctx.printLine("Property " + propertyName + " is not read-only.");
-                return false;
             }
         }
         ctx.printLine("Property '" + propertyName + "' wasn't found among the properties of " + typePath);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/CommandHandlerWithArguments.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/CommandHandlerWithArguments.java
@@ -22,6 +22,7 @@
 package org.jboss.as.cli.handlers;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -76,7 +77,7 @@ public abstract class CommandHandlerWithArguments implements CommandHandler {
     }
 
     @Override
-    public List<CommandArgument> getArguments(CommandContext ctx) {
+    public Collection<CommandArgument> getArguments(CommandContext ctx) {
         return this.args;
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithValue.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithValue.java
@@ -23,6 +23,7 @@ package org.jboss.as.cli.impl;
 
 import java.util.List;
 
+import org.jboss.as.cli.ArgumentValueConverter;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.handlers.CommandHandlerWithArguments;
@@ -35,17 +36,23 @@ import org.jboss.as.cli.operation.ParsedCommandLine;
 public class ArgumentWithValue extends ArgumentWithoutValue {
 
     private final CommandLineCompleter valueCompleter;
+    private final ArgumentValueConverter valueConverter;
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, String fullName) {
         this(handler, fullName, null);
     }
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter, String fullName) {
-        this(handler, valueCompleter, fullName, null);
+        this(handler, valueCompleter, ArgumentValueConverter.DEFAULT, fullName, null);
+    }
+
+    public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter,
+            ArgumentValueConverter valueConverter, String fullName) {
+        this(handler, valueCompleter, valueConverter, fullName, null);
     }
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, String fullName, String shortName) {
-        this(handler, null, fullName, shortName);
+        this(handler, null, ArgumentValueConverter.DEFAULT, fullName, shortName);
     }
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, int index, String fullName) {
@@ -55,11 +62,14 @@ public class ArgumentWithValue extends ArgumentWithoutValue {
     public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter, int index, String fullName) {
         super(handler, index, fullName);
         this.valueCompleter = valueCompleter;
+        valueConverter = ArgumentValueConverter.DEFAULT;
     }
 
-    public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter, String fullName, String shortName) {
+    public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter,
+            ArgumentValueConverter valueConverter, String fullName, String shortName) {
         super(handler, fullName, shortName);
         this.valueCompleter = valueCompleter;
+        this.valueConverter = valueConverter;
     }
 
     public CommandLineCompleter getValueCompleter() {
@@ -121,5 +131,9 @@ public class ArgumentWithValue extends ArgumentWithoutValue {
             return false;
         }
         return true;
+    }
+
+    public ArgumentValueConverter getValueConverter() {
+        return valueConverter;
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandCandidatesProvider.java
@@ -22,6 +22,7 @@
 package org.jboss.as.cli.impl;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,7 +72,7 @@ public class CommandCandidatesProvider implements OperationCandidatesProvider {
     }
 
     @Override
-    public List<CommandArgument> getProperties(CommandContext ctx, String operationName, OperationRequestAddress address) {
+    public Collection<CommandArgument> getProperties(CommandContext ctx, String operationName, OperationRequestAddress address) {
         CommandHandler handler = registry.getCommandHandler(operationName);
         if(handler == null) {
             return Collections.emptyList();

--- a/cli/src/main/java/org/jboss/as/cli/impl/DefaultCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/DefaultCompleter.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.cli.impl;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,7 +35,7 @@ import org.jboss.as.cli.CommandLineCompleter;
 public class DefaultCompleter implements CommandLineCompleter {
 
     public interface CandidatesProvider {
-        List<String> getAllCandidates(CommandContext ctx);
+        Collection<String> getAllCandidates(CommandContext ctx);
     }
 
     private final CandidatesProvider candidatesProvider;
@@ -60,7 +61,7 @@ public class DefaultCompleter implements CommandLineCompleter {
             ++nextCharIndex;
         }
 
-        List<String> all = candidatesProvider.getAllCandidates(ctx);
+        final Collection<String> all = candidatesProvider.getAllCandidates(ctx);
         if (all.isEmpty()) {
             return -1;
         }

--- a/cli/src/main/java/org/jboss/as/cli/operation/OperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/OperationCandidatesProvider.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.cli.operation;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.jboss.as.cli.CommandArgument;
 import org.jboss.as.cli.CommandContext;
@@ -34,11 +34,11 @@ import org.jboss.as.cli.CommandContext;
  */
 public interface OperationCandidatesProvider {
 
-    List<String> getNodeNames(CommandContext ctx, OperationRequestAddress prefix);
+    Collection<String> getNodeNames(CommandContext ctx, OperationRequestAddress prefix);
 
-    List<String> getNodeTypes(CommandContext ctx, OperationRequestAddress prefix);
+    Collection<String> getNodeTypes(CommandContext ctx, OperationRequestAddress prefix);
 
-    List<String> getOperationNames(CommandContext ctx, OperationRequestAddress prefix);
+    Collection<String> getOperationNames(CommandContext ctx, OperationRequestAddress prefix);
 
-    List<CommandArgument> getProperties(CommandContext ctx, String operationName, OperationRequestAddress address);
+    Collection<CommandArgument> getProperties(CommandContext ctx, String operationName, OperationRequestAddress address);
 }

--- a/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestCompleter.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.cli.operation;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -78,7 +79,7 @@ public class OperationRequestCompleter implements CommandLineCompleter {
 
         if (parsedCmd.hasProperties() || parsedCmd.endsOnPropertyListStart()) {
 
-            final List<CommandArgument> allArgs = candidatesProvider.getProperties(ctx, parsedCmd.getOperationName(), parsedCmd.getAddress());
+            final Collection<CommandArgument> allArgs = candidatesProvider.getProperties(ctx, parsedCmd.getOperationName(), parsedCmd.getAddress());
             if (allArgs.isEmpty()) {
                 final CommandLineFormat format = parsedCmd.getFormat();
                 if(format != null && format.getPropertyListEnd() != null) {
@@ -214,7 +215,7 @@ public class OperationRequestCompleter implements CommandLineCompleter {
             if(parsedCmd.getAddress().endsOnType()) {
                 return -1;
             }
-            final List<String> names = candidatesProvider.getOperationNames(ctx, parsedCmd.getAddress());
+            final Collection<String> names = candidatesProvider.getOperationNames(ctx, parsedCmd.getAddress());
             if(names.isEmpty()) {
                 return -1;
             }
@@ -257,7 +258,7 @@ public class OperationRequestCompleter implements CommandLineCompleter {
             chunk = address.toNodeType();
         }
 
-        final List<String> names;
+        final Collection<String> names;
         if(address.endsOnType()) {
             names = candidatesProvider.getNodeNames(ctx, address);
         } else {

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationRequestBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationRequestBuilder.java
@@ -123,8 +123,4 @@ public class DefaultOperationRequestBuilder implements OperationRequestBuilder {
     public ModelNode getModelNode() {
         return request;
     }
-
-    public static void main(String[] args) throws Exception {
-        System.out.println(ModelNode.fromString("(\"prop\"=>\"val\")").getType());
-    }
 }


### PR DESCRIPTION
Sorry, it's all in one commit...
- AS7-2182 add jms generic commands;
- AS7-2183 don't require an id property in generic type commands;
- check whether the operation supports specified property names before sending the request generated by generic command handlers;
- improved generated help contents;
- argument value converter - an experimental converter which supports both DMR and custom format value parsing.

PS: haven't yet created an issue for it, connection-factory 'add' requires 'connector' property, although it's not marked as such in the description.
