### PR TITLE
Fix for AS7-2743

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -78,7 +78,7 @@ public class
         public static final int JNDI_NAMESPACE_INTERCEPTOR = 0x500;
         public static final int INSTANTIATION_INTERCEPTORS = 0x600;
         public static final int RESOURCE_INJECTION_INTERCEPTORS = 0x700;
-        public static final int EJB_SET_SESSION_CONTEXT_METHOD_INVOCATION_INTERCEPTOR = 0x800;
+        public static final int EJB_SET_CONTEXT_METHOD_INVOCATION_INTERCEPTOR = 0x800;
         public static final int WELD_INJECTION = 0x900;
         public static final int JPA_SFSB_CREATE = 0xA00;
         public static final int DEPENDENCY_INJECTION_COMPLETE = 0xA50;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenBeanSetMessageDrivenContextInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenBeanSetMessageDrivenContextInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component.messagedriven;
+
+import javax.ejb.MessageDrivenBean;
+import javax.ejb.MessageDrivenContext;
+
+import org.jboss.as.ee.component.ComponentInstance;
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorContext;
+
+/**
+ * A interceptor for MDBs, which will invoke the {@link MessageDrivenBean#setMessageDrivenContext(javax.ejb.MessageDrivenContext)}
+ * method.
+ *
+ * @author Jaikiran Pai
+ */
+public class MessageDrivenBeanSetMessageDrivenContextInterceptor implements Interceptor {
+
+    static final MessageDrivenBeanSetMessageDrivenContextInterceptor INSTANCE = new MessageDrivenBeanSetMessageDrivenContextInterceptor();
+
+    private MessageDrivenBeanSetMessageDrivenContextInterceptor() {
+
+    }
+
+    @Override
+    public Object processInvocation(InterceptorContext context) throws Exception {
+        final MessageDrivenComponentInstance componentInstance = (MessageDrivenComponentInstance) context.getPrivateData(ComponentInstance.class);
+        final MessageDrivenContext messageDrivenContext = (MessageDrivenContext) componentInstance.getEjbContext();
+        ((MessageDrivenBean) context.getTarget()).setMessageDrivenContext(messageDrivenContext);
+        return context.proceed();
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
@@ -197,6 +197,10 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
         });
     }
 
+    /**
+     * Adds a interceptor to invoke the {@link MessageDrivenBean#setMessageDrivenContext(javax.ejb.MessageDrivenContext)}
+     * if the MDB implements the {@link MessageDrivenBean} interface
+     */
     private void addSetMessageDrivenContextMethodInvocationInterceptor() {
         // add the setMessageDrivenContext(MessageDrivenContext) method invocation interceptor for MDB
         // implementing the javax.ejb.MessageDrivenBean interface

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
@@ -24,6 +24,7 @@ package org.jboss.as.ejb3.component.messagedriven;
 
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 
+import javax.ejb.MessageDrivenBean;
 import javax.ejb.TransactionManagementType;
 import javax.resource.spi.ResourceAdapter;
 import java.util.Properties;
@@ -53,6 +54,7 @@ import org.jboss.as.ejb3.tx.TimerCMTTxInterceptor;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.reflect.ClassIndex;
+import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.metadata.ejb.spec.MessageDrivenBeanMetaData;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -89,8 +91,9 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
         this.activationProps = activationProps;
 
         registerView(messageListenerInterfaceName, MethodIntf.MESSAGE_ENDPOINT);
-
-
+        // add the interceptor which will invoke the setMessageDrivenContext() method on a MDB which implements
+        // MessageDrivenBean interface
+        this.addSetMessageDrivenContextMethodInvocationInterceptor();
     }
 
     @Override
@@ -190,6 +193,19 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
             @Override
             public void configure(DeploymentPhaseContext context, ComponentConfiguration componentConfiguration, ViewDescription description, ViewConfiguration configuration) throws DeploymentUnitProcessingException {
                 configuration.addViewInterceptor(CurrentInvocationContextInterceptor.FACTORY, InterceptorOrder.View.INVOCATION_CONTEXT_INTERCEPTOR);
+            }
+        });
+    }
+
+    private void addSetMessageDrivenContextMethodInvocationInterceptor() {
+        // add the setMessageDrivenContext(MessageDrivenContext) method invocation interceptor for MDB
+        // implementing the javax.ejb.MessageDrivenBean interface
+        this.getConfigurators().add(new ComponentConfigurator() {
+            @Override
+            public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
+                if (MessageDrivenBean.class.isAssignableFrom(configuration.getComponentClass())) {
+                    configuration.addPostConstructInterceptor(new ImmediateInterceptorFactory(MessageDrivenBeanSetMessageDrivenContextInterceptor.INSTANCE), InterceptorOrder.ComponentPostConstruct.EJB_SET_CONTEXT_METHOD_INVOCATION_INTERCEPTOR);
+                }
             }
         });
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentInstance.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentInstance.java
@@ -55,6 +55,10 @@ public class MessageDrivenComponentInstance extends EjbComponentInstance {
         return (MessageDrivenComponent) super.getComponent();
     }
 
+    /**
+     * Returns a {@link javax.ejb.MessageDrivenContext}
+     * @return
+     */
     @Override
     public EJBContextImpl getEjbContext() {
         return messageDrivenContext;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/session/SessionBeanComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/session/SessionBeanComponentDescription.java
@@ -56,7 +56,6 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.invocation.proxy.MethodIdentifier;
-import org.jboss.logging.Logger;
 import org.jboss.metadata.ejb.spec.SessionBeanMetaData;
 import org.jboss.msc.service.ServiceName;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
@@ -393,13 +392,13 @@ public abstract class SessionBeanComponentDescription extends EJBComponentDescri
     }
 
     private void addSetSessionContextMethodInvocationInterceptor() {
-        // add the setSessionContext(SessionContext) method invocation interceptor for session bean implementing the javax.ejb.SessionContext
-        // interface
+        // add the setSessionContext(SessionContext) method invocation interceptor for session bean
+        // implementing the javax.ejb.SessionBean interface
         this.getConfigurators().add(new ComponentConfigurator() {
             @Override
             public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
                 if (SessionBean.class.isAssignableFrom(configuration.getComponentClass())) {
-                    configuration.addPostConstructInterceptor(SessionBeanSetSessionContextMethodInvocationInterceptor.FACTORY, InterceptorOrder.ComponentPostConstruct.EJB_SET_SESSION_CONTEXT_METHOD_INVOCATION_INTERCEPTOR);
+                    configuration.addPostConstructInterceptor(SessionBeanSetSessionContextMethodInvocationInterceptor.FACTORY, InterceptorOrder.ComponentPostConstruct.EJB_SET_CONTEXT_METHOD_INVOCATION_INTERCEPTOR);
                 }
             }
         });

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -101,6 +101,7 @@
                                         <include>org/jboss/as/test/integration/ejb/iiop/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/*/security/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/mdb/**/*TestCase*.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/messagedrivencontext/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/ejb/pool/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/ejb/entity/cmp/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/ejb/remote/entity/cmp/**/*TestCase*.java</include>
@@ -135,6 +136,7 @@
                                         <exclude>org/jboss/as/test/integration/**/*SecondTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/iiop/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/mdb/**/*TestCase*.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/messagedrivencontext/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/pool/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/entity/cmp/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/ejb/remote/entity/cmp/**/*TestCase*.java</exclude>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/messagedrivencontext/SetMessageDrivenContextInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/messagedrivencontext/SetMessageDrivenContextInvocationTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.messagedrivencontext;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.TextMessage;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.common.JMSAdminOperations;
+import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the {@link javax.ejb.MessageDrivenBean#setMessageDrivenContext(javax.ejb.MessageDrivenContext)}
+ * method is invoked on MDBs which implement the {@link javax.ejb.MessageDrivenBean} interface
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class SetMessageDrivenContextInvocationTestCase {
+
+    private static JMSAdminOperations jmsAdminOperations;
+
+    private static final String QUEUE_JNDI_NAME = "java:jboss/queue/set-message-context";
+    private static final String REPLY_QUEUE_JNDI_NAME = "java:jboss/queue/set-message-context-reply-queue";
+
+    @EJB(mappedName = "java:module/JMSMessagingUtil")
+    private JMSMessagingUtil jmsUtil;
+
+    @Resource(mappedName = QUEUE_JNDI_NAME)
+    private Queue queue;
+
+    @Resource(mappedName = REPLY_QUEUE_JNDI_NAME)
+    private Queue replyQueue;
+
+    @Deployment
+    public static Archive createDeployment() {
+        // setup the JMS destinations
+        createJmsDestinations();
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "set-message-driven-context-invocation-test.jar");
+        jar.addClasses(SimpleMDB.class, JMSMessagingUtil.class, JMSAdminOperations.class);
+        return jar;
+    }
+
+    private static void createJmsDestinations() {
+        jmsAdminOperations = new JMSAdminOperations();
+        jmsAdminOperations.createJmsQueue("setMessageDrivenContext/queue", QUEUE_JNDI_NAME);
+        jmsAdminOperations.createJmsQueue("setMessageDrivenContext/replyQueue", REPLY_QUEUE_JNDI_NAME);
+    }
+
+    @AfterClass
+    public static void afterTestClass() {
+        try {
+            jmsAdminOperations.removeJmsQueue("setMessageDrivenContext/queue");
+            jmsAdminOperations.removeJmsQueue("setMessageDrivenContext/replyQueue");
+        } finally {
+            if (jmsAdminOperations != null) {
+                jmsAdminOperations.close();
+            }
+        }
+    }
+
+    /**
+     * Test that the {@link javax.ejb.MessageDrivenBean#setMessageDrivenContext(javax.ejb.MessageDrivenContext)}
+     * was invoked
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSetMessageDrivenContext() throws Exception {
+        this.jmsUtil.sendTextMessage("hello world", this.queue, this.replyQueue);
+        final Message reply = this.jmsUtil.receiveMessage(replyQueue, 5000);
+        Assert.assertNotNull("Reply message was null on reply queue: " + this.replyQueue, reply);
+        final TextMessage textMessage = (TextMessage) reply;
+        Assert.assertEquals("setMessageDrivenContext method was *not* invoked on MDB", SimpleMDB.SUCCESS_REPLY, textMessage.getText());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/messagedrivencontext/SimpleMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/messagedrivencontext/SimpleMDB.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.messagedrivencontext;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJBException;
+import javax.ejb.MessageDriven;
+import javax.ejb.MessageDrivenBean;
+import javax.ejb.MessageDrivenContext;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Jaikiran Pai
+ */
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/queue/set-message-context")
+})
+public class SimpleMDB implements MessageDrivenBean, MessageListener {
+
+    private static final Logger logger = Logger.getLogger(SimpleMDB.class);
+
+    public static final String SUCCESS_REPLY = "setMessageDrivenContext() method was invoked";
+
+    public static final String FAILURE_REPLY = "setMessageDrivenContext() method was *not* invoked";
+
+    @Resource(lookup = "java:/JmsXA")
+    private ConnectionFactory factory;
+
+    private Connection connection;
+    private Session session;
+
+    private MessageDrivenContext messageDrivenContext;
+
+    @PreDestroy
+    protected void preDestroy() throws JMSException {
+        session.close();
+        connection.close();
+    }
+
+    @PostConstruct
+    protected void postConstruct() throws JMSException {
+        connection = factory.createConnection();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+    }
+
+    @Override
+    public void setMessageDrivenContext(MessageDrivenContext ctx) throws EJBException {
+        this.messageDrivenContext = ctx;
+    }
+
+    @Override
+    public void ejbRemove() throws EJBException {
+    }
+
+
+    @Override
+    public void onMessage(Message message) {
+        logger.info("Received message: " + message);
+        try {
+            if (message.getJMSReplyTo() != null) {
+                logger.info("Replying to " + message.getJMSReplyTo());
+                final Destination destination = message.getJMSReplyTo();
+                final MessageProducer replyProducer = session.createProducer(destination);
+                final Message replyMsg;
+                if (this.messageDrivenContext != null) {
+                    replyMsg = session.createTextMessage(SUCCESS_REPLY);
+                } else {
+                    replyMsg = session.createTextMessage(FAILURE_REPLY);
+                }
+                replyMsg.setJMSCorrelationID(message.getJMSMessageID());
+                replyProducer.send(replyMsg);
+                replyProducer.close();
+            }
+        } catch (JMSException jmse) {
+            throw new RuntimeException(jmse);
+        }
+    }
+}


### PR DESCRIPTION
The commits in this branch contain a fix for https://issues.jboss.org/browse/AS7-2743 bug which relates to the setMessageDrivenContext(MessageDrivenContext) method not being called for MDBs which implement javax.ejb.MessageDrivenBean. 

The commits include a testcase too.
