### PR TITLE
AS7-2977 Add sun.io path to the sun.jdk module descriptor

### DIFF
--- a/build/src/main/resources/modules/sun/jdk/main/module.xml
+++ b/build/src/main/resources/modules/sun/jdk/main/module.xml
@@ -37,6 +37,7 @@
                 <path name="com/sun/security/auth/login"/>
                 <path name="com/sun/security/auth/module"/>
                 <path name="sun/misc"/>
+                <path name="sun/io"/>
                 <path name="sun/nio"/>
                 <path name="sun/nio/ch"/>
                 <path name="sun/util"/>


### PR DESCRIPTION
Add sun.io package to the sun.jdk module to support IBM DB2 JDBC driver dependencies.

https://issues.jboss.org/browse/AS7-2977
