### PR TITLE
Modularized testsuite

### DIFF
--- a/testsuite/integration/group-basic/pom.xml
+++ b/testsuite/integration/group-basic/pom.xml
@@ -113,7 +113,7 @@
                                         <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
                                     </additionalClasspathElements>
 
-                                    <reportNameSuffix>tests-basic-integration-default</reportNameSuffix>
+                                    <!--<reportNameSuffix>tests-basic-integration-default</reportNameSuffix>-->
                                 </configuration>
                             </execution>
                             <!-- The second run tests rely on restoring timer services setup in the first run of tests. -->

--- a/testsuite/integration/group-basic/pom.xml
+++ b/testsuite/integration/group-basic/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <version>7.1.0.Alpha2-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- ******************************** Basic Integration ******************************* -->
+    <!-- ********************************************************************************** -->
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-basic</artifactId>
+    <version>7.1.0.Alpha2-SNAPSHOT</version>
+
+    <name>JBoss AS Test Suite: Integration - Basic</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+    </properties>
+
+    <build>
+        <testSourceDirectory>../src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>../src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>../src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>basic.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!no.basic.integration.tests</name>
+                </property>
+            </activation>
+
+            <!--
+                Server configuration executions.
+            -->
+            <build>
+                <plugins>
+
+                    <!-- Build the target/jbossas server configuration. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <!-- Copy in some jars. -->
+                            <execution>
+                                <id>prepare-jars-basic-integration.server</id>
+                                <phase>process-test-resources</phase>
+                                <goals><goal>run</goal></goals>
+                                <configuration>
+                                    <target>
+                                        <property name="tests.resources.dir" value="${basedir}/../src/test/resources"/>
+                                        <property name="tests.output.dir" value="${project.build.directory}"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals><goal>test</goal></goals>
+                                <phase>none</phase>
+                            </execution>
+
+
+                            <execution>
+                                <id>basic-integration-default.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/**/*TestCase*.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/**/*SecondTestCase.java</exclude>
+                                    </excludes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.xml>arquillian.xml</arquillian.xml>
+                                        <arquillian.launch>jboss</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
+                                    </additionalClasspathElements>
+
+                                    <reportNameSuffix>tests-basic-integration-default</reportNameSuffix>
+                                </configuration>
+                            </execution>
+                            <!-- The second run tests rely on restoring timer services setup in the first run of tests. -->
+                            <execution>
+                                <id>basic-integration-2nd.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>false</skipTests>
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <enableAssertions>true</enableAssertions>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/**/*SecondTestCase.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>none</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+</project>

--- a/testsuite/integration/group-clust/pom.xml
+++ b/testsuite/integration/group-clust/pom.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <version>7.1.0.Alpha2-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- *********************************** Clustering *********************************** -->
+    <!-- ********************************************************************************** -->
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-clust</artifactId>
+    <version>7.1.0.Alpha2-SNAPSHOT</version>
+
+    <name>JBoss AS Test Suite: Integration - Clustering</name>
+    
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+    </properties>
+
+    <build>
+        <testSourceDirectory>../src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>../src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>../src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>clustering.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!ts.noClustering</name>
+                </property>
+            </activation>
+
+            <!--
+                Server configuration executions.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>build-clustering.server</id>
+                                <phase>process-test-resources</phase>
+                                <goals><goal>run</goal></goals>
+                                <configuration>
+                                    <target>
+                                        <!-- Build the UDP server configs in target/ . -->
+                                        <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
+                                            <target name="build-clustering-udp"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                       Surefire test executions.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals><goal>test</goal></goals>
+                                <phase>none</phase>
+                            </execution>
+
+                            <!-- Single node clustering tests. -->
+                            <execution>
+                                <id>tests-clustering-single-node.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/clustering/single/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.xml>clustering-arquillian.xml</arquillian.xml>
+                                        <arquillian.launch>clustering-udp-single</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/src/test/resources/clustering</additionalClasspathElement>
+                                    </additionalClasspathElements>
+
+                                    <reportNameSuffix>tests-clustering-single-node</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                            <!-- Multi node clustering tests. -->
+                            <execution>
+                                <id>tests-clustering-multi-node.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/clustering/cluster/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.xml>clustering-arquillian.xml</arquillian.xml>
+                                        <arquillian.launch>clustering-udp</arquillian.launch>
+                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
+                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/src/test/resources/clustering</additionalClasspathElement>
+                                    </additionalClasspathElements>
+
+                                    <reportNameSuffix>tests-clustering-multi-node</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+</project>

--- a/testsuite/integration/group-clust/pom.xml
+++ b/testsuite/integration/group-clust/pom.xml
@@ -109,7 +109,7 @@
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>
-                                        <additionalClasspathElement>${project.basedir}/src/test/resources/clustering</additionalClasspathElement>
+                                        <additionalClasspathElement>${jbossas.ts.integ.dir}/src/test/resources/clustering</additionalClasspathElement>
                                     </additionalClasspathElements>
 
                                     <reportNameSuffix>tests-clustering-single-node</reportNameSuffix>
@@ -136,7 +136,7 @@
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>
-                                        <additionalClasspathElement>${project.basedir}/src/test/resources/clustering</additionalClasspathElement>
+                                        <additionalClasspathElement>${jbossas.ts.integ.dir}/src/test/resources/clustering</additionalClasspathElement>
                                     </additionalClasspathElements>
 
                                     <reportNameSuffix>tests-clustering-multi-node</reportNameSuffix>

--- a/testsuite/integration/group-clust/pom.xml
+++ b/testsuite/integration/group-clust/pom.xml
@@ -139,7 +139,7 @@
                                         <additionalClasspathElement>${jbossas.ts.integ.dir}/src/test/resources/clustering</additionalClasspathElement>
                                     </additionalClasspathElements>
 
-                                    <reportNameSuffix>tests-clustering-multi-node</reportNameSuffix>
+                                    <!--<reportNameSuffix>tests-clustering-multi-node</reportNameSuffix>-->
                                 </configuration>
                             </execution>
 

--- a/testsuite/integration/group-iiop/pom.xml
+++ b/testsuite/integration/group-iiop/pom.xml
@@ -69,7 +69,7 @@
                                 <configuration>
                                     <target>
                                         <!-- build the UDP server configs in target-->
-                                        <ant antfile="${basedir}/../src/test/scripts/iiop-build.xml">
+                                        <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/iiop-build.xml">
                                             <target name="build-iiop"/>
                                         </ant>
                                     </target>
@@ -111,7 +111,7 @@
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>
-                                        <additionalClasspathElement>${project.basedir}/../src/test/resources/iiop</additionalClasspathElement>
+                                        <additionalClasspathElement>${jbossas.ts.integ.dir}/src/test/resources/iiop</additionalClasspathElement>
                                     </additionalClasspathElements>
 
                                     <reportNameSuffix>tests-iiop-multi-node</reportNameSuffix>

--- a/testsuite/integration/group-iiop/pom.xml
+++ b/testsuite/integration/group-iiop/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <version>7.1.0.Alpha2-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- *********************************** IIOP       *********************************** -->
+    <!-- ********************************************************************************** -->
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-iiop</artifactId>
+    <version>7.1.0.Alpha2-SNAPSHOT</version>
+
+    <name>JBoss AS Test Suite: Integration - IIOP</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+    </properties>
+
+    <build>
+        <testSourceDirectory>../src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>../src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>../src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+    </build>
+
+    <profiles>
+
+        <profile>
+            <id>iiop.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!ts.noIIOP</name>
+                </property>
+            </activation>
+            <properties>
+            </properties>
+            <!--
+                Server configuration executions.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>build-clustering.server</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- build the UDP server configs in target-->
+                                        <ant antfile="${basedir}/../src/test/scripts/iiop-build.xml">
+                                            <target name="build-iiop"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                       Surefire test executions
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals><goal>test</goal></goals>
+                                <phase>none</phase>
+                            </execution>
+                            <!-- Multi node clustering tests. -->
+                            <execution>
+                                <id>tests-iiop-multi-node.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/iiop/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.xml>iiop-arquillian.xml</arquillian.xml>
+                                        <arquillian.launch>iiop</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources/iiop</additionalClasspathElement>
+                                    </additionalClasspathElements>
+
+                                    <reportNameSuffix>tests-iiop-multi-node</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
+    </profiles>
+</project>

--- a/testsuite/integration/group-iiop/pom.xml
+++ b/testsuite/integration/group-iiop/pom.xml
@@ -114,7 +114,7 @@
                                         <additionalClasspathElement>${jbossas.ts.integ.dir}/src/test/resources/iiop</additionalClasspathElement>
                                     </additionalClasspathElements>
 
-                                    <reportNameSuffix>tests-iiop-multi-node</reportNameSuffix>
+                                    <!--<reportNameSuffix>tests-iiop-multi-node</reportNameSuffix>-->
                                 </configuration>
                             </execution>
 

--- a/testsuite/integration/group-smoke/pom.xml
+++ b/testsuite/integration/group-smoke/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <version>7.1.0.Alpha2-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- ******************************** Smoke Integration ******************************* -->
+    <!-- ********************************************************************************** -->
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-smoke</artifactId>
+    <version>7.1.0.Alpha2-SNAPSHOT</version>
+
+    <name>JBoss AS Test Suite: Integration - Smoke</name>
+    
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+    </properties>
+
+    <build>
+        <testSourceDirectory>../src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>../src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>../src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+    </build>
+
+
+    <profiles>
+
+        <!-- ********************************************************************************** -->
+        <!-- ****     Smoke tests                                                     ********* -->
+        <!-- ********************************************************************************** -->
+        <profile>
+            <id>smoke.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!noSmoke</name>
+                </property>
+            </activation>
+
+            <properties>
+            </properties>
+
+            <!--
+                Server configuration executions.
+                Naming convention for executions (which we read in the log): for server config X, call it X.server
+            -->
+            <build>
+                <plugins>
+
+                    <!-- Build the target/smoke server configuration. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>build-smoke.server</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- Build the UDP server configs in target. -->
+                                        <ant antfile="${basedir}/../src/test/scripts/smoke-build.xml">
+                                            <target name="build-smoke"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+
+                            <!-- Smoke tests. -->
+                            <execution>
+                                <id>smoke-default.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/smoke/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.xml>smoke-arquillian.xml</arquillian.xml>
+                                        <arquillian.launch>jboss</arquillian.launch>
+
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
+                                    </systemPropertyVariables>
+
+                                    <!-- Access to resources for clustering tests. -->
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources/smoke</additionalClasspathElement>
+                                    </additionalClasspathElements>
+
+                                    <reportNameSuffix>tests-smoke-default</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
+</project>

--- a/testsuite/integration/group-smoke/pom.xml
+++ b/testsuite/integration/group-smoke/pom.xml
@@ -129,7 +129,7 @@
                                         <additionalClasspathElement>${project.basedir}/../src/test/resources/smoke</additionalClasspathElement>
                                     </additionalClasspathElements>
 
-                                    <reportNameSuffix>tests-smoke-default</reportNameSuffix>
+                                    <!--<reportNameSuffix>tests-smoke-default</reportNameSuffix>-->
                                 </configuration>
                             </execution>
 

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -122,7 +122,7 @@
 
         <!-- used to provide an absolute location for the XSLT scripts -->
         <!-- this value is overridden in modules with the correct relative pathname -->
-        <xslt.scripts.dir>${basedir}/src/test/xslt</xslt.scripts.dir>
+        <xslt.scripts.dir>${jbossas.ts.integ.dir}/src/test/xslt</xslt.scripts.dir>
 
         <!-- Enable smoke tests by default -->
         <noSmoke>true</noSmoke>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -108,6 +108,7 @@
             -Djbossas.ts.integ.dir=${jbossas.ts.integ.dir}
             -Djbossas.ts.dir=${jbossas.ts.dir}
             -Djbossas.project.dir=${jbossas.project.dir}
+            -Djboss.dist=${jboss.dist}
         </server.jvm.args.dirs>
         
         <!-- Used to provide an absolute location for the distribution under test. -->

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -99,12 +99,16 @@
     <name>JBoss Application Server Test Suite: Integration Tests</name>
 
     <properties>
+        <!-- Current module's directory. Will automatically pick up sub-module's basedir. -->
+        <jbossas.ts.module.dir>${basedir}</jbossas.ts.module.dir>
+        <!-- Integration module's directory. To be overriden in sub-modules. -->
         <jbossas.ts.integ.dir>${basedir}</jbossas.ts.integ.dir>
         <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <!-- This project's root dir. -->
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <server.jvm.args.dirs>
+            -Djbossas.ts.module.dir=${jbossas.ts.module.dir}
             -Djbossas.ts.integ.dir=${jbossas.ts.integ.dir}
             -Djbossas.ts.dir=${jbossas.ts.dir}
             -Djbossas.project.dir=${jbossas.project.dir}
@@ -188,9 +192,12 @@
                         <node1>${node1}</node1>
                         <udpGroup>${udpGroup}</udpGroup>
 
+                        <jbossas.ts.module.dir>${jbossas.ts.module.dir}</jbossas.ts.module.dir>
                         <jbossas.ts.integ.dir>${jbossas.ts.integ.dir}</jbossas.ts.integ.dir>
                         <jbossas.ts.dir>${jbossas.ts.dir}</jbossas.ts.dir>
                         <jbossas.project.dir>${jbossas.project.dir}</jbossas.project.dir>
+                        <jboss.dist>${jboss.dist}</jboss.dist>
+                        <!-- <jboss.inst>${jbossas.ts.module.dir}/target/jbossas</jboss.inst>  Only to be specified for single-node test groups. -->
 
                         <!--
                             Used in arquillian.xml - arguments for all JBoss AS instances.
@@ -585,6 +592,7 @@
                                         <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <arquillian.launch>jboss</arquillian.launch>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                        <jboss.inst>${jbossas.ts.module.dir}/target/jbossas</jboss.inst>
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>
@@ -699,9 +707,8 @@
                                     <systemPropertyVariables>
                                         <arquillian.xml>smoke-arquillian.xml</arquillian.xml>
                                         <arquillian.launch>jboss</arquillian.launch>
-
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
-                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
+                                        <jboss.inst>${jbossas.ts.module.dir}/target/jbossas</jboss.inst>
                                     </systemPropertyVariables>
 
                                     <!-- Access to resources for clustering tests. -->

--- a/testsuite/integration/pom2.xml
+++ b/testsuite/integration/pom2.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite</artifactId>
+        <version>7.1.0.Alpha2-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+    <packaging>pom</packaging>
+    <version>7.1.0.Alpha2-SNAPSHOT</version>
+
+    <name>JBoss Application Server Test Suite: Integration Aggregator</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}</jbossas.ts.integ.dir>
+        <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <!-- This project's root dir. -->
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <jvm.args.dirs>-Djbossas.ts.integ.dir=${jbossas.ts.integ.dir} -Djbossas.ts.dir=${jbossas.ts.dir} -Djbossas.project.dir=${jbossas.project.dir} -Djboss.dist=${jboss.dist}</jvm.args.dirs>
+        
+        <!-- Used to provide an absolute location for the distribution under test. -->
+        <!-- This value is overridden in modules with the correct relative pathname. -->
+        <jboss.dist>${jbossas.project.dir}/build/target/jboss-as-${jboss.as.release.version}</jboss.dist>
+        <jboss.home>${jboss.dist}</jboss.home>
+        
+        <group.string><!-- Override this in submodules. --></group.string>
+
+        <!-- Used to provide an absolute location for the XSLT scripts. -->
+        <!-- This value is overridden in modules with the correct relative pathname. -->
+        <!-- TODO: Remove, use ${jbossas.ts.integ.dir} in ant scripts. -->
+        <xslt.scripts.dir>${jbossas.ts.dir}/integration/src/test/xslt</xslt.scripts.dir>
+    </properties>
+
+
+    <profiles>
+        
+        <!-- Run all tests on -DallTests. -->
+        <profile>
+            <id>ts.integ.allGroups</id>
+            <activation><property><name>allTests</name></property></activation>
+            <modules>
+                <module>group-smoke</module>
+                <module>group-basic</module>
+                <module>group-clust</module>
+                <module>group-iiop</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.smoke -->
+        <profile>
+            <id>ts.integ.group.smoke</id>
+            <activation><property><name>ts.smoke</name></property></activation>
+            <modules>
+                <module>group-smoke</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.basic -->
+        <profile>
+            <id>ts.integ.group.basic</id>
+            <activation><property><name>ts.basic</name></property></activation>
+            <modules>
+                <module>group-basic</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.clust -->
+        <profile>
+            <id>ts.integ.group.clust</id>
+            <activation><property><name>ts.clust</name></property></activation>
+            <modules>
+                <module>group-clust</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.iiop -->
+        <profile>
+            <id>ts.integ.group.iiop</id>
+            <activation><property><name>ts.iiop</name></property></activation>
+            <modules>
+                <module>group-iiop</module>
+            </modules>
+        </profile>
+
+    </profiles>
+    
+
+    <build>
+        <plugins>
+            <!-- General plugin configuration for all integration tests -->
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-help-plugin</artifactId>
+                <version>2.1.1</version>
+                <inherited>true</inherited>
+                <executions>
+                    <execution><id>help.active-profiles</id>
+                        <phase>initialize</phase>
+                        <goals><goal>active-profiles</goal></goals>
+                        <configuration><output>target/help.active-profiles.txt</output></configuration>
+                    </execution>
+                    <execution><id>help.effective-pom</id>
+                        <phase>initialize</phase>
+                        <goals><goal>effective-pom</goal></goals>
+                        <configuration><output>target/help.effective-pom.txt</output></configuration>
+                    </execution>
+                    <execution><id>help.effective-settings</id>
+                        <phase>initialize</phase>
+                        <goals><goal>effective-settings</goal></goals>
+                        <configuration><output>target/help.effective-settings.txt</output></configuration>
+                    </execution>
+                   <execution><id>help.system</id>
+                        <phase>initialize</phase>
+                        <goals><goal>system</goal></goals>
+                        <configuration><output>target/help.system.txt</output></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            
+            <!-- Copy JBoss AS to target/jbossas. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions combine.children="append">
+                    <!-- First, make a copy for this module. -->
+                    <execution>
+                        <inherited>false</inherited>
+                        <id>ts.copy-jbossas</id>
+                        <phase>generate-test-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${jboss.home}</directory>
+                                    <!-- Modules and bundles not copied as they are read-only (see Surefire props). -->
+                                    <excludes>
+                                        <exclude>modules/</exclude>
+                                        <exclude>bundles/</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <!-- Copy this copy into submodules. -->
+                    <execution>
+                        <inherited>true</inherited>
+                        <id>ts.copy-jbossas.groups</id>
+                        <phase>generate-test-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../target/jbossas</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+
+            <!-- General surefire configuration. Applies to submodules too. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Prevent test and server output appearing in console. -->
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <enableAssertions>true</enableAssertions>
+                    <!--<basedir>${jbossas.ts.integ.dir}</basedir>  <!- - "The base directory of the project being tested." Sets ${basedir}. -->
+                    <workingDirectory>${basedir}/target/workdir</workingDirectory> <!-- Work in submodule's own dir. -->
+
+                    <!-- Forked process timeout -->
+                    <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
+                    <!-- System properties to forked surefire JVM which runs clients. -->
+                    <argLine>${ip.client.stack}</argLine>
+
+                    <!-- System properties passed to test cases -->
+                    <systemPropertyVariables combine.children="append">
+                        <node0>${node0}</node0>
+                        <node1>${node1}</node1>
+                        <udpGroup>${udpGroup}</udpGroup>
+
+                        <jbossas.ts.submodule.dir>${basedir}</jbossas.ts.submodule.dir>
+                        <jbossas.ts.integ.dir>${jbossas.ts.integ.dir}</jbossas.ts.integ.dir>
+                        <jbossas.ts.dir>${jbossas.ts.dir}</jbossas.ts.dir>
+                        <jbossas.project.dir>${jbossas.project.dir}</jbossas.project.dir>
+                        <jboss.dist>${jboss.dist}</jboss.dist>
+
+                        <!--
+                            Used in arquillian.xml - arguments for all JBoss AS instances.
+                            System properties are duplicated here until ARQ-647 is implemented.
+                        -->
+                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                    </systemPropertyVariables>
+                    
+                </configuration>
+            </plugin>
+            
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Dependencies specific to the integration tests. -->
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-webservices-tests-integration</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-demos-legacy</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-demos-internals</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+</project>

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
@@ -1,0 +1,47 @@
+package org.jboss.as.test.smoke;
+
+import java.io.File;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * Tests whether properties we rely on in the tests were properly passed to JUnit.
+ * 
+ * @author Ondrej Zizka
+ */
+@RunWith(Arquillian.class)
+public class TestsuiteSanityTestCase {
+
+		@Test
+		public void testSystemProperties() throws Exception {
+
+				for( String var : new String[]{"jbossas.ts.module.dir", "jbossas.ts.integ.dir", "jbossas.ts.dir", "jbossas.project.dir", "jboss.dist", "jboss.inst"} ){
+						String path = System.getProperty( var );
+						Assert.assertNotNull("Property " + var + " is not set (in container).", path);
+						System.out.println(":: " + var + " == " + path);
+						File dir = new File(path);
+						Assert.assertTrue( "Directory " + dir.getAbsolutePath() + " doesn't exist, check Surefire's system property " + var, dir.exists() );
+				}
+
+		}
+		
+		@Test
+        @RunAsClient
+		public void testSystemPropertiesClient() throws Exception {
+
+				for( String var : new String[]{"jbossas.ts.module.dir", "jbossas.ts.integ.dir", "jbossas.ts.dir", "jbossas.project.dir", "jboss.dist", "jboss.inst"} ){
+						String path = System.getProperty( var );
+						Assert.assertNotNull("Property " + var + " is not set (outside container).", path);
+						System.out.println(":: " + var + " == " + path);
+						File dir = new File(path);
+						Assert.assertTrue( "Directory " + dir.getAbsolutePath() + " doesn't exist, check Surefire's system property " + var, dir.exists() );
+				}
+
+		}
+		
+}// class
+

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
@@ -45,3 +45,4 @@ public class TestsuiteSanityTestCase {
 		
 }// class
 
+

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/TestsuiteSanityTestCase.java
@@ -30,7 +30,7 @@ public class TestsuiteSanityTestCase {
 		}
 		
 		@Test
-        @RunAsClient
+		@RunAsClient
 		public void testSystemPropertiesClient() throws Exception {
 
 				for( String var : new String[]{"jbossas.ts.module.dir", "jbossas.ts.integ.dir", "jbossas.ts.dir", "jbossas.project.dir", "jboss.dist", "jboss.inst"} ){
@@ -44,5 +44,4 @@ public class TestsuiteSanityTestCase {
 		}
 		
 }// class
-
 

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/datasource/AddMySqlDataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/datasource/AddMySqlDataSourceOperationsUnitTestCase.java
@@ -80,8 +80,11 @@ public class AddMySqlDataSourceOperationsUnitTestCase {
 
     @Deployment(testable = false)
     public static Archive<?> getDeployment() {
-        Archive<?> archive = ShrinkWrap.createFromZipFile(JavaArchive.class, new File(
-                "src/test/resources/mysql-connector-java-5.1.15.jar"));
+				File jdbcJar = new File( System.getProperty("jbossas.ts.integ.dir", "."),
+                                 "src/test/resources/mysql-connector-java-5.1.15.jar");
+        if( ! jdbcJar.exists() )
+            throw new IllegalStateException("Can't find " + jdbcJar + " using ${jbossas.ts.dir} == " + System.getProperty("jbossas.ts.dir") );
+        Archive<?> archive = ShrinkWrap.createFromZipFile(JavaArchive.class, jdbcJar);
         Node node = archive.get("META-INF");
         return archive;
         // ShrinkWrapUtils.createJavaArchive("mysql-connector-java-5.1.15.jar").getResources("mysql-connector-java-5.1.15.jar");

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/embedded/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/embedded/parse/ParseAndMarshalModelsTestCase.java
@@ -661,8 +661,8 @@ public class ParseAndMarshalModelsTestCase {
     }
 
     private File getOriginalStandaloneXml(String profile) {
-        File f = new File(".").getAbsoluteFile();
-        f = f.getParentFile().getParentFile().getParentFile();
+				File f = new File( System.getProperty("jbossas.project.dir", "../../..") );
+        f = f.getAbsoluteFile();
         Assert.assertTrue(f.exists());
         f = new File(f, "build");
         Assert.assertTrue("Not found: " + f.getPath(), f.exists());
@@ -684,8 +684,8 @@ public class ParseAndMarshalModelsTestCase {
     private File getDomainConfigDir() {
         //Get the standalone.xml from the build/src directory, since the one in the
         //built server could have changed during running of tests
-        File f = new File(".").getAbsoluteFile();
-        f = f.getParentFile().getParentFile().getParentFile();
+				File f = new File( System.getProperty("jbossas.project.dir", "../../..") );
+        f = f.getAbsoluteFile();
         Assert.assertTrue(f.exists());
         f = new File(f, "build");
         Assert.assertTrue("Not found: " + f.getPath(), f.exists());

--- a/testsuite/integration/src/test/java/org/jboss/as/test/smoke/flat/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/smoke/flat/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -90,9 +90,6 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     }
 
     private File getXmlFile(String xmlName) throws MalformedURLException {
-        if (baseDir() == null)
-            Assert.fail("Server not built");
-
-        return new File(baseDir(), xmlName);
+        return new File(getBaseDir(), xmlName);
     }
 }

--- a/testsuite/integration/src/test/resources/clustering/clustering-arquillian.xml
+++ b/testsuite/integration/src/test/resources/clustering/clustering-arquillian.xml
@@ -4,8 +4,8 @@
 
     <container qualifier="clustering-udp-single" default="true">
         <configuration>
-            <property name="jbossHome">${basedir}/target/clustering-udp-0</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/clustering-udp-0</property>
+            <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-0</property>
+            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-0</property>
             <property name="serverConfig">${server.config:standalone.xml}</property>
         </configuration>
     </container>
@@ -14,16 +14,16 @@
 
         <container qualifier="clustering-udp-0" default="true">
             <configuration>
-                <property name="jbossHome">${basedir}/target/clustering-udp-0</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/clustering-udp-0</property>
+                <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-0</property>
                 <property name="serverConfig">${server.config:standalone-ha.xml}</property>
             </configuration>
         </container>
 
         <container qualifier="clustering-udp-1" default="false">
             <configuration>
-                <property name="jbossHome">${basedir}/target/clustering-udp-1</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/clustering-udp-1 -Djboss.port.offset=100</property>
+                <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${server.config:standalone-ha.xml}</property>
                 <property name="managementPort">10099</property>
             </configuration>

--- a/testsuite/integration/src/test/resources/iiop/iiop-arquillian.xml
+++ b/testsuite/integration/src/test/resources/iiop/iiop-arquillian.xml
@@ -7,8 +7,8 @@
         <!-- The server than invokes the exposed EJB's -->
         <container qualifier="iiop-client" default="true">
             <configuration>
-                <property name="jbossHome">${basedir}/target/iiop-client</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/iiop-client</property>
+                <property name="jbossHome">${basedir}/target/jbossas-iiop-client</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-iiop-client</property>
                 <property name="serverConfig">${server.config:standalone.xml}</property>
             </configuration>
         </container>
@@ -16,8 +16,8 @@
         <!-- The server that expsoses EJB's via IIOP -->
         <container qualifier="iiop-server" default="false">
             <configuration>
-                <property name="jbossHome">${basedir}/target/iiop-server</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/iiop-server</property>
+                <property name="jbossHome">${basedir}/target/jbossas-iiop-server</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-iiop-server</property>
                 <property name="serverConfig">${server.config:standalone.xml}</property>
                 <property name="managementPort">10099</property>
             </configuration>

--- a/testsuite/integration/src/test/resources/smoke/smoke-arquillian.xml
+++ b/testsuite/integration/src/test/resources/smoke/smoke-arquillian.xml
@@ -4,8 +4,8 @@
 
 	<container qualifier="jboss" default="true">
 		<configuration>
-			<property name="jbossHome">${basedir}/target/smoke</property>
-			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/smoke</property>
+			<property name="jbossHome">${basedir}/target/jbossas-smoke</property>
+			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-smoke</property>
 			<property name="serverConfig">${server.config:standalone.xml}</property>
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -99,11 +99,11 @@
 
         <sequential>
 
-            <echo message="Building config @{name} from @{jboss.dist}"/>
+            <echo message="Building AS instance &quot;@{name}&quot; from @{jboss.dist} to @{output.dir}"/>
 
             <!-- copy the base distribution -->
             <!-- we exclude modules and bundles as they are read-only and we locate the via sys props-->
-            <copy todir="@{output.dir}/@{name}">
+            <copy todir="@{output.dir}/jbossas-@{name}">
                 <fileset dir="@{jboss.dist}">
                     <exclude name="**/modules/**"/>
                     <exclude name="**/bundles/**"/>
@@ -111,7 +111,7 @@
             </copy>
 
             <!-- overwrite with configs from test-configs and apply property filtering -->
-            <copy todir="@{output.dir}/@{name}" overwrite="true" failonerror="false">
+            <copy todir="@{output.dir}/jbossas-@{name}" overwrite="true" failonerror="false">
                 <fileset dir="@{test.configs.dir}/@{name}"/>
                 <filterset begintoken="${" endtoken="}">
                     <filter token="node0" value="${node0}"/>
@@ -135,11 +135,11 @@
             <echo message="Changing IP addresses for config @{name}"/>
 
             <!-- process *.xml to *.xml.mod -->
-            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-ha.xml"/>
                 </fileset>
@@ -148,8 +148,8 @@
             </xslt>
 
             <!-- move processed files back -->
-            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-ha.xml.mod"/>
                </fileset>
@@ -174,13 +174,13 @@
             <echo message="Changing IP addresses for config @{name}"/>
 
             <!-- process *.xml to *.xml.mod -->
-            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <!-- can't get this to work -->
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
-                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                 </fileset>
@@ -190,8 +190,8 @@
             </xslt>
 
             <!-- move processed files back -->
-            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                </fileset>
@@ -217,13 +217,13 @@
             <echo message="Adding port offset for config @{name}"/>
 
             <!-- process *.xml to *.xml.mod -->
-            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/addPortOffset.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <!-- can't get this to work -->
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
-                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                 </fileset>
@@ -233,8 +233,8 @@
             </xslt>
 
             <!-- move processed files back -->
-            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                </fileset>
@@ -257,19 +257,19 @@
             <echo message="Enabling JTS for config @{name}"/>
 
             <!-- process *.xml to *.xml.mod -->
-            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${basedir}/src/test/xslt/enableJTS.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                 </fileset>
             </xslt>
 
             <!-- move processed files back -->
-            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                </fileset>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -258,7 +258,7 @@
 
             <!-- process *.xml to *.xml.mod -->
             <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
-                  style="${basedir}/src/test/xslt/enableJTS.xsl"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/enableJTS.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors
@@ -24,23 +23,20 @@
 
 <project>
 
-    <!--
-       Property sets
-    -->
     <propertyset id="ds.properties">
         <propertyref prefix="ds"/>
     </propertyset>
 
+
+
+
     <!--
-      Targets
+          Change AS database configuration.
     -->
-
     <condition property="changeDB">
-        <not>
-            <equals arg1="${ds.db}" arg2=""/>
-        </not>
+        <not><equals arg1="${ds.db}" arg2=""/></not>
     </condition>
-
+    
     <target name="changeDefaultDatabase" description="Changes the default database" if="changeDB">
 
         <echo message="Changing database for ${server-config} with parameters:"/>
@@ -50,19 +46,15 @@
         <echo message="ds.jdbc.user = ${ds.jdbc.user}"/>
         <echo message="ds.jdbc.pass = ${ds.jdbc.pass}"/>
 
-        <property name="server.dir" value="${project.build.directory}/${server-config}"/>
+        <property name="server.dir" value="${project.build.directory}/jbossas"/> <!-- Ant will copy actual instances from this "template" (when imlpemented). -->
         <property name="config.dir" value="${server.dir}/standalone/configuration"/>
 
-        <!-- copy in jar into standalone/deployments; this installs the driver under a new driver name -->
-        <copy file="${main.basedir}/target/jdbcDrivers/${ds.jdbc.driver.jar}" todir="${server.dir}/standalone/deployments"/>
+        <!-- Copy jar into standalone/deployments. This installs the driver under a new driver name. -->
+        <copy file="${jbossas.ts.integ.dir}/target/jdbcDrivers/${ds.jdbc.driver.jar}" todir="${server.dir}/standalone/deployments"/>
 
-        <!-- change standalone/configuration/standalone.xml file:
-              i.e. update datasource subsystem config
-         -->
-        <xslt destdir="${config.dir}"
-              extension=".xml.mod"
-              style="${main.basedir}/../integration/src/test/xslt/changeDatabase.xsl"
-              useImplicitFileset="false">
+        <!-- Change standalone/configuration/standalone.xml file. I.e. update datasource subsystem config. -->
+        <xslt destdir="${config.dir}" extension=".xml.mod" useImplicitFileset="false"
+              style="${jbossas.ts.integ.dir}/src/test/xslt/changeDatabase.xsl">
             <fileset dir="${config.dir}">
                 <include name="standalone.xml"/>
                 <include name="standalone-xts.xml"/>
@@ -74,7 +66,7 @@
             <param name="ds.jdbc.pass" expression="${ds.jdbc.pass}"/>
         </xslt>
 
-        <!-- move processed files back -->
+        <!-- Move processed files back. -->
         <move todir="${config.dir}">
            <fileset dir="${config.dir}">
                <include name="**/standalone.xml.mod"/>
@@ -86,8 +78,11 @@
     </target>
 
 
+
     <!--
-       Macros
+        Build server configutation:
+           * Copy from distribution directory (TODO: Copy from ${basedir}target/jbossas to pick up changes by Maven!
+           * Overwrite some config files, replace tokens.
      -->
     <macrodef name="build-server-config" description="Builds a server configuration">
 
@@ -123,6 +118,11 @@
         </sequential>
     </macrodef>
 
+
+
+    <!--
+        Change IP adresses config.
+     -->
     <macrodef name="change-ip-addresses" description="Changes the IP addresses of a single node configuration">
 
         <attribute name="name" default="jbossas"/>
@@ -134,7 +134,7 @@
 
             <echo message="Changing IP addresses for config @{name}"/>
 
-            <!-- process *.xml to *.xml.mod -->
+            <!-- Process *.xml to *.xml.mod. -->
             <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
@@ -147,7 +147,7 @@
                 <param name="publicIPAddress" expression="@{node}"/>
             </xslt>
 
-            <!-- move processed files back -->
+            <!-- Move processed files back. -->
             <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone.xml.mod"/>
@@ -158,6 +158,11 @@
         </sequential>
     </macrodef>
 
+
+    <!--
+        Change IP adresses, including multicast.
+        This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
+    -->
     <macrodef name="change-ip-multicast-addresses" description="Changes the IP *and* multicast addresses of a node configuration">
 
         <attribute name="name" default="jbossas"/>
@@ -166,19 +171,15 @@
         <attribute name="node" default="${node0}"/>
         <attribute name="mcastaddr" default="${udpGroup}"/>
 
-        <!--
-         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}
-        -->
-
         <sequential>
             <echo message="Changing IP addresses for config @{name}"/>
 
-            <!-- process *.xml to *.xml.mod -->
+            <!-- Process *.xml to *.xml.mod. -->
             <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <!-- can't get this to work -->
+                <!-- Can't get this to work. -->
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
                 <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
@@ -189,7 +190,7 @@
                 <param name="udpMcastAddress" expression="@{mcastaddr}"/>
             </xslt>
 
-            <!-- move processed files back -->
+            <!-- Move processed files back. -->
             <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
@@ -200,6 +201,12 @@
         </sequential>
     </macrodef>
 
+
+    
+    <!--
+        Configure port offset.
+        This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
+    -->
     <macrodef name="add-port-offset" description="Add a port offeset a node configuration">
 
         <attribute name="name" default="jbossas"/>
@@ -209,14 +216,10 @@
         <attribute name="nativePort" default="9999"/>
         <attribute name="httpPort" default="9990"/>
 
-        <!--
-         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}
-        -->
-
         <sequential>
             <echo message="Adding port offset for config @{name}"/>
 
-            <!-- process *.xml to *.xml.mod -->
+            <!-- Process *.xml to *.xml.mod. -->
             <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/addPortOffset.xsl"
                   extension=".xml.mod"
@@ -232,7 +235,7 @@
                 <param name="httpInterfaceManagementPort" expression="@{httpPort}"/>
             </xslt>
 
-            <!-- move processed files back -->
+            <!-- Move processed files back. -->
             <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
@@ -243,20 +246,22 @@
         </sequential>
     </macrodef>
 
+
+    
+    <!--
+        Enable JTS.
+        This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
+    -->
     <macrodef name="add-jts" description="Enable JTS">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
         <attribute name="config.dir.name" default="standalone/configuration"/>
 
-        <!--
-         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}
-        -->
-
         <sequential>
             <echo message="Enabling JTS for config @{name}"/>
 
-            <!-- process *.xml to *.xml.mod -->
+            <!-- Process *.xml to *.xml.mod. -->
             <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/enableJTS.xsl"
                   extension=".xml.mod"
@@ -267,7 +272,7 @@
                 </fileset>
             </xslt>
 
-            <!-- move processed files back -->
+            <!-- Move processed files back. -->
             <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -94,7 +94,7 @@
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
         <attribute name="jboss.dist" default="${jboss.dist}"/>
-        <attribute name="test.configs.dir" default="${basedir}/src/test/resources/test-configs"/>
+        <attribute name="test.configs.dir" default="${jbossas.ts.integ.dir}/src/test/resources/test-configs"/>
         <element name="filter-elements" optional="yes" description="additional filter elements"/>
 
         <sequential>
@@ -118,7 +118,7 @@
                     <filter token="node1" value="${node1}"/>
                     <filter token="udpGroup" value="${udpGroup}"/>
                     <filter-elements/>
-                  </filterset>
+                </filterset>
             </copy>
         </sequential>
     </macrodef>
@@ -136,7 +136,7 @@
 
             <!-- process *.xml to *.xml.mod -->
             <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
-                  style="${basedir}/src/test/xslt/changeIPAddresses.xsl"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
@@ -154,7 +154,7 @@
                    <include name="**/standalone-ha.xml.mod"/>
                </fileset>
                <mapper type="glob" from="*.mod" to="*"/>
-             </move>
+            </move>
         </sequential>
     </macrodef>
 
@@ -175,7 +175,7 @@
 
             <!-- process *.xml to *.xml.mod -->
             <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
-                  style="${basedir}/src/test/xslt/changeIPAddresses.xsl"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <!-- can't get this to work -->
@@ -218,7 +218,7 @@
 
             <!-- process *.xml to *.xml.mod -->
             <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
-                  style="${basedir}/src/test/xslt/addPortOffset.xsl"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/addPortOffset.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <!-- can't get this to work -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -344,6 +344,7 @@
                     <systemPropertyVariables>
                         <jboss.options>${surefire.system.args}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <jboss.dist>${jboss.dist}</jboss.dist>
                         <jboss.home>${basedir}/target/jbossas</jboss.home>
                         <module.path>${jboss.dist}/modules</module.path>
                     </systemPropertyVariables>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -110,7 +110,7 @@
         <!-- common surefire properties -->
         <surefire.memory.args>-Xmx512m -XX:MaxPermSize=256m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
-        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args}</surefire.system.args>
+        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
         <surefire.forked.process.timeout>900</surefire.forked.process.timeout>
         <surefire.test.failure.ignore>false</surefire.test.failure.ignore>
 


### PR DESCRIPTION
This is what I announced at jboss-as7-dev list on Fri, 11 Nov 2011 05:50:56 +0100, so let me copy it here.

There are currently two POMs in integration:
    **pom.xml** - runs the testsuite the old way.
    **pom2.xml** - runs the modularized testsuite, using group-**\* submodules.
I've done this for the case the new concept couldn't be used (e.g. tests not fixed soon enough).

Old way:

```
./build.sh clean install -DallTests
```

To run the pom2.xml:

```
./build.sh clean install -DskipTests
cd integration
mvn clean install -DallTests -f pom2.xml -fae  
```

BTW, I've based this branch on my previous pull request's commits.

---

Hi everyone,

as was discussed on this list, the current testsuite harness had some problems fulfilling even basic requirements for various use cases, including but not limited to:
- Using from IDE through pure maven
- -DallTests vs. individial modules vs. distinctive groups vs. even overlaying groups
- Configuring AS using kind of hierarchical templates
- Imposing certain test groups order
- Invoking only some steps of the testsuite
- Running same tests with different AS configuration
  etc etc.

I've been working on an updated concept, which is currently at https://github.com/OndraZizka/jboss-as/commits/TS-modules-tmp .
I would like you to review it, run it, and send me some comments.

```
 cd testsuite/integration
 mvn clean install -f pom2.xml -DallTests -fae
 mvn clean install -f pom2.xml -Dts.iiop
```

(There are 2 pom.xml's so I can compare two harnesses easily.)
The scripts are not updated yet so they do not work.
CLI and OSGi tests fail. To be sorted out.

The big news are:
- Execution split to modules
- Code and resources remained in the same location
- Added few system properties which provide paths to important directories - see https://docs.jboss.org/author/display/AS71/AS+7+Testsuite+Test+Developer+Guide
- Work directory is now in target/workdir

These cahnges exposed some issues in test code which need to be fixed - hardcoded relative paths.
Since there were no system properties to use, there was no other way, but from now on please use those properties, and fix your existing tests.
(This would happen anyway because some tests clutter workdir (which happens to be module's root dir) with various temp files.)

Thanks,
## Ondra
