### PR TITLE
[JBQA-5483] EJBTHREE->AS7: resource-ref

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -104,6 +104,7 @@
                                         <include>org/jboss/as/test/integration/messaging/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/management/cli/HelpTestCase.java</include>
                                         <include>org/jboss/as/test/integration/management/cli/JmsTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/resource/resourceref/*TestCase.java</include>
                                     </includes>
 
                                     <!-- Parameters to test cases. -->
@@ -142,6 +143,7 @@
                                         <exclude>org/jboss/as/test/integration/messaging/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/cli/HelpTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/cli/JmsTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ee/injection/resource/resourceref/*TestCase.java</exclude>
                                     </excludes>
 
                                     <!-- Parameters to test cases. -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ResourceRefBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ResourceRefBean.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.resourceref;
+
+import java.net.URL;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import org.jboss.logging.Logger;
+
+/**
+ * ResourceRefBean
+ * 
+ * This bean will be used to test the EJBTHREE-1823 issue.
+ * 
+ * Brief description of the issue: If a resource-ref entry is available in jboss.xml, but there is no corresponding resource-ref
+ * entry neither in ejb-jar.xml nor a @Resource in the bean, then because of the non-availability of the "res-type" information,
+ * a NullPointerException gets thrown when the {@link ResourceHandler} tries to process the entries to be made in ENC.
+ * 
+ * @author Jaikiran Pai
+ */
+@Stateless
+public class ResourceRefBean implements ResourceRefRemote {
+
+    private static Logger logger = Logger.getLogger(ResourceRefBean.class);
+
+    /* FIXME: uncomment after solving AS7-2744
+     * @Resource(name = "SomeURL", mappedName = "http://www.jboss.org") */
+    private URL someUrl;
+
+    /**
+     * Looks up a datasource within the ENC of this bean. The datasource is expected to be configured through the deployment
+     * descriptors and should be available at java:comp/env/EJBTHREE-1823_DS
+     * 
+     * The "res-type" of this datasource resource-ref will not be provided through ejb-jar.xml nor through a @Resource
+     * annotation.
+     * 
+     */
+    public boolean isDataSourceAvailableInEnc() throws NamingException {
+        boolean ret = false;
+        Context ctx = new InitialContext();
+        String encJndiName = "java:comp/env/EJBTHREE-1823_DS";
+        DataSource ds = (DataSource) ctx.lookup(encJndiName);
+        ret = ds == null ? false : true;
+        logger.info("Datasource was found: " + ret + ", on: " + encJndiName);
+        return ret;
+    }
+
+    /**
+     * Let's just lookup other resource-ref entries (like a resource-ref for a URL)
+     * 
+     * @return
+     * @throws NamingException
+     */
+    public boolean areOtherResourcesAvailableInEnc() throws NamingException {
+        Context ctx = new InitialContext();
+        String encJndiName = "java:comp/env/SomeURL";
+        URL urlInEnc = (URL) ctx.lookup(encJndiName);
+        if (urlInEnc == null) {
+            logger.error("URL not found in ENC at " + encJndiName);
+            return false;
+        }
+
+        // also check if the resource was injected
+        if (this.someUrl == null) {
+            logger.error("@Resource of type URL not injected");
+            return false;
+        }
+
+        return true;
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ResourceRefRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ResourceRefRemote.java
@@ -22,18 +22,17 @@
 
 package org.jboss.as.test.integration.ee.injection.resource.resourceref;
 
-import javax.annotation.ManagedBean;
-import javax.sql.DataSource;
+import javax.ejb.Remote;
+import javax.naming.NamingException;
 
 /**
- * @author Stuart Douglas
+ * ResourceRefRemote
+ * 
+ * @author Jaikiran Pai
  */
-@ManagedBean("datasourceManagedBean")
-public class DatasourceManagedBean {
+@Remote
+public interface ResourceRefRemote {
+    public boolean isDataSourceAvailableInEnc() throws NamingException;
 
-    private DataSource ds;
-
-    public DataSource getDataSource() {
-        return ds;
-    }
+    public boolean areOtherResourcesAvailableInEnc() throws NamingException;
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ResourceRefTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ResourceRefTestCase.java
@@ -1,8 +1,8 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -19,6 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.jboss.as.test.integration.ee.injection.resource.resourceref;
 
 import javax.naming.InitialContext;
@@ -27,11 +28,14 @@ import javax.sql.DataSource;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,18 +45,35 @@ import org.junit.runner.RunWith;
  * Tests that @Resource bindings on interceptors that are applied to multiple
  * components without their own naming context work properly, and do not try
  * and create two duplicate bindings in the same namespace.
+ * 
+ * Migration test from EJB Testsuite (ejbthree-1823, ejbthree-1858) to AS7 [JIRA JBQA-5483].
+ * - ResourceHandler when resource-ref type is not specified.
+ * - EJBContext is configured through ejb-jar.xml as a resource-env-ref.
  *
- * @author Stuart Douglas
+ * @author Stuart Douglas, Jaikiran Pai, Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
 public class ResourceRefTestCase {
+    private static final Logger log = Logger.getLogger(ResourceRefTestCase.class);
 
     @Deployment
     public static Archive<?> deployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "multiple-bindings-superclass.war");
-        war.addAsWebInfResource(getWebXml(),"web.xml");
-        war.addPackage(ResourceRefTestCase.class.getPackage());
-        return war;
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "resourcerref.ear");
+        
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "managed-bean.war");
+        war.addAsWebInfResource(ResourceRefTestCase.class.getPackage(),"web.xml", "web.xml");
+        war.addClasses(ResourceRefTestCase.class, DatasourceManagedBean.class);
+        
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "resource-ref-test.jar");
+        jar.addClasses(ResourceRefBean.class, ResourceRefRemote.class, StatelessBean.class, StatelessBeanRemote.class);
+        jar.addAsManifestResource(ResourceRefTestCase.class.getPackage(),"jboss-ejb3.xml", "jboss-ejb3.xml");
+        jar.addAsManifestResource(ResourceRefTestCase.class.getPackage(),"ejb-jar.xml", "ejb-jar.xml");
+        
+        ear.addAsModule(jar);
+        ear.addAsModule(war);
+                
+        log.info(ear.toString(true));
+        return ear;
     }
 
     @Test
@@ -68,26 +89,63 @@ public class ResourceRefTestCase {
         DatasourceManagedBean bean = (DatasourceManagedBean)context.lookup("java:module/datasourceManagedBean");
         Assert.assertNotNull(bean.getDataSource());
     }
+    
+    /**
+     * Test that a resource-ref entry with a res-type does not throw an NPE. Furthermore, the test additional provides a
+     * mappedName for the resource-ref in which case the resource ref will be created in the ENC.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testResourceRefEntriesWithoutResType() throws Exception {
+        // lookup the bean
+        InitialContext context = new InitialContext();
+        ResourceRefRemote bean = (ResourceRefRemote) context.lookup("java:app/resource-ref-test/" + ResourceRefBean.class.getSimpleName() + "!" + ResourceRefRemote.class.getName());
+        Assert.assertNotNull("Bean returned from JNDI is null", bean);
 
+        // test datasource resource-ref which does not have a res-type specified
+        boolean result = bean.isDataSourceAvailableInEnc();
+        Assert.assertTrue("Datasource not bound in ENC of the bean", result);
+    }
+    
+    /**
+     * Test that resource-ref with proper res-type are correctly processed (i.e. no regression is caused by the EJBHTREE-1823
+     * fix)
+     * 
+     * @throws Exception
+     */
+    @Ignore("AS7-2744")
+    @Test
+    public void testResourceRefEntriesWithResType() throws Exception {
+        // lookup the bean
+        InitialContext context = new InitialContext();
+        ResourceRefRemote bean = (ResourceRefRemote) context.lookup("java:app/resource-ref-test/" + ResourceRefBean.class.getSimpleName() + "!" + ResourceRefRemote.class.getName());
+        Assert.assertNotNull("Bean returned from JNDI is null", bean);
 
-    private static StringAsset getWebXml() {
-        return new StringAsset("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "\n" +
-                "<web-app version=\"3.0\"\n" +
-                "         xmlns=\"http://java.sun.com/xml/ns/javaee\"\n" +
-                "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-                "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd\"\n" +
-                "         metadata-complete=\"false\">\n" +
-                "\n" +
-                "    <resource-ref>\n" +
-                "        <res-ref-name>ds</res-ref-name>\n" +
-                "        <lookup-name>java:jboss/datasources/ExampleDS</lookup-name>\n" +
-                "        <injection-target>" +
-                "           <injection-target-class>"+ DatasourceManagedBean.class.getName()+"</injection-target-class>"+
-                "           <injection-target-name>ds</injection-target-name>" +
-                "        </injection-target>\n" +
-                "    </resource-ref>\n" +
-                "\n" +
-                "</web-app>");
+        // test other resource-refs which have res-type specified
+        boolean result = bean.areOtherResourcesAvailableInEnc();
+        Assert.assertTrue("Not all resources bound in ENC of the bean", result);
+
+    }
+    
+    /**
+     * Test that the resources configured through resource-env-ref are bound
+     * correctly
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testResourceEnvRefWithoutInjectionTarget() throws Exception
+    {
+        InitialContext context = new InitialContext();
+       StatelessBeanRemote bean = (StatelessBeanRemote) context.lookup("java:app/resource-ref-test/"+StatelessBean.class.getSimpleName() + "!" + StatelessBeanRemote.class.getName());
+       // check EJBContext through resource-env-ref was handled
+       Assert.assertTrue("resource-env-ref did not handle EJBContext", bean.isEJBContextAvailableThroughResourceEnvRef());
+       // check UserTransaction through resource-env-ref was handled
+       Assert.assertTrue("resource-env-ref did not handle UserTransaction", bean
+             .isUserTransactionAvailableThroughResourceEnvRef());
+       // check some other resource through resource-env-ref was handled
+       Assert.assertTrue("resource-env-ref did not setup the other resource in java:comp/env of the bean", bean
+             .isOtherResourceAvailableThroughResourceEnvRef());
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/StatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/StatelessBean.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.resourceref;
+
+import javax.annotation.Resource;
+import javax.ejb.EJBContext;
+import javax.ejb.SessionContext;
+import javax.jms.Queue;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class StatelessBean implements StatelessBeanRemote
+{
+   @Resource
+   private SessionContext sessionContext;
+
+   public boolean isEJBContextAvailableThroughResourceEnvRef()
+   {
+      // resource-env-ref which setups up the EJBContext to be
+      // available (also) under java:comp/env/EJBContext
+      EJBContext ejbContext = (EJBContext) this.sessionContext.lookup("MyEJBContext");
+      // successful if found. An exception (eg: NameNotFound) will be
+      // thrown otherwise
+      return ejbContext != null;
+   }
+
+   public boolean isUserTransactionAvailableThroughResourceEnvRef()
+   {
+      // resource-env-ref which setups up the UserTransaction to be
+      // available (also) under java:comp/env/UserTransaction
+      UserTransaction userTransaction = (UserTransaction) this.sessionContext.lookup("MyUserTransaction");
+      // successful if found. An exception (eg: NameNotFound) will be
+      // thrown otherwise
+      return userTransaction != null;
+   }
+
+   public boolean isOtherResourceAvailableThroughResourceEnvRef()
+   {
+      // resource-env-ref which setups up the Queue to be
+      // available under java:comp/env/MyQueue
+      Queue queue = (Queue) this.sessionContext.lookup("MyQueue");
+      // successful if found. An exception (eg: NameNotFound) will be
+      // thrown otherwise
+      return queue != null;
+
+   }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/StatelessBeanRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/StatelessBeanRemote.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2011, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,18 +22,15 @@
 
 package org.jboss.as.test.integration.ee.injection.resource.resourceref;
 
-import javax.annotation.ManagedBean;
-import javax.sql.DataSource;
-
 /**
- * @author Stuart Douglas
+ * @author Jaikiran Pai
  */
-@ManagedBean("datasourceManagedBean")
-public class DatasourceManagedBean {
+public interface StatelessBeanRemote
+{
 
-    private DataSource ds;
+   boolean isEJBContextAvailableThroughResourceEnvRef();
 
-    public DataSource getDataSource() {
-        return ds;
-    }
+   boolean isUserTransactionAvailableThroughResourceEnvRef();
+
+   boolean isOtherResourceAvailableThroughResourceEnvRef();
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ejb-jar.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                            http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+        version="3.0">
+
+   <enterprise-beans>
+
+        <session>
+            <ejb-name>StatelessBean</ejb-name>
+            <business-remote>org.jboss.as.test.integration.ee.injection.resource.resourceref.StatelessBeanRemote</business-remote>
+            <ejb-class>org.jboss.as.test.integration.ee.injection.resource.resourceref.StatelessBean</ejb-class>
+            <session-type>Stateless</session-type>
+            
+            <resource-env-ref>
+                <resource-env-ref-name>MyEJBContext</resource-env-ref-name>
+                <resource-env-ref-type>javax.ejb.EJBContext</resource-env-ref-type>
+            </resource-env-ref>
+
+            <resource-env-ref>
+                <resource-env-ref-name>MyUserTransaction</resource-env-ref-name>
+                <resource-env-ref-type>javax.transaction.UserTransaction</resource-env-ref-type>
+            </resource-env-ref>
+
+            <resource-env-ref>
+                <resource-env-ref-name>MyQueue</resource-env-ref-name>
+                <resource-env-ref-type>javax.jms.Queue</resource-env-ref-type>
+                <mapped-name>java:/queue/test</mapped-name>
+            </resource-env-ref>
+        </session>
+
+   </enterprise-beans>
+</ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/jboss-ejb3.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>  
+   <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+                  xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+                  version="3.1"
+                  impl-version="2.0">
+    <enterprise-beans>
+        
+        <session>
+            <ejb-name>ResourceRefBean</ejb-name>
+            <!-- This resource-ref has no corresponding res-type specified
+            neither in ejb-jar.xml nor in the bean as a @Resource (see EJBTHREE-1823
+            for the details) -->
+            <resource-ref>
+                <res-ref-name>EJBTHREE-1823_DS</res-ref-name>
+                <jndi-name>java:jboss/datasources/ExampleDS</jndi-name>
+            </resource-ref>
+        </session>
+        
+		<session>
+            <ejb-name>StatelessBean</ejb-name>
+        </session>
+        
+    </enterprise-beans>
+</jboss:ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/web.xml
@@ -1,0 +1,16 @@
+<web-app version="3.0"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         metadata-complete="false">
+
+    <resource-ref>
+        <res-ref-name>ds</res-ref-name>
+        <lookup-name>java:jboss/datasources/ExampleDS</lookup-name>
+        <injection-target>
+           <injection-target-class>org.jboss.as.test.integration.ee.injection.resource.resourceref.DatasourceManagedBean</injection-target-class>
+           <injection-target-name>ds</injection-target-name>
+        </injection-target>
+    </resource-ref>
+
+</web-app>


### PR DESCRIPTION
[JBQA-5483] EJBTHREE->AS7: resource-ref (ejbthree-1823, ejbthree-1858)
Testing injection of ResourceHandler when resource-ref type is not specified and when EJBContext is configured through ejb-jar.xml as a resource-env-ref.
