### PR TITLE
init.d consistent naming + mode selection

### DIFF
--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -5,8 +5,8 @@
 # chkconfig: - 80 20
 # description: JBoss AS Standalone
 # processname: standalone
-# pidfile: /var/run/jboss/jboss-as-standalone.pid
-# config: /etc/jboss/jboss-as.conf
+# pidfile: /var/run/jboss-as/jboss-as-standalone.pid
+# config: /etc/jboss-as/jboss-as.conf
 
 # Source function library.
 . /etc/init.d/functions
@@ -17,7 +17,7 @@ export JAVA_HOME
 
 # Load JBoss AS init.d configuration.
 if [ -z "$JBOSS_CONF" ]; then
-  JBOSS_CONF="/etc/jboss/jboss-as.conf"
+  JBOSS_CONF="/etc/jboss-as/jboss-as.conf"
 fi
 
 [ -r "$JBOSS_CONF" ] && . "${JBOSS_CONF}"
@@ -25,12 +25,12 @@ fi
 # Set defaults.
 
 if [ -z "$JBOSS_HOME" ]; then
-  JBOSS_HOME=/opt/jboss-as
+  JBOSS_HOME=/usr/share/jboss-as
 fi
 export JBOSS_HOME
 
 if [ -z "$JBOSS_PIDFILE" ]; then
-  JBOSS_PIDFILE=/var/run/jboss/jboss-as-standalone.pid
+  JBOSS_PIDFILE=/var/run/jboss-as/jboss-as-standalone.pid
 fi
 export JBOSS_PIDFILE
 
@@ -44,6 +44,10 @@ fi
 
 if [ -z "$SHUTDOWN_WAIT" ]; then
   SHUTDOWN_WAIT=30
+fi
+
+if [ -z "$JBOSS_CONFIG" ]; then
+  JBOSS_CONFIG=standalone.xml
 fi
 
 JBOSS_SCRIPT=$JBOSS_HOME/bin/standalone.sh
@@ -83,9 +87,9 @@ start() {
 
   if [ ! -z "$JBOSS_USER" ]; then
     if [ -x /etc/rc.d/init.d/functions ]; then
-      daemon --user $JBOSS_USER LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=$JBOSS_PIDFILE $JBOSS_SCRIPT 2>&1 > $JBOSS_CONSOLE_LOG &
+      daemon --user $JBOSS_USER LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=$JBOSS_PIDFILE $JBOSS_SCRIPT -c $JBOSS_CONFIG 2>&1 > $JBOSS_CONSOLE_LOG &
     else
-      su - $JBOSS_USER -c "LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=$JBOSS_PIDFILE $JBOSS_SCRIPT" 2>&1 > $JBOSS_CONSOLE_LOG &
+      su - $JBOSS_USER -c "LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=$JBOSS_PIDFILE $JBOSS_SCRIPT -c $JBOSS_CONFIG" 2>&1 > $JBOSS_CONSOLE_LOG &
     fi
   fi
 


### PR DESCRIPTION
Use consistent naming of directories and proper default JBOSS_HOME location. Allow to override mode (configuration).
