### PR TITLE
AS7-2406 fix

### DIFF
--- a/web/src/main/java/org/jboss/as/web/session/AbstractSessionManager.java
+++ b/web/src/main/java/org/jboss/as/web/session/AbstractSessionManager.java
@@ -40,6 +40,7 @@ import org.apache.catalina.connector.Response;
 import org.apache.catalina.session.ManagerBase;
 import org.apache.catalina.util.LifecycleSupport;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
+import org.jboss.metadata.web.spec.SessionConfigMetaData;
 
 /**
  * @author Paul Ferraro
@@ -82,6 +83,11 @@ public abstract class AbstractSessionManager extends ManagerBase implements Sess
         Integer maxActiveSessions = metaData.getMaxActiveSessions();
         if (maxActiveSessions != null) {
             this.setMaxActiveAllowed(maxActiveSessions.intValue());
+        }
+        SessionConfigMetaData config = metaData.getSessionConfig();
+        if (config != null) {
+            // Convert session timeout (minutes) to max inactive interval (seconds)
+            this.setMaxInactiveInterval(config.getSessionTimeout() * 60);
         }
     }
 

--- a/web/src/main/java/org/jboss/as/web/session/SessionManagerMBean.java
+++ b/web/src/main/java/org/jboss/as/web/session/SessionManagerMBean.java
@@ -115,7 +115,7 @@ public interface SessionManagerMBean {
      *
      * @param interval The new maximum interval
      */
-    void setMaxInactiveInterval(int minutes);
+    void setMaxInactiveInterval(int seconds);
 
     /**
      * Gets whether this manager's sessions are distributable.


### PR DESCRIPTION
AS7-2406 Web sessions have a 60 second timeout set when deploying distributable apps to a clustered domain
