### PR TITLE
Add jboss.dist to ${server.jvm.args.dirs} and ${surefire.system.args} ->...

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -108,6 +108,7 @@
             -Djbossas.ts.integ.dir=${jbossas.ts.integ.dir}
             -Djbossas.ts.dir=${jbossas.ts.dir}
             -Djbossas.project.dir=${jbossas.project.dir}
+            -Djboss.dist=${jboss.dist}
         </server.jvm.args.dirs>
         
         <!-- Used to provide an absolute location for the distribution under test. -->

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -99,12 +99,16 @@
     <name>JBoss Application Server Test Suite: Integration Tests</name>
 
     <properties>
+        <!-- Current module's directory. Will automatically pick up sub-module's basedir. -->
+        <jbossas.ts.module.dir>${basedir}</jbossas.ts.module.dir>
+        <!-- Integration module's directory. To be overriden in sub-modules. -->
         <jbossas.ts.integ.dir>${basedir}</jbossas.ts.integ.dir>
         <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <!-- This project's root dir. -->
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <server.jvm.args.dirs>
+            -Djbossas.ts.module.dir=${jbossas.ts.module.dir}
             -Djbossas.ts.integ.dir=${jbossas.ts.integ.dir}
             -Djbossas.ts.dir=${jbossas.ts.dir}
             -Djbossas.project.dir=${jbossas.project.dir}
@@ -188,9 +192,12 @@
                         <node1>${node1}</node1>
                         <udpGroup>${udpGroup}</udpGroup>
 
+                        <jbossas.ts.module.dir>${jbossas.ts.module.dir}</jbossas.ts.module.dir>
                         <jbossas.ts.integ.dir>${jbossas.ts.integ.dir}</jbossas.ts.integ.dir>
                         <jbossas.ts.dir>${jbossas.ts.dir}</jbossas.ts.dir>
                         <jbossas.project.dir>${jbossas.project.dir}</jbossas.project.dir>
+                        <jboss.dist>${jboss.dist}</jboss.dist>
+                        <!-- <jboss.inst>${jbossas.ts.module.dir}/target/jbossas</jboss.inst>  Only to be specified for single-node test groups. -->
 
                         <!--
                             Used in arquillian.xml - arguments for all JBoss AS instances.
@@ -585,6 +592,7 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>jboss</arquillian.launch>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                        <jboss.inst>${jbossas.ts.module.dir}/target/jbossas</jboss.inst>
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>
@@ -699,9 +707,8 @@
                                     <systemPropertyVariables>
                                         <arquillian.xml>smoke-arquillian.xml</arquillian.xml>
                                         <arquillian.launch>jboss</arquillian.launch>
-
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
-                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
+                                        <jboss.inst>${jbossas.ts.module.dir}/target/jbossas</jboss.inst>
                                     </systemPropertyVariables>
 
                                     <!-- Access to resources for clustering tests. -->

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
@@ -1,0 +1,47 @@
+package org.jboss.as.test.smoke;
+
+import java.io.File;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * Tests whether properties we rely on in the tests were properly passed to JUnit.
+ * 
+ * @author Ondrej Zizka
+ */
+@RunWith(Arquillian.class)
+public class TestsuiteSanityTestCase {
+
+		@Test
+		public void testSystemProperties() throws Exception {
+
+				for( String var : new String[]{"jbossas.ts.module.dir", "jbossas.ts.integ.dir", "jbossas.ts.dir", "jbossas.project.dir", "jboss.dist", "jboss.inst"} ){
+						String path = System.getProperty( var );
+						Assert.assertNotNull("Property " + var + " is not set (in container).", path);
+						System.out.println(":: " + var + " == " + path);
+						File dir = new File(path);
+						Assert.assertTrue( "Directory " + dir.getAbsolutePath() + " doesn't exist, check Surefire's system property " + var, dir.exists() );
+				}
+
+		}
+		
+		@Test
+        @RunAsClient
+		public void testSystemPropertiesClient() throws Exception {
+
+				for( String var : new String[]{"jbossas.ts.module.dir", "jbossas.ts.integ.dir", "jbossas.ts.dir", "jbossas.project.dir", "jboss.dist", "jboss.inst"} ){
+						String path = System.getProperty( var );
+						Assert.assertNotNull("Property " + var + " is not set (outside container).", path);
+						System.out.println(":: " + var + " == " + path);
+						File dir = new File(path);
+						Assert.assertTrue( "Directory " + dir.getAbsolutePath() + " doesn't exist, check Surefire's system property " + var, dir.exists() );
+				}
+
+		}
+		
+}// class
+

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -110,7 +110,7 @@
         <!-- common surefire properties -->
         <surefire.memory.args>-Xmx512m -XX:MaxPermSize=256m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
-        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args}</surefire.system.args>
+        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
         <surefire.forked.process.timeout>900</surefire.forked.process.timeout>
         <surefire.test.failure.ignore>false</surefire.test.failure.ignore>
 


### PR DESCRIPTION
... to have it in both in-container and outside-container.
The previous pull request added jboss.inst.
- jboss.dist == Distribution, either built, or provided by user through -Djboss.dist
- jboss.inst == temporary server instance in target/, created by testsuite

Tests need them both - first for modules etc, second for most other actions.
