### PR TITLE
Fix for AS7-2968

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -120,11 +120,12 @@ public class
         public static final int EJB_SECURITY_AUTHORIZATION_INTERCEPTOR                  = 0x300;
         public static final int CDI_REQUEST_SCOPE                                       = 0x350;
         public static final int INVOCATION_CONTEXT_INTERCEPTOR                          = 0x400;
+        public static final int ASSOCIATING_INTERCEPTOR                                 = 0x440;
         // should happen before the CMT/BMT interceptors
         public static final int REMOTE_TRANSACTION_PROPOGATION_INTERCEPTOR              = 0x450;
         public static final int CMT_TRANSACTION_INTERCEPTOR                             = 0x500;
         public static final int HOME_METHOD_INTERCEPTOR                                 = 0x600;
-        public static final int ASSOCIATING_INTERCEPTOR                                 = 0x700;
+
         public static final int JPA_SFSB_INTERCEPTOR                                    = 0x800;
         public static final int SESSION_REMOVE_INTERCEPTOR                              = 0x900;
         public static final int COMPONENT_DISPATCHER                                    = 0xA00;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/Employee.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.entitylistener;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+@EntityListeners({ MyListener.class })
+public class Employee {
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String toString() {
+        return "employee " + name +", " + address + ", #" + id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/EntityListenersTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/EntityListenersTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.entitylistener;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * EntityListeners tests
+ *
+ * @author Scott Marlow
+ */
+@RunWith(Arquillian.class)
+public class EntityListenersTestCase {
+
+    private static final String ARCHIVE_NAME = "jpa_EntityListeners";
+
+    private static final String persistence_xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+            "  <persistence-unit name=\"mypc\">" +
+            "    <description>Persistence Unit." +
+            "    </description>" +
+            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+            "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+            "</properties>" +
+            "  </persistence-unit>" +
+            "</persistence>";
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
+        jar.addClasses(EntityListenersTestCase.class,
+            Employee.class,
+            MyListener.class,
+            SFSBBMT.class,
+            SFSBCMT.class
+        );
+
+        jar.addAsResource(new StringAsset(persistence_xml), "META-INF/persistence.xml");
+        return jar;
+    }
+
+    @ArquillianResource
+    private static InitialContext iniCtx;
+
+
+    protected <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + beanName + "!" + interfaceType.getName()));
+    }
+
+    protected <T> T rawLookup(String name, Class<T> interfaceType) throws NamingException {
+        return interfaceType.cast(iniCtx.lookup(name));
+    }
+
+    @Test
+    public void testBMT() throws Exception {
+        MyListener.setInvocationCount(0);
+        SFSBBMT bmt = lookup("SFSBBMT", SFSBBMT.class);
+        bmt.createEmployee("Alfred E. Neuman", "101010 Mad Street", 1);
+        Employee emp = bmt.getEmployeeNoTX(1);
+        bmt.updateEmployee(emp);
+        assertTrue("could not load added employee", emp != null);
+        assertTrue("EntityListener wasn't invoked twice as expected, instead " + MyListener.getInvocationCount(), 2 == MyListener.getInvocationCount());
+    }
+
+    @Test
+    public void testCMT() throws Exception {
+        MyListener.setInvocationCount(0);
+        SFSBCMT cmt = lookup("SFSBCMT", SFSBCMT.class);
+        cmt.createEmployee("Alfred E. Neuman", "101010 Mad Street", 2);
+        Employee emp = cmt.getEmployeeNoTX(2);
+        cmt.updateEmployee(emp);
+        assertTrue("could not load added employee", emp != null);
+        assertTrue("EntityListener wasn't invoked twice as expected, instead " + MyListener.getInvocationCount(), 2 == MyListener.getInvocationCount());
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/MyListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/MyListener.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.entitylistener;
+
+import javax.ejb.EJBContext;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+
+/**
+ * test case from AS7-2968
+ *
+ */
+public class MyListener {
+
+    public static int getInvocationCount() {
+        return invocationCount;
+    }
+
+    public static void setInvocationCount(int invocationCount) {
+        MyListener.invocationCount = invocationCount;
+    }
+
+    private static volatile int invocationCount = 0;
+
+    @PrePersist
+    @PreUpdate
+    public void onEntityCallback(Object entity) {
+        try {
+            invocationCount++;
+            // Thread.dumpStack();
+            InitialContext jndiContext = new InitialContext();
+            EJBContext ctx = (EJBContext)jndiContext.lookup("java:comp/EJBContext");
+              System.out.println(ctx.getCallerPrincipal().getName() + ", entity=" + entity);
+        } catch (NamingException e) {
+            throw new RuntimeException("initial context error", e);
+        }
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/SFSBBMT.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/SFSBBMT.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.entitylistener;
+
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceContext;
+import javax.transaction.UserTransaction;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+@TransactionManagement(TransactionManagementType.BEAN)
+public class SFSBBMT {
+    @PersistenceContext(unitName = "mypc")
+        EntityManager em;
+
+    @Resource
+    SessionContext sessionContext;
+
+    public void createEmployee(String name, String address, int id) {
+
+
+        Employee emp = new Employee();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setName(name);
+
+        UserTransaction tx1 = sessionContext.getUserTransaction();
+        try {
+            tx1.begin();
+            em.joinTransaction();
+            em.persist(emp);
+            //em.flush();
+            tx1.commit();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("couldn't start tx" , e);
+        }
+    }
+
+    public void updateEmployee(Employee emp) {
+
+        emp.setName("hacked " + emp.getName());
+
+        UserTransaction tx1 = sessionContext.getUserTransaction();
+        try {
+            tx1.begin();
+            em.joinTransaction();
+            em.merge(emp);
+            //em.flush();
+            tx1.commit();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("couldn't start tx" , e);
+        }
+    }
+
+    public Employee getEmployeeNoTX(int id) {
+        return em.find(Employee.class, id, LockModeType.NONE);
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/SFSBCMT.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/SFSBCMT.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.entitylistener;
+
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceContext;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+@TransactionManagement(TransactionManagementType.CONTAINER)
+public class SFSBCMT {
+    @PersistenceContext(unitName = "mypc")
+        EntityManager em;
+
+    @Resource
+    SessionContext sessionContext;
+
+    public void createEmployee(String name, String address, int id) {
+        Employee emp = new Employee();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setName(name);
+        em.joinTransaction();
+        em.persist(emp);
+        //em.flush();
+    }
+
+    public void updateEmployee(Employee emp) {
+        emp.setName("hacked " + emp.getName());
+        em.merge(emp);
+        //em.flush();
+    }
+
+
+    public Employee getEmployeeNoTX(int id) {
+        return em.find(Employee.class, id, LockModeType.NONE);
+    }
+
+}


### PR DESCRIPTION
The commits in this branch contain a fix and a testcase for https://issues.jboss.org/browse/AS7-2968, in which the ComponentInstance was being cleared off from the invocation context at the wrong time. The fix involved moving the interceptor to the correct interceptor order.
