### PR TITLE
Adding label in add-user.bat which can be called from line 49

### DIFF
--- a/build/src/main/resources/bin/add-user.bat
+++ b/build/src/main/resources/bin/add-user.bat
@@ -65,4 +65,5 @@ if "x%MODULEPATH%" == "x" (
      org.jboss.as.domain-add-user ^
      %*
 
+:END
 if "x%NOPAUSE%" == "x" pause


### PR DESCRIPTION
Quick fix for label in add-user.bat
