### PR TITLE
[AS7-2769] Arquillian Managed container always using java command to start the container regardless of JAVA_HOME

### DIFF
--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -47,7 +47,8 @@ public class ManagedContainerConfiguration extends CommonContainerConfiguration 
 
     private boolean allowConnectingToRunningServer = false;
 
-    {
+    public ManagedContainerConfiguration() {
+        // if no javaHome is set use java.home of already running jvm
         if (javaHome == null || javaHome.isEmpty()) {
             javaHome = System.getProperty("java.home");
         }

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -21,6 +21,8 @@ import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.deployment.Validate;
 import org.jboss.as.arquillian.container.CommonContainerConfiguration;
 
+import java.io.File;
+
 /**
  * JBossAsManagedConfiguration
  *
@@ -44,6 +46,12 @@ public class ManagedContainerConfiguration extends CommonContainerConfiguration 
     private String serverConfig = System.getProperty("jboss.server.config.file.name",  "standalone.xml");
 
     private boolean allowConnectingToRunningServer = false;
+
+    {
+        if (javaHome == null || javaHome.isEmpty()) {
+            javaHome = System.getProperty("java.home");
+        }
+    }
 
     @Override
     public void validate() throws ConfigurationException {

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -114,7 +114,11 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             fos.close();
 
             List<String> cmd = new ArrayList<String>();
-            cmd.add("java");
+            String javaExec = config.getJavaHome() + File.separatorChar + "bin" + File.separatorChar + "java";
+            if (config.getJavaHome().contains(" ")) {
+                javaExec = "\"" + javaExec + "\"";
+            }
+            cmd.add(javaExec);
             if (additionalJavaOpts != null) {
                 for (String opt : additionalJavaOpts.split("\\s+")) {
                     cmd.add(opt);


### PR DESCRIPTION
Arquillian Managed container always using java command to start the container regardless of JAVA_HOME setting or javaHome property in arquillian.xml 
