### PR TITLE
Migration of ejb testsuite

### DIFF
--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/ArjunaTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/ArjunaTestCase.java
@@ -1,0 +1,96 @@
+/*
+  * JBoss, Home of Professional Open Source
+  * Copyright 2005, JBoss Inc., and individual contributors as indicated
+  * by the @authors tag. See the copyright.txt in the distribution for a
+  * full listing of individual contributors.
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU Lesser General Public License as
+  * published by the Free Software Foundation; either version 2.1 of
+  * the License, or (at your option) any later version.
+  *
+  * This software is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this software; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  */
+package org.jboss.as.test.integration.ejb.arjuna;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.ee.injection.resource.persistencecontextref.PcMyEntity;
+import org.jboss.as.test.integration.ee.injection.resource.persistencecontextref.PcOtherEntity;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Make sure we can run with Arjuna TM.
+ * 
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ * @deprecated
+ */
+@RunWith(Arquillian.class)
+public class ArjunaTestCase
+{
+   private static final Logger log = Logger.getLogger(ArjunaTestCase.class);
+   
+   private static final String persistence_xml = 
+           "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" +  
+           "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\">" + 
+               "<persistence-unit name=\"test\">" + 
+                   "<description>Persistence Unit</description>" + 
+                   "<jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" + 
+                   "<properties>" +  
+                       "<property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\" />" + 
+                       "<property name=\"PersistenceUnitName\" value=\"test\" />" + 
+                   "</properties>" + 
+               "</persistence-unit>" + 
+           "</persistence>";
+
+   @Deployment
+   public static Archive<?> deploy() {
+       JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "arjuna-test.jar");
+       jar.addPackage(ArjunaTestCase.class.getPackage());
+       // jar.addAsManifestResource("ejb/persistence.xml", "persistence.xml");
+       jar.addAsManifestResource(new StringAsset(persistence_xml), "persistence.xml");
+       return jar;
+   }
+   
+   @Test
+   public void testStatefulTx() throws Exception
+   {     
+      InitialContext ctx = new InitialContext();
+      StatefulTx stateful = (StatefulTx) ctx.lookup("java:module/StatefulTx!org.jboss.as.test.integration.ejb.arjuna.StatefulTx");
+      Assert.assertNotNull(stateful);
+      
+      boolean arjunaTransacted = stateful.isArjunaTransactedRequired();
+      Assert.assertTrue(arjunaTransacted);
+      arjunaTransacted = stateful.isArjunaTransactedRequiresNew();
+      Assert.assertTrue(arjunaTransacted);
+      
+      Entity entity = new Entity();
+      entity.setName("test-entity");
+      entity.setId(1234L);
+      
+      arjunaTransacted = stateful.clear(entity);
+      Assert.assertTrue(arjunaTransacted);
+      
+      arjunaTransacted = stateful.persist(entity);
+      Assert.assertTrue(arjunaTransacted);
+      
+      stateful.clear(entity);
+   }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/Entity.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/Entity.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2005, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.arjuna;
+
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@javax.persistence.Entity
+@Table(name = "ENTITY")
+public class Entity implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String name;
+
+    @Id
+    // @GeneratedValue(strategy= GenerationType.IDENTITY)
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/StatefulTx.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/StatefulTx.java
@@ -1,0 +1,37 @@
+/*
+  * JBoss, Home of Professional Open Source
+  * Copyright 2005, JBoss Inc., and individual contributors as indicated
+  * by the @authors tag. See the copyright.txt in the distribution for a
+  * full listing of individual contributors.
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU Lesser General Public License as
+  * published by the Free Software Foundation; either version 2.1 of
+  * the License, or (at your option) any later version.
+  *
+  * This software is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this software; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  */
+package org.jboss.as.test.integration.ejb.arjuna;
+
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface StatefulTx
+{
+   boolean isArjunaTransactedRequired() throws javax.transaction.SystemException;
+   
+   boolean isArjunaTransactedRequiresNew() throws javax.transaction.SystemException;
+   
+   boolean clear(Entity entity) throws javax.transaction.SystemException;
+   
+   boolean persist(Entity entity) throws javax.transaction.SystemException;
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/StatefulTxBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/arjuna/StatefulTxBean.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2005, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.arjuna;
+
+// import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+// import javax.inject.Inject;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.TransactionManager;
+// import org.jboss.ejb3.annotation.JndiInject;
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateful(name = "StatefulTx")
+@Remote(StatefulTx.class)
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class StatefulTxBean implements StatefulTx {
+    private static final Logger log = Logger.getLogger(StatefulTxBean.class);
+
+    // @JndiInject(jndiName="java:/TransactionManager") private TransactionManager tm;
+    public TransactionManager getTransactionManager() throws javax.transaction.SystemException {
+        try {
+            return (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+        } catch(NamingException e) {
+            throw new javax.transaction.SystemException("Caused by NamingException during search of TransactionManager");
+        }
+
+    }
+
+    @PersistenceContext(unitName = "test")
+    private EntityManager manager;
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public boolean clear(Entity entity) throws javax.transaction.SystemException {
+        entity = manager.find(Entity.class, entity.getId());
+        if (entity != null)
+            manager.remove(entity);
+
+        return getReturn();
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public boolean persist(Entity entity) throws javax.transaction.SystemException {
+        manager.persist(entity);
+
+        return getReturn();
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public boolean isArjunaTransactedRequired() throws javax.transaction.SystemException {
+        return getReturn();
+    }
+
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public boolean isArjunaTransactedRequiresNew() throws javax.transaction.SystemException {
+        return getReturn();
+    }
+
+    protected boolean getReturn() throws javax.transaction.SystemException {
+        if (getTransactionManager().getTransaction() == null)
+            return false;
+
+        if (!getTransactionManager().getClass().toString().contains("arjuna"))
+            return false;
+
+        if (!getTransactionManager().getTransaction().getClass().toString().contains("arjuna"))
+            return false;
+
+        log.error("tm.class: " + getTransactionManager().getClass().toString());
+        log.error("tm.transaction.class: " + getTransactionManager().getTransaction().getClass().toString());
+        return true;
+    }
+
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/BMTUnitTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/BMTUnitTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.naming.InitialContext;
+
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.formatter.Formatters;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.RunWith;
+
+import org.junit.Test;
+
+/**
+ * Sample client for the jboss container.
+ *
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ */
+
+@RunWith(Arquillian.class)
+public class BMTUnitTestCase
+{
+   private static final Logger log = Logger.getLogger(BMTUnitTestCase.class);
+
+   static boolean deployed = false;
+   static int test = 0;
+
+   @Deployment
+   public static Archive<?> deploy() {
+       JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "bmt2-test.jar");
+       jar.addPackage(BMTUnitTestCase.class.getPackage());
+       jar.addAsManifestResource("ejb/entity/bmp2/ejb-jar.xml", "ejb-jar.xml");
+       
+       log.error(jar.toString(Formatters.VERBOSE));
+       
+       return jar;
+   }
+   
+   private InitialContext getInitialContext() throws Exception {
+       return new InitialContext();
+   }
+
+   @Test
+   public void testStateless() throws Exception
+   {
+      TesterRemote tester = (TesterRemote)getInitialContext().lookup("java:module/TesterBean");
+      tester.testStatelessWithoutTx();
+      tester.testStatelessWithTx();
+   }
+
+   @Test
+   public void testStateful() throws Exception
+   {
+      TesterRemote tester = (TesterRemote)getInitialContext().lookup("java:module/TesterBean");
+      tester.testStatefulWithoutTx();
+      tester.testStatefulWithTx();
+   }
+   
+   @Test
+   public void testDeploymentDescriptorStateless() throws Exception
+   {
+      DeploymentDescriptorTesterRemote tester = (DeploymentDescriptorTesterRemote)getInitialContext().lookup("java:module/DeploymentDescriptorTester");
+      tester.testStatelessWithoutTx();
+      tester.testStatelessWithTx();
+   }
+
+   @Test
+   public void testDeploymentDescriptorStateful() throws Exception
+   {
+      DeploymentDescriptorTesterRemote tester = (DeploymentDescriptorTesterRemote)getInitialContext().lookup("java:module/DeploymentDescriptorTester");
+      tester.testStatefulWithoutTx();
+      tester.testStatefulWithTx();
+   }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatefulBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatefulBean.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.interceptor.InvocationContext;
+import javax.naming.InitialContext;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+/**
+ * @version <tt>$Revision: 67628 $</tt>
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public class DeploymentDescriptorStatefulBean implements DeploymentDescriptorStatefulLocal
+{
+   @Resource UserTransaction ut;
+   
+   TransactionManager tm;
+   
+   @PostConstruct
+   public void postConstruct(final InvocationContext context) throws Exception {
+       this.tm = (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+   }
+
+   public Transaction beginNoEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      return tm.getTransaction();
+   }
+
+   public void endCommit(Transaction old) throws Exception
+   {
+      if (old != tm.getTransaction()) throw new TestException("No matching TX");
+      ut.commit();
+   }
+
+   public void endRollback(Transaction old) throws Exception
+   {
+      if (old != tm.getTransaction()) throw new TestException("No matching TX");
+      ut.rollback();
+   }
+
+   public void beginCommitEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.commit();
+   }
+
+   public void beginRollbackEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.rollback();
+   }
+   
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatefulLocal.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatefulLocal.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.transaction.Transaction;
+
+/**
+ * @version <tt>$Revision: 61136 $</tt>
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface DeploymentDescriptorStatefulLocal
+{
+   Transaction beginNoEnd() throws Exception;
+
+   void endCommit(Transaction old) throws Exception;
+
+   void endRollback(Transaction old) throws Exception;
+
+   void beginCommitEnd() throws Exception;
+
+   void beginRollbackEnd() throws Exception;
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatelessBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatelessBean.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.interceptor.InvocationContext;
+import javax.naming.InitialContext;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+
+/**
+ * @version <tt>$Revision: 67628 $</tt>
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public class DeploymentDescriptorStatelessBean implements DeploymentDescriptorStatelessLocal
+{
+   @Resource UserTransaction ut;
+   
+   TransactionManager tm;
+   
+   @PostConstruct
+   public void postConstruct(final InvocationContext context) throws Exception {
+       this.tm = (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+   }
+
+   public void beginNoEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+   }
+
+   public void beginCommitEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.commit();
+   }
+
+   public void beginRollbackEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.rollback();
+   }
+
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatelessLocal.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorStatelessLocal.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+/**
+ * @version <tt>$Revision: 61136 $</tt>
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface DeploymentDescriptorStatelessLocal
+{
+   void beginNoEnd() throws Exception;
+
+   void beginCommitEnd() throws Exception;
+
+   void beginRollbackEnd() throws Exception;
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorTesterBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorTesterBean.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.interceptor.InvocationContext;
+import javax.naming.InitialContext;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+import org.jboss.logging.Logger;
+
+
+/**
+ * @version <tt>$Revision: 67628 $</tt>
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public class DeploymentDescriptorTesterBean implements DeploymentDescriptorTesterRemote
+{
+   @EJB DeploymentDescriptorStatelessLocal stateless;
+   
+   TransactionManager tm;
+   
+   @PostConstruct
+   public void postConstruct(final InvocationContext context) throws Exception {
+       this.tm = (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+   }
+
+
+   protected static Logger log = Logger.getLogger(DeploymentDescriptorTesterBean.class);
+
+   public void testStatelessWithTx() throws Exception
+   {
+      stateless.beginCommitEnd();
+      stateless.beginRollbackEnd();
+
+      try
+      {
+         stateless.beginNoEnd();
+      }
+      catch (Exception e)
+      {
+         if (e instanceof TestException) throw e;
+         log.info("should be EJBException thrown that begin and no end was called: ", e);
+      }
+   }
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   public void testStatelessWithoutTx() throws Exception
+   {
+      stateless.beginCommitEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateless.beginRollbackEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+
+      try
+      {
+         stateless.beginNoEnd();
+      }
+      catch (Exception e)
+      {
+         if (e instanceof TestException) throw e;
+         log.info("should be EJBException thrown that begin and no end was called: ", e);
+      }
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+   }
+
+   DeploymentDescriptorStatefulLocal getStateful() throws Exception
+   {
+      InitialContext ctx = new InitialContext();
+      return (DeploymentDescriptorStatefulLocal)ctx.lookup("java:module/DeploymentDescriptorStateful!org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorStatefulLocal");
+   }
+
+   public void testStatefulWithTx() throws Exception
+   {
+      DeploymentDescriptorStatefulLocal stateful = getStateful();
+      Transaction tx = stateful.beginNoEnd();
+      stateful.endCommit(tx);
+      tx = stateful.beginNoEnd();
+      stateful.endRollback(tx);
+
+      stateful.beginCommitEnd();
+      stateful.beginRollbackEnd();
+
+   }
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   public void testStatefulWithoutTx() throws Exception
+   {
+      DeploymentDescriptorStatefulLocal stateful = getStateful();
+      Transaction tx = stateful.beginNoEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateful.endCommit(tx);
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      tx = stateful.beginNoEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateful.endRollback(tx);
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+
+      stateful.beginCommitEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateful.beginRollbackEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+
+   }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorTesterRemote.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/DeploymentDescriptorTesterRemote.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.Remote;
+
+/**
+ * @version <tt>$Revision: 61136 $</tt>
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Remote
+public interface DeploymentDescriptorTesterRemote
+{
+   void testStatelessWithTx() throws Exception;
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   void testStatelessWithoutTx() throws Exception;
+
+   void testStatefulWithTx() throws Exception;
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   void testStatefulWithoutTx() throws Exception;
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatefulBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatefulBean.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.interceptor.InvocationContext;
+import javax.naming.InitialContext;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 67628 $
+ */
+@Stateful
+@TransactionManagement(TransactionManagementType.BEAN)
+public class StatefulBean implements StatefulLocal
+{
+   @Resource UserTransaction ut;
+   
+   TransactionManager tm;
+   
+   @PostConstruct
+   public void postConstruct(final InvocationContext context) throws Exception {
+       this.tm = (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+   }
+
+   public Transaction beginNoEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      return tm.getTransaction();
+   }
+
+   public void endCommit(Transaction old) throws Exception
+   {
+      if (old != tm.getTransaction()) throw new TestException("No matching TX");
+      ut.commit();
+   }
+
+   public void endRollback(Transaction old) throws Exception
+   {
+      if (old != tm.getTransaction()) throw new TestException("No matching TX");
+      ut.rollback();
+   }
+
+   public void beginCommitEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.commit();
+   }
+
+   public void beginRollbackEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.rollback();
+   }
+   
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatefulLocal.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatefulLocal.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.transaction.Transaction;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 61136 $
+ */
+public interface StatefulLocal
+{
+   Transaction beginNoEnd() throws Exception;
+
+   void endCommit(Transaction old) throws Exception;
+
+   void endRollback(Transaction old) throws Exception;
+
+   void beginCommitEnd() throws Exception;
+
+   void beginRollbackEnd() throws Exception;
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatelessBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatelessBean.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.interceptor.InvocationContext;
+import javax.naming.InitialContext;
+import javax.transaction.TransactionManager;
+import javax.transaction.UserTransaction;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 67628 $
+ */
+@Stateless
+@TransactionManagement(TransactionManagementType.BEAN)
+public class StatelessBean implements StatelessLocal
+{
+   private static final Logger log = Logger.getLogger(StatelessBean.class);
+    
+   @Resource UserTransaction ut;
+   
+   TransactionManager tm;
+   
+   @PostConstruct
+   public void postConstruct(final InvocationContext context) throws Exception {
+       this.tm = (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+   }
+
+   public void beginNoEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+   }
+
+   public void beginCommitEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.commit();
+   }
+
+   public void beginRollbackEnd() throws Exception
+   {
+      if (tm.getTransaction() != null) throw new TestException("THERE IS AN EXISTING TRANSACTION");
+      ut.begin();
+      ut.rollback();
+   }
+
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatelessLocal.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/StatelessLocal.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 61136 $
+ */
+public interface StatelessLocal
+{
+   void beginNoEnd() throws Exception;
+
+   void beginCommitEnd() throws Exception;
+
+   void beginRollbackEnd() throws Exception;
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/TestException.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/TestException.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 61136 $
+ */
+public class TestException extends Exception
+{
+   public TestException()
+   {
+   }
+
+   public TestException(String message)
+   {
+      super(message);
+   }
+
+   public TestException(String message, Throwable cause)
+   {
+      super(message, cause);
+   }
+
+   public TestException(Throwable cause)
+   {
+      super(cause);
+   }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/TesterBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/TesterBean.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.interceptor.InvocationContext;
+import javax.naming.InitialContext;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import org.jboss.logging.Logger;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 67628 $
+ */
+@Stateless
+public class TesterBean implements TesterRemote
+{   
+   @EJB StatelessLocal stateless;
+   
+   TransactionManager tm;
+   
+   @PostConstruct
+   public void postConstruct(final InvocationContext context) throws Exception {
+       this.tm = (TransactionManager) new InitialContext().lookup("java:jboss/TransactionManager");
+   }
+
+
+   protected static Logger log = Logger.getLogger(TesterBean.class);
+
+   public void testStatelessWithTx() throws Exception
+   {
+      stateless.beginCommitEnd();
+      stateless.beginRollbackEnd();
+
+      try
+      {
+         stateless.beginNoEnd();
+      }
+      catch (Exception e)
+      {
+         if (e instanceof TestException) throw e;
+         log.info("should be EJBException thrown that begin and no end was called: ", e);
+      }
+   }
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   public void testStatelessWithoutTx() throws Exception
+   {
+      stateless.beginCommitEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateless.beginRollbackEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      
+      try
+      {
+         stateless.beginNoEnd();
+      }
+      catch (Exception e)
+      {
+         if (e instanceof TestException) throw e;
+         log.info("should be EJBException thrown that begin and no end was called: ", e);
+      }
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+   }
+
+   StatefulLocal getStateful() throws Exception
+   {
+      InitialContext ctx = new InitialContext();
+      return (StatefulLocal)ctx.lookup("java:module/StatefulBean!org.jboss.as.test.integration.ejb.entity.bmp2.StatefulLocal");
+   }
+
+   public void testStatefulWithTx() throws Exception
+   {
+      StatefulLocal stateful = getStateful();
+      Transaction tx = stateful.beginNoEnd();
+      stateful.endCommit(tx);
+      tx = stateful.beginNoEnd();
+      stateful.endRollback(tx);
+
+      stateful.beginCommitEnd();
+      stateful.beginRollbackEnd();
+
+   }
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   public void testStatefulWithoutTx() throws Exception
+   {
+      StatefulLocal stateful = getStateful();
+      Transaction tx = stateful.beginNoEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateful.endCommit(tx);
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      tx = stateful.beginNoEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateful.endRollback(tx);
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+
+      stateful.beginCommitEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+      stateful.beginRollbackEnd();
+      if (tm.getTransaction() != null) throw new RuntimeException("tx is associated");
+
+   }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/TesterRemote.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp2/TesterRemote.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2006, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.bmp2;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.Remote;
+
+/**
+ * Comment
+ *
+ * @author <a href="mailto:bill@jboss.org">Bill Burke</a>
+ * @version $Revision: 61136 $
+ */
+@Remote
+public interface TesterRemote
+{
+   void testStatelessWithTx() throws Exception;
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   void testStatelessWithoutTx() throws Exception;
+
+   void testStatefulWithTx() throws Exception;
+
+   @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+   void testStatefulWithoutTx() throws Exception;
+}

--- a/testsuite/integration/src/test/resources/ejb/entity/bmp2/ejb-jar.xml
+++ b/testsuite/integration/src/test/resources/ejb/entity/bmp2/ejb-jar.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                            http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+        version="3.0">
+   <description>jBoss test application</description>
+   <display-name>Test</display-name>
+   <enterprise-beans>
+      <session>
+         <ejb-name>DeploymentDescriptorTester</ejb-name>
+         <business-remote>org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorTesterRemote</business-remote>
+         <ejb-class>org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorTesterBean</ejb-class>
+         <session-type>Stateless</session-type>
+         <transaction-type>Container</transaction-type>
+      </session>
+      <session>
+         <ejb-name>DeploymentDescriptorStateless</ejb-name>
+		     <business-local>org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorStatelessLocal</business-local>
+         <ejb-class>org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorStatelessBean</ejb-class>
+         <session-type>Stateless</session-type>
+         <transaction-type>Bean</transaction-type>
+      </session>
+      <session>
+         <ejb-name>DeploymentDescriptorStateful</ejb-name>
+         <business-local>org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorStatefulLocal</business-local>
+         <ejb-class>org.jboss.as.test.integration.ejb.entity.bmp2.DeploymentDescriptorStatefulBean</ejb-class>
+         <session-type>Stateful</session-type>
+         <transaction-type>Bean</transaction-type>
+      </session>
+   </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
Hi,

I'm Ondra Chaloupka and I have recently started to work in JBoss QA team in Brno.
I started to work on jira JBQA-5451 and after discussion with Carlo de Wolf I'm trying to migrate EJB testsuite (https://svn.jboss.org/repos/jbossas/projects/ejb3/trunk/testsuite ) to form of AS7 tests. 
These are first two reworked test to be passed to official testsuite.

Thanks
Best Regards
