### PR TITLE
misc bug fixes

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/JVMHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/JVMHandlers.java
@@ -105,7 +105,7 @@ public final class JVMHandlers {
         registration.registerReadWriteAttribute(JVM_AGENT_PATH, null, writeHandler, Storage.CONFIGURATION);
         if (server) {
             registration.registerReadWriteAttribute(JVM_DEBUG_ENABLED, null, booleanWriteHandler, Storage.CONFIGURATION);
-            registration.registerReadWriteAttribute(JVM_DEBUG_OPTIONS, null, booleanWriteHandler, Storage.CONFIGURATION);
+            registration.registerReadWriteAttribute(JVM_DEBUG_OPTIONS, null, writeHandler, Storage.CONFIGURATION);
         }
         registration.registerReadWriteAttribute(JVM_ENV_CLASSPATH_IGNORED, null, booleanWriteHandler, Storage.CONFIGURATION);
         registration.registerReadWriteAttribute(JVM_ENV_VARIABLES, null, writeHandler, Storage.CONFIGURATION);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -666,7 +666,7 @@ public class GlobalOperationHandlers {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             final ImmutableManagementResourceRegistration registry = context.getResourceRegistration();
-            Set<String> childTypes = registry.getChildNames(PathAddress.EMPTY_ADDRESS);
+            Set<String> childTypes = new TreeSet<String>(registry.getChildNames(PathAddress.EMPTY_ADDRESS));
             final ModelNode result = context.getResult();
             result.setEmptyList();
             for (final String key : childTypes) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/JvmOptionsBuilderFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/JvmOptionsBuilderFactory.java
@@ -110,7 +110,13 @@ class JvmOptionsBuilderFactory {
                 command.add("-javaagent:" + jvmElement.getJavaagent());
             }
             if (jvmElement.isDebugEnabled() != null && jvmElement.isDebugEnabled() && jvmElement.getDebugOptions() != null) {
-                command.add(jvmElement.getDebugOptions());
+                String debugOptions = jvmElement.getDebugOptions();
+                if(debugOptions != null) {
+                    if(! debugOptions.startsWith("-X")) {
+                        debugOptions = "-X" + debugOptions;
+                    }
+                    command.add(debugOptions);
+                }
             }
             List<String> options = jvmElement.getJvmOptions().getOptions();
             if (options.size() > 0) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRemoveHandler.java
@@ -22,8 +22,17 @@ package org.jboss.as.host.controller.operations;
 import java.util.Locale;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import org.jboss.as.host.controller.descriptions.HostServerDescription;
 import org.jboss.dmr.ModelNode;
 
@@ -31,6 +40,7 @@ import org.jboss.dmr.ModelNode;
  * {@code OperationHandler} removing an existing server configuration.
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @author Emanuel Muckenhuber
  */
 public class ServerRemoveHandler extends AbstractRemoveStepHandler implements DescriptionProvider {
 
@@ -42,6 +52,30 @@ public class ServerRemoveHandler extends AbstractRemoveStepHandler implements De
      * Create the InterfaceRemoveHandler
      */
     protected ServerRemoveHandler() {
+    }
+
+    @Override
+    protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performRemove(context, operation, model);
+        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+        final String serverName = address.getLastElement().getValue();
+        final ModelNode verifyOp = new ModelNode();
+        verifyOp.get(OP).set("verify-running-server");
+        verifyOp.get(OP_ADDR).add(HOST, address.getElement(0).getValue());
+        context.addStep(context.getResult(), verifyOp, new OperationStepHandler() {
+            @Override
+            public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                final PathAddress serverAddress = PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(SERVER, serverName));
+                final ProxyController controller = context.getResourceRegistration().getProxyController(serverAddress);
+                if(! context.getResourceRegistration().getChildNames(PathAddress.EMPTY_ADDRESS).contains(SERVER)) {
+                    throw new OperationFailedException(new ModelNode().set(context.getResourceRegistration().getChildNames(PathAddress.EMPTY_ADDRESS).toString()));
+                }
+                if(controller != null) {
+                    context.getFailureDescription().set("server (" + serverName + ") still running");
+                }
+                context.completeStep();
+            }
+        }, OperationContext.Stage.IMMEDIATE);
     }
 
     protected boolean requiresRuntime(OperationContext context) {

--- a/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
@@ -239,8 +239,10 @@ final class ManagedProcess {
                 log.stoppingProcess(processName);
                 stopRequested = true;
                 StreamUtils.safeClose(stdin);
+                state = State.STOPPING;
+            } else {
+                processController.removeProcess(processName);
             }
-            state = State.STOPPING;
         }
     }
 

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -78,6 +78,11 @@
                         <module.path>${jboss.home}/modules</module.path>
                     </systemPropertyVariables>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <includes>
+                         <include>org/jboss/as/test/integration/respawn/*TestCase.java</include>
+                         <include>org/jboss/as/test/integration/domain/*TestCase.java</include>
+                         <include>org/jboss/as/test/integration/domain/suites/*TestSuite.java</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainTestSupport.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainTestSupport.java
@@ -174,6 +174,11 @@ public class DomainTestSupport {
     private final DomainLifecycleUtil domainMasterLifecycleUtil;
     private final DomainLifecycleUtil domainSlaveLifecycleUtil;
 
+
+    public DomainTestSupport(final String testClass, final Configuration configuration) throws Exception {
+        this(testClass, configuration.getDomainConfig(), configuration.getMasterConfig(), configuration.getSlaveConfigs());
+    }
+
     public DomainTestSupport(final String testClass, final String domainConfig, final String masterConfig, final String slaveConfig) throws Exception {
         this.domainConfig = domainConfig;
         this.masterConfig = masterConfig;
@@ -215,4 +220,36 @@ public class DomainTestSupport {
             domainMasterLifecycleUtil.stop();
         }
     }
+
+    public static class Configuration {
+
+        private String domainConfig;
+        private String masterConfig;
+        private String slaveConfig;
+
+        protected Configuration(final String domainConfig, final String masterConfig, final String slaveConfig) {
+            this.domainConfig = domainConfig;
+            this.masterConfig = masterConfig;
+            this.slaveConfig = slaveConfig;
+        }
+
+        public String getDomainConfig() {
+            return domainConfig;
+        }
+
+        public String getMasterConfig() {
+            return masterConfig;
+        }
+
+        public String getSlaveConfigs() {
+            return slaveConfig;
+        }
+
+        public static Configuration create(final String domainConfig, final String masterConfig, final String slaveConfig) {
+            return new Configuration(domainConfig, masterConfig, slaveConfig);
+        }
+
+    }
+
+
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CoreResourceManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CoreResourceManagementTestCase.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.test.integration.domain;
+package org.jboss.as.test.integration.domain.suites;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_TIME;
@@ -41,6 +41,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYS
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import org.jboss.as.test.integration.domain.DomainTestSupport;
 import static org.jboss.as.test.integration.domain.DomainTestSupport.validateResponse;
 
 import java.io.IOException;
@@ -124,15 +125,17 @@ public class CoreResourceManagementTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = new DomainTestSupport(CoreResourceManagementTestCase.class.getSimpleName(), "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
-        testSupport.start();
+        testSupport = DomainTestSuite.createSupport(CoreResourceManagementTestCase.class.getSimpleName());
         domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
         domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
     }
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+        DomainTestSuite.stopSupport();
     }
 
     @Test

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.test.integration.domain;
+package org.jboss.as.test.integration.domain.suites;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
@@ -42,6 +42,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_REPLACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UPLOAD_DEPLOYMENT_STREAM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UPLOAD_DEPLOYMENT_URL;
+import org.jboss.as.test.integration.domain.DomainTestSupport;
 import static org.jboss.as.test.integration.domain.DomainTestSupport.cleanFile;
 import static org.jboss.as.test.integration.domain.DomainTestSupport.safeClose;
 import static org.jboss.as.test.integration.domain.DomainTestSupport.validateResponse;
@@ -149,14 +150,14 @@ public class DeploymentManagementTestCase {
         webArchive.as(ExplodedExporter.class).exportExploded(new File(tmpDir, "exploded"));
 
         // Launch the domain
-        testSupport = new DomainTestSupport(DeploymentManagementTestCase.class.getSimpleName(), "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
-        testSupport.start();
+        testSupport = DomainTestSuite.createSupport(DeploymentManagementTestCase.class.getSimpleName());
     }
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
         try {
-            testSupport.stop();
+            testSupport = null;
+            DomainTestSuite.stopSupport();
         } finally {
             cleanFile(tmpDir);
         }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import org.jboss.as.test.integration.domain.DomainTestSupport;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Simple {@code Suite} test wrapper to start the domain only once for multiple
+ * test cases using the same domain configuration.
+ *
+ * @author Emanuel Muckenhuber
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses ({
+        CoreResourceManagementTestCase.class,
+        ManagementReadsTestCase.class,
+        DeploymentManagementTestCase.class,
+        ServerManagementTestCase.class
+})
+public class DomainTestSuite {
+
+    private static final DomainTestSupport.Configuration CONFIGURATION;
+    private static boolean initializedLocally = false;
+    private static volatile DomainTestSupport support;
+
+    static {
+        CONFIGURATION = DomainTestSupport.Configuration.create("domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+    }
+
+    static synchronized DomainTestSupport createSupport(final String testName) {
+        if(support == null) {
+            start(testName);
+        }
+        return support;
+    }
+
+    static synchronized void stopSupport() {
+        if(! initializedLocally) {
+            stop();
+        }
+    }
+
+    private synchronized static void start(final String name) {
+        try {
+            final DomainTestSupport testSupport = new DomainTestSupport(name, CONFIGURATION);
+            // Start!
+            testSupport.start();
+            support = testSupport;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private synchronized static void stop() {
+        if(support != null) {
+            support.stop();
+            support = null;
+        }
+    }
+
+    @BeforeClass
+    public synchronized static void beforeClass() {
+        initializedLocally = true;
+        start(DomainTestSuite.class.getSimpleName());
+    }
+
+    @AfterClass
+    public synchronized static void afterClass() {
+        stop();
+    }
+
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementReadsTestCase.java
@@ -20,17 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.test.integration.domain;
+package org.jboss.as.test.integration.domain.suites;
 
 import org.jboss.as.arquillian.container.domain.managed.DomainLifecycleUtil;
-import org.jboss.as.arquillian.container.domain.managed.JBossAsManagedConfiguration;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import org.jboss.as.test.integration.domain.DomainTestSupport;
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -63,15 +62,18 @@ public class ManagementReadsTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = new DomainTestSupport(ManagementReadsTestCase.class.getSimpleName(), "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
-        testSupport.start();
+        testSupport = DomainTestSuite.createSupport(ManagementReadsTestCase.class.getSimpleName());
+
         domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
         domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
     }
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        testSupport.stop();
+        DomainTestSuite.stopSupport();
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
     }
 
     @Test
@@ -287,7 +289,7 @@ public class ManagementReadsTestCase {
 
         ModelNode response = domainClient.execute(request);
         validateResponse(response);
-        // TODO make some more assertions about result content
+        // TODO make getDeploymentManager();some more assertions about result content
 
         address.setEmptyList();
         address.add(HOST, "slave");

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ServerManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ServerManagementTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+
+import org.jboss.as.arquillian.container.domain.managed.DomainLifecycleUtil;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import org.jboss.as.test.integration.domain.DomainTestSupport;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Emanuel Muckenhuber
+ */
+public class ServerManagementTestCase {
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+
+    private static final ModelNode slave = new ModelNode();
+    private static final ModelNode newServerConfigAddress = new ModelNode();
+    private static final ModelNode newRunningServerAddress = new ModelNode();
+
+    static {
+        // (host=slave)
+        slave.add("host", "slave");
+        // (host=slave),(server-config=new-server)
+        newServerConfigAddress.add("host", "slave");
+        newServerConfigAddress.add("server-config", "new-server");
+        // (host=slave),(server=new-server)
+        newRunningServerAddress.add("host", "slave");
+        newRunningServerAddress.add("server", "new-server");
+    }
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(ServerManagementTestCase.class.getSimpleName());
+
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        DomainTestSuite.stopSupport();
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+    }
+
+    @Test
+    public void testAddAndRemoveServer() throws Exception {
+        final DomainClient client = domainSlaveLifecycleUtil.getDomainClient();
+
+        final ModelNode addServer = new ModelNode();
+        addServer.get(OP).set(ADD);
+        addServer.get(OP_ADDR).set(newServerConfigAddress);
+        addServer.get(GROUP).set("main-server-group");
+        addServer.get(SOCKET_BINDING_GROUP).set("standard-sockets");
+        addServer.get(SOCKET_BINDING_PORT_OFFSET).set(550);
+
+        ModelNode result = client.execute(addServer);
+        validateResponse(result);
+
+        final ModelNode startServer = new ModelNode();
+        startServer.get(OP).set(START);
+        startServer.get(OP_ADDR).set(newServerConfigAddress);
+        result = client.execute(startServer);
+        validateResponse(result);
+
+        final ModelNode stopServer = new ModelNode();
+        stopServer.get(OP).set("stop");
+        stopServer.get(OP_ADDR).set(newServerConfigAddress);
+        result = client.execute(stopServer);
+        validateResponse(result);
+
+        final ModelNode removeServer = new ModelNode();
+        removeServer.get(OP).set(REMOVE);
+        removeServer.get(OP_ADDR).set(newServerConfigAddress);
+
+        result = client.execute(removeServer);
+        validateResponse(result);
+    }
+
+    public static ModelNode validateResponse(ModelNode response) {
+
+        if(! SUCCESS.equals(response.get(OUTCOME).asString())) {
+            System.out.println("Failed response:");
+            System.out.println(response);
+            Assert.fail(response.get(FAILURE_DESCRIPTION).toString());
+        }
+
+        Assert.assertTrue("result exists", response.has(RESULT));
+        return response.get(RESULT);
+    }
+
+}


### PR DESCRIPTION
[AS7-1606] host.xml parse error when debug-enabled is used
[AS7-2237] Domain process is running in loop when invalid host or domain configuration is specified, process must be killed using -9
[AS7-1270] Get the right order of child types in the read-children-types op
[AS7-2044] Prevent removing a server config when the server is running.
