### PR TITLE
Update XNIO to 3.0.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.jboss.ws.spi>2.0.0.Beta14</version.org.jboss.ws.spi>
         <version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>1.0.0.GA</version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>
         <version.org.jboss.xb>2.0.3.GA</version.org.jboss.xb>
-        <version.org.jboss.xnio>3.0.0.CR1</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.0.0.CR2</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>3.0.0.CR5</version.org.jgroups>


### PR DESCRIPTION
Should fix certain hang issues around Remoting endpoint shutdown.
