### PR TITLE
Log EJB iiop invocation errors, on server side, at a higher level

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbHomeCorbaServant.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbHomeCorbaServant.java
@@ -262,9 +262,7 @@ public class EjbHomeCorbaServant extends Servant implements InvokeHandler, Local
                 op.writeRetval(out, retVal);
             }
         } catch (Exception e) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Exception in EJBHome invocation", e);
-            }
+            logger.error("Exception in EJBHome invocation", e);
             RmiIdlUtil.rethrowIfCorbaSystemException(e);
             out = (org.omg.CORBA_2_3.portable.OutputStream) handler.createExceptionReply();
             op.writeException(out, e);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbObjectCorbaServant.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbObjectCorbaServant.java
@@ -276,9 +276,7 @@ public class EjbObjectCorbaServant extends Servant implements InvokeHandler, Loc
                 op.writeRetval(out, retVal);
             }
         } catch (Exception e) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Exception in EJBObject invocation", e);
-            }
+            logger.error("Exception in EJBObject invocation", e);
             if (e instanceof MBeanException) {
                 e = ((MBeanException) e).getTargetException();
             }


### PR DESCRIPTION
Right now if an IIOP invocation on EJB runs into an exception then it's logged at TRACE level on the server side, which effectively means that the exception stacktrace isn't visible at all unless the org.jboss.as.ejb3 logger category is changed to TRACE level. This commit, instead logs those exception messages at ERROR level.
