### PR TITLE
Branch 7.0.2.final ( JMX security fix )

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-jmx_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jmx_1_1.xsd
@@ -1,8 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,26 +20,27 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.0" name="org.jboss.as.jmx">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:jmx:1.1"
+            xmlns="urn:jboss:domain:jmx:1.1"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.1" >
 
-    <resources>
-        <!-- Insert resources here -->
-    </resources>
+    <!-- The jmx subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
 
-    <dependencies>
-        <module name="javax.api"/>
-        <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.as.network"/>
-        <module name="org.jboss.as.server" />
-        <module name="org.jboss.msc"/>
-        <module name="org.jboss.logging"/>
-        <module name="system" export="false">
-            <exports>
-                <include-set>
-                    <path name="com/sun/jmx/remote/security"/>
-                </include-set>
-            </exports>
-        </module>
-    </dependencies>
-</module>
+    <xs:complexType name="subsystem">
+      <xs:sequence>
+         <xs:element name="jmx-connector" type="jmx-connectorType" />
+      </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jmx-connectorType">
+       <xs:attribute name="registry-binding" use="required" />
+       <xs:attribute name="server-binding" use="required" />
+       <xs:attribute name="password-file" use="optional" />
+       <xs:attribute name="access-file" use="optional" />
+    </xs:complexType>
+
+</xs:schema>

--- a/build/src/main/resources/domain/configuration/domain.xml
+++ b/build/src/main/resources/domain/configuration/domain.xml
@@ -156,7 +156,7 @@
                     </long-running-threads>
                 </default-workmanager>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jmx:1.0">
+            <subsystem xmlns="urn:jboss:domain:jmx:1.1">
                  <jmx-connector registry-binding="jmx-connector-registry" server-binding="jmx-connector-server" />
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:jpa:1.0">

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -167,7 +167,7 @@
                 </long-running-threads>
             </default-workmanager>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:jmx:1.0">
+        <subsystem xmlns="urn:jboss:domain:jmx:1.1">
             <jmx-connector registry-binding="jmx-connector-registry" server-binding="jmx-connector-server" />
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:jpa:1.0">

--- a/jmx/jmxremote.access
+++ b/jmx/jmxremote.access
@@ -1,0 +1,79 @@
+######################################################################
+#     Default Access Control File for Remote JMX(TM) Monitoring
+######################################################################
+#
+# Access control file for Remote JMX API access to monitoring.
+# This file defines the allowed access for different roles.  The
+# password file (jmxremote.password by default) defines the roles and their
+# passwords.  To be functional, a role must have an entry in
+# both the password and the access files.
+#
+# The default location of this file is $JRE/lib/management/jmxremote.access
+# You can specify an alternate location by specifying a property in 
+# the management config file $JRE/lib/management/management.properties
+# (See that file for details)
+#
+# The file format for password and access files is syntactically the same
+# as the Properties file format.  The syntax is described in the Javadoc
+# for java.util.Properties.load.
+# A typical access file has multiple lines, where each line is blank,
+# a comment (like this one), or an access control entry.
+#
+# An access control entry consists of a role name, and an
+# associated access level.  The role name is any string that does not
+# itself contain spaces or tabs.  It corresponds to an entry in the
+# password file (jmxremote.password).  The access level is one of the
+# following:
+#       "readonly" grants access to read attributes of MBeans.
+#                   For monitoring, this means that a remote client in this
+#                   role can read measurements but cannot perform any action
+#                   that changes the environment of the running program.
+#       "readwrite" grants access to read and write attributes of MBeans,
+#                   to invoke operations on them, and optionally
+#                   to create or remove them. This access should be granted
+#                   only to trusted clients, since they can potentially
+#                   interfere with the smooth operation of a running program.
+#
+# The "readwrite" access level can optionally be followed by the "create" and/or
+# "unregister" keywords.  The "unregister" keyword grants access to unregister
+# (delete) MBeans.  The "create" keyword grants access to create MBeans of a
+# particular class or of any class matching a particular pattern.  Access
+# should only be granted to create MBeans of known and trusted classes.
+#
+# For example, the following entry would grant readwrite access
+# to "controlRole", as well as access to create MBeans of the class
+# javax.management.monitor.CounterMonitor and to unregister any MBean:
+#  controlRole readwrite \
+#              create javax.management.monitor.CounterMonitorMBean \
+#              unregister
+# or equivalently:
+#  controlRole readwrite unregister create javax.management.monitor.CounterMBean
+#
+# The following entry would grant readwrite access as well as access to create
+# MBeans of any class in the packages javax.management.monitor and
+# javax.management.timer:
+#  controlRole readwrite \
+#              create javax.management.monitor.*,javax.management.timer.* \
+#              unregister
+#
+# The \ character is defined in the Properties file syntax to allow continuation
+# lines as shown here.  A * in a class pattern matches a sequence of characters
+# other than dot (.), so javax.management.monitor.* matches
+# javax.management.monitor.CounterMonitor but not
+# javax.management.monitor.foo.Bar.
+#
+# A given role should have at most one entry in this file.  If a role
+# has no entry, it has no access.
+# If multiple entries are found for the same role name, then the last
+# access entry is used.
+#
+#
+# Default access control entries:
+# o The "monitorRole" role has readonly access.  
+# o The "controlRole" role has readwrite access and can create the standard
+#   Timer and Monitor MBeans defined by the JMX API.
+
+monitorRole   readonly
+controlRole   readwrite \
+              create javax.management.monitor.*,javax.management.timer.* \
+              unregister

--- a/jmx/jmxremote.password
+++ b/jmx/jmxremote.password
@@ -1,0 +1,64 @@
+# ----------------------------------------------------------------------
+#           Template for jmxremote.password
+#
+# o Copy this template to jmxremote.password
+# o Set the user/password entries in jmxremote.password
+# o Change the permission of jmxremote.password to read-only
+#   by the owner.
+#
+# See below for the location of jmxremote.password file.
+# ----------------------------------------------------------------------
+
+##############################################################
+#        Password File for Remote JMX Monitoring
+##############################################################
+#
+# Password file for Remote JMX API access to monitoring.  This
+# file defines the different roles and their passwords.  The access
+# control file (jmxremote.access by default) defines the allowed
+# access for each role.  To be functional, a role must have an entry
+# in both the password and the access files.
+#
+# Default location of this file is $JRE/lib/management/jmxremote.password
+# You can specify an alternate location by specifying a property in 
+# the management config file $JRE/lib/management/management.properties
+# or by specifying a system property (See that file for details).
+
+
+##############################################################
+#    File permissions of the jmxremote.password file
+##############################################################
+#      Since there are cleartext passwords stored in this file,
+#      this file must be readable by ONLY the owner,
+#      otherwise the program will exit with an error. 
+#
+# The file format for password and access files is syntactically the same
+# as the Properties file format.  The syntax is described in the Javadoc
+# for java.util.Properties.load.
+# Typical password file has multiple  lines, where each line is blank,
+# a comment (like this one), or a password entry.
+#
+#
+# A password entry consists of a role name and an associated
+# password.  The role name is any string that does not itself contain
+# spaces or tabs.  The password is again any string that does not
+# contain spaces or tabs.  Note that passwords appear in the clear in
+# this file, so it is a good idea not to use valuable passwords.
+#
+# A given role should have at most one entry in this file.  If a role
+# has no entry, it has no access.
+# If multiple entries are found for the same role name, then the last one
+# is used.
+#
+# In a typical installation, this file can be read by anybody on the
+# local machine, and possibly by people on other machines.
+# For # security, you should either restrict the access to this file,
+# or specify another, less accessible file in the management config file
+# as described above.
+#
+# Following are two commented-out entries.  The "measureRole" role has
+# password "QED".  The "controlRole" role has password "R&D".
+#
+ monitorRole  QED
+ controlRole   R&D
+

--- a/jmx/src/main/java/org/jboss/as/jmx/Attribute.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/Attribute.java
@@ -34,6 +34,8 @@ enum Attribute {
 
     SERVER_BINDING(CommonAttributes.SERVER_BINDING),
     REGISTRY_BINDING(CommonAttributes.REGISTRY_BINDING),
+    PASSWORD_FILE(CommonAttributes.PASSWORD_FILE),
+    ACCESS_FILE(CommonAttributes.ACCESS_FILE),
     ;
     private final String name;
 

--- a/jmx/src/main/java/org/jboss/as/jmx/CommonAttributes.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/CommonAttributes.java
@@ -29,5 +29,7 @@ interface CommonAttributes {
 
     String SERVER_BINDING = "server-binding";
     String REGISTRY_BINDING = "registry-binding";
+    String PASSWORD_FILE = "password-file";
+    String ACCESS_FILE = "access-file";
     String JMX_CONNECTOR = "jmx-connector";
 }

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXConnectorAdd.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXConnectorAdd.java
@@ -53,16 +53,24 @@ class JMXConnectorAdd implements OperationStepHandler {
 
         final String serverBinding = operation.require(CommonAttributes.SERVER_BINDING).asString();
         final String registryBinding = operation.require(CommonAttributes.REGISTRY_BINDING).asString();
+        final String passwordFile = (operation.hasDefined(CommonAttributes.PASSWORD_FILE) ? operation.get(CommonAttributes.PASSWORD_FILE).asString() : null);
+        final String accessFile = (operation.hasDefined(CommonAttributes.ACCESS_FILE) ? operation.get(CommonAttributes.ACCESS_FILE).asString() : null);
 
         model.get(CommonAttributes.SERVER_BINDING).set(serverBinding);
         model.get(CommonAttributes.REGISTRY_BINDING).set(registryBinding);
+        if(passwordFile != null) {
+            model.get(CommonAttributes.PASSWORD_FILE).set(passwordFile);
+        }
+        if(accessFile != null) {
+            model.get(CommonAttributes.ACCESS_FILE).set(accessFile);
+        }
         if(context.getType() == OperationContext.Type.SERVER) {
             context.addStep(new OperationStepHandler() {
                 @Override
                 public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                     final ServiceTarget target = context.getServiceTarget();
                     final ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-                    JMXConnectorService.addService(target, serverBinding, registryBinding, verificationHandler);
+                    JMXConnectorService.addService(target, serverBinding, registryBinding, passwordFile, accessFile, verificationHandler);
                     context.addStep(verificationHandler, OperationContext.Stage.VERIFY);
                     if(context.completeStep() == OperationContext.ResultAction.ROLLBACK) {
                         context.removeService(JMXConnectorService.SERVICE_NAME);

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXExtension.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXExtension.java
@@ -83,7 +83,8 @@ public class JMXExtension implements Extension {
     /** {@inheritDoc} */
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(Namespace.CURRENT.getUriString(), parsers);
+        context.setSubsystemXmlMapping(Namespace.JMX_1_0.getUriString(), parsers);
+        context.setSubsystemXmlMapping(Namespace.JMX_1_1.getUriString(), parsers);
     }
 
     private static ModelNode createAddOperation() {
@@ -93,20 +94,30 @@ public class JMXExtension implements Extension {
         return subsystem;
     }
 
-    private static ModelNode createAddConnectorOperation(String serverBinding, String registryBinding) {
+    private static ModelNode createAddConnectorOperation(String serverBinding, String registryBinding, String passwordFile, String accessFile) {
         final ModelNode connector = new ModelNode();
         connector.get(OP).set(JMXConnectorAdd.OPERATION_NAME);
         connector.get(OP_ADDR).add(SUBSYSTEM, SUBSYSTEM_NAME);
         connector.get(CommonAttributes.SERVER_BINDING).set(serverBinding);
         connector.get(CommonAttributes.REGISTRY_BINDING).set(registryBinding);
+        if(passwordFile != null){
+            connector.get(CommonAttributes.PASSWORD_FILE).set(passwordFile);
+        }
+        if(accessFile != null){
+            connector.get(CommonAttributes.ACCESS_FILE).set(accessFile);
+        }
+
         return connector;
     }
 
     static class JMXSubsystemParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
 
+        private volatile Namespace schemaVer;
+
         /** {@inheritDoc} */
         @Override
         public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
+            schemaVer = Namespace.forUri(reader.getNamespaceURI());
 
             list.add(createAddOperation());
             ParseUtils.requireNoAttributes(reader);
@@ -132,6 +143,8 @@ public class JMXExtension implements Extension {
         void parseConnector(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
             String serverBinding = null;
             String registryBinding = null;
+            String passwordFile = null;
+            String accessFile = null;
             int count = reader.getAttributeCount();
             for (int i = 0; i < count; i++) {
                 final String value = reader.getAttributeValue(i);
@@ -142,6 +155,18 @@ public class JMXExtension implements Extension {
                         break;
                     } case REGISTRY_BINDING: {
                         registryBinding = value;
+                        break;
+                    } case PASSWORD_FILE: {
+                        if(schemaVer == Namespace.JMX_1_0) {
+                            throw ParseUtils.unexpectedAttribute(reader, i);
+                        }
+                        passwordFile = value;
+                        break;
+                    } case ACCESS_FILE: {
+                        if(schemaVer == Namespace.JMX_1_0) {
+                            throw ParseUtils.unexpectedAttribute(reader, i);
+                        }
+                        accessFile = value;
                         break;
                     } default: {
                         throw ParseUtils.unexpectedAttribute(reader, i);
@@ -156,28 +181,46 @@ public class JMXExtension implements Extension {
             if(registryBinding == null) {
                 throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.REGISTRY_BINDING));
             }
-            list.add(createAddConnectorOperation(serverBinding, registryBinding));
+            list.add(createAddConnectorOperation(serverBinding, registryBinding, passwordFile, accessFile));
         }
 
         /** {@inheritDoc} */
         @Override
         public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
-
+            Namespace schemaVer = this.schemaVer == null ? Namespace.CURRENT : this.schemaVer;
             ModelNode node = context.getModelNode();
+
+            if(!node.has(CommonAttributes.SERVER_BINDING)) {
+                throw new XMLStreamException("Required attribute \"server-binding\" is not defined");
+            }
+            if(!node.has(CommonAttributes.REGISTRY_BINDING)) {
+                throw new XMLStreamException("Required attribute \"registry-binding\" is not defined");
+            }
+
+            if ((node.hasDefined(CommonAttributes.PASSWORD_FILE) && !node.hasDefined(CommonAttributes.ACCESS_FILE)) ||
+                    (!node.hasDefined(CommonAttributes.PASSWORD_FILE) && node.hasDefined(CommonAttributes.ACCESS_FILE))) {
+                throw new XMLStreamException("Both \"password-file\" and \"access-file\" attributes must be provided");
+            }
+
+            if (node.hasDefined(CommonAttributes.PASSWORD_FILE) && (schemaVer == Namespace.UNKNOWN ||schemaVer == Namespace.JMX_1_0)) {
+                schemaVer = Namespace.JMX_1_1;
+            }
+
+            context.startSubsystemElement(schemaVer.getUriString(), false);
+
             if(node.has(CommonAttributes.SERVER_BINDING)) {
-                context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);
                 writer.writeStartElement(Element.JMX_CONNECTOR.getLocalName());
                 writer.writeAttribute(Attribute.SERVER_BINDING.getLocalName(), node.get(CommonAttributes.SERVER_BINDING).asString());
                 writer.writeAttribute(Attribute.REGISTRY_BINDING.getLocalName(), node.get(CommonAttributes.REGISTRY_BINDING).asString());
-                writer.writeEndElement();
+                if (node.hasDefined(CommonAttributes.PASSWORD_FILE)) {
+                    writer.writeAttribute(Attribute.PASSWORD_FILE.getLocalName(), node.get(CommonAttributes.PASSWORD_FILE).asString());
+                }
+                if (node.hasDefined(CommonAttributes.ACCESS_FILE)) {
+                    writer.writeAttribute(Attribute.ACCESS_FILE.getLocalName(), node.get(CommonAttributes.ACCESS_FILE).asString());
+                }
                 writer.writeEndElement();
             }
-            else {
-                //TODO seems to be a problem with empty elements cleaning up the queue in FormattingXMLStreamWriter.runAttrQueue
-                //context.startSubsystemElement(NewNamingExtension.NAMESPACE, true);
-                context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);
-                writer.writeEndElement();
-            }
+            writer.writeEndElement();
         }
     }
 
@@ -187,7 +230,7 @@ public class JMXExtension implements Extension {
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             final ModelNode model = context.readModel(PathAddress.EMPTY_ADDRESS);
             context.getResult().add(createAddOperation());
-            context.getResult().add(createAddConnectorOperation(model.require(CommonAttributes.SERVER_BINDING).asString(), model.require(CommonAttributes.REGISTRY_BINDING).asString()));
+            context.getResult().add(createAddConnectorOperation(model.require(CommonAttributes.SERVER_BINDING).asString(), model.require(CommonAttributes.REGISTRY_BINDING).asString(), model.hasDefined(CommonAttributes.PASSWORD_FILE) ? model.get(CommonAttributes.PASSWORD_FILE).asString() : null, model.hasDefined(CommonAttributes.ACCESS_FILE) ? model.get(CommonAttributes.ACCESS_FILE).asString() : null));
             context.completeStep();
         }
 

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemProviders.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemProviders.java
@@ -35,8 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQ
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TAIL_COMMENT_ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
-import static org.jboss.as.jmx.CommonAttributes.REGISTRY_BINDING;
-import static org.jboss.as.jmx.CommonAttributes.SERVER_BINDING;
+import static org.jboss.as.jmx.CommonAttributes.*;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -74,6 +73,14 @@ public class JMXSubsystemProviders {
             subsystem.get(ATTRIBUTES, SERVER_BINDING, REQUIRED).set(true);
             subsystem.get(ATTRIBUTES, SERVER_BINDING, MIN_OCCURS).set(1);
             subsystem.get(ATTRIBUTES, SERVER_BINDING, MAX_OCCURS).set(1);
+
+            subsystem.get(ATTRIBUTES, PASSWORD_FILE, DESCRIPTION).set(bundle.getString("password.file"));
+            subsystem.get(ATTRIBUTES, PASSWORD_FILE, TYPE).set(ModelType.STRING);
+            subsystem.get(ATTRIBUTES, PASSWORD_FILE, REQUIRED).set(false);
+
+            subsystem.get(ATTRIBUTES, ACCESS_FILE, DESCRIPTION).set(bundle.getString("access.file"));
+            subsystem.get(ATTRIBUTES, ACCESS_FILE, TYPE).set(ModelType.STRING);
+            subsystem.get(ATTRIBUTES, ACCESS_FILE, REQUIRED).set(false);
 
             return subsystem;
         }
@@ -113,6 +120,14 @@ public class JMXSubsystemProviders {
             op.get(REQUEST_PROPERTIES, SERVER_BINDING, REQUIRED).set(true);
             op.get(REQUEST_PROPERTIES, SERVER_BINDING, MIN_OCCURS).set(1);
             op.get(REQUEST_PROPERTIES, SERVER_BINDING, MAX_OCCURS).set(1);
+
+            op.get(REQUEST_PROPERTIES, PASSWORD_FILE, DESCRIPTION).set(bundle.getString("password.file"));
+            op.get(REQUEST_PROPERTIES, PASSWORD_FILE, TYPE).set(ModelType.STRING);
+            op.get(REQUEST_PROPERTIES, PASSWORD_FILE, REQUIRED).set(false);
+
+            op.get(REQUEST_PROPERTIES, ACCESS_FILE, DESCRIPTION).set(bundle.getString("password.file"));
+            op.get(REQUEST_PROPERTIES, ACCESS_FILE, TYPE).set(ModelType.STRING);
+            op.get(REQUEST_PROPERTIES, ACCESS_FILE, REQUIRED).set(false);
 
             op.get(REPLY_PROPERTIES).setEmptyObject();
 

--- a/jmx/src/main/java/org/jboss/as/jmx/Namespace.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/Namespace.java
@@ -31,14 +31,14 @@ import java.util.Map;
 enum Namespace {
     // must be first
     UNKNOWN(null),
-
-    JMX_1_0("urn:jboss:domain:jmx:1.0")
+    JMX_1_0("urn:jboss:domain:jmx:1.0"),
+    JMX_1_1("urn:jboss:domain:jmx:1.1")
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = JMX_1_0;
+    public static final Namespace CURRENT = JMX_1_1;
 
     private final String name;
 

--- a/jmx/src/main/resources/org/jboss/as/jmx/LocalDescriptions.properties
+++ b/jmx/src/main/resources/org/jboss/as/jmx/LocalDescriptions.properties
@@ -5,4 +5,6 @@ jmx.connector.remove=Clears the socket bindings for the JMX subsystem.
 
 registry.binding=The name of a socket binding to which external clients will connect.
 server.binding=The name of a socket binding on which which the JMX subsystem's RMI server and the RMIConnectionImpl objects it creates will be exported.
+password.file=The password file used to secure the JMX subsystem. ( layout: see http://download.oracle.com/javase/6/docs/technotes/guides/management/agent.html )
+access.file=The access file used to secure the JMX subsystem. ( layout: see http://download.oracle.com/javase/6/docs/technotes/guides/management/agent.html )
 


### PR DESCRIPTION
Hi

At Statens pensjonskasse we are puting jboss7 into production this weekend.
We have applications deployd that use jmx, and had to be able to restrict access to authenticated users.

As a result we have done some modifications to the jmx subsystem so that we are able to specify password and access files in the jmx-connector.

Since we only use this internaly SSL support has not been implemented.
I had a look at it, but it seems like this is a lot more work to solve.

Hopefully this is something you would like to pull into the project.

Best regards
Hugo Haakseth
Statens pensjonskasse
