### PR TITLE
AS7-2433 Fix for Hibernate session is getting closed during JPA transacti

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/container/EntityManagerUnwrappedTargetInvocationHandler.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/container/EntityManagerUnwrappedTargetInvocationHandler.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.container;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import javax.persistence.EntityManager;
+
+/**
+ * Handle method execution delegation to a wrapped object using the passed entity manager to obtain the target
+ * invocation target.  Forked from Emmanuel's org.jboss.ejb3.entity.hibernate.TransactionScopedSessionInvocationHandler.
+ *
+ * @author Emmanuel Bernard
+ * @author Scott Marlow
+ */
+public class EntityManagerUnwrappedTargetInvocationHandler implements InvocationHandler, Serializable {
+
+    private static final long serialVersionUID = 5254527687L;
+
+    private Class wrappedClass;
+    private EntityManager targetEntityManager;
+
+    public EntityManagerUnwrappedTargetInvocationHandler() {
+
+    }
+
+    public EntityManagerUnwrappedTargetInvocationHandler(EntityManager targetEntityManager, Class wrappedClass) {
+        this.targetEntityManager = targetEntityManager;
+        this.wrappedClass = wrappedClass;
+    }
+
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("close".equals(method.getName())) {
+            throw new IllegalStateException("Illegal to call this method from injected, managed EntityManager");
+        } else {
+            //catch all
+            try {
+                return method.invoke(getWrappedObject(), args);
+            } catch (InvocationTargetException e) {
+                if (e.getTargetException() instanceof RuntimeException) {
+                    throw (RuntimeException) e.getTargetException();
+                } else {
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private Object getWrappedObject() {
+        return targetEntityManager.unwrap(wrappedClass);
+    }
+
+}

--- a/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -121,7 +121,8 @@ public class TransactionUtil {
             if (JPA_LOGGER.isDebugEnabled())
                 JPA_LOGGER.debugf("%s: created entity manager session %s", getEntityManagerDetails(entityManager),
                     getTransaction().toString());
-            registerSynchronization(entityManager, scopedPuName, true);
+            boolean autoCloseEntityManager = true;
+            registerSynchronization(entityManager, scopedPuName, autoCloseEntityManager);
             putEntityManagerInTransactionRegistry(scopedPuName, entityManager);
         } else {
             if (JPA_LOGGER.isDebugEnabled()) {
@@ -135,7 +136,7 @@ public class TransactionUtil {
     private void registerSynchronization(EntityManager entityManager, String puScopedName, boolean closeEMAtTxEnd) {
         Transaction tx = getTransaction();
         try {
-            tx.registerSynchronization(new SessionSynchronization(entityManager, tx, closeEMAtTxEnd, puScopedName));
+            tx.registerSynchronization(new SessionSynchronization(entityManager, closeEMAtTxEnd, puScopedName));
         } catch (RollbackException e) {
             throw new RuntimeException(e);
         } catch (SystemException e) {
@@ -201,7 +202,7 @@ public class TransactionUtil {
         private boolean closeAtTxCompletion;
         private String scopedPuName;
 
-        public SessionSynchronization(EntityManager session, Transaction tx, boolean close, String scopedPuName) {
+        public SessionSynchronization(EntityManager session, boolean close, String scopedPuName) {
             this.manager = session;
             closeAtTxCompletion = close;
             this.scopedPuName = scopedPuName;

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTest.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import javax.ejb.Stateful;
 import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceContextType;
 
 import org.hibernate.Session;
 import org.jboss.as.test.integration.jpa.hibernate.entity.Company;
@@ -43,7 +44,7 @@ import org.jboss.as.test.integration.jpa.hibernate.entity.Ticket;
 @Stateful
 public class EntityTest {
 
-    @PersistenceContext(unitName = "entity_pc")
+    @PersistenceContext(unitName = "entity_pc", type = PersistenceContextType.EXTENDED)
     private Session session;
 
     public Customer oneToManyCreate() throws Exception {

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/EntityTestCase.java
@@ -49,6 +49,8 @@ import org.junit.runner.RunWith;
  * Hibernate entity tests (based on the EAP 5 test), using {@link EntityTest} bean. Tests relations between entities,
  * loading entities and named queries.
  *
+ * Note that this test uses an extended persistence context, so that the Hibernate session will stay open long enough
+ * to complete each test.  A transaction scoped entity manager would be closed after each JTA transaction completes.
  *
  * @author Zbyněk Roubalík
  */

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSession.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SFSBHibernateSession.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.jpa.hibernate;
 
 import javax.ejb.Stateful;
 import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceContextType;
 
 import org.hibernate.Session;
 
@@ -34,7 +35,7 @@ import org.hibernate.Session;
  */
 @Stateful
 public class SFSBHibernateSession {
-    @PersistenceContext(unitName = "mypc")
+    @PersistenceContext(unitName = "mypc", type=PersistenceContextType.EXTENDED)
     Session session;
 
     public void createEmployee(String name, String address, int id) {

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SessionFactoryTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/jpa/hibernate/SessionFactoryTestCase.java
@@ -106,7 +106,10 @@ public class SessionFactoryTestCase {
 //        assertTrue("name read from hibernate session is Sally", "Sally".equals(emp.getName()));
     }
 
-    // Test that a Persistence context can be injected into a Hibernate Session
+    // Test that an extended Persistence context can be injected into a Hibernate Session
+    // We use extended persistence context, otherwise the Hibernate session will be closed after each transaction and
+    // the assert test would fail (due to lazy loading of the Employee entity.
+    // Using extended persistence context allows the hibernate session to stay open long enough for the lazy fetch.
     @Test
     public void testInjectPCIntoHibernateSession() throws Exception {
         SFSBHibernateSession sfsbHibernateSession = lookup("SFSBHibernateSession",SFSBHibernateSession.class);


### PR DESCRIPTION
AS7-2433 Fix for Hibernate session is getting closed during JPA transaction by using proxy similar to one used for AS6.  use extended persistence context in EntityTestCase so that Hibernate session stays open long enough.  The AS6 implementation of the unit test didn't use the Hibernate session for reading entities (http://anonsvn.jboss.org/repos/jbossas/trunk/testsuite/src/main/org/jboss/test/jpa/test/EntityOptimisticLockingUnitTestCase.java + http://anonsvn.jboss.org/repos/jbossas/trunk/testsuite/src/main/org/jboss/test/jpa/entity/ if anyone is interested why we had to use XPC)
