### PR TITLE
[JBQA-5453] EJBTHREE->AS7: primitive types handling

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/Ejb3DescriptorHandlerPrimitiveHandlingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/Ejb3DescriptorHandlerPrimitiveHandlingTestCase.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.primitivehandling;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Migration test from EJB Testsuite (ejbthree-1629) to AS7 [JIRA JBQA-5483].
+ *
+ * Incorrect handling of primitives. The issue arises when there's a bean method
+ * accepting a primitive type (double or float) and also has an annotation on the
+ * method (ex: @TransactionAttribute). Furthermore, the bean needs to have a
+ * corresponding entry (minimally ejb-name and ejb-class) in ejb-jar.xml, for this
+ * issue to manifest.
+ *
+ * @author Jaikiran Pai, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+public class Ejb3DescriptorHandlerPrimitiveHandlingTestCase
+{
+    private static final Logger log = Logger.getLogger(Ejb3DescriptorHandlerPrimitiveHandlingTestCase.class);
+
+    @ArquillianResource
+    InitialContext ctx;
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "primitive-handling.jar")
+                .addPackage(Ejb3DescriptorHandlerPrimitiveHandlingTestCase.class.getPackage());
+                jar.addAsManifestResource(Ejb3DescriptorHandlerPrimitiveHandlingTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+   /**
+    * Test that the bean has been deployed and available for
+    * method invocations.
+    *
+    * @throws Throwable
+    */
+    @Test
+   public void testBeanInvocation() throws Throwable
+   {
+       String jndiName = "java:module/" + Ejb3DescriptorHandlerTestBean.class.getSimpleName() + "!" + Ejb3DescriptorHandlerTestRemote.class.getName();
+      Object bean = ctx.lookup(jndiName);
+      log.info("Successfully looked up the bean at " + jndiName);
+
+      Assert.assertNotNull("Object returned from JNDI lookup for " + jndiName + " is null", bean);
+      Assert.assertTrue("Object returned from JNDI lookup for " + jndiName + " is not an instance of "
+            + Ejb3DescriptorHandlerTestRemote.class, (bean instanceof Ejb3DescriptorHandlerTestRemote));
+
+      // Call the method on the bean
+      Ejb3DescriptorHandlerTestRemote primitiveTesterBean = (Ejb3DescriptorHandlerTestRemote) bean;
+      double someDouble = 2.0;
+      double returnedDouble = primitiveTesterBean.doOpAndReturnDouble(someDouble);
+      Assert.assertEquals("Bean returned unexpected value for primitive double",returnedDouble, someDouble, Double.NaN);
+
+      // test on float
+      float someFloat = 2.5F;
+      float returnedFloat = primitiveTesterBean.doOpAndReturnFloat(someFloat);
+      Assert.assertEquals("Bean returned unexpected value for primitive float",returnedFloat, someFloat, Float.NaN);
+
+      // test on arrays
+      float[] floatArray = new float[]{someFloat};
+      float[] returnedFloatArray = primitiveTesterBean.doOpAndReturnFloat(floatArray);
+      Assert.assertEquals("Bean returned unexpected value for primitive float array",returnedFloatArray.length, floatArray.length);
+      Assert.assertEquals("Bean returned unexpected value for primitive float array contents",returnedFloatArray[0], floatArray[0], Float.NaN);
+
+      double[] doubleArray = new double[]{someDouble};
+      double[] returnedDoubleArray = primitiveTesterBean.doOpAndReturnDouble(doubleArray);
+      Assert.assertEquals("Bean returned unexpected value for primitive double array",returnedDoubleArray.length, doubleArray.length);
+      Assert.assertEquals("Bean returned unexpected value for primitive double array contents",returnedDoubleArray[0], doubleArray[0], Double.NaN);
+
+      // now some simple method which says hi
+      String name = "jai";
+      String returnedMessage = primitiveTesterBean.sayHi(name);
+      Assert.assertEquals("Bean returned unexpected message", returnedMessage, "Hi " + name);
+
+   }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/Ejb3DescriptorHandlerTestBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/Ejb3DescriptorHandlerTestBean.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.primitivehandling;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+/**
+ * Ejb3DescriptorHandlerTestBean
+ *
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(Ejb3DescriptorHandlerTestRemote.class)
+public class Ejb3DescriptorHandlerTestBean implements Ejb3DescriptorHandlerTestRemote
+{
+
+   @TransactionAttribute (TransactionAttributeType.REQUIRED)
+   public double doOpAndReturnDouble(double someDouble)
+   {
+      return someDouble;
+   }
+
+   @TransactionAttribute (TransactionAttributeType.REQUIRED)
+   public float doOpAndReturnFloat(float someFloat)
+   {
+      return someFloat;
+   }
+
+   @TransactionAttribute (TransactionAttributeType.REQUIRED)
+   public double[] doOpAndReturnDouble(double[] someDouble)
+   {
+      return someDouble;
+   }
+
+   @TransactionAttribute (TransactionAttributeType.REQUIRED)
+   public float[] doOpAndReturnFloat(float[] someFloat)
+   {
+      return someFloat;
+   }
+
+   public String sayHi(String name)
+   {
+      return "Hi " + name;
+   }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/Ejb3DescriptorHandlerTestRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/Ejb3DescriptorHandlerTestRemote.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.primitivehandling;
+
+import javax.ejb.Remote;
+
+/**
+ * PrimitiveTesterRemote
+ *
+ * @author Jaikiran Pai
+ */
+@Remote
+public interface Ejb3DescriptorHandlerTestRemote
+{
+   double doOpAndReturnDouble(double someDouble);
+
+   double[] doOpAndReturnDouble(double[] someDouble);
+
+   float[] doOpAndReturnFloat(float[] someFloat);
+
+   float doOpAndReturnFloat(float someFloat);
+
+   String sayHi(String name);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/primitivehandling/ejb-jar.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                            http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+        version="3.0">
+
+   <enterprise-beans>
+
+   		<session>
+            <ejb-name>Ejb3DescriptorHandlerTestBean</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ee.injection.primitivehandling.Ejb3DescriptorHandlerTestBean</ejb-class>
+      	</session>
+
+
+   </enterprise-beans>
+
+
+
+</ejb-jar>


### PR DESCRIPTION
[JBQA-5483] EJBTHREE->AS7: ejbthree-1629
Part of migration of EJB3 testsuite to AS7 testsuite.
Behavior of methods working with primitive data types. 
