### PR TITLE
[AS7-2426] If a slave host controller fails to authenticate against the ...

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -42,6 +42,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
 
 import org.jboss.as.controller.HashUtil;
 import org.jboss.as.controller.ModelController;
@@ -165,6 +166,13 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                break;
             }
             catch (IllegalStateException e) {
+                Throwable cause = e;
+                while ((cause = cause.getCause()) != null) {
+                    if (cause instanceof SaslException) {
+                        throw new IllegalStateException("Unable to connect due to authentication failure.", cause);
+                    }
+                }
+
                 if (System.currentTimeMillis() > endTime) {
                     throw new IllegalStateException("Could not connect to master in " + retries + "attempts within  " + timeout + " ms", e);
                 }


### PR DESCRIPTION
...master host controller is just

keeps retrying, the authentication failure is now detected and aborts the process.
