### PR TITLE
Upgrade to 3.0.0.CR4 of XNIO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.jboss.ws.spi>2.0.0.CR1</version.org.jboss.ws.spi>
         <version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>1.0.0.GA</version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>
         <version.org.jboss.xb>2.0.3.GA</version.org.jboss.xb>
-        <version.org.jboss.xnio>3.0.0.CR3</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.0.0.CR4</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>3.0.0.CR5</version.org.jgroups>


### PR DESCRIPTION
Minor upgrade of XNIO from 3.0.0.CR3 to 3.0.0.CR4. One of the important fixes this new version brings in is https://issues.jboss.org/browse/XNIO-101 which fixed the XNIO worker threads to take into account the THREAD_DAEMON option while creating the threads.
