### PR TITLE
[AS7-2852] RunAsPrincipal annotation processing

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/EjbAnnotationProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/EjbAnnotationProcessor.java
@@ -71,6 +71,7 @@ public class EjbAnnotationProcessor extends AbstractEEAnnotationProcessor {
 
         //security annotations
         factories.add(new RunAsAnnotationInformationFactory());
+        factories.add(new RunAsPrincipalAnnotationInformationFactory());
         factories.add(new SecurityDomainAnnotationInformationFactory());
         factories.add(new DeclareRolesAnnotationInformationFactory());
         factories.add(new RolesAllowedAnnotationInformationFactory());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsPrincipalAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsPrincipalAnnotationInformationFactory.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ejb3.deployment.processors.annotation;
+
+import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.ejb3.annotation.RunAsPrincipal;
+import org.jboss.jandex.AnnotationInstance;
+
+/**
+ * Processes the {@link org.jboss.ejb3.annotation.RunAsPrincipal} annotation on a session bean
+ *
+ * @author Guillaume Grossetie
+ */
+public class RunAsPrincipalAnnotationInformationFactory extends ClassAnnotationInformationFactory<RunAsPrincipal, String> {
+
+    protected RunAsPrincipalAnnotationInformationFactory() {
+        super(RunAsPrincipal.class, null);
+    }
+
+    @Override
+    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+        return annotationInstance.value().asString();
+    }
+}


### PR DESCRIPTION
Add the RunAsPrincipal annotation processing.
Activate RunAsPrincipalTestCase.testJackInABox().

One test is still @Ignore, I don't know when the SecurityException/EJBAccessException has to be thrown... ?
