### PR TITLE
[AS7-3003] JBoss XACML module is missing javax.xml.bind.api module as dependency

### DIFF
--- a/build/src/main/resources/modules/org/jboss/security/xacml/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/security/xacml/main/module.xml
@@ -30,5 +30,6 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="sun.jdk"/>
+        <module name="javax.xml.bind.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Just dependency module added to module.xml file for JBoss XACML module.
