### PR TITLE
Testsuite additions

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -40,6 +40,8 @@
         
         <!-- Used to provide an absolute location for the XSLT scripts. -->
         <xslt.scripts.dir>${jbossas.ts.integ.dir}/src/test/xslt</xslt.scripts.dir>
+        
+        <ts.skipTests>${skipTests}</ts.skipTests>
     </properties>
 
     <profiles>
@@ -191,7 +193,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skipTests>false</skipTests>
+                    <skipTests>${ts.skipTests}</skipTests>
                     <!-- Prevent test and server output appearing in console. -->
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <enableAssertions>true</enableAssertions>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -203,7 +203,7 @@
                     <!-- Forked process timeout -->
                     <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
-                    <argLine>${jvm.args.ip.client}</argLine>
+                    <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
 
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -203,7 +203,7 @@
                     <!-- Forked process timeout -->
                     <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
-                    <argLine>${ip.client.stack}</argLine>
+                    <argLine>${jvm.args.ip.client}</argLine>
 
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/integration/src/test/config/no-op.policy
+++ b/testsuite/integration/src/test/config/no-op.policy
@@ -1,0 +1,15 @@
+
+// TODO: AS7-2826
+
+// Grant all to AS.
+grant codeBase "file:${jboss.dist}/-" {
+  permission java.security.AllPermission;
+};
+grant codeBase "file:${jboss.inst}/-" {
+  permission java.security.AllPermission;
+};
+
+// Grant all to tests.
+grant codeBase "file:${jbossas.ts.root.dir}/-" {
+  permission java.security.AllPermission;
+};

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -98,6 +98,18 @@
         <jvm.args.securityManager></jvm.args.securityManager>
         <jvm.args.securityPolicy></jvm.args.securityPolicy>
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
+        
+        <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
+        <timeout.ratio.fsio>100</timeout.ratio.fsio>
+        <timeout.ratio.netio>100</timeout.ratio.netio>
+        <timeout.ratio.memio>100</timeout.ratio.memio>
+        <timeout.ratio.proc>100</timeout.ratio.proc>
+        <jvm.args.timeouts>
+            -Dts.tr.fsio=${timeout.ratio.fsio}
+            -Dts.tr.netio=${timeout.ratio.netio}
+            -Dts.tr.memio=${timeout.ratio.memio}
+            -Dts.tr.proc=${timeout.ratio.proc}
+        </jvm.args.timeouts>
 
         <!-- Database properties. -->
         <ds.db></ds.db>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -92,10 +92,11 @@
         <!-- IP stack configs. -->
         <ip.client.stack>-Djava.net.preferIPv4Stack=true</ip.client.stack>
         <ip.server.stack>-Djava.net.preferIPv4Stack=true</ip.server.stack>
-
-        <!-- Security properties. -->
-        <security.manager>-Djava.security.manager</security.manager>
-        <security.policy></security.policy>
+        
+        <!-- Security. -->
+        <jvm.args.securityManager></jvm.args.securityManager>
+        <jvm.args.securityPolicy></jvm.args.securityPolicy>
+        <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
 
         <!-- Database properties. -->
         <ds.db></ds.db>
@@ -455,6 +456,8 @@
             <modules><module>stress</module></modules>
         </profile>
 
+
+
         <!--
           Debugging profiles
         -->
@@ -469,6 +472,29 @@
                 <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
+
+
+
+        <!-- Security policy. -->
+        <profile>
+            <id>ts.security.policy</id>
+            <activation><property><name>security.policy</name></property></activation>
+            <properties>
+                <jvm.args.securityManager>-Djava.security.manager</jvm.args.securityManager>
+                <jvm.args.securityPolicy>-Djava.security.policy=${security.policy}</jvm.args.securityPolicy>
+            </properties>
+        </profile>
+
+        <!-- Security manager. -->
+        <profile>
+            <id>ts.security.manager</id>
+            <activation><property><name>security.manager</name></property></activation>
+            <properties>
+                <jvm.args.securityManager>-Djava.security.manager</jvm.args.securityManager>
+            </properties>
+        </profile>
+
+
 
         <!--
           Database profiles

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -90,8 +90,9 @@
         <udpGroup>230.0.0.4</udpGroup>
 
         <!-- IP stack configs. -->
-        <ip.client.stack>-Djava.net.preferIPv4Stack=true</ip.client.stack>
-        <ip.server.stack>-Djava.net.preferIPv4Stack=true</ip.server.stack>
+        <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
+        <jvm.args.ip.server>${jvm.args.ip}</jvm.args.ip.server>
+        <jvm.args.ip.client>${jvm.args.ip}</jvm.args.ip.client>
         
         <!-- Security. -->
         <jvm.args.securityManager></jvm.args.securityManager>
@@ -473,6 +474,15 @@
             </properties>
         </profile>
 
+
+        <!-- IPv6. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation><property><name>ipv6</name></property></activation>
+            <properties>
+                <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
+            </properties>
+        </profile>
 
 
         <!-- Security policy. -->


### PR DESCRIPTION
1) AS7-2827 - Adding props for configurable timeouts (QA req)
2) AS7-2228 - Passing JVM args for IPv6 to Arq (QA req)
3) AS7-2823 - Passing JVM args for security manager to Arq (QA req)
4) AS7-2796 Make -DskipTests skip testsuite tests again (restoring previous behavior).
