### PR TITLE
Added a call to ORB.init() in CorbaORBService to initialize the ORBSingleton

### DIFF
--- a/jacorb/src/main/java/org/jboss/as/jacorb/service/CorbaORBService.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/service/CorbaORBService.java
@@ -118,6 +118,8 @@ public class CorbaORBService implements Service<ORB> {
             try {
                 SecurityActions.setThreadContextClassLoader(SecurityActions.getClassLoader(this.getClass()));
                 this.orb = ORB.init(new String[0], properties);
+                // initialize the ORBSingleton.
+                ORB.init();
             } finally {
                 // restore the thread context classloader.
                 SecurityActions.setThreadContextClassLoader(loader);


### PR DESCRIPTION
This prevents org.omg.CORBA.ORB from using the TCCL to lazy-load the ORBSingleton.
