### PR TITLE
Removing duplicated dependency on jboss-as-jmx from build module

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -795,11 +795,6 @@
 
         <dependency>
             <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-jmx</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-jacorb</artifactId>
         </dependency>
 


### PR DESCRIPTION
Removing duplicated dependency on jboss-as-jmx from build module
