### PR TITLE
Start the thread in a new thread, instead of simply running its run().

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/ServerShutdownHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerShutdownHandler.java
@@ -58,7 +58,7 @@ public class ServerShutdownHandler implements OperationStepHandler, DescriptionP
                 // The intention is that this shutdown is graceful, and so the client gets a reply.
                 // At the time of writing we did not yet have graceful shutdown.
                 thread.setName("Management Triggered Shutdown");
-                thread.run();
+                thread.start();
                 context.completeStep();
             }
         }, OperationContext.Stage.RUNTIME);


### PR DESCRIPTION
Without this change, issuing :shutdown to a standalone process does
not completely shutdown, with threads a-lingerin':

  https://gist.github.com/6bfc9d5349498c39ab37
