### PR TITLE
Update to Modules 1.1.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <version.org.jboss.marshalling.jboss-marshalling-river>1.3.4.GA</version.org.jboss.marshalling.jboss-marshalling-river>
         <version.org.jboss.metadata>7.0.0.Beta20</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.1.3.Final</version.org.jboss.mod_cluster>
-        <version.org.jboss.modules.jboss-modules>1.1.0.CR2</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.1.0.CR3</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.0.1.GA</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.netty>3.2.3.Final</version.org.jboss.netty>
         <version.org.jboss.osgi.blueprint>1.0.3</version.org.jboss.osgi.blueprint>


### PR DESCRIPTION
Contains the following fixes:
- MODULES-115 - Fix JAR entry resource URL issue
- MODULES-118 - add a lib directory for native libraries to filesystem modules
- Forward system package requests up to the parent class loader
