### PR TITLE
unignore testSessionReplication since AS7-2704 is fixed

### DIFF
--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -2,7 +2,6 @@
 <arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
 
-    <!-- For testing AS7-2837. -->
     <engine>
         <property name="deploymentExportPath">target/</property>
     </engine>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusteredWebTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusteredWebTestCase.java
@@ -44,7 +44,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -115,7 +114,6 @@ public class ClusteredWebTestCase {
     }
 
     @Test
-    @Ignore("AS7-2704 StackOverflowError on creating a web session in cluster")
     @OperateOnDeployment("deployment-1") // For change, operate on the 2nd deployment first
     public void testSessionReplication(@ArquillianResource(SimpleServlet.class) URL baseURL) throws IllegalStateException, IOException, InterruptedException {
         DefaultHttpClient client = new DefaultHttpClient();


### PR DESCRIPTION
passes locally 

---
##  T E S T S

Running org.jboss.as.test.clustering.cluster.ClusteredWebTestCase
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 20.002 sec

Results :

Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
