### PR TITLE
Fix for a couple of MDB and resource adapter issues

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/ConnectorMessages.java
+++ b/connector/src/main/java/org/jboss/as/connector/ConnectorMessages.java
@@ -31,6 +31,7 @@ import org.jboss.logging.Cause;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageBundle;
 import org.jboss.logging.Messages;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 import org.jboss.vfs.VirtualFile;
 
@@ -390,4 +391,25 @@ public interface ConnectorMessages {
      */
     @Message(id = 10461, value = "Failed to load native libraries")
     DeploymentUnitProcessingException failedToLoadNativeLibraries(@Cause Throwable cause);
+
+    /**
+     * Creates an exception indicating that the ServiceName doesn't belong to a resource adapter service
+     *
+     * @param serviceName The service name
+     *
+     * @return an {@link IllegalArgumentException} for the error.
+     */
+    @Message(id = 10462, value = "%s isn't a resource adapter service")
+    IllegalArgumentException notResourceAdapterService(ServiceName serviceName);
+
+    /**
+     * Creates and returns an exception indicating that the param named <code>paramName</code> cannot be null
+     * or empty string.
+     *
+     * @param paramName The param name
+     * @return an {@link IllegalArgumentException} for the exception
+     */
+    @Message(id = 10463, value = "%s cannot be null or empty")
+    IllegalArgumentException stringParamCannotBeNullOrEmpty(final String paramName);
+
 }

--- a/connector/src/main/java/org/jboss/as/connector/ConnectorServices.java
+++ b/connector/src/main/java/org/jboss/as/connector/ConnectorServices.java
@@ -294,7 +294,7 @@ public final class ConnectorServices {
      * @param raName The resource adapter name
      * @return
      */
-    public static synchronized Set<ServiceName> getResourceAdapterDependencies(final String raName) {
+    public static synchronized Set<ServiceName> getResourceAdapterServiceNames(final String raName) {
         if (raName == null || raName.trim().isEmpty()) {
             throw MESSAGES.stringParamCannotBeNullOrEmpty("resource adapter name");
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -1820,11 +1820,11 @@ public interface EjbMessages {
      * Creates an exception indicating that there was no message listener of the expected type
      * in the resource adapter
      *
-     * @param resourceAdapterName The resource adapter name
      * @param messageListenerType The message listener type
+     * @param resourceAdapterName The resource adapter name
      *
      * @return a {@link IllegalStateException} for the error.
      */
     @Message(id = 14521, value = "No message listener of type %s found in resource adapter %s")
-    IllegalStateException unknownMessageListenerType(String resourceAdapterName, String messageListenerType);
+    IllegalStateException unknownMessageListenerType(String messageListenerType, String resourceAdapterName);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -1827,4 +1827,15 @@ public interface EjbMessages {
      */
     @Message(id = 14521, value = "No message listener of type %s found in resource adapter %s")
     IllegalStateException unknownMessageListenerType(String messageListenerType, String resourceAdapterName);
+
+    /**
+     * Creates and returns an exception indicating that the param named <code>paramName</code> cannot be null
+     * or empty string.
+     *
+     * @param paramName The param name
+     * @return an {@link IllegalArgumentException} for the exception
+     */
+    @Message(id = 14522, value = "%s cannot be null or empty")
+    IllegalArgumentException stringParamCannotBeNullOrEmpty(final String paramName);
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -92,7 +92,7 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
             // now get the message listeners for this specific ra identifier
             final List<MessageListener> messageListeners = resourceAdapterRepository.getMessageListeners(raIdentifier);
             if (messageListeners == null || messageListeners.isEmpty()) {
-                throw MESSAGES.unknownMessageListenerType(resourceAdapterName, messageListenerInterface.getName());
+                throw MESSAGES.unknownMessageListenerType(messageListenerInterface.getName(), resourceAdapterName);
             }
             MessageListener requiredMessageListener = null;
             // now find the expected message listener from the list of message listeners for this resource adapter
@@ -103,7 +103,7 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
                 }
             }
             if (requiredMessageListener == null) {
-                throw MESSAGES.unknownMessageListenerType(resourceAdapterName, messageListenerInterface.getName());
+                throw MESSAGES.unknownMessageListenerType(messageListenerInterface.getName(), resourceAdapterName);
             }
             // found the message listener, now finally create the activation spec
             final Activation activation = requiredMessageListener.getActivation();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -31,7 +31,6 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 import java.beans.IntrospectionException;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -40,7 +39,6 @@ import java.util.Set;
 import org.jboss.as.connector.ConnectorServices;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
 import org.jboss.as.security.service.SimpleSecurityManager;
-import org.jboss.jca.core.spi.mdr.MetadataRepository;
 import org.jboss.jca.core.spi.rar.Activation;
 import org.jboss.jca.core.spi.rar.MessageListener;
 import org.jboss.jca.core.spi.rar.NotFoundException;
@@ -63,21 +61,13 @@ import org.jboss.util.propertyeditor.PropertyEditors;
 public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
 
 
-    private static final Map<String, String> knownRar = new HashMap<String, String>(1);
-
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb", "utilities");
 
-    private final InjectedValue<MetadataRepository> mdrValue = new InjectedValue<MetadataRepository>();
     private final InjectedValue<ResourceAdapterRepository> resourceAdapterRepositoryValue = new InjectedValue<ResourceAdapterRepository>();
     private final InjectedValue<SimpleSecurityManager> securityManagerValue = new InjectedValue<SimpleSecurityManager>();
     private final InjectedValue<TransactionManager> transactionManagerValue = new InjectedValue<TransactionManager>();
     private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<UserTransaction> userTransactionValue = new InjectedValue<UserTransaction>();
-
-    static {
-        knownRar.put("hornetq-ra", "org.hornetq.ra");
-        knownRar.put("hornetq-ra.rar", "org.hornetq.ra");
-    }
 
     public ActivationSpec createActivationSpecs(final String resourceAdapterName, final Class<?> messageListenerInterface,
                                                 final Properties activationConfigProperties, final ClassLoader classLoader) {
@@ -127,14 +117,6 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
         } catch (IntrospectionException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public MetadataRepository getMdr() {
-        return mdrValue.getOptionalValue();
-    }
-
-    public Injector<MetadataRepository> getMdrInjector() {
-        return mdrValue;
     }
 
     public ResourceAdapterRepository getResourceAdapterRepository() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
@@ -126,7 +126,7 @@ public class MessageDrivenComponentCreateService extends EJBComponentCreateServi
     }
 
     ServiceName getResourceAdapterServiceName() {
-        final Collection<ServiceName> serviceNames = ConnectorServices.getResourceAdapterServiceNames(this.resourceAdapterName);
+        final Collection<ServiceName> serviceNames = ConnectorServices.getResourceAdapterDependencies(this.resourceAdapterName);
         if (serviceNames == null || serviceNames.isEmpty()) {
             throw MESSAGES.failToFindResourceAdapter(this.resourceAdapterName);
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem11Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem11Parser.java
@@ -331,6 +331,14 @@ public class EJB3Subsystem11Parser implements XMLElementReader<List<ModelNode>>,
                 }
             }
         }
+        // if the resource-adapter-ref *hasn't* been explicitly specified, then default it to hornetq-ra
+        if (!ejb3SubsystemAddOperation.hasDefined(EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME)) {
+            final ModelNode defaultRAName = EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME.getDefaultValue();
+            if (defaultRAName != null) {
+                ejb3SubsystemAddOperation.get(EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME).set(defaultRAName);
+            }
+        }
+
         return mdbModelNode;
 
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -546,6 +546,13 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>>,
                 }
             }
         }
+        // if the resource-adapter-ref *hasn't* been explicitly specified, then default it to hornetq-ra
+        if (!ejb3SubsystemAddOperation.hasDefined(EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME)) {
+            final ModelNode defaultRAName = EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME.getDefaultValue();
+            if (defaultRAName != null) {
+                ejb3SubsystemAddOperation.get(EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME).set(defaultRAName);
+            }
+        }
         return mdbModelNode;
 
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -246,7 +246,6 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
             final EJBUtilities utilities = new EJBUtilities();
             newControllers.add(serviceTarget.addService(EJBUtilities.SERVICE_NAME, utilities)
                     .addDependency(ConnectorServices.RA_REPOSISTORY_SERVICE, ResourceAdapterRepository.class, utilities.getResourceAdapterRepositoryInjector())
-                    .addDependency(ConnectorServices.IRONJACAMAR_MDR, MetadataRepository.class, utilities.getMdrInjector())
                     .addDependency(SimpleSecurityManagerService.SERVICE_NAME, SimpleSecurityManager.class, utilities.getSecurityManagerInjector())
                     .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, utilities.getTransactionManagerInjector())
                     .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, utilities.getTransactionSynchronizationRegistryInjector())

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -52,6 +52,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                     .setAllowExpression(true).build();
     public static final SimpleAttributeDefinition DEFAULT_RESOURCE_ADAPTER_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME, ModelType.STRING, true)
+                    .setDefaultValue(new ModelNode().set("hornetq-ra"))
                     .setAllowExpression(true).build();
     public static final SimpleAttributeDefinition DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT, ModelType.LONG, true)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ConfiguredResourceAdapterNameMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ConfiguredResourceAdapterNameMDB.java
@@ -41,7 +41,7 @@ import org.jboss.logging.Logger;
         activationConfig = {
                 @ActivationConfigProperty(propertyName = "destination", propertyValue = ConfiguredResourceAdapterNameTestCase.QUEUE_JNDI_NAME)
 })
-@ResourceAdapter(value = "NoRAShouldBeNamedLikeThis.rar")
+@ResourceAdapter(value = "RARNameOverridenInJBossEJB3Xml.rar")
 public class ConfiguredResourceAdapterNameMDB implements MessageListener {
 
     private static final Logger logger = Logger.getLogger(ConfiguredResourceAdapterNameMDB.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/DeploymentPackagedRATestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/DeploymentPackagedRATestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.resourceadapter;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that a resource adapter packaged in a .ear can be used by a MDB as its resource adapter
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class DeploymentPackagedRATestCase {
+
+    private static final String EAR_NAME = "ear-containing-rar";
+
+    private static final String RAR_NAME = "rar-within-a-ear";
+
+    private static final String EJB_JAR_NAME = "ejb-jar";
+
+    @Deployment
+    public static Archive createDeplyoment() {
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_NAME + ".ear");
+
+        final JavaArchive rar = ShrinkWrap.create(JavaArchive.class, RAR_NAME + ".rar");
+        rar.addAsManifestResource("ejb/mdb/resourceadapter/ra.xml", "ra.xml");
+
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, EJB_JAR_NAME + ".jar");
+        ejbJar.addClasses(NonJMSMDB.class, DeploymentPackagedRATestCase.class);
+
+        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, "common-lib.jar");
+        libJar.addClasses(SimpleActivationSpec.class, SimpleResourceAdapter.class, SimpleMessageListener.class, ResourceAdapterDeploymentTracker.class);
+
+        ear.addAsModule(rar);
+        ear.addAsModule(ejbJar);
+        ear.addAsLibrary(libJar);
+
+        return ear;
+    }
+
+    /**
+     * Tests that a RA deployed within the .ear is deployed and started successfully and it's endpoint
+     * activation is invoked
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRADeployment() throws Exception {
+        Assert.assertTrue("Resource adapter deployed in the .ear was not started", ResourceAdapterDeploymentTracker.INSTANCE.wasEndpointStartCalled());
+        Assert.assertTrue("Resource adapter's endpoint was not activated", ResourceAdapterDeploymentTracker.INSTANCE.wasEndpointActivationCalled());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/NonJMSMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/NonJMSMDB.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.resourceadapter;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+
+import org.jboss.ejb3.annotation.ResourceAdapter;
+
+/**
+ * @author Jaikiran Pai
+ */
+@MessageDriven(messageListenerInterface = SimpleMessageListener.class, activationConfig = {
+        @ActivationConfigProperty(propertyName = "someProp", propertyValue = "hello world")})
+@ResourceAdapter(value = "rar-within-a-ear.rar")
+public class NonJMSMDB implements SimpleMessageListener {
+    
+    @Override
+    public void onMessage(String msg) {
+        
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ResourceAdapterDeploymentTracker.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ResourceAdapterDeploymentTracker.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.resourceadapter;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class ResourceAdapterDeploymentTracker {
+
+    public static final ResourceAdapterDeploymentTracker INSTANCE = new ResourceAdapterDeploymentTracker();
+
+    private boolean endpointActivationCalled;
+    private boolean endpointDeactivationCalled;
+    private boolean endpointStartCalled;
+    private boolean endpointStopCalled;
+
+    private ResourceAdapterDeploymentTracker() {
+
+    }
+
+    void endpointActivationCalled() {
+        this.endpointActivationCalled = true;
+    }
+
+    public boolean wasEndpointActivationCalled() {
+        return this.endpointActivationCalled;
+    }
+
+    void endpointDeactivationCalled() {
+        this.endpointDeactivationCalled = true;
+    }
+
+    public boolean wasEndpointDeactivationCalled() {
+        return this.endpointDeactivationCalled;
+    }
+
+    void endpointStartCalled() {
+        this.endpointStartCalled = true;
+    }
+
+    public boolean wasEndpointStartCalled() {
+        return this.endpointStartCalled;
+    }
+
+    void endpointStopCalled() {
+        this.endpointStopCalled = true;
+    }
+
+    public boolean wasEndpointStopCalled() {
+        return this.endpointStopCalled;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/SimpleActivationSpec.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/SimpleActivationSpec.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.resourceadapter;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ResourceAdapter;
+import java.io.Serializable;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class SimpleActivationSpec implements ActivationSpec, Serializable {
+
+    private ResourceAdapter ra;
+    private String someProp;
+
+    public ResourceAdapter getResourceAdapter() {
+        return this.ra;
+    }
+
+    public void setResourceAdapter(ResourceAdapter ra) throws ResourceException {
+        this.ra = ra;
+    }
+
+    public void validate() throws InvalidPropertyException {
+    }
+
+    public String getSomeProp() {
+        return this.someProp;
+    }
+
+    public void setSomeProp(String prop) {
+        this.someProp = someProp;
+    }
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/SimpleMessageListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/SimpleMessageListener.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.resourceadapter;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface SimpleMessageListener {
+
+    void onMessage(String msg);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/SimpleResourceAdapter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/SimpleResourceAdapter.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.resourceadapter;
+
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.resource.Referenceable;
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.transaction.xa.XAResource;
+import java.io.Serializable;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class SimpleResourceAdapter implements ResourceAdapter, Referenceable, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger logger = Logger.getLogger(SimpleResourceAdapter.class);
+
+    public void endpointActivation(MessageEndpointFactory endpointFactory, ActivationSpec spec)
+            throws ResourceException {
+        logger.info("endpoint activation invoked for endpoint factory " + endpointFactory + " and activation spec " + spec);
+        ResourceAdapterDeploymentTracker.INSTANCE.endpointActivationCalled();
+    }
+
+    public void endpointDeactivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) {
+        logger.info("endpoint de-activation invoked for endpoint factory " + endpointFactory + " and activation spec " + spec);
+        ResourceAdapterDeploymentTracker.INSTANCE.endpointDeactivationCalled();
+    }
+
+    public XAResource[] getXAResources(ActivationSpec[] specs) throws ResourceException {
+        return null;
+    }
+
+    public void start(BootstrapContext ctx) throws ResourceAdapterInternalException {
+        logger.info("resource adapter start invoked");
+        try {
+            /*
+            *  This is a small delay to emulate startup time of an RA.
+            *  I understand that according to the spec, this step of RA should not perform any
+            *  heavy task, and app server could throw WorkRejectedException if it takes too long.
+            *  However, this small delay should be good rough approximation of the total time the RA
+            *  could take to bootstrap itself more so, to reliably repoduce the issue, as otherwise,
+            *  the failure is reproducible only indeterministically.
+            */
+            Thread.sleep(500L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        ResourceAdapterDeploymentTracker.INSTANCE.endpointStartCalled();
+    }
+
+    public void stop() {
+        logger.info("resource adapter stop invoked");
+        ResourceAdapterDeploymentTracker.INSTANCE.endpointStopCalled();
+    }
+
+    public Reference getReference() throws NamingException {
+        return null;
+    }
+
+    public void setReference(Reference reference) {
+    }
+
+}

--- a/testsuite/integration/basic/src/test/resources/ejb/mdb/resourceadapter/ra.xml
+++ b/testsuite/integration/basic/src/test/resources/ejb/mdb/resourceadapter/ra.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector version="1.5" xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd">
+  <description></description>
+  <display-name>Test resource adapter</display-name>
+  <vendor-name>JBoss</vendor-name>
+  <eis-type>resource-adapter</eis-type>
+  <resourceadapter-version>1.0</resourceadapter-version>
+  <resourceadapter>
+    <resourceadapter-class>org.jboss.as.test.integration.ejb.mdb.resourceadapter.SimpleResourceAdapter</resourceadapter-class>
+    <inbound-resourceadapter>
+      <messageadapter>
+        <messagelistener>
+          <messagelistener-type>org.jboss.as.test.integration.ejb.mdb.resourceadapter.SimpleMessageListener</messagelistener-type>
+          <activationspec>
+            <activationspec-class>org.jboss.as.test.integration.ejb.mdb.resourceadapter.SimpleActivationSpec</activationspec-class>
+            <required-config-property>
+              <config-property-name>someProp</config-property-name>
+            </required-config-property>
+          </activationspec>
+        </messagelistener>
+      </messageadapter>
+    </inbound-resourceadapter>
+  </resourceadapter>
+</connector>


### PR DESCRIPTION
The commits in this branch fix a couple of issues related to MDBs and resource adapters which have been reported in https://issues.jboss.org/browse/AS7-2505 and https://issues.jboss.org/browse/AS7-1844. To summarize, the fixes in this branch include: 

1) The ServiceName for the resource adapter dependency wasn't being correctly returned. This has now been fixed to return the ServiceName of the first activation of the resource adapter so that the EJB3 MDB component can depend on that service name

2) The MDB component create service wasn't setting up a dependency on the resource adapter. This has now been fixed to ensure that the MDB component create service has that RA dependency

3) A minor logging fix and a test case for AS7-2505
