### PR TITLE
Logging fixes and additional support

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
@@ -46,6 +46,10 @@ public class SimpleAttributeDefinitionBuilder {
         return new SimpleAttributeDefinitionBuilder(name, type, allowNull);
     }
 
+    public static SimpleAttributeDefinitionBuilder create(final SimpleAttributeDefinition basis) {
+        return new SimpleAttributeDefinitionBuilder(basis);
+    }
+
     private final String name;
     private final ModelType type;
     private String xmlName;
@@ -55,6 +59,7 @@ public class SimpleAttributeDefinitionBuilder {
     private MeasurementUnit measurementUnit;
     private String[] alternatives;
     private String[] requires;
+    private ParameterCorrector corrector;
     private ParameterValidator validator;
     private AttributeAccess.Flag[] flags;
 
@@ -86,7 +91,7 @@ public class SimpleAttributeDefinitionBuilder {
 
     public SimpleAttributeDefinition build() {
         return new SimpleAttributeDefinition(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
-                                     validator, alternatives, requires, flags);
+                                     corrector, validator, alternatives, requires, flags);
     }
 
     public SimpleAttributeDefinitionBuilder setXmlName(String xmlName) {
@@ -111,6 +116,11 @@ public class SimpleAttributeDefinitionBuilder {
 
     public SimpleAttributeDefinitionBuilder setMeasurementUnit(MeasurementUnit unit) {
         this.measurementUnit = unit;
+        return this;
+    }
+
+    public SimpleAttributeDefinitionBuilder setCorrector(ParameterCorrector corrector) {
+        this.corrector = corrector;
         return this;
     }
 

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.logging.handlers.console.Target;
+import org.jboss.as.logging.validators.FileValidator;
 import org.jboss.as.logging.validators.LogLevelValidator;
 import org.jboss.as.logging.validators.OverflowActionValidator;
 import org.jboss.as.logging.validators.SizeValidator;
@@ -72,7 +73,10 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition ENCODING = SimpleAttributeDefinitionBuilder.create("encoding", ModelType.STRING, true).build();
 
-    SimpleAttributeDefinition FILE = SimpleAttributeDefinitionBuilder.create("file", ModelType.OBJECT, true).build();
+    SimpleAttributeDefinition FILE = SimpleAttributeDefinitionBuilder.create("file", ModelType.OBJECT, true).
+            setCorrector(FileCorrector.INSTANCE).
+            setValidator(new FileValidator()).
+            build();
 
     String FILE_HANDLER = "file-handler";
 

--- a/logging/src/main/java/org/jboss/as/logging/FileCorrector.java
+++ b/logging/src/main/java/org/jboss/as/logging/FileCorrector.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging;
+
+import static org.jboss.as.logging.CommonAttributes.PATH;
+import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
+
+import org.jboss.as.controller.ParameterCorrector;
+import org.jboss.as.server.services.path.AbstractPathService;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Corrects the {@link CommonAttributes#RELATIVE_TO relative-to} attribute.
+ * <p/>
+ * Checks the {@link CommonAttributes#PATH path} attribute for an absolute path. If the path is absolute, the current
+ * {@link CommonAttributes#RELATIVE_TO relative-to} attribute is not copied over. If the path is not absolute the
+ * current {@link CommonAttributes#RELATIVE_TO relative-to} attribute is copied over.
+ * <p/>
+ * Date: 29.11.2011
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class FileCorrector implements ParameterCorrector {
+
+    public static final FileCorrector INSTANCE = new FileCorrector();
+
+    @Override
+    public ModelNode correct(final ModelNode newValue, final ModelNode currentValue) {
+        if (newValue.getType() == ModelType.UNDEFINED) {
+            return newValue;
+        }
+        if (newValue.getType() != ModelType.OBJECT || currentValue.getType() != ModelType.OBJECT) {
+            return newValue;
+        }
+        final ModelNode newPath = newValue.get(PATH.getName());
+        if (newPath.isDefined() && !AbstractPathService.isAbsoluteUnixOrWindowsPath(newPath.asString())) {
+            if (currentValue.hasDefined(RELATIVE_TO.getName()) && !newValue.hasDefined(RELATIVE_TO.getName())) {
+                newValue.get(RELATIVE_TO.getName()).set(currentValue.get(RELATIVE_TO.getName()));
+            }
+        }
+        return newValue;
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
@@ -22,6 +22,10 @@
 
 package org.jboss.as.logging;
 
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Cause;
@@ -30,11 +34,14 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageLogger;
 
-import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.WARN;
-
 /**
+ * This module is using message IDs in the range 11500-11599.
+ * <p/>
+ * This file is using the subset 11500-11529 for non-logger messages.
+ * <p/>
+ * See <a href="http://community.jboss.org/docs/DOC-16810">http://community.jboss.org/docs/DOC-16810</a> for the full
+ * list of currently reserved JBAS message id blocks.
+ * <p/>
  * Date: 09.06.2011
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>

--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -31,9 +31,17 @@ import org.jboss.logging.Cause;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageBundle;
 import org.jboss.logging.Messages;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 
 /**
+ * This module is using message IDs in the range 11500-11599.
+ * <p/>
+ * This file is using the subset 11530-11599 for non-logger messages.
+ * <p/>
+ * See <a href="http://community.jboss.org/docs/DOC-16810">http://community.jboss.org/docs/DOC-16810</a> for the full
+ * list of currently reserved JBAS message id blocks.
+ * <p/>
  * Date: 09.06.2011
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -252,4 +260,45 @@ public interface LoggingMessages {
      */
     @Message(id = 11547, value = "Unknown parameter type (%s) for property '%s' on '%s'")
     IllegalArgumentException unknownParameterType(Class<?> type, String propertyName, Class<?> clazz);
+
+    /**
+     * A message indicating the file was not found.
+     *
+     * @param fileName the file name that was not found.
+     *
+     * @return the message.
+     */
+    @Message(id = 11550, value = "File '%s' was not found.")
+    String fileNotFound(String fileName);
+
+    /**
+     * A message indicating the service was not found.
+     *
+     * @param name the name of the service.
+     *
+     * @return the message.
+     */
+    @Message(id = 11551, value = "Service '%s' was not found.")
+    String serviceNotFound(ServiceName name);
+
+    /**
+     * A message indicating an absolute path cannot be specified for relative-to.
+     *
+     * @param relativeTo the invalid absolute path.
+     *
+     * @return the message.
+     */
+    @Message(id = 11552, value = "An absolute path (%s) cannot be specified for relative-to.")
+    String invalidRelativeTo(String relativeTo);
+
+    /**
+     * A message indicating an absolute path cannot be used when a relative-to path is being used.
+     *
+     * @param relativeTo the relative path.
+     * @param path       absolute path.
+     *
+     * @return the message.
+     */
+    @Message(id = 11553, value = "An absolute path (%2$s) cannot be used when a relative-to path (%1$s) is being used.")
+    String invalidPath(String relativeTo, String path);
 }

--- a/logging/src/main/java/org/jboss/as/logging/ObjectTypeAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/ObjectTypeAttributeDefinition.java
@@ -32,6 +32,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -52,8 +53,8 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
     private final AttributeDefinition[] valueTypes;
     private final String suffix;
 
-    private ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
-        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, new ObjectTypeValidator(allowNull, valueTypes), alternatives, requires, flags);
+    private ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull, final ParameterCorrector corrector, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
+        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, new ObjectTypeValidator(allowNull, valueTypes), alternatives, requires, flags);
         this.valueTypes = valueTypes;
         if (suffix == null) {
             this.suffix = "";
@@ -181,6 +182,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
         private final String name;
         private String suffix;
         private final AttributeDefinition[] valueTypes;
+        private ParameterCorrector corrector;
         private String xmlName;
         private boolean allowNull;
         private String[] alternatives;
@@ -199,7 +201,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
 
         public ObjectTypeAttributeDefinition build() {
             if (xmlName == null) xmlName = name;
-            return new ObjectTypeAttributeDefinition(name, xmlName, suffix, valueTypes, allowNull, alternatives, requires, flags);
+            return new ObjectTypeAttributeDefinition(name, xmlName, suffix, valueTypes, allowNull, corrector, alternatives, requires, flags);
         }
 
         public Builder setAllowNull(final boolean allowNull) {
@@ -209,6 +211,11 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
 
         public Builder setAlternates(final String... alternates) {
             this.alternatives = alternates;
+            return this;
+        }
+
+        public Builder setCorrector(final ParameterCorrector corrector) {
+            this.corrector = corrector;
             return this;
         }
 

--- a/logging/src/main/java/org/jboss/as/logging/handlers/AbstractLogHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/AbstractLogHandlerWriteAttributeHandler.java
@@ -78,13 +78,13 @@ public abstract class AbstractLogHandlerWriteAttributeHandler<T extends Handler>
         final String name = address.getLastElement().getValue();
         final ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
         @SuppressWarnings("unchecked")
-        final ServiceController<Handler> controller = (ServiceController<Handler>) serviceRegistry.getService(LogServices.handlerName(name));
+        final ServiceController<T> controller = (ServiceController<T>) serviceRegistry.getService(LogServices.handlerName(name));
         if (controller == null) {
             return false;
         }
         // Attempt to cast handler
         @SuppressWarnings("unchecked")
-        final T handler = (T) controller.getValue();
+        final T handler = controller.getValue();
         if (LEVEL.getName().equals(attributeName)) {
             handler.setLevel(ModelParser.parseLevel(resolvedValue));
         } else if (FILTER.getName().equals(attributeName)) {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/AbstractFileHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/AbstractFileHandlerService.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.handlers.file;
+
+import java.io.FileNotFoundException;
+
+import org.jboss.as.logging.handlers.FlushingHandlerService;
+import org.jboss.msc.inject.Injector;
+
+/**
+ * Date: 23.11.2011
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class AbstractFileHandlerService implements FlushingHandlerService {
+
+    public abstract void setFile(String path) throws FileNotFoundException;
+
+    public abstract Injector<String> getFileNameInjector();
+}

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerAdd.java
@@ -24,19 +24,14 @@ package org.jboss.as.logging.handlers.file;
 
 import static org.jboss.as.logging.CommonAttributes.APPEND;
 import static org.jboss.as.logging.CommonAttributes.FILE;
-import static org.jboss.as.logging.CommonAttributes.PATH;
-import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
 
 import java.util.logging.Handler;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.logging.handlers.FlushingHandlerAddProperties;
-import org.jboss.as.logging.util.LogServices;
-import org.jboss.as.server.services.path.AbstractPathService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 
 /**
@@ -66,14 +61,7 @@ public class FileHandlerAdd extends FlushingHandlerAddProperties<FileHandlerServ
         final ServiceTarget serviceTarget = context.getServiceTarget();
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
-            final HandlerFileService fileService = new HandlerFileService(PATH.validateOperation(file).asString());
-            final ServiceBuilder<?> fileBuilder = serviceTarget.addService(LogServices.handlerFileName(name), fileService);
-            final ModelNode relativeTo = RELATIVE_TO.resolveModelAttribute(context, file);
-            if (relativeTo.isDefined()) {
-                fileBuilder.addDependency(AbstractPathService.pathNameOf(relativeTo.asString()), String.class, fileService.getRelativeToInjector());
-            }
-            fileBuilder.setInitialMode(ServiceController.Mode.ACTIVE).install();
-            serviceBuilder.addDependency(LogServices.handlerFileName(name), String.class, service.getFileNameInjector());
+            FileHandlers.addFile(context, serviceBuilder, service, file, name);
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerService.java
@@ -25,22 +25,21 @@ package org.jboss.as.logging.handlers.file;
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
 import java.util.logging.Filter;
-import java.util.logging.Handler;
 import java.util.logging.Level;
 
 import org.jboss.as.logging.handlers.FormatterSpec;
-import org.jboss.as.logging.handlers.FlushingHandlerService;
 import org.jboss.logmanager.handlers.FileHandler;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.jboss.msc.value.Values;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-public final class FileHandlerService implements FlushingHandlerService {
+public class FileHandlerService extends AbstractFileHandlerService {
 
     private final InjectedValue<String> fileName = new InjectedValue<String>();
 
@@ -79,7 +78,7 @@ public final class FileHandlerService implements FlushingHandlerService {
         value = null;
     }
 
-    public synchronized Handler getValue() throws IllegalStateException {
+    public synchronized FileHandler getValue() throws IllegalStateException {
         return value;
     }
 
@@ -142,7 +141,15 @@ public final class FileHandlerService implements FlushingHandlerService {
         if (handler != null) handler.setAppend(append);
     }
 
+    @Override
     public Injector<String> getFileNameInjector() {
         return fileName;
+    }
+
+    @Override
+    public synchronized void setFile(final String path) throws FileNotFoundException {
+        fileName.setValue(Values.immediateValue(path));
+        final FileHandler handler = value;
+        if (handler != null) handler.setFileName(path);
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlers.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlers.java
@@ -1,0 +1,131 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.handlers.file;
+
+import static org.jboss.as.logging.CommonAttributes.PATH;
+import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
+
+import java.io.FileNotFoundException;
+import java.util.logging.Handler;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.logging.util.LogServices;
+import org.jboss.as.server.services.path.AbstractPathService;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * Date: 23.11.2011
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class FileHandlers {
+
+    static void addFile(final OperationContext context, final ServiceBuilder<Handler> serviceBuilder, final AbstractFileHandlerService service, final ModelNode file, final String name) throws OperationFailedException {
+        if (file.isDefined()) {
+            final ModelNode path = PATH.resolveModelAttribute(context, file);
+            final ModelNode relativeTo = RELATIVE_TO.resolveModelAttribute(context, file);
+            final ServiceName serviceName = LogServices.handlerFileName(name);
+
+            // Retrieve the current service
+            final ServiceTarget serviceTarget = context.getServiceTarget();
+            final HandlerFileService fileService = new HandlerFileService(path.asString());
+            final ServiceBuilder<?> fileBuilder = serviceTarget.addService(serviceName, fileService);
+            // Add the relative path dependency
+            if (relativeTo.isDefined()) {
+                fileBuilder.addDependency(AbstractPathService.pathNameOf(relativeTo.asString()), String.class, fileService.getRelativeToInjector());
+            }
+            fileBuilder.setInitialMode(ServiceController.Mode.ACTIVE).install();
+            serviceBuilder.addDependency(LogServices.handlerFileName(name), String.class, service.getFileNameInjector());
+        }
+    }
+
+    static boolean changeFile(final OperationContext context, final ModelNode oldFile, final ModelNode newFile, final String name) throws OperationFailedException {
+        boolean requiresRestart = false;
+        if (newFile.isDefined()) {
+            final ModelNode path = PATH.resolveModelAttribute(context, newFile);
+            final ModelNode relativeTo = RELATIVE_TO.resolveModelAttribute(context, newFile);
+            final ModelNode currentRelativeTo = RELATIVE_TO.resolveModelAttribute(context, oldFile);
+            // If relative-to is defined, no need to continue.
+            if (relativeTo.isDefined() && !currentRelativeTo.equals(relativeTo) && !AbstractPathService.isAbsoluteUnixOrWindowsPath(path.asString())) {
+                requiresRestart = true;
+            } else {
+                final ServiceName serviceName = LogServices.handlerFileName(name);
+
+                // Retrieve the current service
+                final ServiceRegistry registry = context.getServiceRegistry(true);
+                final ServiceController<?> fileController = registry.getService(serviceName);
+                if (fileController == null) {
+                    throw new OperationFailedException(new ModelNode().set(MESSAGES.serviceNotFound(serviceName)));
+                }
+                final HandlerFileService fileService = (HandlerFileService) fileController.getService();
+                fileService.setPath(path.asString());
+
+                // Find the handler and set the new file
+                @SuppressWarnings("unchecked")
+                final ServiceController<?> handlerController = registry.getService(LogServices.handlerName(name));
+                final AbstractFileHandlerService handlerService = (AbstractFileHandlerService) handlerController.getService();
+                final String fileName = fileService.getValue();
+                try {
+                    handlerService.setFile(fileName);
+                } catch (FileNotFoundException e) {
+                    throw new OperationFailedException(e, new ModelNode().set(MESSAGES.fileNotFound(fileName)));
+                }
+            }
+        }
+        return requiresRestart;
+    }
+
+    static void revertFileChange(final OperationContext context, final ModelNode file, final String name) throws OperationFailedException {
+        if (file.isDefined()) {
+            final ModelNode path = PATH.resolveModelAttribute(context, file);
+            final ServiceName serviceName = LogServices.handlerFileName(name);
+
+            // Retrieve the current service
+            final ServiceRegistry registry = context.getServiceRegistry(true);
+            final ServiceController<?> fileController = registry.getService(serviceName);
+            if (fileController == null) {
+                throw new OperationFailedException(new ModelNode().set(MESSAGES.serviceNotFound(serviceName)));
+            }
+            final HandlerFileService fileService = (HandlerFileService) fileController.getService();
+            fileService.setPath(path.asString());
+
+            // Find the handler and set the new file
+            @SuppressWarnings("unchecked")
+            final ServiceController<?> handlerController = registry.getService(LogServices.handlerName(name));
+            final AbstractFileHandlerService handlerService = (AbstractFileHandlerService) handlerController.getService();
+            final String fileName = fileService.getValue();
+            try {
+                handlerService.setFile(fileName);
+            } catch (FileNotFoundException e) {
+                throw new OperationFailedException(e, new ModelNode().set(MESSAGES.fileNotFound(fileName)));
+            }
+        }
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicRotatingFileHandlerAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicRotatingFileHandlerAdd.java
@@ -24,21 +24,15 @@ package org.jboss.as.logging.handlers.file;
 
 import static org.jboss.as.logging.CommonAttributes.APPEND;
 import static org.jboss.as.logging.CommonAttributes.FILE;
-import static org.jboss.as.logging.CommonAttributes.PATH;
-import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
 import static org.jboss.as.logging.CommonAttributes.SUFFIX;
 
 import java.util.logging.Handler;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.logging.util.LogServices;
 import org.jboss.as.logging.handlers.FlushingHandlerAddProperties;
-import org.jboss.as.server.services.path.AbstractPathService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceTarget;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -62,15 +56,7 @@ public class PeriodicRotatingFileHandlerAdd extends FlushingHandlerAddProperties
         super.updateRuntime(context, serviceBuilder, name, service, model);
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
-            final ServiceTarget serviceTarget = context.getServiceTarget();
-            final HandlerFileService fileService = new HandlerFileService(PATH.resolveModelAttribute(context, file).asString());
-            final ServiceBuilder<?> fileBuilder = serviceTarget.addService(LogServices.handlerFileName(name), fileService);
-            final ModelNode relativeTo = RELATIVE_TO.resolveModelAttribute(context, file);
-            if (relativeTo.isDefined()) {
-                fileBuilder.addDependency(AbstractPathService.pathNameOf(relativeTo.asString()), String.class, fileService.getRelativeToInjector());
-            }
-            fileBuilder.setInitialMode(ServiceController.Mode.ACTIVE).install();
-            serviceBuilder.addDependency(LogServices.handlerFileName(name), String.class, service.getFileNameInjector());
+            FileHandlers.addFile(context, serviceBuilder, service, file, name);
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, model);
         if (append.isDefined()) {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicRotatingFileHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicRotatingFileHandlerService.java
@@ -24,24 +24,23 @@ package org.jboss.as.logging.handlers.file;
 
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
 
 import org.jboss.as.logging.handlers.FormatterSpec;
-import org.jboss.as.logging.handlers.FlushingHandlerService;
 import org.jboss.logmanager.handlers.PeriodicRotatingFileHandler;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-
-import java.util.logging.Filter;
-import java.util.logging.Handler;
-import java.util.logging.Level;
+import org.jboss.msc.value.Values;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-public final class PeriodicRotatingFileHandlerService implements FlushingHandlerService {
+public class PeriodicRotatingFileHandlerService extends AbstractFileHandlerService {
 
     private final InjectedValue<String> fileName = new InjectedValue<String>();
 
@@ -152,6 +151,14 @@ public final class PeriodicRotatingFileHandlerService implements FlushingHandler
         if (handler != null) handler.setSuffix(suffix);
     }
 
+    @Override
+    public synchronized void setFile(final String path) throws FileNotFoundException {
+        fileName.setValue(Values.immediateValue(path));
+        final PeriodicRotatingFileHandler handler = value;
+        if (handler != null) handler.setFileName(path);
+    }
+
+    @Override
     public Injector<String> getFileNameInjector() {
         return fileName;
     }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingFileHandlerAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingFileHandlerAdd.java
@@ -25,21 +25,16 @@ package org.jboss.as.logging.handlers.file;
 import static org.jboss.as.logging.CommonAttributes.APPEND;
 import static org.jboss.as.logging.CommonAttributes.FILE;
 import static org.jboss.as.logging.CommonAttributes.MAX_BACKUP_INDEX;
-import static org.jboss.as.logging.CommonAttributes.PATH;
-import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
 import static org.jboss.as.logging.CommonAttributes.ROTATE_SIZE;
 
 import java.util.logging.Handler;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.logging.util.LogServices;
 import org.jboss.as.logging.handlers.FlushingHandlerAddProperties;
 import org.jboss.as.logging.util.ModelParser;
-import org.jboss.as.server.services.path.AbstractPathService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceController;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -67,14 +62,7 @@ public class SizeRotatingFileHandlerAdd extends FlushingHandlerAddProperties<Siz
         }
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
-            final HandlerFileService fileService = new HandlerFileService(PATH.resolveModelAttribute(context, file).asString());
-            final ServiceBuilder<?> fileBuilder = context.getServiceTarget().addService(LogServices.handlerFileName(name), fileService);
-            final ModelNode relativeTo = RELATIVE_TO.resolveModelAttribute(context, file);
-            if (relativeTo.isDefined()) {
-                fileBuilder.addDependency(AbstractPathService.pathNameOf(relativeTo.asString()), String.class, fileService.getRelativeToInjector());
-            }
-            fileBuilder.setInitialMode(ServiceController.Mode.ACTIVE).install();
-            serviceBuilder.addDependency(LogServices.handlerFileName(name), String.class, service.getFileNameInjector());
+            FileHandlers.addFile(context, serviceBuilder, service, file, name);
         }
         final ModelNode maxBackupIndex = MAX_BACKUP_INDEX.resolveModelAttribute(context, model);
         if (maxBackupIndex.isDefined()) {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingFileHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingFileHandlerService.java
@@ -24,24 +24,23 @@ package org.jboss.as.logging.handlers.file;
 
 import java.io.FileNotFoundException;
 import java.io.UnsupportedEncodingException;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
 
 import org.jboss.as.logging.handlers.FormatterSpec;
-import org.jboss.as.logging.handlers.FlushingHandlerService;
 import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-
-import java.util.logging.Filter;
-import java.util.logging.Handler;
-import java.util.logging.Level;
+import org.jboss.msc.value.Values;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-public final class SizeRotatingFileHandlerService implements FlushingHandlerService {
+public class SizeRotatingFileHandlerService extends AbstractFileHandlerService {
 
     private final InjectedValue<String> fileName = new InjectedValue<String>();
 
@@ -172,6 +171,14 @@ public final class SizeRotatingFileHandlerService implements FlushingHandlerServ
         if (handler != null) handler.setRotateSize(rotateSize);
     }
 
+    @Override
+    public synchronized void setFile(final String path) throws FileNotFoundException {
+        fileName.setValue(Values.immediateValue(path));
+        final SizeRotatingFileHandler handler = value;
+        if (handler != null) handler.setFileName(path);
+    }
+
+    @Override
     public Injector<String> getFileNameInjector() {
         return fileName;
     }

--- a/logging/src/main/java/org/jboss/as/logging/validators/FileValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/FileValidator.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.validators;
+
+import static org.jboss.as.logging.CommonAttributes.PATH;
+import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.as.server.services.path.AbstractPathService;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Validates the {@link org.jboss.as.logging.CommonAttributes#FILE file} attribute.
+ * <p/>
+ * A valid {@link org.jboss.as.logging.CommonAttributes#FILE file} attribute must have an absolute
+ * {@link org.jboss.as.logging.CommonAttributes#PATH path} attribute or a
+ * {@link org.jboss.as.logging.CommonAttributes#PATH path} attribute with a valid
+ * {@link org.jboss.as.logging.CommonAttributes#RELATIVE_TO relative-to} attribute.
+ * <p/>
+ * Date: 28.11.2011
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class FileValidator extends ModelTypeValidator {
+
+    public FileValidator() {
+        super(ModelType.OBJECT);
+    }
+
+    @Override
+    public void validateParameter(final String parameterName, final ModelNode value) throws OperationFailedException {
+        super.validateParameter(parameterName, value);
+        final ModelNode clone = value.clone();
+        RELATIVE_TO.getValidator().validateParameter(parameterName, clone.get(RELATIVE_TO.getName()));
+        PATH.getValidator().validateParameter(parameterName, clone.get(PATH.getName()));
+        if (value.isDefined()) {
+            // Could have relative-to
+            if (value.hasDefined(RELATIVE_TO.getName())) {
+                final String relativeTo = value.get(RELATIVE_TO.getName()).asString();
+                // Can't be an absolute path
+                if (AbstractPathService.isAbsoluteUnixOrWindowsPath(relativeTo)) {
+                    throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidRelativeTo(relativeTo)));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds fixes for the ability to change the file on a file log handler. Also enables the write-attribute and update-properties operations to change the file.

Fixed the update-properties operation from clearing previously declared attributes and values.

Finally added support for the SimpleAttributeDefinitionBuilder to define a ParameterCorrector.
