### PR TITLE
Upgrade JBoss Remoting to 3.2.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <version.org.jboss.osgi.webapp>1.0.5</version.org.jboss.osgi.webapp>
         <version.org.jboss.osgi.webconsole>1.0.6</version.org.jboss.osgi.webconsole>
         <version.org.jboss.osgi.xerces>2.9.1.SP7</version.org.jboss.osgi.xerces>
-        <version.org.jboss.remoting3.jboss-remoting>3.2.0.CR2</version.org.jboss.remoting3.jboss-remoting>
+        <version.org.jboss.remoting3.jboss-remoting>3.2.0.CR3</version.org.jboss.remoting3.jboss-remoting>
         <version.org.jboss.resteasy.resteasy-jaxrs>2.2.3.GA</version.org.jboss.resteasy.resteasy-jaxrs>
         <version.org.jboss.sasl>1.0.0.Beta3</version.org.jboss.sasl>
         <version.org.jboss.seam.int>6.0.0.GA</version.org.jboss.seam.int>


### PR DESCRIPTION
Includes:

[REM3-128] Allow for initial Sasl message from client side.
[REM2-128] Additional changes to suspend the reads around the client possibly generating an initial SASL message as this could involve a call out to a CallbackHandler.
Add SocketAddress-based connection APIs
