### PR TITLE
JPA/EJB leak fix AS7-2932

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -114,6 +114,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             return;
         }
         final ClassLoader tccl = SecurityActions.getContextClassLoader();
+        Runnable runnable = null;
         try {
             //set the correct TCCL for unmarshalling
             SecurityActions.setContextClassLoader(ejbDeploymentInformation.getDeploymentClassLoader());
@@ -154,8 +155,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             }
             unMarshaller.finish();
 
-            // invoke the method and write out the response on a separate thread
-            executorService.submit(new Runnable() {
+            runnable = new Runnable() {
 
                 @Override
                 public void run() {
@@ -203,10 +203,13 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                         return;
                     }
                 }
-            });
+            };
         } finally {
             SecurityActions.setContextClassLoader(tccl);
         }
+        // invoke the method and write out the response on a separate thread
+        executorService.submit(runnable);
+
 
     }
 

--- a/jpa/hibernate4/src/main/java/org/jboss/as/jpa/hibernate4/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate4/src/main/java/org/jboss/as/jpa/hibernate4/HibernatePersistenceProviderAdaptor.java
@@ -45,7 +45,6 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
 
 
     private volatile JBossAppServerJtaPlatform appServerJtaPlatform;
-    private final HibernateManagementAdaptor hibernateManagementAdaptor = new HibernateManagementAdaptor();
 
     @Override
     public void injectJtaManager(JtaManager jtaManager) {
@@ -118,7 +117,7 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
 
     @Override
     public ManagementAdaptor getManagementAdaptor() {
-        return hibernateManagementAdaptor;
+        return HibernateManagementAdaptor.getInstance();
     }
 
 }

--- a/jpa/hibernate4/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateManagementAdaptor.java
+++ b/jpa/hibernate4/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateManagementAdaptor.java
@@ -48,6 +48,9 @@ import org.jboss.dmr.ModelNode;
  */
 public class HibernateManagementAdaptor implements ManagementAdaptor {
 
+    // shared instance for all Hibernate 4 JPA deployments
+    private static final HibernateManagementAdaptor INSTANCE = new HibernateManagementAdaptor();
+
     private static final String PROVIDER_LABEL = "hibernate-persistence-unit";
     public static final String OPERATION_CLEAR = "clear";
     public static final String OPERATION_EVICTALL = "evict-all";
@@ -87,6 +90,14 @@ public class HibernateManagementAdaptor implements ManagementAdaptor {
     public static final String OPERATION_OPTIMISTIC_FAILURE_COUNT = "optimistic-failure-count";
 
     private PersistenceUnitServiceRegistry persistenceUnitRegistry;
+
+    /**
+     * The management statistics are shared across all Hibernate 4 JPA deployments
+     * @return shared instance for all Hibernate 4 JPA deployments
+     */
+    public static HibernateManagementAdaptor getInstance() {
+        return INSTANCE;
+    }
 
     @Override
     public void register(final ManagementResourceRegistration jpaSubsystemDeployments, PersistenceUnitServiceRegistry persistenceUnitRegistry) {


### PR DESCRIPTION
Clear MethodInvocationMessageHandler tccl + jpa change to use a persistence provider adaptor per app deployment instead of sharing global
