### PR TITLE
Fix for AS7-2709 

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerAdd.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.clustering.infinispan.InfinispanMessages.MESSAGES;
 
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -455,7 +456,12 @@ public class CacheContainerAdd extends AbstractAddStepHandler implements Descrip
                 builder.addDependency(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketBinding), OutboundSocketBinding.class, new Injector<OutboundSocketBinding>() {
                     @Override
                     public void inject(OutboundSocketBinding value) throws InjectionException {
-                        String address = value.getDestinationAddress().getHostAddress()+":"+Integer.toString(value.getDestinationPort());
+                        final String address;
+                        try {
+                            address = value.getDestinationAddress().getHostAddress()+":"+Integer.toString(value.getDestinationPort());
+                        } catch (UnknownHostException uhe) {
+                            throw new InjectionException("Could not resolve destination address for outbound socket binding named " + value, uhe);
+                        }
                         String serverList = storeConfig.getHotRodClientProperties().getProperty(ConfigurationProperties.SERVER_LIST);
                         serverList = serverList==null?address:serverList+";"+address;
                         storeConfig.getHotRodClientProperties().setProperty(ConfigurationProperties.SERVER_LIST, serverList);

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailMessages.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailMessages.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.mail.extension;
 
+import java.net.UnknownHostException;
+
 import org.jboss.logging.Cause;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageBundle;
@@ -51,4 +53,15 @@ interface MailMessages {
      */
     @Message(id = 15450, value = "No outbound socket binding configuration '%s' is available.")
     StartException outboundSocketBindingNotAvailable(String outgoingSocketBindingRef);
+
+    /**
+     * Creates an exception indicating that the destination address of the outgoing socket binding, that the
+     * mail service depends on, could not be resolved
+     *
+     * @param outgoingSocketBindingRef the name of the socket binding configuration.
+     *
+     * @return a {@link RuntimeException} for the error.
+     */
+    @Message(id = 15451, value = "Unknwon host for outbound socket binding configuration '%s'.")
+    RuntimeException unknownOutboundSocketBindingDesintation(@Cause UnknownHostException cause, String outgoingSocketBindingRef);
 }

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSessionService.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSessionService.java
@@ -1,7 +1,9 @@
 package org.jboss.as.mail.extension;
 
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -117,7 +119,13 @@ public class MailSessionService implements Service<Session> {
         if (ref == null) {
             throw MailMessages.MESSAGES.outboundSocketBindingNotAvailable(ref);
         }
-        return new InetSocketAddress(binding.getDestinationAddress(), binding.getDestinationPort());
+        final InetAddress destinationAddress;
+        try {
+            destinationAddress = binding.getDestinationAddress();
+        } catch (UnknownHostException uhe) {
+            throw MailMessages.MESSAGES.unknownOutboundSocketBindingDesintation(uhe, ref);
+        }
+        return new InetSocketAddress(destinationAddress, binding.getDestinationPort());
     }
 
 

--- a/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingService.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingService.java
@@ -22,12 +22,13 @@
 
 package org.jboss.as.server.services.net;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.value.InjectedValue;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 
 /**
  * Service that represents a local-destination outbound socket binding
@@ -43,24 +44,35 @@ public class LocalDestinationOutboundSocketBindingService extends OutboundSocket
         super(name, sourcePort, fixedSourcePort);
     }
 
+    synchronized Injector<SocketBinding> getLocalDestinationSocketBindingInjector() {
+        return this.localDestinationSocketBindingInjectedValue;
+    }
+
     @Override
-    protected synchronized InetAddress getDestinationAddress() {
+    protected OutboundSocketBinding createOutboundSocketBinding() {
+        // unlike the RemoteDestinationOutboundSocketBindingService, we resolve the destination address
+        // here itself (instead of doing it lazily in the OutboundSocketBinding) is because we already
+        // inject a SocketBinding reference which is local to the server instance and is expected to have
+        // already resolved the (local) address (via the NetworkInterfaceBinding).
+        final InetAddress destinationAddress = this.getDestinationAddress();
+        final int destinationPort = this.getDestinationPort();
+        return new OutboundSocketBinding(this.outboundSocketName, this.socketBindingManagerInjectedValue.getValue(),
+                destinationAddress, destinationPort, this.sourceInterfaceInjectedValue.getOptionalValue(), this.sourcePort,
+                this.fixedSourcePort);
+    }
+
+    private InetAddress getDestinationAddress() {
         final SocketBinding localDestinationSocketBinding = this.localDestinationSocketBindingInjectedValue.getValue();
         return localDestinationSocketBinding.getSocketAddress().getAddress();
     }
 
-    @Override
-    protected synchronized int getDestinationPort() {
+    private int getDestinationPort() {
         final SocketBinding localDestinationSocketBinding = this.localDestinationSocketBindingInjectedValue.getValue();
         // instead of directly using SocketBinding.getPort(), we go via the SocketBinding.getSocketAddress()
         // since the getPort() method doesn't take into account whether the port is a fixed port or whether a offset
         // needs to be added. Alternatively, we could introduce a getAbsolutePort() in the SocketBinding class.
         final InetSocketAddress socketAddress = localDestinationSocketBinding.getSocketAddress();
         return socketAddress.getPort();
-    }
-
-    synchronized Injector<SocketBinding> getLocalDestinationSocketBindingInjector() {
-        return this.localDestinationSocketBindingInjectedValue;
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingService.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingService.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.server.services.net;
 
-import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.NetworkInterfaceBinding;
+import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBindingManager;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
@@ -31,8 +31,6 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-
-import java.net.InetAddress;
 
 /**
  * Service that represents a outbound socket binding
@@ -42,10 +40,10 @@ import java.net.InetAddress;
 public abstract class OutboundSocketBindingService implements Service<OutboundSocketBinding> {
 
     protected final String outboundSocketName;
-    private final Integer sourcePort;
-    private final InjectedValue<SocketBindingManager> socketBindingManagerInjectedValue = new InjectedValue<SocketBindingManager>();
-    private final InjectedValue<NetworkInterfaceBinding> sourceInterfaceInjectedValue = new InjectedValue<NetworkInterfaceBinding>();
-    private final boolean fixedSourcePort;
+    protected final Integer sourcePort;
+    protected final InjectedValue<SocketBindingManager> socketBindingManagerInjectedValue = new InjectedValue<SocketBindingManager>();
+    protected final InjectedValue<NetworkInterfaceBinding> sourceInterfaceInjectedValue = new InjectedValue<NetworkInterfaceBinding>();
+    protected final boolean fixedSourcePort;
 
     private volatile OutboundSocketBinding outboundSocketBinding;
 
@@ -57,16 +55,7 @@ public abstract class OutboundSocketBindingService implements Service<OutboundSo
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
-        final InetAddress destinationHost = this.getDestinationAddress();
-        if (destinationHost == null) {
-            throw new IllegalStateException("Destination host cannot be null for outbound socket binding: " + this.outboundSocketName);
-        }
-        final int destinationPort = this.getDestinationPort();
-        if (destinationPort < 0) {
-            throw new IllegalStateException("Destination port " + destinationPort + " cannot be negative for outbound socket binding: " + this.outboundSocketName);
-        }
-        this.outboundSocketBinding = new OutboundSocketBinding(this.outboundSocketName, this.socketBindingManagerInjectedValue.getValue(),
-                destinationHost, destinationPort, this.sourceInterfaceInjectedValue.getOptionalValue(), this.sourcePort, this.fixedSourcePort);
+        this.outboundSocketBinding = this.createOutboundSocketBinding();
     }
 
     @Override
@@ -87,8 +76,9 @@ public abstract class OutboundSocketBindingService implements Service<OutboundSo
         return this.sourceInterfaceInjectedValue;
     }
 
-    protected abstract InetAddress getDestinationAddress();
-
-    protected abstract int getDestinationPort();
-
+    /**
+     * Create and return the {@link OutboundSocketBinding} for this outbound socket binding service
+     * @return
+     */
+    protected abstract OutboundSocketBinding createOutboundSocketBinding();
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingAddHandler.java
@@ -31,7 +31,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.POR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOURCE_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOURCE_PORT;
 
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -119,7 +118,6 @@ public class RemoteDestinationOutboundSocketBindingAddHandler extends AbstractAd
 
         // destination host
         final String destinationHost = RemoteDestinationOutboundSocketBindingResourceDefinition.HOST.validateResolvedOperation(model).asString();
-        final InetAddress destinationHostAddress = InetAddress.getByName(destinationHost);
         // port
         final int destinationPort = RemoteDestinationOutboundSocketBindingResourceDefinition.PORT.validateResolvedOperation(model).asInt();
 
@@ -133,7 +131,7 @@ public class RemoteDestinationOutboundSocketBindingAddHandler extends AbstractAd
         final ModelNode fixedSourcePortModelNode = OutboundSocketBindingResourceDefinition.FIXED_SOURCE_PORT.validateResolvedOperation(model);
         final boolean fixedSourcePort = fixedSourcePortModelNode.isDefined() ? fixedSourcePortModelNode.asBoolean() : false;
         // create the service
-        final OutboundSocketBindingService outboundSocketBindingService = new RemoteDestinationOutboundSocketBindingService(outboundSocketName, destinationHostAddress, destinationPort, sourcePort, fixedSourcePort);
+        final OutboundSocketBindingService outboundSocketBindingService = new RemoteDestinationOutboundSocketBindingService(outboundSocketName, destinationHost, destinationPort, sourcePort, fixedSourcePort);
         final ServiceBuilder<OutboundSocketBinding> serviceBuilder = serviceTarget.addService(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketName), outboundSocketBindingService);
         // if a source interface has been specified then add a dependency on it
         if (sourceInterfaceName != null) {

--- a/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingService.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingService.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.server.services.net;
 
-import java.net.InetAddress;
+import org.jboss.as.network.OutboundSocketBinding;
 
 /**
  * Service that represents a remote-destination outbound socket binding
@@ -31,15 +31,15 @@ import java.net.InetAddress;
  */
 public class RemoteDestinationOutboundSocketBindingService extends OutboundSocketBindingService {
 
-    private final InetAddress destinationHost;
+    private final String destinationHost;
     private final int destinationPort;
 
-    public RemoteDestinationOutboundSocketBindingService(final String name, final InetAddress destinationHost, final int destinationPort,
+    public RemoteDestinationOutboundSocketBindingService(final String name, final String destinationHost, final int destinationPort,
                                                          final Integer sourcePort, final boolean fixedSourcePort) {
 
         super(name, sourcePort, fixedSourcePort);
-        if (destinationHost == null) {
-            throw new IllegalArgumentException("Destination host cannot be null for outbound socket binding " + name);
+        if (destinationHost == null || destinationHost.trim().isEmpty()) {
+            throw new IllegalArgumentException("Destination host cannot be null or empty for outbound socket binding " + name);
         }
         if (destinationPort < 0) {
             throw new IllegalArgumentException("Destination port cannot be a negative value for outbound socket binding " + name);
@@ -49,12 +49,9 @@ public class RemoteDestinationOutboundSocketBindingService extends OutboundSocke
     }
 
     @Override
-    protected InetAddress getDestinationAddress() {
-        return this.destinationHost;
-    }
-
-    @Override
-    protected int getDestinationPort() {
-        return this.destinationPort;
+    protected OutboundSocketBinding createOutboundSocketBinding() {
+        return new OutboundSocketBinding(this.outboundSocketName, this.socketBindingManagerInjectedValue.getValue(),
+                destinationHost, destinationPort, this.sourceInterfaceInjectedValue.getOptionalValue(), this.sourcePort,
+                this.fixedSourcePort);
     }
 }


### PR DESCRIPTION
This commit provides a fix for https://issues.jboss.org/browse/AS7-2709.

We used to (incorrectly and unintentionally) try and resolve the destination address of a outbound socket binding even if that binding wasn't used by any resources. This commit fixes that issue by not resolving the destination address until the dependent resource asks for or tries to connect to the remote destination.
