### PR TITLE
AS7-2463 Fixes blocker issue with non-local purging of web sessions on undeploy due to ISPN-1583

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/AbstractAdvancedCache.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/AbstractAdvancedCache.java
@@ -1,3 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.clustering.infinispan;
 
 import org.infinispan.AbstractDelegatingAdvancedCache;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/AbstractAdvancedCache.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/AbstractAdvancedCache.java
@@ -1,0 +1,30 @@
+package org.jboss.as.clustering.infinispan;
+
+import org.infinispan.AbstractDelegatingAdvancedCache;
+import org.infinispan.AdvancedCache;
+import org.infinispan.context.Flag;
+
+/**
+ * Workaround for ISPN-1583.
+ * @author Paul Ferraro
+ * @param <K> Cache key type
+ * @param <V> Cache value type
+ */
+public abstract class AbstractAdvancedCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> {
+
+    protected AbstractAdvancedCache(AdvancedCache<K, V> cache) {
+        super(cache);
+    }
+
+    protected abstract AdvancedCache<K, V> wrap(AdvancedCache<K, V> cache);
+
+    @Override
+    public AdvancedCache<K, V> withFlags(Flag... flags) {
+        return this.wrap(this.cache.withFlags(flags));
+    }
+
+    @Override
+    public AdvancedCache<K, V> with(ClassLoader classLoader) {
+        return this.wrap(this.cache.with(classLoader));
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
@@ -30,6 +30,7 @@ import org.infinispan.AbstractDelegatingAdvancedCache;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.config.Configuration;
+import org.infinispan.context.Flag;
 import org.infinispan.manager.AbstractDelegatingEmbeddedCacheManager;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -180,12 +181,9 @@ public class DefaultEmbeddedCacheManager extends AbstractDelegatingEmbeddedCache
         return this.cm.getGlobalConfiguration().getCacheManagerName();
     }
 
-    class DelegatingCache<K, V> extends AbstractDelegatingAdvancedCache<K, V> {
-        private final AdvancedCache<K, V> cache;
-
+    class DelegatingCache<K, V> extends AbstractAdvancedCache<K, V> {
         DelegatingCache(AdvancedCache<K, V> cache) {
             super(cache);
-            this.cache = cache;
         }
 
         DelegatingCache(Cache<K, V> cache) {
@@ -193,13 +191,13 @@ public class DefaultEmbeddedCacheManager extends AbstractDelegatingEmbeddedCache
         }
 
         @Override
-        public EmbeddedCacheManager getCacheManager() {
-            return DefaultEmbeddedCacheManager.this;
+        protected AdvancedCache<K, V> wrap(AdvancedCache<K, V> cache) {
+            return new DelegatingCache<K, V>(cache);
         }
 
         @Override
-        public AdvancedCache<K, V> getAdvancedCache() {
-            return this;
+        public EmbeddedCacheManager getCacheManager() {
+            return DefaultEmbeddedCacheManager.this;
         }
 
         @Override

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/atomic/AtomicMapCache.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/atomic/AtomicMapCache.java
@@ -3,17 +3,19 @@ package org.jboss.as.clustering.infinispan.atomic;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.infinispan.AbstractDelegatingAdvancedCache;
 import org.infinispan.AdvancedCache;
 import org.infinispan.atomic.AtomicMapLookup;
 import org.infinispan.util.concurrent.NotifyingFuture;
+import org.jboss.as.clustering.infinispan.AbstractAdvancedCache;
 
-public class AtomicMapCache<K, MK, MV> extends AbstractDelegatingAdvancedCache<K, Map<MK, MV>> {
-    private final AdvancedCache<K, Map<MK, MV>> cache;
-
+public class AtomicMapCache<K, MK, MV> extends AbstractAdvancedCache<K, Map<MK, MV>> {
     public AtomicMapCache(AdvancedCache<K, Map<MK, MV>> cache) {
         super(cache);
-        this.cache = cache;
+    }
+
+    @Override
+    protected AdvancedCache<K, Map<MK, MV>> wrap(AdvancedCache<K, Map<MK, MV>> cache) {
+        return new AtomicMapCache<K, MK, MV>(cache);
     }
 
     @SuppressWarnings("unchecked")
@@ -25,18 +27,6 @@ public class AtomicMapCache<K, MK, MV> extends AbstractDelegatingAdvancedCache<K
     @Override
     public Map<MK, MV> putIfAbsent(K key, Map<MK, MV> value) {
         return AtomicMapLookup.getAtomicMap(this.cache, key, true);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public Map<MK, MV> remove(Object key) {
-        AtomicMapLookup.removeAtomicMap(this.cache, (K) key);
-        return null;
-    }
-
-    @Override
-    public AdvancedCache<K, Map<MK, MV>> getAdvancedCache() {
-        return this;
     }
 
     @Override

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EmbeddedCacheManagerDefaultsService.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EmbeddedCacheManagerDefaultsService.java
@@ -119,10 +119,9 @@ public class EmbeddedCacheManagerDefaultsService implements Service<EmbeddedCach
             if (mode.isSynchronous()) {
                 fluent.sync().replTimeout(17500L);
             } else {
-                FluentConfiguration.AsyncConfig async = fluent.async();
                 // ISPN-835 workaround
                 if (configuration.isFetchInMemoryState()) {
-                    async.useReplQueue(true).replQueueMaxElements(10);
+                    fluent.async().useReplQueue(true).replQueueMaxElements(1);
                 }
             }
             defaults.add(mode, configuration);

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/ClassLoaderAwareCacheTest.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/ClassLoaderAwareCacheTest.java
@@ -32,6 +32,7 @@ import org.infinispan.AdvancedCache;
 import org.infinispan.commands.VisitableCommand;
 import org.infinispan.commands.read.KeySetCommand;
 import org.infinispan.container.DataContainer;
+import org.infinispan.context.Flag;
 import org.infinispan.context.InvocationContext;
 import org.infinispan.interceptors.base.CommandInterceptor;
 import org.infinispan.notifications.Listener;
@@ -105,7 +106,22 @@ public class ClassLoaderAwareCacheTest {
     public void with() {
         assertSame(this.cache, this.cache.with(Thread.currentThread().getContextClassLoader()));
     }
-    
+
+    @Test
+    public void withFlags() {
+        AdvancedCache<Object, Object> flaggedCache = mock(AdvancedCache.class);
+        
+        when(this.mockCache.withFlags(Flag.CACHE_MODE_LOCAL)).thenReturn(flaggedCache);
+        
+        AdvancedCache<Object, Object> result = this.cache.withFlags(Flag.CACHE_MODE_LOCAL);
+        
+        assertNotSame(this.cache, result);
+        
+        result.clear();
+        
+        verify(flaggedCache).clear();
+    }
+
     @Test
     public void addListener() throws Throwable {
         ArgumentCaptor<ClassLoaderAwareListener> capturedListener = ArgumentCaptor.forClass(ClassLoaderAwareListener.class);

--- a/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/DistributedCacheManager.java
+++ b/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/DistributedCacheManager.java
@@ -326,7 +326,7 @@ public class DistributedCacheManager<T extends OutgoingDistributableSessionData,
         Operation<Map<Object, Object>> operation = new Operation<Map<Object, Object>>() {
             @Override
             public Map<Object, Object> invoke(Cache<K, Map<Object, Object>> cache) {
-                return cache.getAdvancedCache().withFlags(local ? Flag.CACHE_MODE_LOCAL : Flag.SKIP_REMOTE_LOOKUP).remove(key);
+                return cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD, local ? Flag.CACHE_MODE_LOCAL : Flag.SKIP_REMOTE_LOOKUP).remove(key);
             }
         };
 

--- a/clustering/web-infinispan/src/test/java/org/jboss/as/clustering/web/infinispan/DistributedCacheManagerTest.java
+++ b/clustering/web-infinispan/src/test/java/org/jboss/as/clustering/web/infinispan/DistributedCacheManagerTest.java
@@ -322,7 +322,7 @@ public class DistributedCacheManagerTest {
         Map<Object, Object> expectedMap = mock(Map.class);
 
         when(this.sessionCache.getAdvancedCache()).thenReturn(this.sessionCache);
-        when(this.sessionCache.withFlags(Flag.SKIP_REMOTE_LOOKUP)).thenReturn(this.sessionCache);
+        when(this.sessionCache.withFlags(Flag.SKIP_CACHE_LOAD, Flag.SKIP_REMOTE_LOOKUP)).thenReturn(this.sessionCache);
         when(this.sessionCache.remove(key)).thenReturn(expectedMap);
 
         Map<Object, Object> resultMap = operation.invoke(this.sessionCache);
@@ -348,7 +348,7 @@ public class DistributedCacheManagerTest {
         Map<Object, Object> expectedMap = mock(Map.class);
 
         when(this.sessionCache.getAdvancedCache()).thenReturn(this.sessionCache);
-        when(this.sessionCache.withFlags(Flag.CACHE_MODE_LOCAL)).thenReturn(this.sessionCache);
+        when(this.sessionCache.withFlags(Flag.SKIP_CACHE_LOAD, Flag.CACHE_MODE_LOCAL)).thenReturn(this.sessionCache);
         when(this.sessionCache.remove(key)).thenReturn(expectedMap);
 
         Map<Object, Object> resultMap = operation.invoke(this.sessionCache);
@@ -374,7 +374,7 @@ public class DistributedCacheManagerTest {
         Map<Object, Object> expectedMap = mock(Map.class);
 
         when(this.sessionCache.getAdvancedCache()).thenReturn(this.sessionCache);
-        when(this.sessionCache.withFlags(Flag.CACHE_MODE_LOCAL)).thenReturn(this.sessionCache);
+        when(this.sessionCache.withFlags(Flag.SKIP_CACHE_LOAD, Flag.CACHE_MODE_LOCAL)).thenReturn(this.sessionCache);
         when(this.sessionCache.remove(key)).thenReturn(expectedMap);
 
         Map<Object, Object> resultMap = operation.invoke(this.sessionCache);

--- a/web/src/test/java/org/jboss/as/web/session/SessionTestUtil.java
+++ b/web/src/test/java/org/jboss/as/web/session/SessionTestUtil.java
@@ -186,10 +186,7 @@ public class SessionTestUtil {
         config.fluent().syncCommitPhase(true).syncRollbackPhase(true).invocationBatching().transaction().transactionMode(TransactionMode.TRANSACTIONAL).useSynchronization(true);
 
         if (passivationDir != null) {
-            // Dodge failures due to ISPN-1470
-            // Until this is fixed, we can expect test failures involving cache load preloading and DIST
-//            fluent.loaders().passivation(true).preload(!purgeCacheLoader && !mode.isDistributed()).addCacheLoader(new FileCacheStoreConfig().location(passivationDir).fetchPersistentState(mode.isReplicated()).purgeOnStartup(purgeCacheLoader));
-            config.fluent().loaders().passivation(true).preload(!purgeCacheLoader).addCacheLoader(new FileCacheStoreConfig().location(passivationDir).fetchPersistentState(mode.isReplicated()).purgeOnStartup(purgeCacheLoader));
+            config.fluent().loaders().passivation(true).preload(!purgeCacheLoader).addCacheLoader(new FileCacheStoreConfig().location(passivationDir).fetchPersistentState(mode.isReplicated()).purgeOnStartup(purgeCacheLoader).purgeSynchronously(true));
         }
 
         final EmbeddedCacheManager container = new DefaultCacheManager(global, config, false);


### PR DESCRIPTION
Contains workaround for ISPN-1583: AbstractDelegatingAdvancedCache with(ClassLoader), withFlags(Flag...) logic is broken
