### PR TITLE
AS7-2318 Don't set the threshold level on the FILE handler (server.log)

### DIFF
--- a/build/src/main/resources/domain/configuration/domain.xml
+++ b/build/src/main/resources/domain/configuration/domain.xml
@@ -64,7 +64,6 @@
                 </console-handler>
 
                 <periodic-rotating-file-handler name="FILE">
-                    <level name="INFO"/>
                     <formatter>
                         <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                     </formatter>
@@ -397,7 +396,6 @@
                 </console-handler>
 
                 <periodic-rotating-file-handler name="FILE">
-                    <level name="INFO"/>
                     <formatter>
                         <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                     </formatter>

--- a/build/src/main/resources/standalone/configuration/standalone-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-ha.xml
@@ -72,7 +72,6 @@
             </console-handler>
 
             <periodic-rotating-file-handler name="FILE">
-                <level name="INFO"/>
                 <formatter>
                     <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>

--- a/build/src/main/resources/standalone/configuration/standalone-osgi-only.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-osgi-only.xml
@@ -56,7 +56,6 @@
             </console-handler>
 
             <periodic-rotating-file-handler name="FILE">
-                <level name="INFO"/>
                 <formatter>
                     <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>

--- a/build/src/main/resources/standalone/configuration/standalone-xts.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-xts.xml
@@ -71,7 +71,6 @@
             </console-handler>
 
             <periodic-rotating-file-handler name="FILE">
-                <level name="INFO"/>
                 <formatter>
                     <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -72,7 +72,6 @@
             </console-handler>
 
             <periodic-rotating-file-handler name="FILE">
-                <level name="INFO"/>
                 <formatter>
                     <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>


### PR DESCRIPTION
Currently in the logging subsystem configuration (standalone.xml/domain.xml) we set the threshold level on the FILE handler (the one which logs to server.log) to INFO. Some users have suggested that it would be better not to set any value for the FILE handler threshold so that they can easily change the log level of the loggers of their choice without additionally having to tweak the level of the FILE handler, to get the logs in server.log. I think that's a reasonable request since by default we already set the root logger threshold to INFO, which prevents flooding the server.log (and other handlers) with too many messages.   

This commit removes the default level that's set on the FILE handler.
