### PR TITLE
Support for EJB client configuration via deployment descriptor

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_0.xsd
@@ -1,0 +1,93 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:ejb-client:1.0"
+            xmlns="urn:jboss:ejb-client:1.0"
+            elementFormDefault="unqualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <!-- Root element -->
+    <xsd:element name="jboss-ejb-client" type="jboss-ejb-clientType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Root element for a jboss-ejb-client.xml file
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="jboss-ejb-clientType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The EJB client configurations
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:all>
+            <xsd:element name="client-context" type="client-contextType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configurations that will be used to setup an EJB client context for the
+                        deployment.
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:all>
+
+    </xsd:complexType>
+
+    <xsd:complexType name="client-contextType">
+        <xsd:all>
+            <xsd:element name="ejb-receivers" type="ejb-receiversType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures EJB receivers for the client context
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+
+    <xsd:complexType name="ejb-receiversType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="remoting-ejb-receiver" type="remoting-ejb-receiverType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures a remoting based EJB receiver
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="remoting-ejb-receiverType">
+        <xsd:attribute name="outbound-connection-ref" type="xsd:string" use="required">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    Reference to an outbound connection configured in the remoting subsytem
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+</xsd:schema>
+

--- a/ee/src/main/java/org/jboss/as/ee/EeMessages.java
+++ b/ee/src/main/java/org/jboss/as/ee/EeMessages.java
@@ -22,10 +22,11 @@
 
 package org.jboss.as.ee;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
+import javax.xml.namespace.QName;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
+import java.lang.reflect.Method;
+import java.util.Collection;
 
 import org.jboss.as.ee.component.BindingConfiguration;
 import org.jboss.as.ee.component.ComponentConfiguration;
@@ -806,4 +807,47 @@ public interface EeMessages {
 
     @Message(id = 11093, value = "Could not load component class %s")
     DeploymentUnitProcessingException couldNotLoadComponentClass(@Cause Throwable cause, final String className);
+
+    /**
+     * Creates an exception indicating an unexpected element, represented by the {@code name} parameter, was
+     * encountered.
+     *
+     * @param name     the unexpected element name.
+     * @param location the location of the error.
+     *
+     * @return a {@link XMLStreamException} for the error.
+     */
+    @Message(id = 11094, value = "Unexpected element '%s' encountered")
+    XMLStreamException unexpectedElement(QName name, @Param Location location);
+
+    /**
+     * Creates an exception indicating that the jboss-ejb-client.xml couldn't be processed
+     *
+     * @return a {@link DeploymentUnitProcessingException} for the error.
+     */
+    @Message(id = 11095, value = "Failed to process jboss-ejb-client.xml")
+    DeploymentUnitProcessingException failedToProcessEJBClientDescriptor(@Cause Throwable cause);
+
+    /**
+     * Creates an exception indicating that there was a exception while parsing a jboss-ejb-client.xml
+     *
+     *
+     * @param fileLocation the location of jboss-ejb-client.xml
+     *
+     * @return a {@link DeploymentUnitProcessingException} for the error.
+     */
+    @Message(id = 11096, value = "Exception while parsing jboss-ejb-client.xml file found at %s")
+    DeploymentUnitProcessingException xmlErrorParsingEJBClientDescriptor(@Cause XMLStreamException cause, String fileLocation);
+
+    /**
+     * Creates an exception indicating that there was a exception while parsing a jboss-ejb-client.xml
+     *
+     * @param message The error message
+     * @param location The location of the error
+     *
+     * @return a {@link XMLStreamException} for the error.
+     */
+    @Message(id = 11097, value = "%s")
+    XMLStreamException errorParsingEJBClientDescriptor(String message, @Param Location location);
+
 }

--- a/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ee.metadata;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Metadata for configurations contained in jboss-ejb-client.xml descriptor
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBClientDescriptorMetaData {
+
+    private Set<String> remotingReceiverConnectionRefs = new HashSet<String>();
+
+    /**
+     * Adds a outbound connection reference used by a remoting receivers in the client context represented
+     * by this {@link EJBClientDescriptorMetaData}
+     *
+     * @param outboundConnectionRef The name of the outbound connection. Cannot be null or empty string.
+     */
+    public void addRemotingReceiverConnectionRef(final String outboundConnectionRef) {
+        if (outboundConnectionRef == null || outboundConnectionRef.trim().isEmpty()) {
+            throw new IllegalArgumentException("Cannot add a remoting receiver which references a null/empty outbound connection");
+        }
+        this.remotingReceiverConnectionRefs.add(outboundConnectionRef);
+    }
+
+    /**
+     * Returns a collection of outbound connection references that are used by the remoting receivers
+     * configured in the client context of this {@link EJBClientDescriptorMetaData}
+     *
+     * @return
+     */
+    public Collection<String> getRemotingReceiverConnectionRefs() {
+        return this.remotingReceiverConnectionRefs;
+    }
+}

--- a/ee/src/main/java/org/jboss/as/ee/structure/Attachments.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/Attachments.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.ee.structure;
 
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.metadata.ear.jboss.JBossAppMetaData;
 import org.jboss.metadata.ear.spec.EarMetaData;
@@ -41,6 +42,8 @@ public final class Attachments {
     public static final AttachmentKey<JBossAppMetaData> JBOSS_APP_METADATA = AttachmentKey.create(JBossAppMetaData.class);
 
     public static final AttachmentKey<ModuleMetaData> MODULE_META_DATA = AttachmentKey.create(ModuleMetaData.class);
+
+    public static final AttachmentKey<EJBClientDescriptorMetaData> EJB_CLIENT_METADATA = AttachmentKey.create(EJBClientDescriptorMetaData.class);
 
     /**
      * The alternate deployment descriptor location

--- a/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor10Parser.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor10Parser.java
@@ -1,0 +1,309 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ee.structure;
+
+import static javax.xml.stream.XMLStreamConstants.ATTRIBUTE;
+import static javax.xml.stream.XMLStreamConstants.CDATA;
+import static javax.xml.stream.XMLStreamConstants.CHARACTERS;
+import static javax.xml.stream.XMLStreamConstants.COMMENT;
+import static javax.xml.stream.XMLStreamConstants.DTD;
+import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.ENTITY_DECLARATION;
+import static javax.xml.stream.XMLStreamConstants.ENTITY_REFERENCE;
+import static javax.xml.stream.XMLStreamConstants.NAMESPACE;
+import static javax.xml.stream.XMLStreamConstants.NOTATION_DECLARATION;
+import static javax.xml.stream.XMLStreamConstants.PROCESSING_INSTRUCTION;
+import static javax.xml.stream.XMLStreamConstants.SPACE;
+import static javax.xml.stream.XMLStreamConstants.START_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.ee.EeMessages;
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+/**
+ * Parser for urn:jboss:ejb-client:1.0:jboss-ejb-client
+ *
+ * @author Jaikiran Pai
+ */
+class EJBClientDescriptor10Parser implements XMLElementReader<EJBClientDescriptorMetaData> {
+
+    public static final String NAMESPACE_1_0 = "urn:jboss:ejb-client:1.0";
+
+    public static final EJBClientDescriptor10Parser INSTANCE = new EJBClientDescriptor10Parser();
+
+
+    private EJBClientDescriptor10Parser() {
+    }
+
+
+    enum Element {
+        CLIENT_CONTEXT,
+        EJB_RECEIVERS,
+        JBOSS_EJB_CLIENT,
+        REMOTING_EJB_RECEIVER,
+        // default unknown element
+        UNKNOWN;
+
+        private static final Map<QName, Element> elements;
+
+        static {
+            Map<QName, Element> elementsMap = new HashMap<QName, Element>();
+            elementsMap.put(new QName(NAMESPACE_1_0, "jboss-ejb-client"), Element.JBOSS_EJB_CLIENT);
+            elementsMap.put(new QName(NAMESPACE_1_0, "client-context"), Element.CLIENT_CONTEXT);
+            elementsMap.put(new QName(NAMESPACE_1_0, "ejb-receivers"), Element.EJB_RECEIVERS);
+            elementsMap.put(new QName(NAMESPACE_1_0, "remoting-ejb-receiver"), Element.REMOTING_EJB_RECEIVER);
+            elements = elementsMap;
+        }
+
+        static Element of(QName qName) {
+            QName name;
+            if (qName.getNamespaceURI().equals("")) {
+                name = new QName(NAMESPACE_1_0, qName.getLocalPart());
+            } else {
+                name = qName;
+            }
+            final Element element = elements.get(name);
+            return element == null ? UNKNOWN : element;
+        }
+    }
+
+    enum Attribute {
+        OUTBOUND_CONNECTION_REF,
+
+        // default unknown attribute
+        UNKNOWN;
+
+        private static final Map<QName, Attribute> attributes;
+
+        static {
+            Map<QName, Attribute> attributesMap = new HashMap<QName, Attribute>();
+            attributesMap.put(new QName("outbound-connection-ref"), OUTBOUND_CONNECTION_REF);
+            attributes = attributesMap;
+        }
+
+        static Attribute of(QName qName) {
+            final Attribute attribute = attributes.get(qName);
+            return attribute == null ? UNKNOWN : attribute;
+        }
+    }
+
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+
+                    switch (element) {
+                        case CLIENT_CONTEXT:
+                            this.parseClientContext(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    this.unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseClientContext(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        final Set<Element> visited = EnumSet.noneOf(Element.class);
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    if (visited.contains(element)) {
+                        this.unexpectedElement(reader);
+                    }
+                    visited.add(element);
+                    switch (element) {
+                        case EJB_RECEIVERS:
+                            this.parseEJBReceivers(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseEJBReceivers(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case REMOTING_EJB_RECEIVER:
+                            this.parseRemotingReceiver(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseRemotingReceiver(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        String outboundConnectionRef = null;
+        final Set<Attribute> required = EnumSet.of(Attribute.OUTBOUND_CONNECTION_REF);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case OUTBOUND_CONNECTION_REF:
+                    outboundConnectionRef = reader.getAttributeValue(i).trim();
+                    ejbClientDescriptorMetaData.addRemotingReceiverConnectionRef(outboundConnectionRef);
+                    break;
+                default:
+                    unexpectedContent(reader);
+            }
+        }
+        if (!required.isEmpty()) {
+            missingAttributes(reader.getLocation(), required);
+        }
+    }
+
+    private static void unexpectedEndOfDocument(final Location location) throws XMLStreamException {
+        throw EeMessages.MESSAGES.errorParsingEJBClientDescriptor("Unexpected end of document", location);
+    }
+
+    private static void missingAttributes(final Location location, final Set<Attribute> required) throws XMLStreamException {
+        final StringBuilder b = new StringBuilder("Missing one or more required attributes:");
+        for (Attribute attribute : required) {
+            b.append(' ').append(attribute);
+        }
+        throw EeMessages.MESSAGES.errorParsingEJBClientDescriptor(b.toString(), location);
+    }
+
+    /**
+     * Throws a XMLStreamException for the unexpected element that was encountered during the parse
+     *
+     * @param reader the stream reader
+     * @throws XMLStreamException
+     */
+    public static void unexpectedElement(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        throw EeMessages.MESSAGES.unexpectedElement(reader.getName(), reader.getLocation());
+    }
+
+    private static void unexpectedContent(final XMLStreamReader reader) throws XMLStreamException {
+        final String kind;
+        switch (reader.getEventType()) {
+            case ATTRIBUTE:
+                kind = "attribute";
+                break;
+            case CDATA:
+                kind = "cdata";
+                break;
+            case CHARACTERS:
+                kind = "characters";
+                break;
+            case COMMENT:
+                kind = "comment";
+                break;
+            case DTD:
+                kind = "dtd";
+                break;
+            case END_DOCUMENT:
+                kind = "document end";
+                break;
+            case END_ELEMENT:
+                kind = "element end";
+                break;
+            case ENTITY_DECLARATION:
+                kind = "entity declaration";
+                break;
+            case ENTITY_REFERENCE:
+                kind = "entity ref";
+                break;
+            case NAMESPACE:
+                kind = "namespace";
+                break;
+            case NOTATION_DECLARATION:
+                kind = "notation declaration";
+                break;
+            case PROCESSING_INSTRUCTION:
+                kind = "processing instruction";
+                break;
+            case SPACE:
+                kind = "whitespace";
+                break;
+            case START_DOCUMENT:
+                kind = "document start";
+                break;
+            case START_ELEMENT:
+                kind = "element start";
+                break;
+            default:
+                kind = "unknown";
+                break;
+        }
+        final StringBuilder b = new StringBuilder("Unexpected content of type '").append(kind).append('\'');
+        if (reader.hasName()) {
+            b.append(" named '").append(reader.getName()).append('\'');
+        }
+        if (reader.hasText()) {
+            b.append(", text is: '").append(reader.getText()).append('\'');
+        }
+        throw EeMessages.MESSAGES.errorParsingEJBClientDescriptor(b.toString(), reader.getLocation());
+    }
+
+}

--- a/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptorParsingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptorParsingProcessor.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ee.structure;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.as.ee.EeMessages;
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.as.server.moduleservice.ServiceModuleLoader;
+import org.jboss.logging.Logger;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.staxmapper.XMLMapper;
+import org.jboss.vfs.VirtualFile;
+
+/**
+ * A deployment unit processor which parses jboss-ejb-client.xml in top level deployments.
+ * If a jboss-ejb-client.xml is found in the top level deployment, then this processor creates a {@link EJBClientDescriptorMetaData}
+ * out of it and attaches it to the deployment unit at {@link Attachments#EJB_CLIENT_METADATA}
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBClientDescriptorParsingProcessor implements DeploymentUnitProcessor {
+
+    private static final Logger logger = Logger.getLogger(EJBClientDescriptorParsingProcessor.class);
+
+    public static final String[] EJB_CLIENT_DESCRIPTOR_LOCATIONS = {"META-INF/jboss-ejb-client.xml", "WEB-INF/jboss-ejb-client.xml"};
+
+
+    private static final QName ROOT_1_0 = new QName(EJBClientDescriptor10Parser.NAMESPACE_1_0, "jboss-ejb-client");
+    private static final QName ROOT_NO_NAMESPACE = new QName("jboss-ejb-client");
+
+
+    private static final XMLInputFactory INPUT_FACTORY = XMLInputFactory.newInstance();
+
+    private final XMLMapper mapper;
+
+    public EJBClientDescriptorParsingProcessor() {
+        mapper = XMLMapper.Factory.create();
+        mapper.registerRootElement(ROOT_1_0, EJBClientDescriptor10Parser.INSTANCE);
+        mapper.registerRootElement(ROOT_NO_NAMESPACE, EJBClientDescriptor10Parser.INSTANCE);
+    }
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final ResourceRoot resourceRoot = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.DEPLOYMENT_ROOT);
+        final ServiceModuleLoader moduleLoader = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.SERVICE_MODULE_LOADER);
+
+        VirtualFile descriptorFile = null;
+        for (final String loc : EJB_CLIENT_DESCRIPTOR_LOCATIONS) {
+            final VirtualFile file = resourceRoot.getRoot().getChild(loc);
+            if (file.exists()) {
+                descriptorFile = file;
+                break;
+            }
+        }
+        if (descriptorFile == null) {
+            return;
+        }
+        if (deploymentUnit.getParent() != null) {
+            logger.warnf("%s in subdeployment ignored. jboss-ejb-client.xml is only parsed for top level deployments.", descriptorFile.getPathName());
+            return;
+        }
+        final File ejbClientDeploymentDescriptorFile;
+        try {
+            ejbClientDeploymentDescriptorFile = descriptorFile.getPhysicalFile();
+        } catch (IOException e) {
+            throw EeMessages.MESSAGES.failedToProcessEJBClientDescriptor(e);
+        }
+        final EJBClientDescriptorMetaData ejbClientDescriptorMetaData = parse(ejbClientDeploymentDescriptorFile, deploymentUnit, moduleLoader);
+        logger.debug("Successfully parsed jboss-ejb-client.xml for deployment unit " + deploymentUnit);
+        // attach the metadata
+        deploymentUnit.putAttachment(Attachments.EJB_CLIENT_METADATA, ejbClientDescriptorMetaData);
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+    private EJBClientDescriptorMetaData parse(final File file, final DeploymentUnit deploymentUnit, final ModuleLoader moduleLoader) throws DeploymentUnitProcessingException {
+        final FileInputStream fis;
+        try {
+            fis = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            throw EeMessages.MESSAGES.failedToProcessEJBClientDescriptor(e);
+        }
+        try {
+            return parse(fis, file, deploymentUnit, moduleLoader);
+        } finally {
+            safeClose(fis);
+        }
+    }
+
+    private EJBClientDescriptorMetaData parse(final InputStream source, final File file, final DeploymentUnit deploymentUnit, final ModuleLoader moduleLoader)
+            throws DeploymentUnitProcessingException {
+        try {
+
+            final XMLInputFactory inputFactory = INPUT_FACTORY;
+            setIfSupported(inputFactory, XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
+            setIfSupported(inputFactory, XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+            final XMLStreamReader streamReader = inputFactory.createXMLStreamReader(source);
+            try {
+                final EJBClientDescriptorMetaData result = new EJBClientDescriptorMetaData();
+                mapper.parseDocument(result, streamReader);
+                return result;
+            } finally {
+                safeClose(streamReader);
+            }
+        } catch (XMLStreamException e) {
+            throw EeMessages.MESSAGES.xmlErrorParsingEJBClientDescriptor(e, file.getAbsolutePath());
+        }
+    }
+
+    private void setIfSupported(final XMLInputFactory inputFactory, final String property, final Object value) {
+        if (inputFactory.isPropertySupported(property)) {
+            inputFactory.setProperty(property, value);
+        }
+    }
+
+    private static void safeClose(final Closeable closeable) {
+        if (closeable != null)
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                // ignore
+            }
+    }
+
+    private static void safeClose(final XMLStreamReader streamReader) {
+        if (streamReader != null)
+            try {
+                streamReader.close();
+            } catch (XMLStreamException e) {
+                // ignore
+            }
+    }
+}

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
@@ -54,6 +54,7 @@ import org.jboss.as.ee.naming.ApplicationContextProcessor;
 import org.jboss.as.ee.naming.ModuleContextProcessor;
 import org.jboss.as.ee.structure.ApplicationClientDeploymentProcessor;
 import org.jboss.as.ee.structure.ComponentAggregationProcessor;
+import org.jboss.as.ee.structure.EJBClientDescriptorParsingProcessor;
 import org.jboss.as.ee.structure.EarDependencyProcessor;
 import org.jboss.as.ee.structure.EarInitializationProcessor;
 import org.jboss.as.ee.structure.EarLibManifestClassPathProcessor;
@@ -119,6 +120,7 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_EAR_DEPLOYMENT_INIT, new EarInitializationProcessor());
                 processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_EAR_APP_XML_PARSE, new EarMetaDataParsingProcessor());
                 processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_EAR_JBOSS_APP_XML_PARSE, new JBossAppMetaDataParsingProcessor());
+                processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_JBOSS_EJB_CLIENT_XML_PARSE, new EJBClientDescriptorParsingProcessor());
                 processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_EJB_EAR_APPLICATION_NAME, new EarApplicationNameProcessor());
                 processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_EAR, new EarStructureProcessor());
                 processorTarget.addDeploymentProcessor(Phase.STRUCTURE, Phase.STRUCTURE_EJB_JAR_IN_EAR, new EjbJarDeploymentProcessor());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.deployment.processors;
+
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.as.ee.structure.Attachments;
+import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
+import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
+import org.jboss.as.ejb3.remote.DescriptorBasedEJBClientContextService;
+import org.jboss.as.remoting.AbstractOutboundConnectionService;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * A deployment unit processor which processing only top level deployment units and checks for the presence
+ * of a {@link Attachments#EJB_CLIENT_METADATA} key corresponding to {@link EJBClientDescriptorMetaData}, in the
+ * deployment unit.
+ * <p/>
+ * If a {@link EJBClientDescriptorMetaData} is available then this deployment unit processor
+ * creates and installs a {@link DescriptorBasedEJBClientContextService}. It then attaches the
+ * {@link ServiceName name of the installed service} to the deployment unit at {@link EjbDeploymentAttachmentKeys#EJB_CLIENT_CONTEXT_SERVICE_NAME}
+ * <p/>
+ * If the deployment unit doesn't have a {@link EJBClientDescriptorMetaData} then this processors attaches
+ * {@link DefaultEjbClientContextService#DEFAULT_SERVICE_NAME} as the {@link EjbDeploymentAttachmentKeys#EJB_CLIENT_CONTEXT_SERVICE_NAME}
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProcessor {
+
+    private static final Logger logger = Logger.getLogger(EJBClientDescriptorMetaDataProcessor.class);
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        // we only process top level deployment units
+        if (deploymentUnit.getParent() != null) {
+            return;
+        }
+        final EJBClientDescriptorMetaData ejbClientDescriptorMetaData = deploymentUnit.getAttachment(Attachments.EJB_CLIENT_METADATA);
+        if (ejbClientDescriptorMetaData == null) {
+            logger.debug("Deployment unit " + deploymentUnit + " doesn't have any EJB client descriptor metadata associated. " +
+                    "Falling back on the default " + DefaultEjbClientContextService.DEFAULT_SERVICE_NAME + " EJB client context service");
+            // no client descriptor, so fallback to default EJB client context service
+            deploymentUnit.putAttachment(EjbDeploymentAttachmentKeys.EJB_CLIENT_CONTEXT_SERVICE_NAME, DefaultEjbClientContextService.DEFAULT_SERVICE_NAME);
+            return;
+        }
+        // install the descriptor based EJB client context service
+        final ServiceName ejbClientContextServiceName = DescriptorBasedEJBClientContextService.BASE_SERVICE_NAME.append(deploymentUnit.getName());
+        final ServiceTarget serviceTarget = phaseContext.getServiceTarget();
+        // create the service
+        final DescriptorBasedEJBClientContextService service = new DescriptorBasedEJBClientContextService();
+        // add the service
+        final ServiceBuilder serviceBuilder = serviceTarget.addService(ejbClientContextServiceName, service);
+        // add the remoting connection reference dependencies
+        for (final String connectionRef : ejbClientDescriptorMetaData.getRemotingReceiverConnectionRefs()) {
+            final ServiceName connectionDependencyService = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionRef);
+            service.addRemotingConnectionDependency(serviceBuilder, connectionDependencyService);
+        }
+        // install the service
+        serviceBuilder.install();
+        logger.debug("Deployment unit " + deploymentUnit + " will use " + ejbClientContextServiceName + " as the EJB client context service");
+
+        // attach the service name of this EJB client context to the deployment unit
+        deploymentUnit.putAttachment(EjbDeploymentAttachmentKeys.EJB_CLIENT_CONTEXT_SERVICE_NAME, ejbClientContextServiceName);
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
@@ -41,7 +41,7 @@ import org.jboss.msc.value.InjectedValue;
  *
  * @author Stuart Douglas
  */
-public class EjbClientContextService implements Service<EJBClientContext> {
+public class DefaultEjbClientContextService implements Service<EJBClientContext> {
 
     /**
      * The base service name for these services

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.remoting.AbstractOutboundConnectionService;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.remoting.IoFutureHelper;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.remoting3.Connection;
+import org.xnio.IoFuture;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class DescriptorBasedEJBClientContextService implements Service<EJBClientContext> {
+
+    public static final ServiceName BASE_SERVICE_NAME = ServiceName.JBOSS.append("ejb3", "dd-based-ejb-client-context");
+
+    private static final Logger logger = Logger.getLogger(DescriptorBasedEJBClientContextService.class);
+
+    private static final long DEFAULT_CONNECTION_TIMEOUT = 5000L;
+
+    /**
+     * The outbound connection references from which the remoting EJB receivers will be created
+     */
+    private final List<InjectedValue<AbstractOutboundConnectionService>> remotingOutboundConnections = new ArrayList<InjectedValue<AbstractOutboundConnectionService>>();
+
+    /**
+     * The client context
+     */
+    private volatile EJBClientContext ejbClientContext;
+
+    @Override
+    public synchronized void start(StartContext startContext) throws StartException {
+        final Collection<Connection> connections = this.createRemotingConnections();
+        // setup the context with the receivers
+        EJBClientContext context = EJBClientContext.create();
+        for (final Connection conection : connections) {
+            context.registerConnection(conection);
+        }
+        logger.debug("Descriptor based EJB client context created with " + connections.size() + " remoting EJB receivers");
+        this.ejbClientContext = context;
+    }
+
+    @Override
+    public synchronized void stop(StopContext context) {
+        this.ejbClientContext = null;
+    }
+
+    @Override
+    public EJBClientContext getValue() throws IllegalStateException, IllegalArgumentException {
+        return this.ejbClientContext;
+    }
+
+    public void addRemotingConnectionDependency(final ServiceBuilder<EJBClientContext> serviceBuilder, final ServiceName serviceName) {
+        final InjectedValue<AbstractOutboundConnectionService> value = new InjectedValue<AbstractOutboundConnectionService>();
+        serviceBuilder.addDependency(serviceName, AbstractOutboundConnectionService.class, value);
+        remotingOutboundConnections.add(value);
+    }
+
+    private Collection<Connection> createRemotingConnections() {
+        final Collection<Connection> connections = new ArrayList<Connection>();
+
+        for (final InjectedValue<AbstractOutboundConnectionService> injectedValue : this.remotingOutboundConnections) {
+            final AbstractOutboundConnectionService outboundConnectionService = injectedValue.getValue();
+            final String connectionName = outboundConnectionService.getConnectionName();
+            logger.debug("Creating remoting EJB receiver for connection " + connectionName);
+            try {
+                final IoFuture<Connection> futureConnection = outboundConnectionService.connect();
+                // TODO: Make the timeout configurable
+                final Connection connection = IoFutureHelper.get(futureConnection, DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+                // add it to the successful connection list to be returned
+                connections.add(connection);
+
+            } catch (IOException ioe) {
+                // just log a WARN and move on to the next
+                logger.warn(connectionName + " connection will not be used for EJB client context due " +
+                        "to error during connection creation", ioe);
+            }
+        }
+        return connections;
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -33,11 +33,13 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.ee.structure.EJBClientDescriptorParsingProcessor;
 import org.jboss.as.ejb3.component.EJBUtilities;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.processors.ApplicationExceptionAnnotationProcessor;
 import org.jboss.as.ejb3.deployment.processors.BusinessViewAnnotationProcessor;
 import org.jboss.as.ejb3.deployment.processors.DeploymentRepositoryProcessor;
+import org.jboss.as.ejb3.deployment.processors.EJBClientDescriptorMetaDataProcessor;
 import org.jboss.as.ejb3.deployment.processors.EjbCleanUpProcessor;
 import org.jboss.as.ejb3.deployment.processors.EjbClientContextParsingProcessor;
 import org.jboss.as.ejb3.deployment.processors.EjbClientContextSetupProcessor;
@@ -83,7 +85,7 @@ import org.jboss.as.ejb3.deployment.processors.merging.TransactionAttributeMergi
 import org.jboss.as.ejb3.deployment.processors.merging.TransactionManagementMergingProcessor;
 import org.jboss.as.ejb3.iiop.POARegistry;
 import org.jboss.as.ejb3.deployment.processors.security.JaccEjbDeploymentProcessor;
-import org.jboss.as.ejb3.remote.EjbClientContextService;
+import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
 import org.jboss.as.ejb3.remote.LocalEjbReceiver;
 import org.jboss.as.ejb3.remote.TCCLBasedEJBClientContextSelector;
 import org.jboss.as.jacorb.service.CorbaPOAService;
@@ -154,6 +156,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_SESSION_BEAN_DD, new SessionBeanXmlDescriptorProcessor(appclient));
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_ANNOTATION_EJB, new EjbAnnotationProcessor());
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_INJECTION_ANNOTATION, new EjbResourceInjectionAnnotationProcessor());
+                processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_CLIENT_METADATA, new EJBClientDescriptorMetaDataProcessor());
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_ENTITY_BEAN_CREATE_COMPONENT_DESCRIPTIONS, new EntityBeanComponentDescriptionFactory(appclient));
 
                 processorTarget.addDeploymentProcessor(Phase.DEPENDENCIES, Phase.DEPENDENCIES_EJB, new EjbDependencyDeploymentUnitProcessor());
@@ -271,8 +274,8 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         //add the default EjbClientContext
         //TODO: This should be managed
-        final EjbClientContextService clientContextService = new EjbClientContextService();
-        final ServiceBuilder<EJBClientContext> clientContextServiceBuilder = context.getServiceTarget().addService(EjbClientContextService.DEFAULT_SERVICE_NAME,
+        final DefaultEjbClientContextService clientContextService = new DefaultEjbClientContextService();
+        final ServiceBuilder<EJBClientContext> clientContextServiceBuilder = context.getServiceTarget().addService(DefaultEjbClientContextService.DEFAULT_SERVICE_NAME,
                 clientContextService).addDependency(TCCLBasedEJBClientContextSelector.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME,
                 TCCLBasedEJBClientContextSelector.class, clientContextService.getTCCLBasedEJBClientContextSelectorInjector());
 

--- a/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -210,6 +210,41 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
         }
     }
 
+    /**
+     * Tests that the outbound connections configured in the remoting subsytem are processed and services
+     * are created for them
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testOutboundConnections() throws Exception {
+        final int outboundSocketBindingPort = 6799;
+        final int socketBindingPort = 1234;
+        KernelServices services = installInController(new AdditionalInitialization(){
+                @Override
+                protected void setupController(ControllerInitializer controllerInitializer) {
+                    controllerInitializer.addSocketBinding("test", socketBindingPort);
+                    controllerInitializer.addRemoteOutboundSocketBinding("dummy-outbound-socket", "localhost", outboundSocketBindingPort);
+                    controllerInitializer.addRemoteOutboundSocketBinding("other-outbound-socket", "localhost", outboundSocketBindingPort);
+                }
+
+            },readResource("remoting-with-outbound-connections.xml"));
+
+        ServiceController<?> endPointService = services.getContainer().getRequiredService(RemotingServices.SUBSYSTEM_ENDPOINT);
+        assertNotNull("Endpoint service was null", endPointService);
+
+        final String remoteOutboundConnectionName = "remote-conn1";
+        ServiceName remoteOutboundConnectionServiceName = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(remoteOutboundConnectionName);
+        ServiceController<?> remoteOutboundConnectionService = services.getContainer().getRequiredService(remoteOutboundConnectionServiceName);
+        assertNotNull("Remote outbound connection service for outbound connection:" + remoteOutboundConnectionName + " was null", remoteOutboundConnectionService);
+
+
+        final String localOutboundConnectionName = "local-conn1";
+        ServiceName localOutboundConnectionServiceName = LocalOutboundConnectionService.LOCAL_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(localOutboundConnectionName);
+        ServiceController<?> localOutboundConnectionService = services.getContainer().getRequiredService(localOutboundConnectionServiceName);
+        assertNotNull("Local outbound connection service for outbound connection:" + localOutboundConnectionName + " was null", localOutboundConnectionService);
+    }
+
     @Override
     protected String getSubsystemXml() throws IOException {
         return readResource("remoting.xml");

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
@@ -1,0 +1,16 @@
+<subsystem xmlns="urn:jboss:domain:remoting:1.1"
+    worker-read-threads="5"
+    worker-task-core-threads="6"
+    worker-task-keepalive="7"
+    worker-task-limit="8"
+    worker-task-max-threads="9"
+    worker-write-threads="10"
+>
+    <connector name="test-connector" socket-binding="test"/>
+
+    <outbound-connections>
+        <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket"/>
+        <local-outbound-connection name="local-conn1" outbound-socket-binding-ref="other-outbound-socket"/>
+    </outbound-connections>
+</subsystem>
+

--- a/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionService.java
@@ -47,7 +47,10 @@ public abstract class AbstractOutboundConnectionService<T extends AbstractOutbou
 
     protected volatile OptionMap connectionCreationOptions;
 
-    protected AbstractOutboundConnectionService(final OptionMap connectionCreationOptions) {
+    protected final String connectionName;
+
+    protected AbstractOutboundConnectionService(final String connectionName, final OptionMap connectionCreationOptions) {
+        this.connectionName = connectionName;
         this.connectionCreationOptions = connectionCreationOptions == null ? OptionMap.EMPTY : connectionCreationOptions;
     }
 
@@ -68,5 +71,9 @@ public abstract class AbstractOutboundConnectionService<T extends AbstractOutbou
     }
 
 
-    abstract IoFuture<Connection> connect() throws IOException;
+    public String getConnectionName() {
+        return this.connectionName;
+    }
+
+    public abstract IoFuture<Connection> connect() throws IOException;
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionService.java
@@ -22,6 +22,10 @@
 
 package org.jboss.as.remoting;
 
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
 import java.io.IOException;
 
 import org.jboss.msc.inject.Injector;
@@ -76,4 +80,25 @@ public abstract class AbstractOutboundConnectionService<T extends AbstractOutbou
     }
 
     public abstract IoFuture<Connection> connect() throws IOException;
+
+    protected CallbackHandler getCallbackHandler() {
+        return new AnonymousCallbackHandler();
+    }
+
+    // TODO: This is temporary for now, till we decide about security related configurations
+    // for outbound connections, post Beta1
+    private class AnonymousCallbackHandler implements CallbackHandler {
+
+        @Override
+        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+            for (Callback current : callbacks) {
+                if (current instanceof NameCallback) {
+                    NameCallback ncb = (NameCallback) current;
+                    ncb.setName("anonymous");
+                } else {
+                    throw new UnsupportedCallbackException(current);
+                }
+            }
+        }
+    }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
@@ -103,10 +103,10 @@ class GenericOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler 
         // Get the destination URI
         final URI uri = getDestinationURI(context, outboundConnection);
         // create the service
-        final GenericOutboundConnectionService outboundRemotingConnectionService = new GenericOutboundConnectionService(uri, connectionCreationOptions);
+        final GenericOutboundConnectionService outboundRemotingConnectionService = new GenericOutboundConnectionService(connectionName, uri, connectionCreationOptions);
         final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
         // also add a alias service name to easily distinguish between a generic, remote and local type of connection services
-        final ServiceName aliasServiceName = GenericOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName aliasServiceName = GenericOutboundConnectionService.GENERIC_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
         final ServiceBuilder<GenericOutboundConnectionService> svcBuilder = context.getServiceTarget().addService(serviceName, outboundRemotingConnectionService)
                 .addAliases(aliasServiceName)
                 .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, outboundRemotingConnectionService.getEnpointInjector());

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionService.java
@@ -45,9 +45,9 @@ public class GenericOutboundConnectionService extends AbstractOutboundConnection
 
     private volatile URI destination;
 
-    public GenericOutboundConnectionService(final URI destination, final OptionMap connectionCreationOptions) {
+    public GenericOutboundConnectionService(final String connectionName, final URI destination, final OptionMap connectionCreationOptions) {
 
-        super(connectionCreationOptions);
+        super(connectionName, connectionCreationOptions);
 
         if (destination == null) {
             throw new IllegalArgumentException("Destination URI cannot be null while creating a outbound remote connection service");
@@ -56,7 +56,7 @@ public class GenericOutboundConnectionService extends AbstractOutboundConnection
     }
 
     @Override
-    IoFuture<Connection> connect() throws IOException {
+    public IoFuture<Connection> connect() throws IOException {
         final Endpoint endpoint = this.endpointInjectedValue.getValue();
         return endpoint.connect(this.destination, this.connectionCreationOptions);
     }

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionService.java
@@ -58,7 +58,7 @@ public class GenericOutboundConnectionService extends AbstractOutboundConnection
     @Override
     public IoFuture<Connection> connect() throws IOException {
         final Endpoint endpoint = this.endpointInjectedValue.getValue();
-        return endpoint.connect(this.destination, this.connectionCreationOptions);
+        return endpoint.connect(this.destination, this.connectionCreationOptions, getCallbackHandler());
     }
 
     @Override

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
@@ -102,10 +102,10 @@ class LocalOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler {
         // fetch the connection creation options from the model
         final OptionMap connectionCreationOptions = getConnectionCreationOptions(outboundConnection);
         // create the service
-        final LocalOutboundConnectionService outboundConnectionService = new LocalOutboundConnectionService(connectionCreationOptions);
+        final LocalOutboundConnectionService outboundConnectionService = new LocalOutboundConnectionService(connectionName, connectionCreationOptions);
         final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
         // also add a alias service name to easily distinguish between a generic, remote and local type of connection services
-        final ServiceName aliasServiceName = LocalOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName aliasServiceName = LocalOutboundConnectionService.LOCAL_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
         final ServiceBuilder<LocalOutboundConnectionService> svcBuilder = context.getServiceTarget().addService(serviceName, outboundConnectionService)
                 .addAliases(aliasServiceName)
                 .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, outboundConnectionService.getEnpointInjector())

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionService.java
@@ -68,7 +68,7 @@ public class LocalOutboundConnectionService extends AbstractOutboundConnectionSe
             throw new RuntimeException(e);
         }
         final Endpoint endpoint = this.endpointInjectedValue.getValue();
-        return endpoint.connect(uri, this.connectionCreationOptions);
+        return endpoint.connect(uri, this.connectionCreationOptions, getCallbackHandler());
     }
 
     Injector<OutboundSocketBinding> getDestinationOutboundSocketBindingInjector() {

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionService.java
@@ -51,13 +51,13 @@ public class LocalOutboundConnectionService extends AbstractOutboundConnectionSe
 
     private URI connectionURI;
 
-    public LocalOutboundConnectionService(final OptionMap connectionCreationOptions) {
-        super(connectionCreationOptions);
+    public LocalOutboundConnectionService(final String connectionName, final OptionMap connectionCreationOptions) {
+        super(connectionName, connectionCreationOptions);
     }
 
 
     @Override
-    IoFuture<Connection> connect() throws IOException {
+    public IoFuture<Connection> connect() throws IOException {
         final URI uri;
         try {
             // we lazily generate the URI on first request to connect() instead of on start() of the service

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
@@ -102,10 +102,10 @@ class RemoteOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler {
         // fetch the connection creation options from the model
         final OptionMap connectionCreationOptions = getConnectionCreationOptions(remoteOutboundConnection);
         // create the service
-        final RemoteOutboundConnectionService outboundConnectionService = new RemoteOutboundConnectionService(connectionCreationOptions);
+        final RemoteOutboundConnectionService outboundConnectionService = new RemoteOutboundConnectionService(connectionName, connectionCreationOptions);
         final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
         // also add a alias service name to easily distinguish between a generic, remote and local type of connection services
-        final ServiceName aliasServiceName = RemoteOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
+        final ServiceName aliasServiceName = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);
         final ServiceBuilder<RemoteOutboundConnectionService> svcBuilder = context.getServiceTarget().addService(serviceName, outboundConnectionService)
                 .addAliases(aliasServiceName)
                 .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, outboundConnectionService.getEnpointInjector())

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -89,7 +89,7 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
             throw new RuntimeException(e);
         }
         final Endpoint endpoint = this.endpointInjectedValue.getValue();
-        return endpoint.connect(uri, this.connectionCreationOptions);
+        return endpoint.connect(uri, this.connectionCreationOptions, getCallbackHandler());
     }
 
     Injector<OutboundSocketBinding> getDestinationOutboundSocketBindingInjector() {

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -54,8 +54,8 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
 
     private URI connectionURI;
 
-    public RemoteOutboundConnectionService(final OptionMap connectionCreationOptions) {
-        super(connectionCreationOptions);
+    public RemoteOutboundConnectionService(final String connectionName, final OptionMap connectionCreationOptions) {
+        super(connectionName, connectionCreationOptions);
     }
 
     @Override
@@ -78,7 +78,7 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
     }
 
     @Override
-    IoFuture<Connection> connect() throws IOException {
+    public IoFuture<Connection> connect() throws IOException {
         final URI uri;
         try {
             // we lazily generate the URI on first request to connect() instead of on start() of the service

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
@@ -42,7 +42,6 @@ import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
 import static org.jboss.as.remoting.CommonAttributes.FORWARD_SECRECY;
 import static org.jboss.as.remoting.CommonAttributes.INCLUDE_MECHANISMS;
 import static org.jboss.as.remoting.CommonAttributes.LOCAL_OUTBOUND_CONNECTION;
-import static org.jboss.as.remoting.CommonAttributes.NAME;
 import static org.jboss.as.remoting.CommonAttributes.NO_ACTIVE;
 import static org.jboss.as.remoting.CommonAttributes.NO_ANONYMOUS;
 import static org.jboss.as.remoting.CommonAttributes.NO_DICTIONARY;
@@ -639,28 +638,31 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             if (model.hasDefined(OUTBOUND_CONNECTION)) {
                 final List<Property> outboundConnections = model.get(OUTBOUND_CONNECTION).asPropertyList();
                 for (Property property : outboundConnections) {
+                    final String connectionName = property.getName();
                     // get the specific outbound-connection
                     final ModelNode genericOutboundConnectionModel = property.getValue();
                     // process and write outbound connection
-                    this.writeOutboundConnection(writer, genericOutboundConnectionModel);
+                    this.writeOutboundConnection(writer, connectionName, genericOutboundConnectionModel);
                 }
             }
             if (model.hasDefined(REMOTE_OUTBOUND_CONNECTION)) {
                 final List<Property> remoteOutboundConnections = model.get(REMOTE_OUTBOUND_CONNECTION).asPropertyList();
                 for (Property property : remoteOutboundConnections) {
+                    final String connectionName = property.getName();
                     // get the specific remote outbound connection
                     final ModelNode remoteOutboundConnectionModel = property.getValue();
                     // process and write remote outbound connection
-                    this.writeRemoteOutboundConnection(writer, remoteOutboundConnectionModel);
+                    this.writeRemoteOutboundConnection(writer, connectionName, remoteOutboundConnectionModel);
                 }
             }
             if (model.hasDefined(LOCAL_OUTBOUND_CONNECTION)) {
                 final List<Property> localOutboundConnections = model.get(LOCAL_OUTBOUND_CONNECTION).asPropertyList();
                 for (Property property : localOutboundConnections) {
+                    final String connectionName = property.getName();
                     // get the specific local outbound connection
                     final ModelNode localOutboundConnectionModel = property.getValue();
                     // process and write local outbound connection
-                    this.writeLocalOutboundConnection(writer, localOutboundConnectionModel);
+                    this.writeLocalOutboundConnection(writer, connectionName, localOutboundConnectionModel);
 
                 }
             }
@@ -729,11 +731,10 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeEndElement();
     }
 
-    private void writeOutboundConnection(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
+    private void writeOutboundConnection(final XMLExtendedStreamWriter writer, final String connectionName, final ModelNode model) throws XMLStreamException {
         // <outbound-connection>
         writer.writeStartElement(Element.OUTBOUND_CONNECTION.getLocalName());
 
-        final String connectionName = model.get(NAME).asString();
         writer.writeAttribute(Attribute.NAME.getLocalName(), connectionName);
 
         final String uri = model.get(URI).asString();
@@ -748,11 +749,10 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeEndElement();
     }
 
-    private void writeRemoteOutboundConnection(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
+    private void writeRemoteOutboundConnection(final XMLExtendedStreamWriter writer, final String connectionName, final ModelNode model) throws XMLStreamException {
         // <remote-outbound-connection>
         writer.writeStartElement(Element.REMOTE_OUTBOUND_CONNECTION.getLocalName());
 
-        final String connectionName = model.get(NAME).asString();
         writer.writeAttribute(Attribute.NAME.getLocalName(), connectionName);
 
         final String outboundSocketRef = model.get(OUTBOUND_SOCKET_BINDING_REF).asString();
@@ -767,11 +767,10 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeEndElement();
     }
 
-    private void writeLocalOutboundConnection(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
+    private void writeLocalOutboundConnection(final XMLExtendedStreamWriter writer, final String connectionName, final ModelNode model) throws XMLStreamException {
         // <local-outbound-connection>
         writer.writeStartElement(Element.LOCAL_OUTBOUND_CONNECTION.getLocalName());
 
-        final String connectionName = model.get(NAME).asString();
         writer.writeAttribute(Attribute.NAME.getLocalName(), connectionName);
 
         final String outboundSocketRef = model.get(OUTBOUND_SOCKET_BINDING_REF).asString();

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -186,6 +186,7 @@ public enum Phase {
     public static final int STRUCTURE_EAR_DEPLOYMENT_INIT               = 0x0600;
     public static final int STRUCTURE_EAR_APP_XML_PARSE                 = 0x0700;
     public static final int STRUCTURE_EAR_JBOSS_APP_XML_PARSE           = 0x0800;
+    public static final int STRUCTURE_JBOSS_EJB_CLIENT_XML_PARSE        = 0x0825;
     public static final int STRUCTURE_EJB_EAR_APPLICATION_NAME          = 0x0850;
     public static final int STRUCTURE_EAR                               = 0x0900;
     public static final int STRUCTURE_APP_CLIENT                        = 0x0950;
@@ -225,6 +226,7 @@ public enum Phase {
     // create and attach EJB metadata for EJB deployments
     public static final int PARSE_EJB_DEPLOYMENT                        = 0x1100;
     public static final int PARSE_APP_CLIENT_XML                        = 0x1101;
+    public static final int PARSE_EJB_CLIENT_METADATA                   = 0x1102;
     public static final int PARSE_SESSION_BEAN_CREATE_COMPONENT_DESCRIPTIONS     = 0x1150;
     public static final int PARSE_MDB_CREATE_COMPONENT_DESCRIPTIONS     = 0x1151;
     public static final int PARSE_ENTITY_BEAN_CREATE_COMPONENT_DESCRIPTIONS = 0x1152;

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/DelegateEchoBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/DelegateEchoBean.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.client.descriptor;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(RemoteEcho.class)
+public class DelegateEchoBean implements RemoteEcho {
+
+    @Override
+    public String echo(String moduleName, String msg) {
+        return msg;
+    }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
@@ -1,0 +1,173 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.client.descriptor;
+
+import javax.ejb.EJBException;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.container.Authentication;
+import org.jboss.as.test.integration.ejb.remote.common.EJBRemoteManagementUtil;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that deployments containing a jboss-ejb-client.xml are processed correctly for EJB client context
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EJBClientDescriptorTestCase {
+
+    private static final Logger logger = Logger.getLogger(EJBClientDescriptorTestCase.class);
+
+    private static final String APP_NAME = "";
+    private static final String DISTINCT_NAME = "";
+
+    private static final String MODULE_NAME_ONE = "ejb-client-descriptor-test";
+    private static final String MODULE_NAME_TWO = "ejb-client-descriptor-with-no-receiver-test";
+
+    private static Context context;
+
+    private static final String outboundSocketName = "ejb-client-descriptor-test-outbound-socket";
+    private static final String outboundConnectionName = "ejb-client-descriptor-test-remote-outbound-connection";
+
+    private static boolean outboundSocketCreated;
+    private static boolean outboundConnectionCreated;
+
+
+    @Deployment(name = "good-client-config", testable = false)
+    public static Archive createDeployment() throws Exception {
+        setupRemoteOutboundConnection();
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME_ONE + ".jar");
+        jar.addPackage(EchoBean.class.getPackage());
+        jar.addAsManifestResource("ejb/client/descriptor/jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        return jar;
+    }
+
+    @Deployment(name = "no-ejb-receiver-client-config", testable = false)
+    public static Archive createAnotherDeployment() throws Exception {
+        setupRemoteOutboundConnection();
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME_TWO + ".jar");
+        jar.addPackage(EchoBean.class.getPackage());
+        jar.addAsManifestResource("ejb/client/descriptor/no-ejb-receiver-jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        return jar;
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        context = new InitialContext(props);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (outboundSocketCreated) {
+            EJBRemoteManagementUtil.removeLocalOutboundSocket("localhost", 9999, "standard-sockets", outboundSocketName, Authentication.getCallbackHandler());
+            logger.info("Removed local outbound socket " + outboundSocketName);
+        }
+        if (outboundConnectionCreated) {
+            EJBRemoteManagementUtil.removeRemoteOutboundConnection("localhost", 9999, outboundConnectionName, Authentication.getCallbackHandler());
+            logger.info("Removed remote outbound connection " + outboundConnectionName);
+        }
+    }
+
+    private static void setupRemoteOutboundConnection() throws Exception {
+        if (!outboundSocketCreated) {
+            final String socketBindingRef = "remoting";
+            EJBRemoteManagementUtil.createLocalOutboundSocket("localhost", 9999, "standard-sockets", outboundSocketName, socketBindingRef, Authentication.getCallbackHandler());
+            outboundSocketCreated = true;
+            logger.info("Created local outbound socket " + outboundSocketName);
+        }
+
+        if (!outboundConnectionCreated) {
+            final Map<String, String> connectionCreationOptions = new HashMap<String, String>();
+            connectionCreationOptions.put("SSL_ENABLED", "false");
+            connectionCreationOptions.put("SASL_POLICY_NOANONYMOUS", "false");
+
+            EJBRemoteManagementUtil.createRemoteOutboundConnection("localhost", 9999, outboundConnectionName, outboundSocketName, connectionCreationOptions, Authentication.getCallbackHandler());
+            outboundConnectionCreated = true;
+            logger.info("Created remote outbound connection " + outboundConnectionName);
+        }
+    }
+
+    /**
+     * Tests that a deployment containing jboss-ejb-client.xml with remoting EJB receivers configured, works as expected
+     *
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment("good-client-config")
+    public void testEJBClientContextConfiguration() throws Exception {
+        final RemoteEcho remoteEcho = (RemoteEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME_ONE + "/" + DISTINCT_NAME
+                + "/" + EchoBean.class.getSimpleName() + "!" + RemoteEcho.class.getName());
+        Assert.assertNotNull("Lookup returned a null bean proxy", remoteEcho);
+        final String msg = "Hello world from a EJB client descriptor test!!!";
+        final String echo = remoteEcho.echo(MODULE_NAME_ONE, msg);
+        logger.info("Received echo " + echo);
+        Assert.assertEquals("Unexpected echo returned from remote bean", msg, echo);
+    }
+
+    /**
+     * Tests that a deployment with a jboss-ejb-client.xml with no EJB receivers configured, fails due to
+     * non-availability of EJB receivers in the EJB client context
+     *
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment("no-ejb-receiver-client-config")
+    public void testEJBClientContextWithNoReceiversConfiguration() throws Exception {
+        final RemoteEcho remoteEcho = (RemoteEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME_TWO + "/" + DISTINCT_NAME
+                + "/" + EchoBean.class.getSimpleName() + "!" + RemoteEcho.class.getName());
+        Assert.assertNotNull("Lookup returned a null bean proxy", remoteEcho);
+        final String msg = "Hello world from a EJB client descriptor test!!!";
+        try {
+            final String echo = remoteEcho.echo(MODULE_NAME_TWO, msg);
+            Assert.fail("Exepcted to fail due to no EJB receivers availability");
+        } catch (EJBException e) {
+            // no EJB receivers available, so expected to fail
+            logger.info("Received the expected exception during testing with no EJB receivers", e);
+            // TODO: We could even narrow down into the exception to ensure we got the right exception.
+            // But that's a bit brittle too since there's no guarantee in terms of API on what underlying
+            // exception will be thrown for non-availability of EJB receivers.
+        }
+    }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EchoBean.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EchoBean.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.client.descriptor;
+
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.naming.Context;
+
+import java.util.Hashtable;
+
+import org.jboss.as.naming.InitialContext;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(RemoteEcho.class)
+public class EchoBean implements RemoteEcho {
+
+    @Override
+    public String echo(final String moduleName, final String msg) {
+        try {
+            final Hashtable props = new Hashtable();
+            props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+            final Context context = new javax.naming.InitialContext(props);
+            RemoteEcho delegate = (RemoteEcho) context.lookup("ejb:" + "" + "/" + moduleName + "/" + "" + "/" + DelegateEchoBean.class.getSimpleName() + "!" + RemoteEcho.class.getName());
+            return delegate.echo(moduleName, msg);
+            
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/RemoteEcho.java
+++ b/testsuite/integration/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/RemoteEcho.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.client.descriptor;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface RemoteEcho {
+
+    String echo(String moduleName, String msg);
+}

--- a/testsuite/integration/src/test/resources/ejb/client/descriptor/jboss-ejb-client.xml
+++ b/testsuite/integration/src/test/resources/ejb/client/descriptor/jboss-ejb-client.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
+    <client-context>
+        <ejb-receivers>
+            <remoting-ejb-receiver outbound-connection-ref="ejb-client-descriptor-test-remote-outbound-connection"/>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>
+

--- a/testsuite/integration/src/test/resources/ejb/client/descriptor/no-ejb-receiver-jboss-ejb-client.xml
+++ b/testsuite/integration/src/test/resources/ejb/client/descriptor/no-ejb-receiver-jboss-ejb-client.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
+    <client-context>
+        <ejb-receivers>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>
+


### PR DESCRIPTION
This branch implements the support that's outlined in https://issues.jboss.org/browse/AS7-1934, for configuring EJB client context via a deployment descriptor. The commits in the branch include:

1) Support for a jboss-ejb-client.xml which will be processed (only) for top level deployments
2) Ability to configure a EJB client context with receivers in the jboss-ejb-client.xml:

```
    <jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
        <client-context>
            <ejb-receivers>
                <remoting-ejb-receiver outbound-connection-ref="ejb-client-descriptor-test-remote-outbound-connection"/>
            </ejb-receivers>
        </client-context>
    </jboss-ejb-client>
```

3) Ability to setup the receiver to refer to a named outbound connection that's setup in the remoting subsystem:

```
    <remoting-ejb-receiver outbound-connection-ref="ejb-client-descriptor-test-remote-outbound-connection"/>
```

4) A few bug fixes in remoting outbound connection setup
5) Testcases for setting up of remoting outbound connections and also processing of jboss-ejb-client.xml deployment descriptors.
