### PR TITLE
cli updates

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -23,12 +23,10 @@ package org.jboss.as.cli;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.jboss.as.cli.operation.OperationFormatException;
 import org.jboss.as.cli.operation.OperationRequestAddress;
-import org.jboss.as.cli.operation.OperationRequestAddress.Node;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
@@ -39,7 +39,6 @@ import org.jboss.as.cli.operation.OperationRequestAddress.Node;
 import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
 import org.jboss.as.cli.util.SimpleTable;
-import org.jboss.as.cli.util.StrictSizeTable;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -212,12 +211,12 @@ public class LsHandler extends CommandHandlerWithHelp {
                                     final List<Property> props = resourceResult.asPropertyList();
                                     if (!props.isEmpty()) {
                                         // potentially, allowed and default values
-//                                        SimpleTable attrTable = attrDescriptions == null ? null :
-//                                            new SimpleTable(new String[]{"ATTR NAME", "VALUE", "TYPE", "NILLABLE", "REQUIRED", "ACCESS", "EXPR", "RESTART", "STORAGE"});
-//                                      SimpleTable childrenTable = childDescriptions == null ? null :
-//                                            new SimpleTable(new String[]{"CHILD NAME", "MIN-OCCURS", "MAX-OCCURS"});
-                                        StrictSizeTable attrTable = attrDescriptions == null ? null : new StrictSizeTable(attrDescriptions.keys().size());
-                                        StrictSizeTable childrenTable = childDescriptions == null ? null : new StrictSizeTable(childDescriptions.keys().size());
+                                        SimpleTable attrTable = attrDescriptions == null ? null :
+                                            new SimpleTable(new String[]{"ATTRIBUTE", "VALUE", "TYPE"});
+                                      SimpleTable childrenTable = childDescriptions == null ? null :
+                                            new SimpleTable(new String[]{"CHILD", "MIN-OCCURS", "MAX-OCCURS"});
+                                        //StrictSizeTable attrTable = attrDescriptions == null ? null : new StrictSizeTable(attrDescriptions.keys().size());
+                                        //StrictSizeTable childrenTable = childDescriptions == null ? null : new StrictSizeTable(childDescriptions.keys().size());
                                         if(typeNames == null && attrTable == null && childrenTable == null) {
                                             typeNames = new ArrayList<String>();
                                         }
@@ -237,18 +236,11 @@ public class LsHandler extends CommandHandlerWithHelp {
                                                 } else {
                                                     if(attrDescriptions.hasDefined(prop.getName())) {
                                                         final ModelNode attrDescr = attrDescriptions.get(prop.getName());
-/*                                                        attrTable.addLine(new String[]{prop.getName(),
+                                                        attrTable.addLine(new String[]{prop.getName(),
                                                                 prop.getValue().asString(),
                                                                 getAsString(attrDescr, Util.TYPE),
-                                                                getAsString(attrDescr, Util.NILLABLE),
-                                                                getAsString(attrDescr, Util.REQUIRED),
-                                                                getAsString(attrDescr, Util.ACCESS_TYPE),
-                                                                getAsString(attrDescr, Util.EXPRESSIONS_ALLOWED),
-                                                                getAsString(attrDescr, Util.RESTART_REQUIRED),
-                                                                getAsString(attrDescr, Util.STORAGE)
                                                                 });
-*/
-                                                        attrTable.addCell("ATTRIBUTE", prop.getName());
+/*                                                        attrTable.addCell("ATTRIBUTE", prop.getName());
                                                         attrTable.addCell(Util.VALUE, prop.getValue().asString());
                                                         for(String name : attrDescr.keys()) {
                                                             if(!Util.DESCRIPTION.equals(name) &&
@@ -257,28 +249,25 @@ public class LsHandler extends CommandHandlerWithHelp {
                                                                 attrTable.addCell(name, attrDescr.get(name).asString());
                                                             }
                                                         }
-                                                    } else {
-/*                                                        attrTable.addLine(new String[]{prop.getName(),
-                                                                prop.getValue().asString(),
-                                                                "n/a", "n/a", "n/a", "n/a", "n/a", "n/a"
-                                                            });
-*/
-                                                        attrTable.addCell("ATTRIBUTE", prop.getName());
-                                                        attrTable.addCell(Util.VALUE, prop.getValue().asString());
+*/                                                    } else {
+                                                        attrTable.addLine(new String[]{prop.getName(), prop.getValue().asString(), "n/a"});
+                                                        //attrTable.addCell("ATTRIBUTE", prop.getName());
+                                                        //attrTable.addCell(Util.VALUE, prop.getValue().asString());
                                                     }
-                                                    if(!attrTable.isAtLastRow()) {
+/*                                                    if(!attrTable.isAtLastRow()) {
                                                         attrTable.nextRow();
                                                     }
-                                                }
+*/                                                }
                                             } else if(childDescriptions != null) {
                                                 if(childDescriptions.hasDefined(prop.getName())) {
                                                     final ModelNode childDescr = childDescriptions.get(prop.getName());
-/*                                                    childrenTable.addLine(new String[]{prop.getName(),
+                                                    final Integer maxOccurs = getAsInteger(childDescr, Util.MAX_OCCURS);
+                                                    childrenTable.addLine(new String[]{prop.getName(),
                                                             getAsString(childDescr, Util.MIN_OCCURS),
-                                                            getAsString(childDescr, Util.MAX_OCCURS)
+                                                            maxOccurs == null ? "n/a" : (maxOccurs == Integer.MAX_VALUE ? "unbounded" : maxOccurs.toString())
                                                             });
-*/
-                                                    childrenTable.addCell("CHILD", prop.getName());
+
+/*                                                    childrenTable.addCell("CHILD", prop.getName());
                                                     for(String name : childDescr.keys()) {
                                                         if(!Util.DESCRIPTION.equals(name) &&
                                                                 !Util.HEAD_COMMENT_ALLOWED.equals(name) &&
@@ -286,21 +275,31 @@ public class LsHandler extends CommandHandlerWithHelp {
                                                             childrenTable.addCell(name, childDescr.get(name).asString());
                                                         }
                                                     }
-                                                } else {
-//                                                    attrTable.addLine(new String[]{prop.getName(), "n/a", "n/a"});
-                                                    childrenTable.addCell("CHILD", prop.getName());
+*/                                                } else {
+                                                    attrTable.addLine(new String[]{prop.getName(), "n/a", "n/a"});
+                                                    //childrenTable.addCell("CHILD", prop.getName());
                                                 }
-                                                if(!childrenTable.isAtLastRow()) {
+/*                                                if(!childrenTable.isAtLastRow()) {
                                                     childrenTable.nextRow();
                                                 }
-                                            }
+*/                                            }
                                         }
 
-                                        if(childrenTable != null && !childrenTable.isEmpty()) {
-                                            ctx.printLine(childrenTable.toString());
-                                        }
+                                        StringBuilder buf = null;
                                         if(attrTable != null && !attrTable.isEmpty()) {
-                                            ctx.printLine(attrTable.toString());
+                                            buf = new StringBuilder();
+                                            attrTable.append(buf, true);
+                                        }
+                                        if(childrenTable != null && !childrenTable.isEmpty()) {
+                                            if(buf == null) {
+                                                buf = new StringBuilder();
+                                            } else {
+                                                buf.append("\n\n");
+                                            }
+                                            childrenTable.append(buf, true);
+                                        }
+                                        if(buf != null) {
+                                            ctx.printLine(buf.toString());
                                         }
                                     }
                                 } else {
@@ -332,7 +331,15 @@ public class LsHandler extends CommandHandlerWithHelp {
         }
         return attrDescr.has(name) ? attrDescr.get(name).asString() : "n/a";
     }
-/*
+
+    protected Integer getAsInteger(final ModelNode attrDescr, String name) {
+        if(attrDescr == null) {
+            return null;
+        }
+        return attrDescr.has(name) ? attrDescr.get(name).asInt() : null;
+    }
+
+    /*
     public static void main(String[] args) throws Exception {
 
         //System.out.printf("%-8s %-11s %-8s %-11s", "name", "type", "required", "access-type");

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReadAttributeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReadAttributeHandler.java
@@ -107,7 +107,7 @@ public class ReadAttributeHandler extends BaseOperationCommand {
                     return Collections.emptyList();
                 }
                 return Collections.emptyList();
-            }}), "--name");
+            }}), 0, "--name");
 
         includeDefaults = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--include-defaults");
 

--- a/cli/src/main/java/org/jboss/as/cli/util/SimpleTable.java
+++ b/cli/src/main/java/org/jboss/as/cli/util/SimpleTable.java
@@ -59,6 +59,10 @@ public class SimpleTable {
         columnLengths = new int[columnsTotal];
     }
 
+    public int columnsTotal() {
+        return columnLengths.length;
+    }
+
     public void addLine(String[] line) {
         if(line == null) {
            throw new IllegalArgumentException("The line can't be null.");

--- a/cli/src/main/java/org/jboss/as/cli/util/SimpleTable.java
+++ b/cli/src/main/java/org/jboss/as/cli/util/SimpleTable.java
@@ -94,7 +94,10 @@ public class SimpleTable {
     }
 
     public String toString(boolean order) {
-        StringBuilder buf = new StringBuilder();
+        return append(new StringBuilder(), order).toString();
+    }
+
+    public StringBuilder append(StringBuilder buf, boolean order) {
         Formatter formatter = new Formatter(buf);
         final StringBuilder formatBuf = new StringBuilder();
         for(int length : columnLengths) {
@@ -122,6 +125,6 @@ public class SimpleTable {
             buf.append('\n');
             formatter.format(format, (Object[])lines.get(i));
         }
-        return buf.toString();
+        return buf;
     }
 }

--- a/cli/src/main/resources/help/ls.txt
+++ b/cli/src/main/resources/help/ls.txt
@@ -4,21 +4,28 @@ SYNOPSIS
 
 DESCRIPTION
 
-    Lists the contents of a node path.
+    Lists the contents of a node path. Which includes node types and attributes,
+    if the node path ends on a node name, or node names if the node path ends on a node type.
 
 ARGUMENTS
 
- node-path    - optional, the node path the contents of which should be printed.
+ node-path    - (optional) the node path the contents of which to print.
                 If not specified, the contents of the current node path (indicated in the prompt) will be printed.
                 The node path can end on either node type (in this case the contents will be the child node names)
-                or the node name (in this case the contents will be the child node types).
+                or the node name (in this case the contents will be the child node types and attributes).
                 If the node path has no contents, nothing will be printed.
 
-                If specified, the node-path is expected to follow the following format:
+                If specified, the node-path is expected to follow format:
                 [node-type [=node-name (,node-type[=node-name])*]].
 
- -l           - by default the result is printed in columns using the whole width of the terminal,
-                the -l switch will make it printed one name per line.  
+ -l           - (optional) by default the result consists of a list of names and is printed in columns
+                using the whole width of the terminal.
+                If the node path ends on a node name, the -l switch will print two tables:
+                - one for attributes displaying the name, value and type of the attributes;
+                - one for child types displaying the type name, min and max allowed occurrences
+                  of instances of those types in the domain configuration.
+                If the node path ends on a node type, the -l switch will print all the available
+                child names one per line, i.e. in a column.  
 				
 The following navigation signs are supported in the node-path:
  /      - the root node (e.g. 'cd /' or 'cd /some=thing');

--- a/cli/src/main/resources/help/ls.txt
+++ b/cli/src/main/resources/help/ls.txt
@@ -1,6 +1,6 @@
 SYNOPSIS
 
-    ls [node_path] [-l]
+    ls [node_path] [-l (--attribute-description-property)*]
 
 DESCRIPTION
 
@@ -26,7 +26,16 @@ ARGUMENTS
                   of instances of those types in the domain configuration.
                 If the node path ends on a node type, the -l switch will print all the available
                 child names one per line, i.e. in a column.  
-				
+
+ --attribute-description-property  - (optional) by default, -l will display attribute name, value and type.
+                                     Full attribute description (which you can see by executing
+                                     'read-attribute <attribute-name> --verbose') includes more
+                                     properties. To include those into the 'ls -l' results,
+                                     just list those properties as arguments to the ls command
+                                     prefixing their names with '--'. E.g.
+                                     'ls -l --nillable --storage'.
+                                      
+ 
 The following navigation signs are supported in the node-path:
  /      - the root node (e.g. 'cd /' or 'cd /some=thing');
  ..     - parent node (e.g. 'cd ..');

--- a/cli/src/main/resources/help/read-attribute.txt
+++ b/cli/src/main/resources/help/read-attribute.txt
@@ -1,7 +1,7 @@
 SYNOPSIS
 
     read-attribute --help |
-                   [--node=node_path] --name=attribute_name [--include-defaults=true|false] [--verbose]
+                   [--node=node_path] <attribute_name> [--include-defaults=true|false] [--verbose]
 
 DESCRIPTION
 
@@ -10,18 +10,18 @@ DESCRIPTION
 
 ARGUMENTS
 
- --help          - prints this message.
+ --help              - prints this message.
  
- --node          - (optional) the node path of the managed resource
-                   to which the target attribute belongs.
-                   If not present, the current node path (indicated in the prompt) is assumed.
+ --node              - (optional) the node path of the managed resource
+                       to which the target attribute belongs.
+                       If not present, the current node path (indicated in the prompt) is assumed.
                 
- --name          - (required) the name of the target attribute.
+ <attribute_name>    - (required) the name of the target attribute.
  
  --include-defaults  - (optional) boolean to enable/disable default reading.
                        In case it is set to false only the values set by user are returned.
                        Attributes that were not explicitly initialized, will appear
                        as not having any value.
  
- --verbose (-v)  - will print all the available meta information about the attribute
-                   in addition to the attribute value.
+ --verbose (-v)      - will print all the available meta information about the attribute
+                       in addition to the attribute value.


### PR DESCRIPTION
'ls -l' command:
- limited attribute properties displayed by default, they are name, value and type;
- additional properties from model description can be added by specifying them as command arguments and prefixing with '--'.

read-attribute command:
- don't require '--name=' for attribute name argument, i.e. accept it as a plain value too.

Thanks,
Alexey
