### PR TITLE
AS7-2761 fix

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/ConnectorServices.java
+++ b/connector/src/main/java/org/jboss/as/connector/ConnectorServices.java
@@ -45,6 +45,12 @@ public final class ConnectorServices {
     private static Map<String, Set<ServiceName>> deploymentServiceNames = new HashMap<String, Set<ServiceName>>();
     private static Map<String, Set<Integer>> deploymentIdentifiers = new HashMap<String, Set<Integer>>();
 
+    /**
+     * A map whose key corresponds to a ra name and whose value is a identifier with which the RA
+     * is registered in the {@link org.jboss.jca.core.spi.rar.ResourceAdapterRepository}
+     */
+    private static Map<String, String> resourceAdapterRepositoryIdentifiers = new HashMap<String, String>();
+
     public static final ServiceName CONNECTOR_CONFIG_SERVICE = ServiceName.JBOSS.append("connector", "config");
 
     public static final ServiceName BEAN_VALIDATION_CONFIG_SERVICE = ServiceName.JBOSS.append("connector", "bean_validation", "config");
@@ -120,7 +126,7 @@ public final class ConnectorServices {
         }
 
         Integer identifier = Integer.valueOf(1);
-        for (;;) {
+        for (; ; ) {
             if (!entries.contains(identifier)) {
                 entries.add(identifier);
                 return identifier;
@@ -195,7 +201,7 @@ public final class ConnectorServices {
         }
 
         Integer identifier = Integer.valueOf(1);
-        for (;;) {
+        for (; ; ) {
             if (!entries.contains(identifier)) {
                 entries.add(identifier);
                 return identifier;
@@ -256,5 +262,35 @@ public final class ConnectorServices {
 
     public static synchronized Set<ServiceName> getResourceAdapterServiceNames(String raName) {
         return resourceAdapterServiceNames.get(raName);
+    }
+
+    /**
+     * Returns the identifier with which the resource adapter named <code>raName</code> is registered
+     * in the {@link org.jboss.jca.core.spi.rar.ResourceAdapterRepository}. Returns null, if there's no
+     * registration for a resource adapter named <code>raName</code>
+     *
+     * @param raName The resource adapter name
+     * @return
+     */
+    public static String getRegisteredResourceAdapterIdentifier(final String raName) {
+        synchronized (resourceAdapterRepositoryIdentifiers) {
+            return resourceAdapterRepositoryIdentifiers.get(raName);
+        }
+    }
+
+    /**
+     * Makes a note of the resource adapter identifier with which a resource adapter named <code>raName</code>
+     * is registered in the {@link org.jboss.jca.core.spi.rar.ResourceAdapterRepository}.
+     * <p/>
+     * Subsequent calls to {@link #getRegisteredResourceAdapterIdentifier(String)} with the passed <code>raName</code>
+     * return the <code>raIdentifier</code>
+     *
+     * @param raName       The resource adapter name
+     * @param raIdentifier The resource adapter identifier
+     */
+    public static void registerResourceAdapterIdentifier(final String raName, final String raIdentifier) {
+        synchronized (resourceAdapterRepositoryIdentifiers) {
+            resourceAdapterRepositoryIdentifiers.put(raName, raIdentifier);
+        }
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/ConnectorServices.java
+++ b/connector/src/main/java/org/jboss/as/connector/ConnectorServices.java
@@ -293,4 +293,19 @@ public final class ConnectorServices {
             resourceAdapterRepositoryIdentifiers.put(raName, raIdentifier);
         }
     }
+
+    /**
+     * Clears the mapping between the <code>raName</code> and the resource adapter identifier, with which the resource
+     * adapter is registered with the {@link org.jboss.jca.core.spi.rar.ResourceAdapterRepository}
+     * <p/>
+     * Subsequent calls to {@link #getRegisteredResourceAdapterIdentifier(String)} with the passed <code>raName</code>
+     * return null
+     *
+     * @param raName       The resource adapter name
+     */
+    public static void unregisterResourceAdapterIdentifier(final String raName) {
+        synchronized (resourceAdapterRepositoryIdentifiers) {
+            resourceAdapterRepositoryIdentifiers.remove(raName);
+        }
+    }
 }

--- a/connector/src/main/java/org/jboss/as/connector/metadata/deployment/AbstractResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/metadata/deployment/AbstractResourceAdapterDeploymentService.java
@@ -425,7 +425,10 @@ public abstract class AbstractResourceAdapterDeploymentService {
 
         @Override
         protected String registerResourceAdapterToResourceAdapterRepository(ResourceAdapter instance) {
-            return raRepository.getValue().registerResourceAdapter(instance);
+            final String raIdentifer = raRepository.getValue().registerResourceAdapter(instance);
+            // make a note of this identifier for future use
+            ConnectorServices.registerResourceAdapterIdentifier(this.deploymentName, raIdentifer);
+            return raIdentifer;
 
         }
 

--- a/connector/src/main/java/org/jboss/as/connector/metadata/deployment/ResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/metadata/deployment/ResourceAdapterDeploymentService.java
@@ -129,6 +129,10 @@ public final class ResourceAdapterDeploymentService extends AbstractResourceAdap
             ConnectorServices.unregisterDeployment(raName, deploymentServiceName);
         }
 
+        if (raName != null) {
+            ConnectorServices.unregisterResourceAdapterIdentifier(raName);
+        }
+
         managementRepository.getValue().getConnectors().remove(value.getDeployment().getConnector());
         super.stop(context);
     }

--- a/connector/src/main/java/org/jboss/as/connector/metadata/deployment/ResourceAdapterXmlDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/metadata/deployment/ResourceAdapterXmlDeploymentService.java
@@ -135,6 +135,10 @@ public final class ResourceAdapterXmlDeploymentService extends AbstractResourceA
             ConnectorServices.unregisterDeployment(raName, deploymentServiceName);
         }
 
+        if (raName != null) {
+            ConnectorServices.unregisterResourceAdapterIdentifier(raName);
+        }
+
         managementRepository.getValue().getConnectors().remove(value.getDeployment().getConnector());
         super.stop(context);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -352,7 +352,7 @@ public interface EjbMessages {
      * @return a {@link IllegalStateException} for the error.
      */
     @Message(id = 14331, value = "No resource adapter registered with resource adapter name %s")
-    IllegalStateException failToRegisteredResourceAdapter(String resourceAdapterName);
+    IllegalStateException unknownResourceAdapter(String resourceAdapterName);
 
     /**
      * Creates an exception indicating multiple resource adapter was registered
@@ -1815,4 +1815,16 @@ public interface EjbMessages {
 
     @Message(id=14520, value="Could not determine ClassLoader for stub %s")
     RuntimeException couldNotFindClassLoaderForStub(String stub);
+
+    /**
+     * Creates an exception indicating that there was no message listener of the expected type
+     * in the resource adapter
+     *
+     * @param resourceAdapterName The resource adapter name
+     * @param messageListenerType The message listener type
+     *
+     * @return a {@link IllegalStateException} for the error.
+     */
+    @Message(id = 14521, value = "No message listener of type %s found in resource adapter %s")
+    IllegalStateException unknownMessageListenerType(String resourceAdapterName, String messageListenerType);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -82,7 +82,7 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
     public ActivationSpec createActivationSpecs(final String resourceAdapterName, final Class<?> messageListenerInterface,
                                                 final Properties activationConfigProperties, final ClassLoader classLoader) {
         try {
-            // first get the ra "identifier" (with which it is registed in the resource adapter repository) for the
+            // first get the ra "identifier" (with which it is registered in the resource adapter repository) for the
             // ra name
             final String raIdentifier = ConnectorServices.getRegisteredResourceAdapterIdentifier(resourceAdapterName);
             if (raIdentifier == null) {


### PR DESCRIPTION
The commits in this branch fix the issue reported in https://issues.jboss.org/browse/AS7-2761. The bug was related to how a MessageListener was selected based on the resource adapter name and the message listener class type. These commits ensure that the EJB3 part no longer goes into checking the internal details of the RA identifier and instead relies on the ConnectorServices to just return it the correct RA identifier which can then be used to find the message listener in the RA.
