### PR TITLE
[AS7-886] PersistenceUnitMetadata.getNewTempClassLoader() cannot load the entity classes

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/classloader/TempClassLoader.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/classloader/TempClassLoader.java
@@ -23,8 +23,8 @@
 package org.jboss.as.jpa.classloader;
 
 import org.jboss.modules.ConcurrentClassLoader;
-import org.jboss.modules.ModuleClassLoader;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -37,35 +37,70 @@ import java.util.Enumeration;
  * <p/>
  * TempClassLoader is suitable for implementing javax.persistence.spi.PersistenceUnitInfo.getNewTempClassLoader()
  * <p/>
- * TODO:  prove that loaded application classes aren't visible to PUI.getClassLoader()
  *
  * @author Scott Marlow
+ * @author Antti Laisi
  */
 public class TempClassLoader extends ConcurrentClassLoader {
 
-    private final ModuleClassLoader delegate;
+    private final ClassLoader delegate;
 
-    public TempClassLoader(final ModuleClassLoader delegate) {
+    TempClassLoader(final ClassLoader delegate) {
+        super(null);
         this.delegate = delegate;
     }
 
     @Override
+    protected Class<?> findClass(String name, boolean exportsOnly, boolean resolve) throws ClassNotFoundException {
+
+        Class<?> loaded = findLoadedClass(name);
+        if (loaded != null) {
+            return loaded;
+        }
+
+        // javax.persistence classes must be loaded by module classloader, otherwise
+        // the persistence provider can't read JPA annotations with reflection
+        if (name.startsWith("javax.")) {
+            return Class.forName(name, resolve, delegate);
+        }
+
+        InputStream resource = delegate.getResourceAsStream(name.replace('.', '/') + ".class");
+        if (resource == null) {
+            throw new ClassNotFoundException(name);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            byte[] buffer = new byte[1024];
+            for (int i = 0; (i = resource.read(buffer, 0, buffer.length)) != -1;) {
+                baos.write(buffer, 0, i);
+            }
+            buffer = baos.toByteArray();
+            return defineClass(name, buffer, 0, buffer.length);
+        } catch (IOException e) {
+            throw new ClassNotFoundException(name, e);
+        } finally {
+            try {
+                resource.close();
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    @Override
     protected URL findResource(String name, boolean exportsOnly) {
-        return delegate.findResource(name, exportsOnly);
+        return delegate.getResource(name);
     }
 
     @Override
     protected Enumeration<URL> findResources(String name, boolean exportsOnly) throws IOException {
-        return delegate.findResources(name, exportsOnly);
+        return delegate.getResources(name);
     }
 
     @Override
     protected InputStream findResourceAsStream(String name, boolean exportsOnly) {
-        return super.findResourceAsStream(name, exportsOnly);
+        return delegate.getResourceAsStream(name);
     }
 
-    @Override
-    protected Class<?> findClass(String className, boolean exportsOnly, boolean resolve) throws ClassNotFoundException {
-        return super.findClass(className, exportsOnly, resolve);
-    }
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/classloader/TempClassLoaderFactoryImpl.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/classloader/TempClassLoaderFactoryImpl.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.classloader;
+
+import org.jboss.as.jpa.spi.TempClassLoaderFactory;
+
+/**
+ * Factory implementation that creates {@link TempClassLoader} instances.
+ *
+ * @author Antti Laisi
+ */
+public class TempClassLoaderFactoryImpl implements TempClassLoaderFactory {
+
+    private final ClassLoader delegateClassLoader;
+
+    public TempClassLoaderFactoryImpl(final ClassLoader delegateClassLoader) {
+        this.delegateClassLoader = delegateClassLoader;
+    }
+
+    @Override
+    public ClassLoader createNewTempClassLoader() {
+        return new TempClassLoader(delegateClassLoader);
+    }
+
+}

--- a/jpa/core/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -24,6 +24,7 @@
 package org.jboss.as.jpa.config;
 
 import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
+import org.jboss.as.jpa.spi.TempClassLoaderFactory;
 import org.jboss.jandex.Index;
 
 import javax.persistence.SharedCacheMode;
@@ -101,7 +102,7 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
 
     private ClassLoader classloader;
 
-    private ClassLoader tempClassloader;
+    private TempClassLoaderFactory tempClassLoaderFactory;
 
     private Map<URL,Index> annotationIndex;
 
@@ -375,13 +376,14 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
     }
 
     @Override
-    public void setTempClassloader(ClassLoader cl) {
-        this.tempClassloader = cl;
+    public void setTempClassLoaderFactory(TempClassLoaderFactory tempClassloaderFactory) {
+        this.tempClassLoaderFactory = tempClassloaderFactory;
     }
 
     @Override
     public ClassLoader getNewTempClassLoader() {
-        return tempClassloader;
+        return tempClassLoaderFactory != null ?
+                tempClassLoaderFactory.createNewTempClassLoader() : null;
     }
 
     @Override

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitDeploymentProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitDeploymentProcessor.java
@@ -46,7 +46,7 @@ import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.structure.DeploymentType;
 import org.jboss.as.ee.structure.DeploymentTypeMarker;
-import org.jboss.as.jpa.classloader.TempClassLoader;
+import org.jboss.as.jpa.classloader.TempClassLoaderFactoryImpl;
 import org.jboss.as.jpa.config.Configuration;
 import org.jboss.as.jpa.config.PersistenceProviderDeploymentHolder;
 import org.jboss.as.jpa.config.PersistenceUnitMetadataHolder;
@@ -237,7 +237,7 @@ public class PersistenceUnitDeploymentProcessor implements DeploymentUnitProcess
             for (PersistenceUnitMetadataHolder holder : puList) {
                 for (PersistenceUnitMetadata pu : holder.getPersistenceUnits()) {
                     pu.setClassLoader(classLoader);
-                    pu.setTempClassloader(new TempClassLoader(classLoader));
+                    pu.setTempClassLoaderFactory(new TempClassLoaderFactoryImpl(classLoader));
                     try {
                         final HashMap properties = new HashMap();
                         if (!ValidationMode.NONE.equals(pu.getValidationMode())) {

--- a/jpa/core/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
@@ -76,9 +76,8 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
             pu.setJtaDataSource(jtaDataSource.getOptionalValue());
             pu.setNonJtaDataSource(nonJtaDataSource.getOptionalValue());
             this.entityManagerFactory = createContainerEntityManagerFactory();
-
         } finally {
-            pu.setTempClassloader(null);    // release the temp classloader (only needed when creating the EMF)
+            pu.setTempClassLoaderFactory(null);    // release the temp classloader factory (only needed when creating the EMF)
         }
     }
 
@@ -153,7 +152,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
                 persistenceProviderAdaptor.afterCreateContainerEntityManagerFactory(pu);
             } finally {
                 pu.setAnnotationIndex(null);    // close reference to Annotation Index (only needed during call to createContainerEntityManagerFactory)
-                pu.setTempClassloader(null);    // close reference to temp classloader (only needed during call to createEntityManagerFactory)
+                pu.setTempClassLoaderFactory(null);    // close reference to temp classloader factory (only needed during call to createEntityManagerFactory)
             }
         }
     }

--- a/jpa/core/src/test/java/org/jboss/as/jpa/classloader/TempClassLoaderTestCase.java
+++ b/jpa/core/src/test/java/org/jboss/as/jpa/classloader/TempClassLoaderTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.classloader;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.persistence.Entity;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+
+/**
+ * @author Antti Laisi
+ */
+public class TempClassLoaderTestCase {
+
+    private TempClassLoaderFactoryImpl factory = new TempClassLoaderFactoryImpl(getClass().getClassLoader());
+    
+    @Test
+    public void testLoadEntityClass() throws Exception {
+        ClassLoader tempClassLoader = factory.createNewTempClassLoader();
+        String className = TestEntity.class.getName();
+        
+        Class<?> entityClass = tempClassLoader.loadClass(className);
+        Object entity = entityClass.newInstance();
+
+        assertFalse(entityClass.equals(TestEntity.class));
+        assertFalse(entity instanceof TestEntity);
+        assertTrue(entity.getClass().isAnnotationPresent(Entity.class));
+        assertTrue(entityClass == tempClassLoader.loadClass(className));
+    }
+    
+    @Test
+    public void testLoadResources() throws IOException {
+        ClassLoader tempClassLoader = factory.createNewTempClassLoader();
+        String resource = TestEntity.class.getName().replace('.', '/') + ".class";
+        
+        assertNotNull(tempClassLoader.getResource(resource));
+        assertTrue(tempClassLoader.getResources(resource).hasMoreElements());
+        
+        InputStream resourceStream = tempClassLoader.getResourceAsStream(resource);
+        assertNotNull(resourceStream);
+        resourceStream.close();
+    }
+
+    @Entity
+    public static class TestEntity { }
+
+}

--- a/jpa/spi/src/main/java/org/jboss/as/jpa/spi/PersistenceUnitMetadata.java
+++ b/jpa/spi/src/main/java/org/jboss/as/jpa/spi/PersistenceUnitMetadata.java
@@ -88,7 +88,7 @@ public interface PersistenceUnitMetadata extends PersistenceUnitInfo {
 
     void setClassLoader(ClassLoader cl);
 
-    void setTempClassloader(ClassLoader cl);
+    void setTempClassLoaderFactory(TempClassLoaderFactory tempClassLoaderFactory);
 
     void setSharedCacheMode(SharedCacheMode sharedCacheMode);
 }

--- a/jpa/spi/src/main/java/org/jboss/as/jpa/spi/TempClassLoaderFactory.java
+++ b/jpa/spi/src/main/java/org/jboss/as/jpa/spi/TempClassLoaderFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.spi;
+
+/**
+ * Factory for creating temporary classloaders used by persistence providers.
+ *
+ * @author Antti Laisi
+ */
+public interface TempClassLoaderFactory {
+
+    /**
+     * Creates a temporary classloader with the same scope and classpath as the persistence unit classloader.
+     *
+     * @see javax.persistence.spi.PersistenceUnitInfo#getNewTempClassLoader()
+     */
+    ClassLoader createNewTempClassLoader();
+
+}


### PR DESCRIPTION
Fixed implementation of org.jboss.as.jpa.classloader.TempClassLoader and added a unit test case.
