### PR TITLE
adding forgotten security tests to default configuration of ts.basic

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -99,6 +99,7 @@
                                     <includes>
                                         <include>org/jboss/as/test/integration/**/*SecondTestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/iiop/**/*TestCase*.java</include>
+                                        <include>org/jboss/as/test/integration/*/security/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/mdb/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/ejb/entity/cmp/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/ejb/remote/entity/cmp/**/*TestCase*.java</include>


### PR DESCRIPTION
Security tests were omitted from default config when splitting to full and web profile executions.
