### PR TITLE
Add default goal to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -166,12 +166,13 @@ main() {
     for param in $@ ; do
         case $param in
             -DallTests)  TESTS=$ALL_TESTS ;;
-            -*) ADDIT_PARAMS="$ADDIT_PARAMS $param";;
-            clean) MVN_GOAL="$MVN_GOAL$param ";;
-            test) MVN_GOAL="$MVN_GOAL$param ";;
+            -*)      ADDIT_PARAMS="$ADDIT_PARAMS $param";;
+            clean)   MVN_GOAL="$MVN_GOAL$param ";;
+            test)    MVN_GOAL="$MVN_GOAL$param ";;
             install) MVN_GOAL="$MVN_GOAL$param ";;
-            deploy) MVN_GOAL="$MVN_GOAL$param ";;
-            site) MVN_GOAL="$MVN_GOAL$param ";;
+            deploy)  MVN_GOAL="$MVN_GOAL$param ";;
+            site)    MVN_GOAL="$MVN_GOAL$param ";;
+            *)       ADDIT_PARAMS="$ADDIT_PARAMS $param";;
         esac
     done
     #  Default goal if none specified.

--- a/build.sh
+++ b/build.sh
@@ -155,22 +155,26 @@ main() {
     #  to be in the same directory as build.xml.
     cd $DIRNAME
 
-    MVN_GOAL=$@
-    if [ -z "$MVN_GOAL" ]; then
-        MVN_GOAL="install"
-    fi
 
     . testsuite/groupDefs.sh
 
     #  Add smoke integration test directives before calling maven.
     TESTS=$SMOKE_TESTS
+    MVN_GOAL="";
     #  For each parameter, check for testsuite directives.
     for param in $@ ; do
         case $param in
-            -DallTests)
-                TESTS=$ALL_TESTS ;;
+            -DallTests)  TESTS=$ALL_TESTS ;;
+            -*) ;;
+            clean) MVN_GOAL="$MVN_GOAL$param ";;
+            test) MVN_GOAL="$MVN_GOAL$param ";;
+            install) MVN_GOAL="$MVN_GOAL$param ";;
+            deploy) MVN_GOAL="$MVN_GOAL$param ";;
+            site) MVN_GOAL="$MVN_GOAL$param ";;
         esac
     done
+    #  Default goal if none specified.
+    if [ -z "$MVN_GOAL" ]; then MVN_GOAL="install"; fi
 
     MVN_GOAL="$MVN_GOAL $TESTS"
 

--- a/build.sh
+++ b/build.sh
@@ -161,11 +161,12 @@ main() {
     #  Add smoke integration test directives before calling maven.
     TESTS=$SMOKE_TESTS
     MVN_GOAL="";
+    ADDIT_PARAMS="";
     #  For each parameter, check for testsuite directives.
     for param in $@ ; do
         case $param in
             -DallTests)  TESTS=$ALL_TESTS ;;
-            -*) ;;
+            -*) ADDIT_PARAMS="$ADDIT_PARAMS $param";;
             clean) MVN_GOAL="$MVN_GOAL$param ";;
             test) MVN_GOAL="$MVN_GOAL$param ";;
             install) MVN_GOAL="$MVN_GOAL$param ";;
@@ -181,13 +182,13 @@ main() {
     #  Export some stuff for maven.
     export MVN MAVEN_HOME MVN_OPTS MVN_GOAL
 
-    echo "$MVN $MVN_OPTIONS $MVN_GOAL"
+    echo "$MVN $MVN_OPTIONS $MVN_GOAL $ADDIT_PARAMS"
 
     #  Execute in debug mode, or simply execute.
     if [ "x$MVN_DEBUG" != "x" ]; then
-        /bin/sh -x $MVN $MVN_OPTIONS $MVN_GOAL
+        /bin/sh -x $MVN $MVN_OPTIONS $MVN_GOAL $ADDIT_PARAMS
     else
-        exec $MVN $MVN_OPTIONS $MVN_GOAL
+        exec $MVN $MVN_OPTIONS $MVN_GOAL $ADDIT_PARAMS
     fi
 }
 

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -68,6 +68,8 @@ TESTS_SPECIFIED="N"
 #
 process_test_directives() {
 
+  MVN_GOALS="";
+
   # For each parameter, check for testsuite directives.
   for param in $@
   do
@@ -123,6 +125,12 @@ process_test_directives() {
         CMD_LINE_PARAMS="$CMD_LINE_PARAMS $param" # -DfailIfNoTests=false
         TESTS_SPECIFIED="Y"
         ;;
+      # Collect Maven goals.
+      clean)   MVN_GOALS="$MVN_GOALS$param ";;
+      test)    MVN_GOALS="$MVN_GOALS$param ";;
+      install) MVN_GOALS="$MVN_GOALS$param ";;
+      deploy)  MVN_GOALS="$MVN_GOALS$param ";;
+      site)    MVN_GOALS="$MVN_GOALS$param ";;
       # pass through all other params
       *)
         CMD_LINE_PARAMS="$CMD_LINE_PARAMS $param"
@@ -130,7 +138,11 @@ process_test_directives() {
     esac
   done
 
-  # if no tests specified, run smoke tests
+  #  Default goal if none specified.
+  if [ -z "$MVN_GOALS" ]; then MVN_GOALS="install"; fi
+  CMD_LINE_PARAMS="$MVN_GOALS $CMD_LINE_PARAMS";
+
+  # If no tests specified, run smoke tests.
   if [[ $TESTS_SPECIFIED == "N" ]]; then
     CMD_LINE_PARAMS="$CMD_LINE_PARAMS $SMOKE_TESTS"
   fi


### PR DESCRIPTION
This improves batch scripts to allow e.g.

   build.sh --DallTests

I.e. no need to specify a default goal.
