### PR TITLE
Add <relativePath> to shared module - it uses AS parent pom.xml

### DIFF
--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -8,6 +8,7 @@
         <groupId>org.jboss.as</groupId>
         <artifactId>jboss-as-parent</artifactId>
         <version>7.1.0.CR1-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
     </parent>
 
     <groupId>org.jboss.as</groupId>


### PR DESCRIPTION
The build didn't fail in the verification run because the pom was in local repo.
Which BTW brought me to an idea to add a profile for a run with a clean local repo, or at least run dependency:purge-local-repository.
