### PR TITLE
Fix EJB security-role-ref handling and linking of roles with principal names

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -155,13 +155,6 @@ public interface EjbLogger extends BasicLogger {
     void failToFindSfsbWithId(SessionID sessionId, String componentName);
 
     /**
-     * Logs an warning message indicating security-role-ref for message driven beans isn't yet implemented
-     */
-    @LogMessage(level = WARN)
-    @Message(id = 14109, value = "security-role-ref for message driven beans isn't yet implemented")
-    void securityRoleForMdbNotImplemented();
-
-    /**
      * Logs an warning message indicating Default interceptor class is not listed in the <interceptors> section of ejb-jar.xml and will not be applied"
      */
     @LogMessage(level = WARN)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/SecurityRoleRefDDProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/SecurityRoleRefDDProcessor.java
@@ -52,13 +52,7 @@ public class SecurityRoleRefDDProcessor extends AbstractEjbXmlDescriptorProcesso
 
     @Override
     protected void processBeanMetaData(final EnterpriseBeanMetaData beanMetaData, final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
-        SecurityRoleRefsMetaData securityRoleRefs = null;
-        if (beanMetaData instanceof SessionBeanMetaData) {
-            securityRoleRefs = beanMetaData.getSecurityRoleRefs();
-        } else if (beanMetaData instanceof MessageDrivenBeanMetaData) {
-            // TODO: Why doesn't MessageDrivenBeanMetaData have security role refs metadata
-            ROOT_LOGGER.securityRoleForMdbNotImplemented();
-        }
+        final SecurityRoleRefsMetaData securityRoleRefs = beanMetaData.getSecurityRoleRefs();
         if (securityRoleRefs == null) {
             return;
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/RunAsMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/RunAsMergingProcessor.java
@@ -21,9 +21,8 @@
  */
 package org.jboss.as.ejb3.deployment.processors.merging;
 
-import java.util.List;
-
 import javax.annotation.security.RunAs;
+import java.util.List;
 
 import org.jboss.as.ee.component.EEApplicationClasses;
 import org.jboss.as.ee.component.EEModuleClassDescription;
@@ -38,8 +37,6 @@ import org.jboss.ejb3.annotation.RunAsPrincipal;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
 import org.jboss.metadata.ejb.spec.SecurityIdentityMetaData;
 import org.jboss.metadata.javaee.spec.RunAsMetaData;
-import org.jboss.metadata.javaee.spec.SecurityRoleMetaData;
-import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
 
 /**
  * Handles the {@link javax.annotation.security.RunAs} annotation merging
@@ -118,15 +115,6 @@ public class RunAsMergingProcessor extends AbstractMergingProcessor<EJBComponent
                     }
                 }
 
-                // get extra roles from role-mapping
-                List<SecurityRoleMetaData> list = jbossMetaData.getAssemblyDescriptor().getAny(SecurityRoleMetaData.class);
-                SecurityRolesMetaData securityRoles = new SecurityRolesMetaData();
-                if (list != null) {
-                    for (SecurityRoleMetaData securityRoleMetaData : list) {
-                        securityRoles.add(securityRoleMetaData);
-                    }
-                }
-                componentConfiguration.setSecurityRoles(securityRoles);
                 if (principal != null)
                     componentConfiguration.setRunAsPrincipal(principal);
                 else if (globalRunAsPrincipal != null)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/SecurityRolesMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/SecurityRolesMergingProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.deployment.processors.merging;
+
+import java.util.List;
+
+import org.jboss.as.ee.component.EEApplicationClasses;
+import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.metadata.ejb.spec.EjbJarMetaData;
+import org.jboss.metadata.javaee.spec.SecurityRoleMetaData;
+import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
+
+/**
+ * A processor which sets the {@link EJBComponentDescription#setSecurityRoles(org.jboss.metadata.javaee.spec.SecurityRolesMetaData)}
+ * with the principal to role mapping defined in the assembly descriptor section of the jboss-ejb3.xml via elements from
+ * urn:security-roles namespace
+ *
+ * @author Jaikiran Pai
+ * @see {@link org.jboss.as.ejb3.security.parser.SecurityRoleMetaDataParser}
+ */
+public class SecurityRolesMergingProcessor extends AbstractMergingProcessor<EJBComponentDescription> {
+
+    public SecurityRolesMergingProcessor() {
+        super(EJBComponentDescription.class);
+    }
+
+    @Override
+    protected void handleAnnotations(DeploymentUnit deploymentUnit, EEApplicationClasses applicationClasses, DeploymentReflectionIndex deploymentReflectionIndex, Class<?> componentClass, EJBComponentDescription description) throws DeploymentUnitProcessingException {
+        // no-op
+    }
+
+    @Override
+    protected void handleDeploymentDescriptor(DeploymentUnit deploymentUnit, DeploymentReflectionIndex deploymentReflectionIndex, Class<?> componentClass, EJBComponentDescription ejbComponentDescription) throws DeploymentUnitProcessingException {
+        final EjbJarMetaData ejbJarMetaData = deploymentUnit.getAttachment(EjbDeploymentAttachmentKeys.EJB_JAR_METADATA);
+        if (ejbJarMetaData != null) {
+            // get the mapping between principal to rolename, defined in the assembly descriptor
+            final List<SecurityRoleMetaData> securityRoleMetaDatas = ejbJarMetaData.getAssemblyDescriptor().getAny(SecurityRoleMetaData.class);
+            final SecurityRolesMetaData roleMappings = new SecurityRolesMetaData();
+            if (securityRoleMetaDatas != null) {
+                for (SecurityRoleMetaData securityRoleMetaData : securityRoleMetaDatas) {
+                    roleMappings.add(securityRoleMetaData);
+                }
+            }
+            // add it to the EJB component description
+            ejbComponentDescription.setSecurityRoles(roleMappings);
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/SecurityRolesMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/SecurityRolesMergingProcessor.java
@@ -30,6 +30,7 @@ import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.metadata.ejb.spec.AssemblyDescriptorMetaData;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
 import org.jboss.metadata.javaee.spec.SecurityRoleMetaData;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
@@ -57,8 +58,12 @@ public class SecurityRolesMergingProcessor extends AbstractMergingProcessor<EJBC
     protected void handleDeploymentDescriptor(DeploymentUnit deploymentUnit, DeploymentReflectionIndex deploymentReflectionIndex, Class<?> componentClass, EJBComponentDescription ejbComponentDescription) throws DeploymentUnitProcessingException {
         final EjbJarMetaData ejbJarMetaData = deploymentUnit.getAttachment(EjbDeploymentAttachmentKeys.EJB_JAR_METADATA);
         if (ejbJarMetaData != null) {
+            final AssemblyDescriptorMetaData assemblyDescriptorMetaData = ejbJarMetaData.getAssemblyDescriptor();
+            if (assemblyDescriptorMetaData == null) {
+                return;
+            }
             // get the mapping between principal to rolename, defined in the assembly descriptor
-            final List<SecurityRoleMetaData> securityRoleMetaDatas = ejbJarMetaData.getAssemblyDescriptor().getAny(SecurityRoleMetaData.class);
+            final List<SecurityRoleMetaData> securityRoleMetaDatas = assemblyDescriptorMetaData.getAny(SecurityRoleMetaData.class);
             final SecurityRolesMetaData roleMappings = new SecurityRolesMetaData();
             if (securityRoleMetaDatas != null) {
                 for (SecurityRoleMetaData securityRoleMetaData : securityRoleMetaDatas) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityMetaData.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityMetaData.java
@@ -22,14 +22,19 @@
 
 package org.jboss.as.ejb3.security;
 
+import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.metadata.javaee.spec.SecurityRoleMetaData;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
 
-import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 /**
  * Holds the EJB component level security metadata.
  * <p/>
@@ -69,6 +74,11 @@ public class EJBSecurityMetaData {
     private final SecurityRolesMetaData securityRoles;
 
     /**
+     * Security role links. The key is the "from" role name and the value is a collection of "to" role names of the link.
+     */
+    private final Map<String, Collection<String>> securityRoleLinks;
+
+    /**
      * @param componentConfiguration Component configuration of the EJB component
      */
     public EJBSecurityMetaData(final ComponentConfiguration componentConfiguration) {
@@ -82,10 +92,59 @@ public class EJBSecurityMetaData {
         this.securityDomain = ejbComponentDescription.getSecurityDomain();
         this.runAsPrincipal = ejbComponentDescription.getRunAsPrincipal();
         this.securityRoles = ejbComponentDescription.getSecurityRoles();
+        this.securityRoleLinks = ejbComponentDescription.getSecurityRoleLinks();
         // @DeclareRoles
         final Set<String> roles = ejbComponentDescription.getDeclaredRoles();
         this.declaredRoles = roles == null ? Collections.<String>emptySet() : Collections.unmodifiableSet(roles);
 
+        // The jboss-ejb3.xml allows for mapping a security role to a principal:
+        // <security-role>
+        //  <principal-name>fooPrincipal</principal-name>
+        //  <role-name>Administrator</role-name>
+        // </security-role>
+        //
+        // The ejb-jar.xml allows for linking a "x" role to a "y" alias role via the security-role-ref element:
+        //
+        // <security-role-ref>
+        //  <role-name>ADM</role-name>
+        //  <role-link>Administrator</role-link>
+        // </security-role-ref>
+        //
+        // The code here ensures that we setup the appropriate metadata to ensure that the "fooPrincipal" prinicipal
+        // is mapped to the role alias "ADM".
+        // So ultimately we will have a fooPrincipal -> Administrator and fooPrincipal -> ADM mapping in our security roles
+        if (this.securityRoleLinks != null && this.securityRoles != null) {
+            for (final Map.Entry<String, Collection<String>> entry : this.securityRoleLinks.entrySet()) {
+                final String aliasRoleName = entry.getKey();
+                // get the real role names for this alias
+                final Collection<String> roleNames = entry.getValue();
+                if (roleNames == null || roleNames.isEmpty()) {
+                    continue;
+                }
+                // for each of these roles, see if we have a role name to principals mapping
+                for (final String roleName : roleNames) {
+                    if (roleName == null || roleName.isEmpty()) {
+                        continue;
+                    }
+                    final SecurityRoleMetaData securityRole = this.getSecurityRole(roleName);
+                    if (securityRole == null) {
+                        continue;
+                    }
+                    // found a role name to principal(s) mapping, we'll now create a mapping between these
+                    // principals to the alias role
+                    final Set<String> principals = securityRole.getPrincipals();
+                    if (principals == null || principals.isEmpty()) {
+                        continue;
+                    }
+                    // create a new security role which maps the principals to the alias role
+                    final SecurityRoleMetaData aliasSecurityRole = new SecurityRoleMetaData();
+                    aliasSecurityRole.setRoleName(aliasRoleName);
+                    aliasSecurityRole.setPrincipals(principals);
+                    // add this new security role to our existing security role collection for this bean
+                    this.securityRoles.add(aliasSecurityRole);
+                }
+            }
+        }
     }
 
     /**
@@ -131,6 +190,28 @@ public class EJBSecurityMetaData {
      */
     public SecurityRolesMetaData getSecurityRoles() {
         return securityRoles;
+    }
+
+    /**
+     * Returns the {@link SecurityRoleMetaData} for the passed <code>roleName</code>, from the collection of security
+     * roles configured for this bean. Returns null if there's no security role for the role name.
+     *
+     * @param roleName The role name
+     * @return
+     */
+    private SecurityRoleMetaData getSecurityRole(final String roleName) {
+        if (roleName == null || roleName.trim().isEmpty()) {
+            EjbMessages.MESSAGES.stringParamCannotBeNullOrEmpty("Role name");
+        }
+        if (this.securityRoles == null) {
+            return null;
+        }
+        for (final SecurityRoleMetaData securityRole : this.securityRoles) {
+            if (roleName.equals(securityRole.getRoleName())) {
+                return securityRole;
+            }
+        }
+        return null;
     }
 
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
@@ -59,8 +59,9 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
         final String runAsPrincipal = securityMetaData.getRunAsPrincipal();
         final SecurityRolesMetaData securityRoles = securityMetaData.getSecurityRoles();
         Set<String> extraRoles = null;
-        if (securityRoles != null)
+        if (securityRoles != null && runAsPrincipal != null) {
             extraRoles = securityRoles.getSecurityRoleNamesByPrincipal(runAsPrincipal);
+        }
         return new SecurityContextInterceptor(securityManager, securityDomain, runAs, runAsPrincipal, extraRoles);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -76,6 +76,7 @@ import org.jboss.as.ejb3.deployment.processors.merging.RemoveMethodMergingProces
 import org.jboss.as.ejb3.deployment.processors.merging.ResourceAdaptorMergingProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.RunAsMergingProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.SecurityDomainMergingProcessor;
+import org.jboss.as.ejb3.deployment.processors.merging.SecurityRolesMergingProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.SessionSynchronizationMergingProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.StartupMergingProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.StatefulTimeoutMergingProcessor;
@@ -205,6 +206,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_STATEFUL_TIMEOUT, new StatefulTimeoutMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_SESSION_SYNCHRONIZATION, new SessionSynchronizationMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_INIT_METHOD, new InitMethodMergingProcessor());
+                    processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_SECURITY_PRINCIPAL_ROLE_MAPPING_MERGE, new SecurityRolesMergingProcessor());
                     processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_LOCAL_HOME, new SessionBeanHomeProcessor());
 
                     processorTarget.addDeploymentProcessor(Phase.INSTALL, Phase.INSTALL_DEPENDS_ON_ANNOTATION, new EjbDependsOnMergingProcessor());

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -331,6 +331,7 @@ public enum Phase {
     public static final int POST_MODULE_EJB_ASYNCHRONOUS_MERGE          = 0x060E;
     public static final int POST_MODULE_EJB_SESSION_SYNCHRONIZATION     = 0x060F;
     public static final int POST_MODULE_EJB_INIT_METHOD                 = 0x0610;
+    public static final int POST_MODULE_EJB_SECURITY_PRINCIPAL_ROLE_MAPPING_MERGE   = 0x0611;
     public static final int POST_MODULE_WELD_COMPONENT_INTEGRATION      = 0x0800;
     public static final int POST_MODULE_INSTALL_EXTENSION               = 0x0A00;
     public static final int POST_MODULE_VALIDATOR_FACTORY               = 0x0B00;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
@@ -1,8 +1,8 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright (c) 2010, JBoss Inc., and individual contributors as indicated
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/CallerRoleCheckerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/CallerRoleCheckerBean.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.rolelink;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@LocalBean
+@SecurityDomain(value = CallerRoleCheckerBean.SECURITY_DOMAIN_NAME)
+public class CallerRoleCheckerBean {
+
+    public static final String SECURITY_DOMAIN_NAME = "security-link-test-security-domain";
+
+    @Resource
+    private SessionContext sessionContext;
+
+    public boolean isCallerInRole(final String role) {
+        return this.sessionContext.isCallerInRole(role);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/SecurityRoleLinkTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/SecurityRoleLinkTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.rolelink;
+
+import javax.naming.InitialContext;
+import javax.security.auth.login.LoginContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.ejb.security.SecurityTest;
+import org.jboss.as.test.integration.ejb.security.Util;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the security role linking via the ejb-jar.xml and the jboss-ejb3.xml works as expected
+ * 
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class SecurityRoleLinkTestCase {
+
+    private static final String MODULE_NAME = "security-role-link-test";
+
+    @Deployment
+    public static Archive createDeployment() throws Exception {
+        // setup the security-domain
+        SecurityTest.createSecurityDomain(CallerRoleCheckerBean.SECURITY_DOMAIN_NAME);
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(CallerRoleCheckerBean.class.getPackage());
+        jar.addClasses(Util.class, SecurityTest.class);
+        jar.addAsResource("ejb/security/rolelink/users.properties", "users.properties");
+        jar.addAsResource("ejb/security/rolelink/roles.properties", "roles.properties");
+        jar.addAsManifestResource("ejb/security/rolelink/ejb-jar.xml", "ejb-jar.xml");
+        jar.addAsManifestResource("ejb/security/rolelink/jboss-ejb3.xml", "jboss-ejb3.xml");
+
+        return jar;
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        SecurityTest.removeSecurityDomain(CallerRoleCheckerBean.SECURITY_DOMAIN_NAME);
+    }
+
+    /**
+     * Test that when the security role linking via the security-role-ref element in the ejb-jar.xml
+     * takes into account the security-role mapping between the principal and the role name in the jboss-ejb3.xml.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testIsCallerInRole() throws Exception {
+        final CallerRoleCheckerBean callerRoleCheckerBean = InitialContext.doLookup("java:module/" + CallerRoleCheckerBean.class.getSimpleName());
+
+        final LoginContext loginContext = Util.getCLMLoginContext("phantom", "pass");
+        loginContext.login();
+        try {
+            final String realRoleName = "RealRole";
+            final boolean callerInRealRole = callerRoleCheckerBean.isCallerInRole(realRoleName);
+            Assert.assertTrue("Caller was expected to be in " + realRoleName + " but wasn't", callerInRealRole);
+
+            final String aliasRoleName = "AliasRole";
+            final boolean callerInAliasRole = callerRoleCheckerBean.isCallerInRole(aliasRoleName);
+            Assert.assertTrue("Caller was expected to be in " + aliasRoleName + " but wasn't", callerInAliasRole);
+
+            final String invalidRole = "UselessRole";
+            final boolean callerInUselessRole = callerRoleCheckerBean.isCallerInRole(invalidRole);
+            Assert.assertFalse("Caller wasn't expected to be in " + invalidRole + " but was", callerInUselessRole);
+
+        } finally {
+            loginContext.logout();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/ejb-jar.xml
@@ -1,0 +1,43 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+         version="3.1">
+    <enterprise-beans>
+        <session>
+            <ejb-name>CallerRoleCheckerBean</ejb-name>
+            <security-role-ref>
+                <role-name>AliasRole</role-name>
+                <role-link>RealRole</role-link>
+            </security-role-ref>
+        </session>
+    </enterprise-beans>
+
+    <assembly-descriptor>
+        <security-role>
+            <role-name>RealRole</role-name>
+        </security-role>
+    </assembly-descriptor>
+</ejb-jar>
+

--- a/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/jboss-ejb3.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss:jboss
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:s="urn:security" xmlns:sr="urn:security-role"
+        version="3.1" impl-version="2.0">
+    
+    <assembly-descriptor>
+        <!-- Map the role to the principal -->
+		<sr:security-role>
+			<sr:role-name>RealRole</sr:role-name>
+			<sr:principal-name>phantom</sr:principal-name>
+		</sr:security-role>
+    </assembly-descriptor>
+</jboss:jboss>
+

--- a/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/roles.properties
+++ b/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/roles.properties
@@ -1,0 +1,23 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+foo=bar
+

--- a/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/users.properties
+++ b/testsuite/integration/basic/src/test/resources/ejb/security/rolelink/users.properties
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+phantom=pass


### PR DESCRIPTION
The commits in this branch fix handling of security-role-ref in ejb-jar.xml and the mapping of principal with role names via jboss-ejb3.xml. 

If a security-role-ref defines a alias role to a real role and the jboss-ejb3.xml sets up a mapping between some principal "joe" to the real role, then the call to isCallerInRole(realRole) and isCallerInRole(aliasRole) on the EJB context is expected to return true if the "joe" is the current logged-in user.

ejb-jar.xml:

```
    <session>
        <ejb-name>foo</ejb-name>
        <security-role-ref>
            <role-name>AliasRole</role-name>
            <role-link>RealRole</role-link>
        </security-role-ref>
    </session>
    <assembly-descriptor>
        <security-role>
            <role-name>RealRole</role-name>
        </security-role>
    </assembly-descriptor>      
```

jboss-ejb3.xml:

```
    <assembly-descriptor>
        <security-role xmlns="urn:security-role">
            <role-name>RealRole</role-name>
            <principal-name>joe</principal-name>
        </security-role>
    </assembly-descriptor>
```

Application code:

```
    // login as joe
    securityUtil.login("joe", "pass");
    bean.isCallerInRole("RealRole"); // returns true
    bean.isCallerInRole("AliasRole"); // returns true
```

With this commit, the above usecase works correctly now.
