### PR TITLE
Remove dependency on (no longer present) jboss-as-demos-internals

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -139,12 +139,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-demos-internals</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-subsystem-test</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
The testsuite/integration/pom.xml has a dependency on the demos-internals artifact which was nuked recently. This causes build failures (which won't be noticed if the demos-internals 7.0.0.CR1-SNAPSHOT was already built in a previous run and is available in your local maven repo).

This commit gets rid of that dependency from the testsuite/integration pom.
