### PR TITLE
Get rid of the unused/confusing "jndi" port 1099 references in the standalone/domain configurations

### DIFF
--- a/build/src/main/resources/domain/configuration/domain-osgi-only.xml
+++ b/build/src/main/resources/domain/configuration/domain-osgi-only.xml
@@ -102,7 +102,6 @@
             <socket-binding name="https" port="8443"/>
             <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
             <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
-            <socket-binding name="jndi" port="1099"/>
             <socket-binding name="osgi-http" interface="management" port="8090"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>

--- a/build/src/main/resources/domain/configuration/domain.xml
+++ b/build/src/main/resources/domain/configuration/domain.xml
@@ -789,7 +789,6 @@
             <socket-binding name="jacorb-ssl" port="3529"/>
             <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
             <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
-            <socket-binding name="jndi" port="1099"/>
             <socket-binding name="messaging" port="5445" />
             <socket-binding name="messaging-throughput" port="5455"/>
             <socket-binding name="osgi-http" interface="management" port="8090"/>
@@ -810,7 +809,6 @@
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
             <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
-            <socket-binding name="jndi" port="1099"/>
             <socket-binding name="messaging" port="5445" />
             <socket-binding name="messaging-throughput" port="5455"/>
             <socket-binding name="modcluster" port="0"  multicast-address="224.0.1.105" multicast-port="23364"/>

--- a/build/src/main/resources/standalone/configuration/standalone-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-ha.xml
@@ -487,7 +487,6 @@
         <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
         <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
         <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
-        <socket-binding name="jndi" port="1099"/>
         <socket-binding name="messaging" port="5445" />
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="modcluster" port="0"  multicast-address="224.0.1.105" multicast-port="23364"/>

--- a/build/src/main/resources/standalone/configuration/standalone-xts.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-xts.xml
@@ -405,7 +405,6 @@
         <socket-binding name="jacorb-ssl" port="3529"/>
         <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
         <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
-        <socket-binding name="jndi" port="1099"/>
         <socket-binding name="messaging" port="5445" />
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="osgi-http" interface="management" port="8090"/>

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -432,7 +432,6 @@
         <socket-binding name="jacorb-ssl" port="3529"/>
         <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
         <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
-        <socket-binding name="jndi" port="1099"/>
         <socket-binding name="messaging" port="5445"/>
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="osgi-http" interface="management" port="8090"/>


### PR DESCRIPTION
The standalone/domain configurations have a unused/redundant JNDI port in the socket-binding group(s) which points to the legacy 1099 port. This has caused confusion among users who think that AS7 allows JNDI access via that port. The port is currently unused and this commit gets rid of those references from the configuration files.
