### PR TITLE
Fix security role linking for EJBs

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -327,7 +327,7 @@ public abstract class EJBComponent extends BasicComponent {
     }
 
     public boolean isCallerInRole(final String roleName) throws IllegalStateException {
-        return utilities.getSecurityManager().isCallerInRole(securityMetaData.getSecurityRoles(), roleName);
+        return utilities.getSecurityManager().isCallerInRole(securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
     }
 
     public Object lookup(String name) throws IllegalArgumentException {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.ejb3.security;
 
+import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+
 import java.lang.reflect.Method;
 import java.util.Collection;
 
@@ -31,7 +33,6 @@ import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.security.service.SimpleSecurityManager;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
-import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 /**
  * EJB authorization interceptor responsible for handling invocation on EJB methods and doing the necessary authorization
  * checks on the invoked method.
@@ -95,7 +96,8 @@ public class AuthorizationInterceptor implements Interceptor {
             if (!allowedRoles.isEmpty()) {
                 // call the security API to do authorization check
                 final SimpleSecurityManager securityManager = ejbComponent.getSecurityManager();
-                if (!securityManager.isCallerInRole(ejbComponent.getSecurityMetaData().getSecurityRoles(), allowedRoles.toArray(new String[allowedRoles.size()]))) {
+                final EJBSecurityMetaData ejbSecurityMetaData = ejbComponent.getSecurityMetaData();
+                if (!securityManager.isCallerInRole(ejbSecurityMetaData.getSecurityRoles(), ejbSecurityMetaData.getSecurityRoleLinks(), allowedRoles.toArray(new String[allowedRoles.size()]))) {
                     throw MESSAGES.invocationOfMethodNotAllowed(invokedMethod,ejbComponent.getComponentName());
                 }
             }


### PR DESCRIPTION
The commit in this branch fixes an issue with the way the security-role-ref metadata was being used while determining a caller's role. This should now take care of some TCK failures that we had been seeing in the security tests.
