### PR TITLE
[JBQA-5483] EJBTHREE->AS7: enventry

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -104,6 +104,7 @@
                                         <include>org/jboss/as/test/integration/messaging/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/management/cli/HelpTestCase.java</include>
                                         <include>org/jboss/as/test/integration/management/cli/JmsTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/resource/enventry/EnvEntryTestCase.java</include>
                                     </includes>
 
                                     <!-- Parameters to test cases. -->
@@ -142,6 +143,7 @@
                                         <exclude>org/jboss/as/test/integration/messaging/**/*TestCase*.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/cli/HelpTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/management/cli/JmsTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ee/injection/resource/enventry/EnvEntryTestCase.java</exclude>
                                     </excludes>
 
                                     <!-- Parameters to test cases. -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/DuplicateGlobalBindingInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/DuplicateGlobalBindingInjectionTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.ee.injection.resource.enventry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.ee.component.EnvEntryInjectionSource;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -45,7 +46,10 @@ public class DuplicateGlobalBindingInjectionTestCase {
     @Deployment(name = "dep1", managed = true, testable = true)
     public static WebArchive deployment1() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "dep1.war");
-        war.addPackage(DuplicateGlobalBindingInjectionTestCase.class.getPackage());
+        war.addClasses(
+                EnvEntryInjectionServlet.class,
+                EnvEntryManagedBean.class, 
+                DuplicateGlobalBindingInjectionTestCase.class);
         war.addAsWebInfResource(getWebXml(), "web.xml");
         return war;
     }
@@ -54,7 +58,11 @@ public class DuplicateGlobalBindingInjectionTestCase {
     public static WebArchive deployment2() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "dep2.war");
         war.addPackage(HttpRequest.class.getPackage());
-        war.addPackage(DuplicateGlobalBindingInjectionTestCase.class.getPackage());
+        // war.addPackage(DuplicateGlobalBindingInjectionTestCase.class.getPackage());
+        war.addClasses(
+                EnvEntryInjectionServlet.class,
+                EnvEntryManagedBean.class, 
+                DuplicateGlobalBindingInjectionTestCase.class);
         war.addAsWebInfResource(getWebXml(), "web.xml");
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/EnvEntryInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/EnvEntryInjectionTestCase.java
@@ -49,7 +49,11 @@ public class EnvEntryInjectionTestCase {
     public static WebArchive deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "war-example.war");
         war.addPackage(HttpRequest.class.getPackage());
-        war.addPackage(EnvEntryInjectionTestCase.class.getPackage());
+        war.addClasses(
+                EnvEntryInjectionServlet.class,
+                EnvEntryManagedBean.class,
+                EnvEntryInjectionTestCase.class
+                );
         war.addAsWebInfResource(getWebXml(), "web.xml");
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/EnvEntryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/EnvEntryTestCase.java
@@ -1,0 +1,192 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.MapMessage;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.JMSAdminOperations;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Migration test from EJB Testsuite (ejbthree-985 + enventry) to AS7 [JIRA JBQA-5483]. 
+ * Test to see if optional env-entry-value works (16.4.1.3).
+ * Testing of behaviour of environment variables in ejb-jar.xml.
+ * 
+ * @author Carlo de Wolf, William DeCoste, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+public class EnvEntryTestCase {
+    private static final Logger log = Logger.getLogger(EnvEntryTestCase.class);
+
+    @ArquillianResource
+    InitialContext ctx;
+
+    private static JMSAdminOperations adminOps;
+
+    @Deployment
+    public static Archive<?> deploymentOptional() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "env-entry-test.jar")
+                .addClasses(
+                        ExtendedTestEnvEntryBean.class,
+                        OptionalEnvEntry.class,
+                        OptionalEnvEntryBean.class,
+                        TestEnvEntry.class,
+                        TestEnvEntryBean.class,
+                        TestEnvEntryBeanBase.class,
+                        TestEnvEntryMDBean.class,
+                        EnvEntryTestCase.class,
+                        JMSAdminOperations.class);
+        jar.addAsManifestResource(EnvEntryTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        log.info(jar.toString(true));
+        return jar;
+    }
+    
+    private static JMSAdminOperations getAdminOps() {
+        if(adminOps == null) {
+            adminOps = new JMSAdminOperations();
+        }
+        return adminOps;
+    }
+    
+    @BeforeClass 
+    public static void init() {
+        // queue has to be ready before deploy
+        try {
+            getAdminOps().createJmsQueue("queue/testEnvEntry", "java:jboss/queue/testEnvEntry");
+        } catch (Exception e) {
+            log.error("createJmsQueue problem", e);
+            // nothing
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        getAdminOps().removeJmsQueue("queue/testEnvEntry");
+        getAdminOps().close();
+    }
+
+    // Deployment optional
+    private OptionalEnvEntry lookupEnvEntryBean() throws Exception {
+        return (OptionalEnvEntry) ctx.lookup("java:module/OptionalEnvEntryBean");
+    }
+
+    @Test
+    public void test() throws Exception {
+        OptionalEnvEntry bean = lookupEnvEntryBean();
+        Double actual = bean.getEntry();
+        // 1.1 is defined in OptionalEnvEntryBean
+        Assert.assertEquals(new Double(1.1), actual);
+    }
+
+    @Test
+    public void testLookup() throws Exception {
+        OptionalEnvEntry bean = lookupEnvEntryBean();
+        bean.checkLookup();
+    }
+
+    // Deployment enventry
+    @Test
+    public void testEnvEntries() throws Exception {
+        TestEnvEntry test = (TestEnvEntry) ctx.lookup("java:module/TestEnvEntry!" + TestEnvEntry.class.getName());
+        Assert.assertNotNull(test);
+
+        int maxExceptions = test.getMaxExceptions();
+        Assert.assertEquals(15, maxExceptions);
+
+        int minExceptions = test.getMinExceptions();
+        Assert.assertEquals(5, minExceptions);
+
+        int numExceptions = test.getNumExceptions();
+        Assert.assertEquals(10, numExceptions);
+
+        TestEnvEntry etest = (TestEnvEntry) ctx.lookup("java:module/ExtendedTestEnvEntry!" + TestEnvEntry.class.getName());
+        Assert.assertNotNull(etest);
+
+        maxExceptions = etest.getMaxExceptions();
+        Assert.assertEquals(14, maxExceptions);
+
+        minExceptions = etest.getMinExceptions();
+        Assert.assertEquals(6, minExceptions);
+
+        numExceptions = etest.getNumExceptions();
+        Assert.assertEquals(11, numExceptions);
+    }
+
+    @Test
+    public void testEnvEntriesMDB() throws Exception {
+        ConnectionFactory factory = (ConnectionFactory) ctx.lookup("ConnectionFactory");
+        Connection con = factory.createConnection();
+        try {
+            Destination dest = (Destination) ctx.lookup("java:jboss/queue/testEnvEntry");
+
+            Session session = con.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageProducer producer = session.createProducer(dest);
+
+            Queue replyQueue = session.createTemporaryQueue();
+            MessageConsumer consumer = session.createConsumer(replyQueue);
+
+            con.start();
+
+            TextMessage msg = session.createTextMessage();
+            msg.setJMSReplyTo(replyQueue);
+            msg.setText("This is message one");
+            producer.send(msg);
+
+            MapMessage replyMsg = (MapMessage) consumer.receive(5000);
+            Assert.assertNotNull(replyMsg);
+            Assert.assertEquals(16, replyMsg.getInt("maxExceptions"));
+            Assert.assertEquals(12, replyMsg.getInt("numExceptions"));
+            Assert.assertEquals(7, replyMsg.getInt("minExceptions"));
+        } finally {
+            con.close();
+        }
+    }
+
+    @Test
+    public void testJNDI() throws Exception {
+        TestEnvEntry test = (TestEnvEntry) ctx.lookup("java:module/TestEnvEntry!" + TestEnvEntry.class.getName());
+        Assert.assertNotNull(test);
+
+        Assert.assertEquals(15, test.checkJNDI());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/ExtendedTestEnvEntryBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/ExtendedTestEnvEntryBean.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateless(name = "ExtendedTestEnvEntry")
+@Remote(TestEnvEntry.class)
+public class ExtendedTestEnvEntryBean extends TestEnvEntryBeanBase {
+    @Resource(name = "maxExceptions")
+    private int maxExceptions = 3;
+
+    @Resource
+    private int numExceptions = 2;
+
+    @Resource
+    SessionContext sessionCtx;
+
+    private int minExceptions = 0;
+
+    public int getMaxExceptions() {
+        return maxExceptions;
+    }
+
+    public int getNumExceptions() {
+        return numExceptions;
+    }
+
+    public int getMinExceptions() {
+        return minExceptions;
+    }
+
+    public SessionContext getSessionContext() {
+        return this.sessionCtx;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/OptionalEnvEntry.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/OptionalEnvEntry.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+/**
+ * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
+ */
+public interface OptionalEnvEntry {
+    void checkLookup();
+
+    Double getEntry();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/OptionalEnvEntryBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/OptionalEnvEntryBean.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+
+/**
+ * Return the value of a burried env entry.
+ * 
+ * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
+ */
+@Stateless
+@Remote(OptionalEnvEntry.class)
+public class OptionalEnvEntryBean implements OptionalEnvEntry {
+    // @Resource(name="entry")
+    private Double entry = 1.1;
+
+    public void checkLookup() {
+        try {
+            InitialContext ctx = new InitialContext();
+            ctx.lookup("java:comp/env/entry");
+            throw new RuntimeException("Should have thrown a NameNotFoundException");
+        } catch (NameNotFoundException e) {
+            // okay
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Double getEntry() {
+        return entry;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntry.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntry.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.naming.NamingException;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ * @version <tt>$Revision: 80158 $</tt>
+ */
+public interface TestEnvEntry {
+
+    int checkJNDI() throws NamingException;
+
+    int getMaxExceptions();
+
+    int getMinExceptions();
+
+    int getNumExceptions();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntryBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntryBean.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateless(name = "TestEnvEntry")
+@Remote(TestEnvEntry.class)
+public class TestEnvEntryBean extends TestEnvEntryBeanBase implements TestEnvEntry {
+    @Resource(name = "maxExceptions")
+    private int maxExceptions = 4;
+
+    @Resource
+    private int numExceptions = 3;
+
+    @Resource
+    SessionContext sessionCtx;
+
+    private int minExceptions = 1;
+
+    public int getMaxExceptions() {
+        return this.maxExceptions;
+    }
+
+    public int getNumExceptions() {
+        return this.numExceptions;
+    }
+
+    public int getMinExceptions() {
+        return this.minExceptions;
+    }
+
+    public SessionContext getSessionContext() {
+        return this.sessionCtx;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntryBeanBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntryBeanBase.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.ejb.SessionContext;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Common base class for "enventry" test EJBs
+ * 
+ * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
+ */
+public abstract class TestEnvEntryBeanBase implements TestEnvEntry {
+
+    public int checkJNDI() throws NamingException {
+        InitialContext ctx = new InitialContext();
+        int rtn = (Integer) ctx.lookup("java:comp/env/maxExceptions");
+        if (rtn != (Integer) getSessionContext().lookup("maxExceptions"))
+            throw new RuntimeException("Failed to match env lookup");
+        return rtn;
+    }
+
+    public abstract int getMaxExceptions();
+
+    public abstract int getNumExceptions();
+
+    public abstract int getMinExceptions();
+
+    public abstract SessionContext getSessionContext();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntryMDBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/TestEnvEntryMDBean.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry;
+
+import javax.annotation.Resource;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.Session;
+
+import org.jboss.ejb3.annotation.ResourceAdapter;
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="mailto:carlo@nerdnet.nl">Carlo de Wolf</a>
+ */
+@MessageDriven(name = "TestEnvEntryMD", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/queue/testEnvEntry") })
+@ResourceAdapter(value = "hornetq-ra.rar")
+public class TestEnvEntryMDBean implements MessageListener {
+    private static final Logger log = Logger.getLogger(TestEnvEntryMDBean.class);
+
+    @Resource(mappedName = "java:/ConnectionFactory")
+    private QueueConnectionFactory connectionFactory;
+
+    @Resource(name = "maxExceptions")
+    private int maxExceptions = 4;
+
+    @Resource
+    private int numExceptions = 3;
+
+    private int minExceptions = 1;
+
+    public void onMessage(Message msg) {
+        log.info("OnMessage working...");
+        try {
+            Destination destination = msg.getJMSReplyTo();
+            Connection conn = connectionFactory.createConnection();
+            try {
+                Session session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                MessageProducer replyProducer = session.createProducer(destination);
+                MapMessage replyMsg = session.createMapMessage();
+                replyMsg.setJMSCorrelationID(msg.getJMSMessageID());
+
+                replyMsg.setInt("maxExceptions", maxExceptions);
+                replyMsg.setInt("numExceptions", numExceptions);
+                replyMsg.setInt("minExceptions", minExceptions);
+
+                // System.err.println("reply to: " + destination);
+                // System.err.println("maxExceptions: " + maxExceptions);
+                // System.err.println("numExceptions: " + numExceptions);
+                // System.err.println("minExceptions: " + minExceptions);
+
+                replyProducer.send(replyMsg);
+            } finally {
+                conn.close();
+            }
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/ejb-jar.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	version="3.0"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd">
+	<display-name>EnvEntry Tests</display-name>
+	<enterprise-beans>
+		<!-- Optional -->
+		<session>
+			<ejb-name>OptionalEnvEntryBean</ejb-name>
+			<env-entry>
+				<description>default env-entry</description>
+				<env-entry-name>entry</env-entry-name>
+				<env-entry-type>java.lang.Double</env-entry-type>
+				<injection-target>
+					<injection-target-class>org.jboss.as.test.integration.ee.injection.resource.enventry.OptionalEnvEntryBean</injection-target-class>
+					<injection-target-name>entry</injection-target-name>
+				</injection-target>
+			</env-entry>
+		</session>
+
+		<!-- EnvEntry -->
+		<session>
+			<ejb-name>TestEnvEntry</ejb-name>
+			<env-entry>
+				<env-entry-name>maxExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>15</env-entry-value>
+			</env-entry>
+			<env-entry>
+				<env-entry-name>minExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>5</env-entry-value>
+				<injection-target>
+					<injection-target-class>org.jboss.as.test.integration.ee.injection.resource.enventry.TestEnvEntryBean</injection-target-class>
+					<injection-target-name>minExceptions</injection-target-name>
+				</injection-target>
+			</env-entry>
+			<env-entry>
+				<env-entry-name>org.jboss.as.test.integration.ee.injection.resource.enventry.TestEnvEntryBean/numExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>10</env-entry-value>
+			</env-entry>
+		</session>
+		<session>
+			<ejb-name>ExtendedTestEnvEntry</ejb-name>
+			<env-entry>
+				<env-entry-name>maxExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>14</env-entry-value>
+			</env-entry>
+			<env-entry>
+				<env-entry-name>minExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>6</env-entry-value>
+				<injection-target>
+					<injection-target-class>org.jboss.as.test.integration.ee.injection.resource.enventry.ExtendedTestEnvEntryBean</injection-target-class>
+					<injection-target-name>minExceptions</injection-target-name>
+				</injection-target>
+			</env-entry>
+			<env-entry>
+				<env-entry-name>org.jboss.as.test.integration.ee.injection.resource.enventry.ExtendedTestEnvEntryBean/numExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>11</env-entry-value>
+			</env-entry>
+		</session>
+		<message-driven>
+			<ejb-name>TestEnvEntryMD</ejb-name>
+			<env-entry>
+				<env-entry-name>maxExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>16</env-entry-value>
+			</env-entry>
+			<env-entry>
+				<env-entry-name>minExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>7</env-entry-value>
+				<injection-target>
+					<injection-target-class>org.jboss.as.test.integration.ee.injection.resource.enventry.TestEnvEntryMDBean</injection-target-class>
+					<injection-target-name>minExceptions</injection-target-name>
+				</injection-target>
+			</env-entry>
+			<env-entry>
+				<env-entry-name>org.jboss.as.test.integration.ee.injection.resource.enventry.TestEnvEntryMDBean/numExceptions</env-entry-name>
+				<env-entry-type>java.lang.Integer</env-entry-type>
+				<env-entry-value>12</env-entry-value>
+			</env-entry>
+		</message-driven>
+	</enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
[JBQA-5483] EJBTHREE->AS7: enventry (ejbthree-985 + enventry optional)
Test to see if optional env-entry-value works (16.4.1.3).
Testing of behaviour of environment variables in ejb-jar.xml.
Changes pom.xml for run inside of full profile. Needed for using of queue.
