### PR TITLE
AS7-2838 added missing second deployment to the ClusteredWebTestCase 

### DIFF
--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -2,6 +2,11 @@
 <arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
 
+    <!-- For testing AS7-2837. -->
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
+
     <container qualifier="clustering-udp-single" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-0</property>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusteredWebTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusteredWebTestCase.java
@@ -39,6 +39,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -77,6 +78,7 @@ public class ClusteredWebTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.addAsWebInfResource(ClusteredWebTestCase.class.getPackage(), "web.xml");
+        war.addAsWebInfResource(EmptyAsset.INSTANCE, "force-hashcode-change.txt");
         System.out.println(war.toString(true));
         return war;
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/force-hashcode-change.txt
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/force-hashcode-change.txt
@@ -1,0 +1,1 @@
+Workaround AS7-2779 until Aslak fixes it.


### PR DESCRIPTION
Pretty much straightforward. 

(btw ARQ will need fixing https://issues.jboss.org/browse/AS7-2837)

Tests are okay 
./integration-tests.sh clean install -Dts.clust -Dts.noSmoke

---
##  T E S T S

Running org.jboss.as.test.clustering.cluster.ClusteredWebTestCase
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.039 sec

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
