### PR TITLE
Move parsers

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
@@ -166,9 +166,6 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XMLElementWriter<ModelMarshallingContext> {
 
-    // TODO perhaps have this provided by subclasses via an abstract method
-    protected static final Logger log = Logger.getLogger("org.jboss.as.controller");
-
     /** The restricted path names. */
     protected static final Set<String> RESTRICTED_PATHS;
 

--- a/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
@@ -166,6 +166,9 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XMLElementWriter<ModelMarshallingContext> {
 
+    // TODO perhaps have this provided by subclasses via an abstract method
+    protected static final Logger log = Logger.getLogger("org.jboss.as.controller");
+
     /** The restricted path names. */
     protected static final Set<String> RESTRICTED_PATHS;
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -26,8 +26,8 @@ import java.util.concurrent.ExecutorService;
 
 import javax.xml.namespace.QName;
 
-import org.jboss.as.controller.parsing.DomainXml;
-import org.jboss.as.controller.parsing.HostXml;
+import org.jboss.as.host.controller.parsing.DomainXml;
+import org.jboss.as.host.controller.parsing.HostXml;
 import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.as.controller.persistence.BackupXmlConfigurationPersister;
 import org.jboss.as.controller.persistence.ConfigurationFile;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.controller.parsing;
+package org.jboss.as.host.controller.parsing;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
@@ -67,6 +67,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.parsing.Attribute;
+import org.jboss.as.controller.parsing.CommonXml;
+import org.jboss.as.controller.parsing.Element;
+import org.jboss.as.controller.parsing.Namespace;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.resource.SocketBindingGroupResourceDefinition;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.controller.parsing;
+package org.jboss.as.host.controller.parsing;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
@@ -68,6 +68,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.Attribute;
+import org.jboss.as.controller.parsing.CommonXml;
+import org.jboss.as.controller.parsing.Element;
+import org.jboss.as.controller.parsing.Namespace;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -25,13 +25,11 @@ package org.jboss.as.server;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import javax.security.auth.login.Configuration;
 import javax.xml.namespace.QName;
 
 import org.jboss.as.controller.parsing.Namespace;
-import org.jboss.as.controller.parsing.StandaloneXml;
+import org.jboss.as.server.parsing.StandaloneXml;
 import org.jboss.as.controller.persistence.BackupXmlConfigurationPersister;
-import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.modules.Module;

--- a/server/src/main/java/org/jboss/as/server/EmbeddedStandAloneServerFactory.java
+++ b/server/src/main/java/org/jboss/as/server/EmbeddedStandAloneServerFactory.java
@@ -51,7 +51,7 @@ import org.jboss.as.controller.client.helpers.standalone.DeploymentPlan;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentPlanResult;
 import org.jboss.as.controller.parsing.Namespace;
-import org.jboss.as.controller.parsing.StandaloneXml;
+import org.jboss.as.server.parsing.StandaloneXml;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
 import org.jboss.as.controller.persistence.TransientConfigurationPersister;
 import org.jboss.as.embedded.ServerStartException;

--- a/server/src/main/java/org/jboss/as/server/ServerStartTask.java
+++ b/server/src/main/java/org/jboss/as/server/ServerStartTask.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.parsing.StandaloneXml;
+import org.jboss.as.server.parsing.StandaloneXml;
 import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.controller.parsing;
+package org.jboss.as.server.parsing;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.ControllerLogger.ROOT_LOGGER;
@@ -63,6 +63,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.Attribute;
+import org.jboss.as.controller.parsing.CommonXml;
+import org.jboss.as.controller.parsing.Element;
+import org.jboss.as.controller.parsing.Namespace;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.resource.SocketBindingGroupResourceDefinition;

--- a/server/src/test/java/org/jboss/as/server/parsing/Jbas9020TestCase.java
+++ b/server/src/test/java/org/jboss/as/server/parsing/Jbas9020TestCase.java
@@ -19,8 +19,9 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.controller.parsing;
+package org.jboss.as.server.parsing;
 
+import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLMapper;
 import org.junit.Test;

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -22,45 +22,6 @@
 
 package org.jboss.as.server.test;
 
-import junit.framework.Assert;
-import org.jboss.as.controller.AbstractControllerService;
-import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.ControlledProcessState;
-import org.jboss.as.controller.ModelController;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.controller.client.Operation;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.descriptions.common.InterfaceDescription;
-import org.jboss.as.controller.parsing.StandaloneXml;
-import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
-import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
-import org.jboss.as.controller.persistence.ModelMarshallingContext;
-
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-
-import org.jboss.as.controller.registry.Resource;
-
-import org.jboss.as.server.ServerControllerModelUtil;
-import org.jboss.as.server.ServerEnvironment;
-
-import org.jboss.as.server.Services;
-import org.jboss.as.server.controller.descriptions.ServerDescriptionProviders;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceContainer;
-import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
-import org.jboss.staxmapper.XMLElementWriter;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
@@ -70,7 +31,38 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.as.controller.AbstractControllerService;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ModelController;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.common.InterfaceDescription;
+import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.ServerControllerModelUtil;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.Services;
+import org.jboss.as.server.controller.descriptions.ServerDescriptionProviders;
+import org.jboss.as.server.parsing.StandaloneXml;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Basic server controller unit test.

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/embedded/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/embedded/parse/ParseAndMarshalModelsTestCase.java
@@ -69,7 +69,6 @@ import javax.xml.namespace.QName;
 
 import junit.framework.Assert;
 import junit.framework.AssertionFailedError;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.controller.AbstractControllerService;
@@ -98,10 +97,7 @@ import org.jboss.as.controller.operations.common.SystemPropertyValueWriteAttribu
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
 import org.jboss.as.controller.operations.global.WriteAttributeHandlers;
-import org.jboss.as.controller.parsing.DomainXml;
-import org.jboss.as.controller.parsing.HostXml;
 import org.jboss.as.controller.parsing.Namespace;
-import org.jboss.as.controller.parsing.StandaloneXml;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.persistence.XmlConfigurationPersister;
@@ -120,8 +116,11 @@ import org.jboss.as.host.controller.operations.IsMasterHandler;
 import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
 import org.jboss.as.host.controller.operations.NativeManagementAddHandler;
 import org.jboss.as.host.controller.operations.ServerAddHandler;
+import org.jboss.as.host.controller.parsing.DomainXml;
+import org.jboss.as.host.controller.parsing.HostXml;
 import org.jboss.as.server.ServerControllerModelUtil;
 import org.jboss.as.server.deployment.repository.api.ContentRepository;
+import org.jboss.as.server.parsing.StandaloneXml;
 import org.jboss.as.server.services.net.SpecifiedInterfaceAddHandler;
 import org.jboss.as.test.smoke.modular.utils.ShrinkWrapUtils;
 import org.jboss.dmr.ModelNode;


### PR DESCRIPTION
Move the core model parsers out of the controller module so they can have access to classes in the server, host-controller and domain-controller modules.
