### PR TITLE
Fix the location of process-controller boot.log for Windows

### DIFF
--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -90,7 +90,7 @@ echo.
 
 :RESTART
 "%JAVA%" %PROCESS_CONTROLLER_JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\process-controller\log\boot.log" ^
+ "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\domain\log\process-controller\boot.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/domain/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%MODULEPATH%" ^


### PR DESCRIPTION
See http://community.jboss.org/thread/174889
This is just a minor fix which brings domain.bat to the same functionality than domain.sh (which is the documented location)
