### PR TITLE
[JBQA-5483] EJBTHREE->AS7: remove method working

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/AbstractRemoveBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/AbstractRemoveBean.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+/**
+ * 
+ * AbstractRemoveBean.
+ * 
+ * @author <a href="arubinge@redhat.com">ALR</a>
+ */
+public class AbstractRemoveBean implements Remove {
+    // Class Members
+    public static final String RETURN_STRING = "Remove";
+
+    // Required Implementations
+    public String remove() {
+        return AbstractRemoveBean.RETURN_STRING;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Delegate.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Delegate.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Remote;
+
+/**
+ * A Delegate to invoke upon local views of the Remove EJBs
+ * 
+ * @author <a href="arubinge@redhat.com">ALR</a>
+ */
+@Remote
+public interface Delegate {
+    String invokeStatelessRemove();
+
+    String invokeStatefulRemove();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/DelegateBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/DelegateBean.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+
+@Stateless
+public class DelegateBean implements Delegate {
+    // Instance Members
+
+    @EJB
+    private RemoveStatefulLocal stateful;
+
+    @EJB
+    private RemoveStatelessLocal stateless;
+
+    // Required Implementations
+
+    public String invokeStatefulRemove() {
+        return stateful.remove();
+    }
+
+    public String invokeStatelessRemove() {
+        return stateless.remove();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21View.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21View.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * An Ejb21View.
+ * 
+ * @author <a href="arubinge@redhat.com">ALR</a>
+ */
+public interface Ejb21View extends EJBObject {
+    String test() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21ViewBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21ViewBean.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.RemoteHome;
+import javax.ejb.Stateful;
+
+@Stateful
+@RemoteHome(Ejb21ViewHome.class)
+public class Ejb21ViewBean {
+    // Class Members
+
+    public static final String TEST_STRING = "Test";
+
+    // Required Implementations
+
+    public String test() throws RemoteException {
+        return Ejb21ViewBean.TEST_STRING;
+    }
+
+    public void ejbCreate() {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21ViewHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21ViewHome.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBHome;
+
+/**
+ * @author carlo
+ * 
+ */
+public interface Ejb21ViewHome extends EJBHome {
+    Ejb21View create() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Remove.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Remove.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+/**
+ * Defines a method named "remove" of return type "String"
+ * 
+ * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+public interface Remove {
+    String remove();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodUnitTestCase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import java.rmi.NoSuchObjectException;
+
+import javax.ejb.EJBObject;
+import javax.naming.InitialContext;
+import javax.rmi.PortableRemoteObject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Migration test from EJB Testsuite (ejbthree-786) to AS7 [JIRA JBQA-5483].
+ * We want a remove action on a backing bean.
+ * 
+ * @author Carlo de Wolf, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+public class RemoveMethodUnitTestCase {
+    private static final Logger log = Logger.getLogger(RemoveMethodUnitTestCase.class);
+
+    @ArquillianResource
+    InitialContext ctx;
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "remove-method-test.jar").addPackage(
+                RemoveMethodUnitTestCase.class.getPackage());
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    @Test
+    public void testRemoveStatefulRemote() throws Exception {
+        RemoveStatefulRemote session = (RemoveStatefulRemote) ctx.lookup("java:module/" + StatefulRemoveBean.class.getSimpleName() + "!" + RemoveStatefulRemote.class.getName());
+        String result = session.remove();
+        Assert.assertEquals(AbstractRemoveBean.RETURN_STRING, result);
+    }
+
+    @Test
+    public void testRemoveStatelessRemote() throws Exception {
+        RemoveStatelessRemote session = (RemoveStatelessRemote) ctx.lookup("java:module/" + StatelessRemoveBean.class.getSimpleName() + "!" + RemoveStatelessRemote.class.getName());
+        String result = session.remove();
+        Assert.assertEquals(AbstractRemoveBean.RETURN_STRING, result);
+    }
+
+    @Test
+    public void testRemoveStatefulLocalViaDelegate() throws Exception {
+        Delegate session = (Delegate) ctx.lookup("java:module/" + DelegateBean.class.getSimpleName() + "!" + Delegate.class.getName());
+        String result = session.invokeStatefulRemove();
+        Assert.assertEquals(AbstractRemoveBean.RETURN_STRING, result);
+    }
+
+    @Test
+    public void testRemoveStatelessLocalViaDelegate() throws Exception {
+        Delegate session = (Delegate) ctx.lookup("java:module/" + DelegateBean.class.getSimpleName() + "!" + Delegate.class.getName());
+        String result = session.invokeStatelessRemove();
+        Assert.assertEquals(AbstractRemoveBean.RETURN_STRING, result);
+    }
+
+    @Test
+    public void testExplicitExtensionEjbObjectInProxy() throws Exception {
+        // Obtain stub
+        Object obj = ctx.lookup("java:module/" + Ejb21ViewBean.class.getSimpleName() + "!" + Ejb21ViewHome.class.getName());
+        Ejb21ViewHome home = (Ejb21ViewHome) PortableRemoteObject.narrow(obj, Ejb21ViewHome.class);
+        Ejb21View session = home.create();
+
+        // Ensure EJBObject
+        Assert.assertTrue(session instanceof EJBObject);
+
+        // Cast and remove appropriately, ensuring removed
+        boolean removed = false;
+        String result = session.test();
+        Assert.assertEquals(Ejb21ViewBean.TEST_STRING, result);
+        session.remove();
+        try {
+            session.test();
+        } catch (Exception e) {
+            if (e instanceof NoSuchObjectException || e.getCause() instanceof NoSuchObjectException) {
+                removed = true;
+            } else {
+                Assert.fail("Exception received, " + e + ", was not expected and should have had root cause of " + NoSuchObjectException.class);
+            }
+        }
+        Assert.assertTrue("SFSB instance was not removed as expected", removed);
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatefulLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatefulLocal.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Local;
+
+/**
+ * Local implementation of "Remove"
+ * 
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+@Local
+public interface RemoveStatefulLocal extends Remove {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatefulRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatefulRemote.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Remote;
+
+/**
+ * Remote implementation of "Remove"
+ * 
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+@Remote
+public interface RemoveStatefulRemote extends Remove {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatelessLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatelessLocal.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Local;
+
+/**
+ * Local implementation of "Remove"
+ * 
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+@Local
+public interface RemoveStatelessLocal extends Remove {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatelessRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveStatelessRemote.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Remote;
+
+/**
+ * Remote implementation of "Remove"
+ * 
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+@Remote
+public interface RemoveStatelessRemote extends Remove {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/StatefulRemoveBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/StatefulRemoveBean.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Stateful;
+
+/**
+ * Defines a custom "remove" method that is not associated w/ EJBOBject/EJBLocalObject.remove
+ * 
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+@Stateful
+public class StatefulRemoveBean extends AbstractRemoveBean implements RemoveStatefulRemote, RemoveStatefulLocal {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/StatelessRemoveBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/StatelessRemoveBean.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Stateless;
+
+/**
+ * Defines a custom "remove" method that is not associated w/ EJBOBject/EJBLocalObject.remove
+ * 
+ * @author <a href="mailto:arubinge@redhat.com">ALR</a>
+ */
+@Stateless
+public class StatelessRemoveBean extends AbstractRemoveBean implements RemoveStatelessRemote, RemoveStatelessLocal {
+}


### PR DESCRIPTION
[JBQA-5483] EJBTHREE->AS7: ejbthree-786
Part of migration of EJB3 testsuite to AS7 testsuite.
Testing correct work of remove method.
