### PR TITLE
Ensure that RunAs is propagated after the first call

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/CallerWithIdentity.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/CallerWithIdentity.java
@@ -38,10 +38,10 @@ import javax.ejb.Stateless;
 @RunAsPrincipal("jackinabox")
 @SecurityDomain("other")
 public class CallerWithIdentity implements WhoAmI {
-    @EJB(beanName = "StatelessBBean")
-    private WhoAmI beanB;
+    @EJB(beanName = "StatelessABean")
+    private WhoAmI beanA;
 
     public String getCallerPrincipal() {
-        return beanB.getCallerPrincipal();
+        return beanA.getCallerPrincipal();
     }
 }


### PR DESCRIPTION
The test case needs to check that the RunAs is propagated after the first call :
http://community.jboss.org/message/597385#597385

Previously CallerWithIdentity invoked method getCallerPrincipal() directly on StatelessBBean (StatelessABean wasn't used).
