### PR TITLE
Propagate ${jboss.inst} to Arquillian.

### DIFF
--- a/testsuite/integration/src/test/resources/arquillian.xml
+++ b/testsuite/integration/src/test/resources/arquillian.xml
@@ -4,9 +4,11 @@
 
 	<container qualifier="jboss" default="true">
 		<configuration>
-			<property name="jbossHome">target/jbossas</property>
-				<property name="javaVmArguments">${server.jvm.args}</property>
-				<property name="serverConfig">${server.config:standalone.xml}</property>
+			<property name="jbossHome">${basedir}/target/jbossas</property>
+			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
+			<property name="serverConfig">${server.config:standalone.xml}</property>
+			<!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+			     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>
 	</container>

--- a/testsuite/integration/src/test/resources/clustering/clustering-arquillian.xml
+++ b/testsuite/integration/src/test/resources/clustering/clustering-arquillian.xml
@@ -4,8 +4,8 @@
 
     <container qualifier="clustering-udp-single" default="true">
         <configuration>
-            <property name="jbossHome">target/clustering-udp-0</property>
-            <property name="javaVmArguments">${server.jvm.args}</property>
+            <property name="jbossHome">${basedir}/target/clustering-udp-0</property>
+            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/clustering-udp-0</property>
             <property name="serverConfig">${server.config:standalone.xml}</property>
         </configuration>
     </container>
@@ -14,16 +14,16 @@
 
         <container qualifier="clustering-udp-0" default="true">
             <configuration>
-                <property name="jbossHome">target/clustering-udp-0</property>
-                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossHome">${basedir}/target/clustering-udp-0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/clustering-udp-0</property>
                 <property name="serverConfig">${server.config:standalone-ha.xml}</property>
             </configuration>
         </container>
 
         <container qualifier="clustering-udp-1" default="false">
             <configuration>
-                <property name="jbossHome">target/clustering-udp-1</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.port.offset=100</property>
+                <property name="jbossHome">${basedir}/target/clustering-udp-1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/clustering-udp-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${server.config:standalone-ha.xml}</property>
                 <property name="managementPort">19999</property>
             </configuration>

--- a/testsuite/integration/src/test/resources/iiop/iiop-arquillian.xml
+++ b/testsuite/integration/src/test/resources/iiop/iiop-arquillian.xml
@@ -7,8 +7,8 @@
         <!-- The server than invokes the exposed EJB's -->
         <container qualifier="iiop-client" default="true">
             <configuration>
-                <property name="jbossHome">target/iiop-client</property>
-                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossHome">${basedir}/target/iiop-client</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/iiop-client</property>
                 <property name="serverConfig">${server.config:standalone.xml}</property>
             </configuration>
         </container>
@@ -16,8 +16,8 @@
         <!-- The server that expsoses EJB's via IIOP -->
         <container qualifier="iiop-server" default="false">
             <configuration>
-                <property name="jbossHome">target/iiop-server</property>
-                <property name="javaVmArguments">${server.jvm.args}</property>
+                <property name="jbossHome">${basedir}/target/iiop-server</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/iiop-server</property>
                 <property name="serverConfig">${server.config:standalone.xml}</property>
                 <property name="managementPort">19999</property>
             </configuration>

--- a/testsuite/integration/src/test/resources/smoke/smoke-arquillian.xml
+++ b/testsuite/integration/src/test/resources/smoke/smoke-arquillian.xml
@@ -4,9 +4,9 @@
 
 	<container qualifier="jboss" default="true">
 		<configuration>
-			<property name="jbossHome">target/smoke</property>
-            <property name="javaVmArguments">${server.jvm.args}</property>
-            <property name="serverConfig">${server.config:standalone.xml}</property>
+			<property name="jbossHome">${basedir}/target/smoke</property>
+			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/smoke</property>
+			<property name="serverConfig">${server.config:standalone.xml}</property>
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>
 	</container>


### PR DESCRIPTION
Changes in arquillian configs:
- Added ${jboss.inst} to JVM sys props
- Added ${basedir} to JBoss AS path which is now ${basedir}/target/<server-config-name>
