### PR TITLE
[AS7-2425] Move to patched saaj-impl

### DIFF
--- a/build/src/main/resources/modules/com/sun/xml/messaging/saaj/main/module.xml
+++ b/build/src/main/resources/modules/com/sun/xml/messaging/saaj/main/module.xml
@@ -31,12 +31,6 @@
     <dependencies>
         <module name="javax.api" />
         <module name="javax.xml.soap.api" />
-        <system>
-            <paths>
-                <path name="com/sun/org/apache/xerces/internal"/>
-                <path name="com/sun/org/apache/xerces/internal/dom"/>
-                <path name="com/sun/org/apache/xerces/internal/jaxp"/>
-            </paths>
-        </system>
+        <module name="org.apache.xerces" services="import" />
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/com/sun/xml/messaging/saaj/main/module.xml
+++ b/build/src/main/resources/modules/com/sun/xml/messaging/saaj/main/module.xml
@@ -34,6 +34,8 @@
         <system>
             <paths>
                 <path name="com/sun/org/apache/xerces/internal"/>
+                <path name="com/sun/org/apache/xerces/internal/dom"/>
+                <path name="com/sun/org/apache/xerces/internal/jaxp"/>
             </paths>
         </system>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
         <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
         <version.osgi>4.2.0</version.osgi>
         <version.sun.jaxb>2.2</version.sun.jaxb>
-        <version.sun.saaj-impl>1.3.2</version.sun.saaj-impl>
+        <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>
         <version.wsdl4j>1.6.2</version.wsdl4j>
 
         <!-- Non-default plugin versions and configuration -->


### PR DESCRIPTION
saaj-impl used to require classes from com/sun/org/apache/xerces/internal/dom/ and com/sun/org/apache/xerces/internal/jaxp. Now a patched saaj-impl is used to avoid that and instead use what comes from the org.apache.xerces module.
