### PR TITLE
[JBWS-3373] Port component link

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemAdd.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemAdd.java
@@ -43,6 +43,7 @@ import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.webservices.config.ServerConfigImpl;
 import org.jboss.as.webservices.service.EndpointRegistryService;
+import org.jboss.as.webservices.service.PortComponentLinkService;
 import org.jboss.as.webservices.service.ServerConfigService;
 import org.jboss.as.webservices.util.ModuleClassLoaderProvider;
 import org.jboss.as.webservices.util.WSServices;
@@ -127,6 +128,7 @@ public class WSSubsystemAdd extends AbstractBoottimeAddStepHandler {
             ServerConfigImpl serverConfig = createServerConfig(model, false);
             newControllers.add(ServerConfigService.install(serviceTarget, serverConfig, verificationHandler));
             newControllers.add(EndpointRegistryService.install(serviceTarget, verificationHandler));
+            newControllers.add(PortComponentLinkService.install(serviceTarget, verificationHandler));
         }
     }
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/service/PortComponentLinkService.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/service/PortComponentLinkService.java
@@ -54,7 +54,7 @@ public final class PortComponentLinkService implements Service<WebAppController>
 
     private final ServiceName name;
     private final InjectedValue<VirtualHost> hostInjector = new InjectedValue<VirtualHost>();
-    private WebAppController pclwa;
+    private volatile WebAppController pclwa;
     private final InjectedValue<ServerConfig> serverConfigInjectorValue = new InjectedValue<ServerConfig>();
     private static final String DEFAULT_HOST_NAME = "default-host";
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/service/PortComponentLinkService.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/service/PortComponentLinkService.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.webservices.service;
+
+import static org.jboss.as.webservices.WSLogger.ROOT_LOGGER;
+
+import org.jboss.as.web.VirtualHost;
+import org.jboss.as.web.WebSubsystemServices;
+import org.jboss.as.webservices.util.WSServices;
+import org.jboss.as.webservices.util.WebAppController;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceBuilder.DependencyType;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceListener;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.wsf.spi.classloading.ClassLoaderProvider;
+import org.jboss.wsf.spi.management.ServerConfig;
+
+/**
+ * PortComponentLink service, retrieves a WebAppController instance to start/stop port component link servlet on demand; that is
+ * required to allow remote port-component-link resolution as per JSR-109 requirements.
+ *
+ * @author alessio.soldano@jboss.com
+ * @since 02-Dec-2011
+ */
+public final class PortComponentLinkService implements Service<WebAppController> {
+
+    private final ServiceName name;
+    private final InjectedValue<VirtualHost> hostInjector = new InjectedValue<VirtualHost>();
+    private WebAppController pclwa;
+    private final InjectedValue<ServerConfig> serverConfigInjectorValue = new InjectedValue<ServerConfig>();
+    private static final String DEFAULT_HOST_NAME = "default-host";
+
+    private PortComponentLinkService() {
+        this.name = WSServices.PORT_COMPONENT_LINK_SERVICE;
+    }
+
+    @Override
+    public WebAppController getValue() {
+        return pclwa;
+    }
+
+    public ServiceName getName() {
+        return name;
+    }
+
+    public InjectedValue<VirtualHost> getHostInjector() {
+        return hostInjector;
+    }
+
+    @Override
+    public void start(final StartContext ctx) throws StartException {
+        ROOT_LOGGER.starting(name);
+        String serverTempDir = serverConfigInjectorValue.getValue().getServerTempDir().getAbsolutePath();
+        ClassLoader cl = ClassLoaderProvider.getDefaultProvider().getServerJAXRPCIntegrationClassLoader();
+        pclwa = new WebAppController(hostInjector.getValue().getHost(), "org.jboss.ws.core.server.PortComponentLinkServlet",
+                cl, "/jbossws", "/pclink", serverTempDir);
+    }
+
+    @Override
+    public void stop(final StopContext ctx) {
+        ROOT_LOGGER.stopping(name);
+        pclwa = null;
+    }
+
+    public Injector<ServerConfig> getServerConfigInjector() {
+        return serverConfigInjectorValue;
+    }
+
+    public static ServiceBuilder<WebAppController> createServiceBuilder(final ServiceTarget serviceTarget,
+            final String hostName) {
+        final PortComponentLinkService service = new PortComponentLinkService();
+        final ServiceBuilder<WebAppController> builder = serviceTarget.addService(service.getName(), service);
+        builder.addDependency(DependencyType.REQUIRED, WSServices.REGISTRY_SERVICE);
+        builder.addDependency(DependencyType.REQUIRED, WSServices.CONFIG_SERVICE, ServerConfig.class,
+                service.getServerConfigInjector());
+        builder.addDependency(WebSubsystemServices.JBOSS_WEB_HOST.append(hostName), VirtualHost.class,
+                service.getHostInjector());
+        return builder;
+    }
+
+    public static ServiceController<WebAppController> install(final ServiceTarget serviceTarget, final ServiceListener<Object>... listeners) {
+        return install(serviceTarget, DEFAULT_HOST_NAME, listeners);
+    }
+
+    public static ServiceController<WebAppController> install(final ServiceTarget serviceTarget, final String hostName, final ServiceListener<Object>... listeners) {
+        ServiceBuilder<WebAppController> builder = createServiceBuilder(serviceTarget, hostName);
+        builder.addListener(listeners);
+        builder.setInitialMode(Mode.ON_DEMAND);
+        return builder.install();
+    }
+
+}

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/WSServices.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/WSServices.java
@@ -42,6 +42,7 @@ public final class WSServices {
     public static final ServiceName MODEL_SERVICE = WS_SERVICE.append("model");
     public static final ServiceName ENDPOINT_SERVICE = WS_SERVICE.append("endpoint");
     public static final ServiceName ENDPOINT_PUBLISH_SERVICE = WS_SERVICE.append("endpoint-publish");
+    public static final ServiceName PORT_COMPONENT_LINK_SERVICE = WS_SERVICE.append("port-component-link");
 
     private static WeakReference<ServiceRegistry> registry;
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/WebAppController.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/WebAppController.java
@@ -1,0 +1,182 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.webservices.util;
+
+import static org.jboss.as.webservices.WSMessages.MESSAGES;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+
+import javax.naming.NamingException;
+import javax.servlet.Servlet;
+
+import org.apache.catalina.Container;
+import org.apache.catalina.Host;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.Loader;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.startup.ContextConfig;
+import org.apache.tomcat.InstanceManager;
+import org.jboss.as.web.deployment.WebCtxLoader;
+import org.jboss.msc.service.StartException;
+
+/**
+ * WebAppController allows for automatically starting/stopping a webapp (servlet) depending on the actual need. This is useful
+ * for WS deployments needing a given utility servlet to be up (for instance the port component link servlet)
+ *
+ * @author alessio.soldano@jboss.com
+ * @since 02-Dec-2011
+ */
+public class WebAppController {
+
+    private Host host;
+    private String contextRoot;
+    private String urlPattern;
+    private String serverTempDir;
+    private String servletClass;
+    private ClassLoader classloader;
+    private volatile StandardContext ctx;
+    private int count = 0;
+
+    public WebAppController(Host host, String servletClass, ClassLoader classloader, String contextRoot, String urlPattern,
+            String serverTempDir) {
+        this.host = host;
+        this.contextRoot = contextRoot;
+        this.urlPattern = urlPattern;
+        this.serverTempDir = serverTempDir;
+        this.classloader = classloader;
+        this.servletClass = servletClass;
+    }
+
+    public synchronized int incrementUsers() throws StartException {
+        if (count == 0) {
+            try {
+                ctx = startWebApp(host);
+            } catch (Exception e) {
+                throw new StartException(e);
+            }
+        }
+        return count++;
+    }
+
+    public synchronized int decrementUsers() {
+        if (count == 0) {
+            throw new IllegalStateException();
+        }
+        count--;
+        if (count == 0) {
+            try {
+                stopWebApp(ctx);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return count;
+    }
+
+    private StandardContext startWebApp(Host host) throws Exception {
+        StandardContext context = new StandardContext();
+        try {
+            context.setPath(contextRoot);
+            context.addLifecycleListener(new ContextConfig());
+            File docBase = new File(serverTempDir, contextRoot);
+            if (!docBase.exists()) {
+                docBase.mkdirs();
+            }
+            context.setDocBase(docBase.getPath());
+
+            final Loader loader = new WebCtxLoader(classloader);
+            loader.setContainer(host);
+            context.setLoader(loader);
+            context.setInstanceManager(new LocalInstanceManager());
+
+            final int j = servletClass.indexOf(".");
+            final String servletName = j < 0 ? servletClass : servletClass.substring(j + 1);
+            final Class<?> clazz = classloader.loadClass(servletClass);
+            final Wrapper wsfsWrapper = context.createWrapper();
+            wsfsWrapper.setName(servletName);
+            wsfsWrapper.setServlet((Servlet) clazz.newInstance());
+            wsfsWrapper.setServletClass(servletClass);
+            context.addChild(wsfsWrapper);
+            context.addServletMapping(urlPattern, servletName);
+
+            host.addChild(context);
+            context.create();
+        } catch (Exception e) {
+            throw MESSAGES.createContextPhaseFailed(e);
+        }
+        try {
+            context.start();
+        } catch (LifecycleException e) {
+            throw MESSAGES.startContextPhaseFailed(e);
+        }
+        return context;
+    }
+
+    private void stopWebApp(StandardContext context) throws Exception {
+        try {
+            Container container = context.getParent();
+            container.removeChild(context);
+            context.stop();
+        } catch (LifecycleException e) {
+            throw MESSAGES.stopContextPhaseFailed(e);
+        }
+        try {
+            context.destroy();
+        } catch (Exception e) {
+            throw MESSAGES.destroyContextPhaseFailed(e);
+        }
+    }
+
+    private static class LocalInstanceManager implements InstanceManager {
+        LocalInstanceManager() {
+        }
+
+        @Override
+        public Object newInstance(String className) throws IllegalAccessException, InvocationTargetException, NamingException,
+                InstantiationException, ClassNotFoundException {
+            return Class.forName(className).newInstance();
+        }
+
+        @Override
+        public Object newInstance(String fqcn, ClassLoader classLoader) throws IllegalAccessException,
+                InvocationTargetException, NamingException, InstantiationException, ClassNotFoundException {
+            return Class.forName(fqcn, false, classLoader).newInstance();
+        }
+
+        @Override
+        public Object newInstance(Class<?> c) throws IllegalAccessException, InvocationTargetException, NamingException,
+                InstantiationException {
+            return c.newInstance();
+        }
+
+        @Override
+        public void newInstance(Object o) throws IllegalAccessException, InvocationTargetException, NamingException {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public void destroyInstance(Object o) throws IllegalAccessException, InvocationTargetException {
+        }
+    }
+}


### PR DESCRIPTION
This is about having an on-demand service for starting the PortComponentLinkServlet that we used to have in the jbossws-console.war in AS6 days and which is required to satisfy a jsr109 req with remote jaxrpc client using port-component-link in webservices.xml.
The service is started when a ws deployment is processed, however the actual web app is only created/started only when a jaxrpc deployment is processed and pull down when no jaxrpc deployment is active on the server.
