### PR TITLE
AS7-2209 Support for OpenJPA runtime enhancement of entities

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -587,6 +587,10 @@
             <maven-resource group="org.jboss.as" artifact="jboss-as-jpa-hibernate4"/>
         </module-def>
 
+        <module-def name="org.jboss.as.jpa.openjpa">
+            <maven-resource group="org.jboss.as" artifact="jboss-as-jpa-openjpa"/>
+        </module-def>
+
         <module-def name="org.jboss.as.jpa.spi">
             <maven-resource group="org.jboss.as" artifact="jboss-as-jpa-spi"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -945,6 +945,11 @@
 
         <dependency>
             <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-jpa-openjpa</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-jpa-spi</artifactId>
         </dependency>
 

--- a/build/src/main/resources/modules/org/jboss/as/jpa/openjpa/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jpa/openjpa/main/module.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<!-- contains the JPA integration classes for OpenJPA 2.x --> 
+<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.jpa.openjpa">
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.annotation.api"/>
+        <module name="javax.persistence.api"/>
+        <module name="javax.transaction.api"/>
+
+        <module name="org.jboss.as.jpa.spi"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.jandex"/>
+
+        <module name="org.apache.openjpa" optional="true"/>  <!-- org.apache.openjpa:main must be created manually with OpenJPA jars -->
+    </dependencies>
+</module>

--- a/jpa/openjpa/pom.xml
+++ b/jpa/openjpa/pom.xml
@@ -29,31 +29,41 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-parent</artifactId>
+        <artifactId>jboss-as-jpa-parent</artifactId>
         <version>7.1.0.CR1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-jpa-parent</artifactId>
+    <artifactId>jboss-as-jpa-openjpa</artifactId>
     <version>7.1.0.CR1-SNAPSHOT</version>
-    <packaging>pom</packaging>
 
-    <name>JBoss Application Server: JPA Subsystem</name>
-
-    <modules>
-        <module>core</module>
-        <module>util</module>
-        <module>spi</module>
-        <module>hibernate4</module>
-        <module>hibernate3</module>
-        <module>openjpa</module>
-    </modules>
+    <name>JBoss Application Server: OpenJPA 2.x JPA integration</name>
 
     <dependencies>
+
+        <!-- Internal -->
+
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-jpa-spi</artifactId>
         </dependency>
+
+        <!-- External -->
+
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa-kernel</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa-lib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.openjpa</groupId>
+            <artifactId>openjpa-persistence</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/jpa/openjpa/src/main/java/org/jboss/as/jpa/openjpa/JBossPersistenceMetaDataFactory.java
+++ b/jpa/openjpa/src/main/java/org/jboss/as/jpa/openjpa/JBossPersistenceMetaDataFactory.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.openjpa;
+
+import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+
+import javax.persistence.Entity;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.openjpa.persistence.PersistenceMetaDataFactory;
+
+/**
+ * OpenJPA MetaDataFactory that uses the annotation index provided by PersistenceUnitMetadata
+ * to search entity classes from the persistence unit.
+ *
+ * @author Antti Laisi
+ */
+public class JBossPersistenceMetaDataFactory extends PersistenceMetaDataFactory {
+
+    private static ThreadLocal<PersistenceUnitMetadata> persistenceUnitMetadata = new ThreadLocal<PersistenceUnitMetadata>();
+
+    @Override
+    protected Set<String> parsePersistentTypeNames(ClassLoader loader) {
+        PersistenceUnitMetadata pu = persistenceUnitMetadata.get();
+        if (pu == null) {
+            return Collections.emptySet();
+        }
+
+        return findPersistenceTypeNames(pu);
+    }
+
+    static void setThreadLocalPersistenceUnitMetadata(PersistenceUnitMetadata pu) {
+        persistenceUnitMetadata.set(pu);
+    }
+
+    static void clearThreadLocalPersistenceUnitMetadata() {
+        persistenceUnitMetadata.remove();
+    }
+
+    private Set<String> findPersistenceTypeNames(PersistenceUnitMetadata pu) {
+        Set<String> persistenceTypeNames = new HashSet<String>();
+
+        for (Map.Entry<URL, Index> entry : pu.getAnnotationIndex().entrySet()) {
+            List<AnnotationInstance> instances = entry.getValue().getAnnotations(DotName.createSimple(Entity.class.getName()));
+            for (AnnotationInstance instance : instances) {
+                AnnotationTarget target = instance.target();
+                if (target instanceof ClassInfo) {
+                    ClassInfo classInfo = (ClassInfo) target;
+                    persistenceTypeNames.add(classInfo.name().toString());
+                }
+            }
+        }
+        return persistenceTypeNames;
+    }
+
+}

--- a/jpa/openjpa/src/main/java/org/jboss/as/jpa/openjpa/OpenJPAPersistenceProviderAdaptor.java
+++ b/jpa/openjpa/src/main/java/org/jboss/as/jpa/openjpa/OpenJPAPersistenceProviderAdaptor.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.openjpa;
+
+import org.jboss.as.jpa.spi.JtaManager;
+import org.jboss.as.jpa.spi.ManagementAdaptor;
+import org.jboss.as.jpa.spi.PersistenceProviderAdaptor;
+import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
+import org.jboss.msc.service.ServiceName;
+
+import java.util.Map;
+
+/**
+ * Implements the {@link PersistenceProviderAdaptor} for OpenJPA 2.x.
+ *
+ * @author Antti Laisi
+ */
+public class OpenJPAPersistenceProviderAdaptor implements PersistenceProviderAdaptor {
+
+    private static final String TRANSACTION_MODE = "openjpa.TransactionMode";
+    private static final String MANAGED_RUNTIME  = "openjpa.ManagedRuntime";
+    private static final String METADATA_FACTORY = "openjpa.MetaDataFactory";
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void addProviderProperties(Map properties, PersistenceUnitMetadata pu) {
+        if(!pu.getProperties().containsKey(TRANSACTION_MODE)) {
+            properties.put(TRANSACTION_MODE, "managed");
+        }
+        if(!pu.getProperties().containsKey(MANAGED_RUNTIME)) {
+            properties.put(MANAGED_RUNTIME, "jndi(TransactionManagerName=java:jboss/TransactionManager)");
+        }
+        if(!pu.getProperties().containsKey(METADATA_FACTORY)) {
+            properties.put(METADATA_FACTORY, JBossPersistenceMetaDataFactory.class.getName());
+        }
+    }
+
+    @Override
+    public void beforeCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
+        JBossPersistenceMetaDataFactory.setThreadLocalPersistenceUnitMetadata(pu);
+    }
+
+    @Override
+    public void afterCreateContainerEntityManagerFactory(PersistenceUnitMetadata pu) {
+        JBossPersistenceMetaDataFactory.clearThreadLocalPersistenceUnitMetadata();
+    }
+
+    @Override
+    public void injectJtaManager(JtaManager jtaManager) {
+
+    }
+
+    @Override
+    public Iterable<ServiceName> getProviderDependencies(PersistenceUnitMetadata pu) {
+        return null;
+    }
+
+    @Override
+    public ManagementAdaptor getManagementAdaptor() {
+        return null;
+    }
+
+}

--- a/jpa/openjpa/src/main/resources/META-INF/services/org.jboss.as.jpa.spi.PersistenceProviderAdaptor
+++ b/jpa/openjpa/src/main/resources/META-INF/services/org.jboss.as.jpa.spi.PersistenceProviderAdaptor
@@ -1,0 +1,1 @@
+org.jboss.as.jpa.openjpa.OpenJPAPersistenceProviderAdaptor

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <version.org.apache.httpcomponents.httpclient>4.1.2</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.1.2</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.neethi>3.0.1</version.org.apache.neethi>
+        <version.org.apache.openjpa>2.1.1</version.org.apache.openjpa>
         <version.org.apache.santuario.xmlsec>1.4.5</version.org.apache.santuario.xmlsec>
         <version.org.apache.velocity>1.6.3</version.org.apache.velocity>
         <version.org.apache.ws.scout>1.1.1</version.org.apache.ws.scout>
@@ -2837,6 +2838,66 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+            
+            <dependency>
+                <groupId>org.apache.openjpa</groupId>
+                <artifactId>openjpa-persistence</artifactId>
+                <version>${version.org.apache.openjpa}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.openjpa</groupId>
+                        <artifactId>openjpa-kernel</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jpa_2.0_spec</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.openjpa</groupId>
+                <artifactId>openjpa-kernel</artifactId>
+                <version>${version.org.apache.openjpa}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.openjpa</groupId>
+                        <artifactId>openjpa-lib</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jta_1.1_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-pool</groupId>
+                        <artifactId>commons-pool</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jms_1.1_spec</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.openjpa</groupId>
+                <artifactId>openjpa-lib</artifactId>
+                <version>${version.org.apache.openjpa}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-lang</groupId>
+                        <artifactId>commons-lang</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-collections</groupId>
+                        <artifactId>commons-collections</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.sourceforge.serp</groupId>
+                        <artifactId>serp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.santuario</groupId>
@@ -3547,6 +3608,12 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-jpa-hibernate4</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-jpa-openjpa</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/Employee.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/Employee.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.openjpa;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee  {
+
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.openjpa;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import javax.naming.InitialContext;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Create org.apache.openjpa:main module before running this test. The module
+ * must depend on javaee.api and org.jboss.as.jpa.openjpa. 
+ *
+ * @author Antti Laisi
+ */
+@RunWith(Arquillian.class)
+@Ignore  // only for manual testing currently
+public class OpenJPASharedModuleProviderTestCase {
+
+    private static final String ARCHIVE_NAME = "openjpa_module_test";
+
+    private static final String persistence_xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+        "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+        "   <persistence-unit name=\"openjpa_pc\">" +
+        "       <provider>org.apache.openjpa.persistence.PersistenceProviderImpl</provider>"+
+        "       <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+        "       <properties>" +
+        "           <property name=\"openjpa.jdbc.SynchronizeMappings\" value=\"buildSchema(SchemaAction='drop,add')\"/>" +
+        "           <property name=\"openjpa.InitializeEagerly\" value=\"true\"/>" +
+        "           <property name=\"openjpa.RuntimeUnenhancedClasses\" value=\"supported\"/>" +
+        "           <property name=\"jboss.as.jpa.providerModule\" value=\"org.apache.openjpa\"/>" +
+        "           <property name=\"jboss.as.jpa.adapterModule\" value=\"org.jboss.as.jpa.openjpa\"/>" +
+        "       </properties>" +
+        "  </persistence-unit>" +
+        "</persistence>";
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
+        lib.addClasses(SFSB1.class);
+        ear.addAsModule(lib);
+
+        lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
+        lib.addClasses(Employee.class);
+        lib.addAsManifestResource(new StringAsset(persistence_xml), "persistence.xml");
+        ear.addAsLibraries(lib);
+
+        WebArchive main = ShrinkWrap.create(WebArchive.class, "main.war");
+        main.addClasses(OpenJPASharedModuleProviderTestCase.class);
+        ear.addAsModule(main);
+        
+        return ear;
+    }
+
+    @Test
+    public void testSimpleCreateAndLoadEntities() throws Exception {
+        SFSB1 sfsb1 = InitialContext.doLookup("java:global/" + ARCHIVE_NAME + "/beans/SFSB1");
+        sfsb1.createEmployee("Kelly Smith", "Watford, England", 10);
+        sfsb1.createEmployee("Alex Scott", "London, England", 20);
+        sfsb1.getEmployeeNoTX(10);
+        sfsb1.getEmployeeNoTX(20);
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/SFSB1.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/SFSB1.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.openjpa;
+
+import javax.ejb.Stateful;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+public class SFSB1 {
+    @PersistenceContext(unitName = "openjpa_pc")
+    EntityManager em;
+
+    public void createEmployee(String name, String address, int id) {
+        Employee emp = new Employee();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setName(name);
+        em.persist(emp);
+    }
+
+    public Employee getEmployeeNoTX(int id) {
+        return em.find(Employee.class, id);
+    }
+
+}


### PR DESCRIPTION
Added new JPA adaptor module jboss-as-jpa-openjpa that handles setting up OpenJPAs java.lang.instrument.ClassFileTransformer for the ModuleClassLoader of the application.

Added logic to automatically add dependencies to OpenJPA provider module and adaptor module if running with OpenJPA persistence provider and jboss.as.jpa.providerModule and jboss.as.jpa.adapterModule have not been set in persistence unit properties.
