### PR TITLE
[AS7-2843] some management.cli tests failing due to direct invocation of java executable - fixed

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -302,7 +302,12 @@ public class CLIWrapper implements Runnable {
         String asDist = System.getProperty("jboss.dist");
         String asInst = System.getProperty("jboss.inst");
 
-        cliCommand = "java -Djboss.home.dir=" + asInst +
+        String javaExec = System.getProperty("java.home") + File.separatorChar + "bin" + File.separatorChar + "java";
+        if (javaExec.contains(" ")) {
+            javaExec = "\"" + javaExec + "\"";
+        }
+
+        cliCommand = javaExec + " -Djboss.home.dir=" + asInst +
             " -Djboss.modules.dir=" + asDist + "/modules" +
             " -Djline.WindowsTerminal.directConsole=false" +
             " -jar " + asDist + "/jboss-modules.jar" +


### PR DESCRIPTION
## Problem is fixed:
##  T E S T S

Running org.jboss.as.test.integration.management.cli.HelpTestCase
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 21.285 sec

Results :

Tests run: 16, Failures: 0, Errors: 0, Skipped: 0
