### PR TITLE
[AS7-2550] Add dependency on jbossws-native-core to javax.activation module

### DIFF
--- a/build/src/main/resources/modules/javax/activation/api/main/module.xml
+++ b/build/src/main/resources/modules/javax/activation/api/main/module.xml
@@ -28,6 +28,7 @@
         <module name="javax.mail.api">
             <imports><include path="META-INF"/></imports>
         </module>
+        <module name="org.jboss.ws.native.jbossws-native-core"/>
     </dependencies>
 
     <resources>


### PR DESCRIPTION
[AS7-2550] Add dependency on jbossws-native-core to javax.activation module for allowing building jbws jaxrpc motm/swa related data content handlers
