### PR TITLE
Testsuite additions II

### DIFF
--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -22,30 +22,25 @@ MAVEN_HOME=""
 MAVEN_OPTS="$MAVEN_OPTS -Xmx512M"
 export MAVEN_OPTS
 
-# the default search path for maven
+# The default search path for Maven.
 MAVEN_SEARCH_PATH="\
     tools
     tools/maven \
     tools/apache/maven \
     maven"
 
-# the default arguments
+# The default arguments.
 MVN_OPTIONS="-s ../tools/maven/conf/settings.xml"
 
-# Use the maximum available, or set MAX_FD != -1 to use that
+# Use the maximum available, or set MAX_FD != -1 to use that.
 MAX_FD="maximum"
 
 # OS specific support (must be 'true' or 'false').
 cygwin=false;
 darwin=false;
 case "`uname`" in
-    CYGWIN*)
-        cygwin=true
-        ;;
-
-    Darwin*)
-        darwin=true
-        ;;
+    CYGWIN*)  cygwin=true;;
+    Darwin*)  darwin=true;;
 esac
 
 
@@ -68,14 +63,13 @@ TESTS_SPECIFIED="N"
 #
 process_test_directives() {
 
-  MVN_GOALS="";
+    MVN_GOALS="";
 
-  # For each parameter, check for testsuite directives.
-  for param in $@
-  do
+    # For each parameter, check for testsuite directives.
+    for param in $@ ; do
     case $param in
       ## -DallTests runs all tests except benchmark and stress.
-      -DallTests)        TESTS_SPECIFIED="Y";  CMD_LINE_PARAMS="$CMD_LINE_PARAMS -DallTests";;
+      -DallTests)        TESTS_SPECIFIED="Y";  CMD_LINE_PARAMS="$CMD_LINE_PARAMS -DallTests -fae";;
 
       -Dinteg-tests)     TESTS_SPECIFIED="Y";  CMD_LINE_PARAMS="$CMD_LINE_PARAMS $INTEGRATION_TESTS";;
       -Dcluster-tests)   TESTS_SPECIFIED="Y";  CMD_LINE_PARAMS="$CMD_LINE_PARAMS $CLUSTER_TESTS";;
@@ -97,16 +91,16 @@ process_test_directives() {
       ## Pass through all other params.
       *)      CMD_LINE_PARAMS="$CMD_LINE_PARAMS $param";;
     esac
-  done
+    done
 
-  #  Default goal if none specified.
-  if [ -z "$MVN_GOALS" ]; then MVN_GOALS="install"; fi
-  CMD_LINE_PARAMS="$MVN_GOALS $CMD_LINE_PARAMS";
+    #  Default goal if none specified.
+    if [ -z "$MVN_GOALS" ]; then MVN_GOALS="install"; fi
+    CMD_LINE_PARAMS="$MVN_GOALS $CMD_LINE_PARAMS";
 
-  # If no tests specified, run smoke tests.
-  if [[ $TESTS_SPECIFIED == "N" ]]; then
-    CMD_LINE_PARAMS="$CMD_LINE_PARAMS $SMOKE_TESTS"
-  fi
+    # If no tests specified, run smoke tests.
+    if [[ $TESTS_SPECIFIED == "N" ]]; then
+        CMD_LINE_PARAMS="$CMD_LINE_PARAMS $SMOKE_TESTS"
+    fi
 }
 
 #
@@ -129,22 +123,22 @@ warn() {
 #
 maybe_source() {
     for file in $*; do
-	if [ -f "$file" ]; then
-	    . $file
-	fi
+        if [ -f "$file" ]; then
+            . $file
+        fi
     done
 }
 
-search() {
+find_maven() {
     search="$*"
     for d in $search; do
-	MAVEN_HOME="`pwd`/$d"
-	MVN="$MAVEN_HOME/bin/mvn"
-	if [ -x "$MVN" ]; then
-	    # found one
-	    echo $MAVEN_HOME
-	    break
-	fi
+        MAVEN_HOME="`pwd`/$d"
+        MVN="$MAVEN_HOME/bin/mvn"
+        if [ -x "$MVN" ]; then
+            # found one
+            echo $MAVEN_HOME
+            break
+        fi
     done
 }
 
@@ -152,89 +146,89 @@ search() {
 # Main function.
 #
 main() {
-    # if there is a build config file. then source it
+    #  If there is a build config file. then source it.
     maybe_source "$DIRNAME/build.conf" "$HOME/.build.conf"
 
-    # Increase the maximum file descriptors if we can
+    #  Increase the maximum file descriptors if we can.
     if [ $cygwin = "false" ]; then
-	MAX_FD_LIMIT=`ulimit -H -n`
-	if [ $? -eq 0 ]; then
-	    if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ]; then
-		# use the system max
-		MAX_FD="$MAX_FD_LIMIT"
-	    fi
+        MAX_FD_LIMIT=`ulimit -H -n`
+        if [ $? -eq 0 ]; then
+            if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ]; then
+                #  Use the system max.
+                MAX_FD="$MAX_FD_LIMIT"
+            fi
 
-	    ulimit -n $MAX_FD
-	    if [ $? -ne 0 ]; then
-		warn "Could not set maximum file descriptor limit: $MAX_FD"
-	    fi
-	else
-	    warn "Could not query system maximum file descriptor limit: $MAX_FD_LIMIT"
-	fi
+            ulimit -n $MAX_FD
+            if [ $? -ne 0 ]; then
+                warn "Could not set maximum file descriptor limit: $MAX_FD"
+            fi
+        else
+            warn "Could not query system maximum file descriptor limit: $MAX_FD_LIMIT"
+        fi
     fi
 
-    # try the search path
-    MAVEN_HOME=`search $MAVEN_SEARCH_PATH`
+    #  Try the search path.
+    MAVEN_HOME=`find_maven $MAVEN_SEARCH_PATH`
 
-    # try looking up to root
+    #  Try looking up to root.
     if [ "x$MAVEN_HOME" = "x" ]; then
-	target="build"
-	_cwd=`pwd`
+        target="build"
+        _cwd=`pwd`
 
-	while [ "x$MAVEN_HOME" = "x" ] && [ "$cwd" != "$ROOT" ]; do
-	    cd ..
-	    cwd=`pwd`
-	    MAVEN_HOME=`search $MAVEN_SEARCH_PATH`
-	done
+        while [ "x$MAVEN_HOME" = "x" ] && [ "$cwd" != "$ROOT" ]; do
+            cd ..
+            cwd=`pwd`
+            MAVEN_HOME=`search $MAVEN_SEARCH_PATH`
+        done
 
-	# make sure we get back
-	cd $_cwd
+        #  Make sure we get back.
+        cd $_cwd
 
-	if [ "$cwd" != "$ROOT" ]; then
-	    found="true"
-	fi
+        if [ "$cwd" != "$ROOT" ]; then
+            found="true"
+        fi
 
-	# complain if we did not find anything
-	if [ "$found" != "true" ]; then
-	    die "Could not locate Maven; check \$MVN or \$MAVEN_HOME."
-	fi
+        #  Complain if we did not find anything.
+        if [ "$found" != "true" ]; then
+            die "Could not locate Maven; check \$MVN or \$MAVEN_HOME."
+        fi
     fi
 
-    # make sure we have one
+    #  Make sure we have one.
     MVN=$MAVEN_HOME/bin/mvn
     if [ ! -x "$MVN" ]; then
-	die "Maven file is not executable: $MVN"
+        die "Maven file is not executable: $MVN"
     fi
 
-    # need to specify planet57/buildmagic protocol handler package
+    #  Need to specify planet57/buildmagic protocol handler package.
     MVN_OPTS="-Djava.protocol.handler.pkgs=org.jboss.net.protocol"
 
-    # setup some build properties
+    #  Setup some build properties.
     MVN_OPTS="$MVN_OPTS -Dbuild.script=$0"
 
-    # change to the directory where the script lives so users are not forced
-    # to be in the same directory as build.xml
+    #  Change to the directory where the script lives 
+    #  so users are not forced to be in the same directory as build.xml.
     cd $DIRNAME/testsuite
 
     MVN_GOAL=$@
     if [ -z "$MVN_GOAL" ]; then
-      MVN_GOAL="install"
+        MVN_GOAL="install"
     fi
 
-    # process test directives before calling maven
+    #  Process test directives before calling maven.
     process_test_directives $MVN_GOAL
     MVN_GOAL=$CMD_LINE_PARAMS
 
-    # export some stuff for maven
+    # Export some stuff for maven.
     export MVN MAVEN_HOME MVN_OPTS MVN_GOAL
 
     echo "$MVN $MVN_OPTIONS $MVN_GOAL"
 
-    # execute in debug mode, or simply execute
+    #  Execute in debug mode, or simply execute.
     if [ "x$MVN_DEBUG" != "x" ]; then
-	  /bin/sh -x $MVN $MVN_OPTIONS $MVN_GOAL
+        /bin/sh -x $MVN $MVN_OPTIONS $MVN_GOAL
     else
-	  exec $MVN $MVN_OPTIONS $MVN_GOAL
+        exec $MVN $MVN_OPTIONS $MVN_GOAL
     fi
 
     cd $DIRNAME

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -161,7 +161,7 @@
                                 <phase>test</phase>
                                 <goals><goal>test</goal></goals>
                                 <configuration>
-                                    <skipTests>false</skipTests>
+                                    <skipTests>${ts.skipTests}</skipTests>
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                                     <enableAssertions>true</enableAssertions>
                                     <includes>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -185,7 +185,7 @@
         <!-- This changes the FULL exec so that it includes all tests. -->
         <profile>
             <id>webProfileExclusion.profile</id>
-            <activation><property><name>!noWebProfile</name></property></activation>
+            <activation><property><name>noWebProfile</name></property></activation>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -126,7 +126,9 @@
                                 <configuration>
                                     <!-- Tests to execute. Overriden in webProfileExclusion.profile . -->
                                     <excludes>
+                                        <!-- 2nd run tests are run in other execution. -->
                                         <exclude>org/jboss/as/test/integration/**/*SecondTestCase.java</exclude>
+                                        <!-- Tests which need FULL config. -->
                                         <exclude>org/jboss/as/test/integration/ejb/iiop/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/mdb/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/entity/cmp/**/*TestCase*.java</exclude>
@@ -179,58 +181,38 @@
             </build>
         </profile>
         
-        <!-- TODO is this still needed after I (Kabir) did the split in basic.integration.tests.profile? 
-              I disabled it for now
-         -->
-        <!-- Web profile - separation of web~ and full~profile tests. -->
+        <!-- With -DnoWebProfile, the all tests will run with standalone-full.xml. -->
+        <!-- This changes the FULL exec so that it includes all tests. -->
         <profile>
             <id>webProfileExclusion.profile</id>
-            <!-- With -DnoWebProfile, the all tests will run with standalone-full.xml. -->
-            <!--  DISABLED  -->
-            <!-- activation><property><name>!noWebProfile</name></property></activation -->
+            <activation><property><name>!noWebProfile</name></property></activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <!-- Run the tests with web profile. -->
                         <executions>
+                            <!-- Disable execution with WEB config. -->
                             <execution>
-                                <!-- Overrides the default execution. -->
-                                <id>basic-integration-web.surefire</id>
-                                <phase>test</phase>
+                                <id>basic-integration-default-web.surefire</id>
+                                <phase>none</phase>
                                 <goals><goal>test</goal></goals>
-                                <configuration>
-                                    <!-- Parameters to test cases. -->
-                                    <systemPropertyVariables>
-                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
-                                    </systemPropertyVariables>
-                                    <!-- Exclude jacorb, hornetq, jaxr, and webservices. -->
-                                    <excludes>
-                                        <exclude>org/jboss/as/test/integration/**/*SecondTestCase.java</exclude>
-                                        <exclude>org/jboss/as/test/integration/jacorb/**/*</exclude>
-                                        <exclude>org/jboss/as/test/integration/hornetq/**/*</exclude>
-                                        <exclude>org/jboss/as/test/integration/jaxr/**/*</exclude>
-                                        <exclude>org/jboss/as/test/integration/ws/**/*</exclude>
-                                    </excludes>
-                                </configuration>
                             </execution>
-                            <!-- Run the rest with full profile. -->
+                            <!-- Run the ALL tests with FULL config. -->
                             <execution>
-                                <id>basic-integration-non-web.surefire</id>
+                                <id>basic-integration-default-full.surefire</id>
                                 <phase>test</phase>
                                 <goals><goal>test</goal></goals>
                                 <configuration>
                                     <systemPropertyVariables>
                                         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
-                                    <!-- Run only jacorb, hornetq, jaxr, and webservices. -->
                                     <includes>
-                                        <include>org/jboss/as/test/integration/jacorb/**/*TestCase.java</include>
-                                        <include>org/jboss/as/test/integration/hornetq/**/*TestCase.java</include>
-                                        <include>org/jboss/as/test/integration/jaxr/**/*TestCase.java</include>
-                                        <include>org/jboss/as/test/integration/ws/**/*TestCase.java</include>
+                                        <include>**/*TestCase.java</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/**/*SecondTestCase.java</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>
@@ -238,6 +220,8 @@
                 </plugins>
             </build>
         </profile>
+
+
 
         <!-- When -Dtest=... is set, only the default surefire execution with standalone-full.xml will run. -->
         <profile>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -83,11 +83,7 @@
                         <executions combine.children="append">
 
                             <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals><goal>test</goal></goals>
-                                <phase>none</phase>
-                            </execution>
+                            <execution><id>default-test</id><goals><goal>test</goal></goals><phase>none</phase></execution>
 
 
                             <execution>
@@ -245,7 +241,7 @@
 
         <!-- When -Dtest=... is set, only the default surefire execution with standalone-full.xml will run. -->
         <profile>
-            <id>onlyOneSurefireExecution.profile</id>
+            <id>onlyOneSurefireExecution.basic.profile</id>
             <activation><property><name>test</name></property></activation>
             <build>
                 <plugins>
@@ -253,8 +249,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
-                            <execution><id>basic-integration-web.surefire</id><phase>none</phase></execution>
-                            <execution><id>basic-integration-non-web.surefire</id><phase>none</phase></execution>
+                            <execution><id>basic-integration-default-full.surefire</id><phase>none</phase></execution>
+                            <execution><id>basic-integration-default-web.surefire</id><phase>none</phase></execution>
                             <execution><id>basic-integration-2nd.surefire</id><phase>none</phase></execution>
                         </executions>
                     </plugin>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -40,6 +40,8 @@
         
         <!-- Used to provide an absolute location for the XSLT scripts. -->
         <xslt.scripts.dir>${jbossas.ts.integ.dir}/src/test/xslt</xslt.scripts.dir>
+        
+        <ts.skipTests>${skipTests}</ts.skipTests>
     </properties>
 
     <profiles>
@@ -191,7 +193,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <skipTests>false</skipTests>
+                    <skipTests>${ts.skipTests}</skipTests>
                     <!-- Prevent test and server output appearing in console. -->
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <enableAssertions>true</enableAssertions>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -203,7 +203,7 @@
                     <!-- Forked process timeout -->
                     <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
-                    <argLine>${jvm.args.ip.client}</argLine>
+                    <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
 
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -203,7 +203,7 @@
                     <!-- Forked process timeout -->
                     <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
-                    <argLine>${ip.client.stack}</argLine>
+                    <argLine>${jvm.args.ip.client}</argLine>
 
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${ip.server.stack} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -151,7 +151,7 @@
         <!-- This changes the FULL exec so that it includes all tests. -->
         <profile>
             <id>webProfileExclusion.profile</id>
-            <activation><property><name>!noWebProfile</name></property></activation>
+            <activation><property><name>noWebProfile</name></property></activation>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -145,6 +145,49 @@
                 </plugins>
             </build>
         </profile>
+        
+        
+        <!-- With -DnoWebProfile, the all tests will run with standalone-full.xml. -->
+        <!-- This changes the FULL exec so that it includes all tests. -->
+        <profile>
+            <id>webProfileExclusion.profile</id>
+            <activation><property><name>!noWebProfile</name></property></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <!-- Disable execution with WEB config. -->
+                            <execution>
+                                <id>smoke-web.surefire</id>
+                                <phase>none</phase>
+                                <goals><goal>test</goal></goals>
+                            </execution>
+                            <!-- Run the ALL tests with FULL config. -->
+                            <execution>
+                                <id>smoke-full.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+                                    <includes>
+                                        <include>**/*TestCase.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/**/*SecondTestCase.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
+        
 
         <!-- When -Dtest=... is set, only the default surefire execution with standalone-full.xml will run. -->
         <profile>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -87,30 +87,21 @@
                         </executions>
                     </plugin>
 
-
+                    <!-- Surefire. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions combine.children="append">
 
                             <!-- Disable default-test execution. -->
-                            <execution>
-                                <id>default-test</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <phase>none</phase>
-                            </execution>
+                            <execution><id>default-test</id><goals><goal>test</goal></goals><phase>none</phase></execution>
 
-                            <!-- Smoke tests. -->
+                            <!-- Smoke tests - FULL. -->
                             <execution>
                                 <id>smoke-full.surefire</id>
                                 <phase>test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
+                                <goals><goal>test</goal></goals>
                                 <configuration>
-                                    <!-- Tests to execute. -->
                                     <includes>
                                         <include>org/jboss/as/test/smoke/embedded/demos/client/jms/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/smoke/embedded/demos/client/messaging/**/*TestCase.java</include>
@@ -126,14 +117,12 @@
                                 </configuration>
                             </execution>
 
+                            <!-- Smoke tests - WEB. -->
                             <execution>
                                 <id>smoke-web.surefire</id>
                                 <phase>test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
+                                <goals><goal>test</goal></goals>
                                 <configuration>
-                                    <!-- Tests to execute. -->
                                     <excludes>
                                         <exclude>org/jboss/as/test/smoke/embedded/demos/client/jms/**/*</exclude>
                                         <exclude>org/jboss/as/test/smoke/embedded/demos/client/messaging/**/*</exclude>
@@ -153,6 +142,24 @@
 
                     </plugin>
 
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- When -Dtest=... is set, only the default surefire execution with standalone-full.xml will run. -->
+        <profile>
+            <id>onlyOneSurefireExecution.smoke.profile</id>
+            <activation><property><name>test</name></property></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution><id>smoke-full.surefire</id><phase>none</phase></execution>
+                            <execution><id>smoke-web.surefire</id><phase>none</phase></execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/testsuite/integration/src/test/config/no-op.policy
+++ b/testsuite/integration/src/test/config/no-op.policy
@@ -1,0 +1,15 @@
+
+// TODO: AS7-2826
+
+// Grant all to AS.
+grant codeBase "file:${jboss.dist}/-" {
+  permission java.security.AllPermission;
+};
+grant codeBase "file:${jboss.inst}/-" {
+  permission java.security.AllPermission;
+};
+
+// Grant all to tests.
+grant codeBase "file:${jbossas.ts.root.dir}/-" {
+  permission java.security.AllPermission;
+};

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -98,6 +98,18 @@
         <jvm.args.securityManager></jvm.args.securityManager>
         <jvm.args.securityPolicy></jvm.args.securityPolicy>
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
+        
+        <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
+        <timeout.ratio.fsio>100</timeout.ratio.fsio>
+        <timeout.ratio.netio>100</timeout.ratio.netio>
+        <timeout.ratio.memio>100</timeout.ratio.memio>
+        <timeout.ratio.proc>100</timeout.ratio.proc>
+        <jvm.args.timeouts>
+            -Dts.tr.fsio=${timeout.ratio.fsio}
+            -Dts.tr.netio=${timeout.ratio.netio}
+            -Dts.tr.memio=${timeout.ratio.memio}
+            -Dts.tr.proc=${timeout.ratio.proc}
+        </jvm.args.timeouts>
 
         <!-- Database properties. -->
         <ds.db></ds.db>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -92,10 +92,11 @@
         <!-- IP stack configs. -->
         <ip.client.stack>-Djava.net.preferIPv4Stack=true</ip.client.stack>
         <ip.server.stack>-Djava.net.preferIPv4Stack=true</ip.server.stack>
-
-        <!-- Security properties. -->
-        <security.manager>-Djava.security.manager</security.manager>
-        <security.policy></security.policy>
+        
+        <!-- Security. -->
+        <jvm.args.securityManager></jvm.args.securityManager>
+        <jvm.args.securityPolicy></jvm.args.securityPolicy>
+        <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
 
         <!-- Database properties. -->
         <ds.db></ds.db>
@@ -455,6 +456,8 @@
             <modules><module>stress</module></modules>
         </profile>
 
+
+
         <!--
           Debugging profiles
         -->
@@ -469,6 +472,29 @@
                 <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
+
+
+
+        <!-- Security policy. -->
+        <profile>
+            <id>ts.security.policy</id>
+            <activation><property><name>security.policy</name></property></activation>
+            <properties>
+                <jvm.args.securityManager>-Djava.security.manager</jvm.args.securityManager>
+                <jvm.args.securityPolicy>-Djava.security.policy=${security.policy}</jvm.args.securityPolicy>
+            </properties>
+        </profile>
+
+        <!-- Security manager. -->
+        <profile>
+            <id>ts.security.manager</id>
+            <activation><property><name>security.manager</name></property></activation>
+            <properties>
+                <jvm.args.securityManager>-Djava.security.manager</jvm.args.securityManager>
+            </properties>
+        </profile>
+
+
 
         <!--
           Database profiles

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -90,8 +90,9 @@
         <udpGroup>230.0.0.4</udpGroup>
 
         <!-- IP stack configs. -->
-        <ip.client.stack>-Djava.net.preferIPv4Stack=true</ip.client.stack>
-        <ip.server.stack>-Djava.net.preferIPv4Stack=true</ip.server.stack>
+        <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
+        <jvm.args.ip.server>${jvm.args.ip}</jvm.args.ip.server>
+        <jvm.args.ip.client>${jvm.args.ip}</jvm.args.ip.client>
         
         <!-- Security. -->
         <jvm.args.securityManager></jvm.args.securityManager>
@@ -473,6 +474,15 @@
             </properties>
         </profile>
 
+
+        <!-- IPv6. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation><property><name>ipv6</name></property></activation>
+            <properties>
+                <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
+            </properties>
+        </profile>
 
 
         <!-- Security policy. -->


### PR DESCRIPTION
1) AS7-2827 - Adding props for configurable timeouts (QA req)
2) AS7-2228 - Passing JVM args for IPv6 to Arq (QA req)
3) AS7-2823 - Passing JVM args for security manager to Arq (QA req)
4) AS7-2796 Make -DskipTests skip testsuite tests again (restoring previous behavior).
5) JBPAPP-7588 - Update EAP configuration and testsuite to use full EE profile.
6) Fix the onlyOneSurefireExecution.profile
