### PR TITLE
[JBQA-5451] EJBTHREE->AS7: ejbthree989 (inject URL as @Resource)

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/ResUrlChecker.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/ResUrlChecker.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2007, Red Hat Middleware LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ee.injection.url;
+
+import java.net.URL;
+
+/**
+ * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
+ */
+public interface ResUrlChecker {
+    URL getURL1();
+
+    URL getURL2();
+
+    URL getURL3();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/ResUrlCheckerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/ResUrlCheckerBean.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2007, Red Hat Middleware LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ee.injection.url;
+
+import java.net.URL;
+
+import javax.annotation.Resource;
+import javax.annotation.Resources;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Let's see what we can do with resources of the URL breed.
+ * 
+ * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
+ */
+@Stateless
+@Remote(ResUrlChecker.class)
+// @Resources({ @Resource(name = "url3", type = java.net.URL.class, mappedName = "http://localhost/url3") })
+public class ResUrlCheckerBean implements ResUrlChecker {
+    // @Resource(mappedName = "http://localhost")
+    private URL url1;
+
+    // coming in via res-url
+    @Resource(name = "url2")
+    private URL url2;
+
+    public URL getURL1() {
+        return url1;
+    }
+
+    public URL getURL2() {
+        return url2;
+    }
+
+    public URL getURL3() {
+        try {
+            return (URL) new InitialContext().lookup("java:comp/env/url3");
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/ResUrlCheckerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/ResUrlCheckerTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2007, Red Hat Middleware LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ee.injection.url;
+
+import java.net.URL;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Migration test from EJB Testsuite (ejbthree-989) to AS7 [JIRA JBQA-5483].
+ * 
+ * Test to see if resources of type URL work.
+ * 
+ * @author Carlo de Wolf, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+public class ResUrlCheckerTestCase {
+    private static final Logger log = Logger.getLogger(ResUrlCheckerTestCase.class);
+
+    @ArquillianResource
+    InitialContext ctx;
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "url-injection-test.jar")
+                .addPackage(ResUrlCheckerTestCase.class.getPackage());
+                jar.addAsManifestResource(ResUrlCheckerTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    private InitialContext getInitialContext() {
+        return ctx;
+    }
+
+    private ResUrlChecker lookupBean() throws NamingException {
+        return (ResUrlChecker) getInitialContext().lookup("java:module/ResUrlCheckerBean");
+    }
+    
+    @Ignore("AS7-2744") // TODO: @see ResUrlCheckerBean and uncomment @Resource annotations
+    @Test
+    public void test1() throws Exception {
+        ResUrlChecker bean = lookupBean();
+        // defined in ResUrlCheckerBean
+        URL expected = new URL("http://localhost");
+        URL actual = bean.getURL1();
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void test2() throws Exception {
+        ResUrlChecker bean = lookupBean();
+        // defined in jboss.xml
+        URL expected = new URL("http://localhost/url2");
+        URL actual = bean.getURL2();
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Ignore("AS7-2744")
+    @Test
+    public void test3() throws Exception {
+        ResUrlChecker bean = lookupBean();
+        // defined in ResUrlCheckerBean
+        URL expected = new URL("http://localhost/url3");
+        URL actual = bean.getURL3();
+        Assert.assertEquals(expected, actual);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/url/jboss-ejb3.xml
@@ -1,0 +1,39 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+                  xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+                  version="3.1"
+                  impl-version="2.0">
+    <enterprise-beans>
+        <session>
+            <ejb-name>ResUrlCheckerBean</ejb-name>
+			<resource-ref>
+				<res-ref-name>url2</res-ref-name>
+				<res-url>http://localhost/url2</res-url>
+			</resource-ref>
+        </session>
+    </enterprise-beans>
+</jboss:ejb-jar>


### PR DESCRIPTION
Part of migration of EJB3 testsuite to AS7 testsuite [JBQA-5483].
Test to see if injection of URL type resource works.
Part of test tests not implemented features with @Resource annotation (now ignored). The related jira could be find on: https://issues.jboss.org/browse/AS7-2744.
