### PR TITLE
update read-resource and introduce an undefine-attribute operation

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
@@ -85,12 +85,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
 import java.util.List;
 import java.util.Map;
 
-import javax.resource.spi.TransactionSupport;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -103,9 +101,7 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.descriptions.common.CommonProviders;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
-import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
@@ -164,7 +160,6 @@ public class ResourceAdaptersExtension implements Extension {
         final ManagementResourceRegistration connectionDefinition = resourceadapter.registerSubModel(PathElement.pathElement(CONNECTIONDEFINITIONS_NAME), CONNECTION_DEFINITION_DESC);
         connectionDefinition.registerOperationHandler(ADD, ConnectionDefinitionAdd.INSTANCE, ADD_CONNECTION_DEFINITION_DESC, false);
         connectionDefinition.registerOperationHandler(REMOVE, ReloadRequiredRemoveStepHandler.INSTANCE, REMOVE_CONNECTION_DEFINITION_DESC, false);
-        connectionDefinition.registerOperationHandler(WRITE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.WRITE_ATTRIBUTE, CommonProviders.WRITE_ATTRIBUTE_PROVIDER, true);
 
         final ManagementResourceRegistration configCF = connectionDefinition.registerSubModel(PathElement.pathElement(CONFIG_PROPERTIES.getName()), CONFIG_PROPERTIES_DESC);
         configCF.registerOperationHandler(ADD, CDConfigPropertyAdd.INSTANCE, ADD_CONFIG_PROPERTIES_DESC, false);

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -645,6 +645,16 @@ public abstract class AttributeDefinition {
         }
 
         @Override
+        public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            //
+        }
+
+        @Override
+        public void addStep(OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            //
+        }
+
+        @Override
         public void acquireControllerLock() {
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -54,6 +54,18 @@ public interface OperationContext {
     void addStep(OperationStepHandler step, Stage stage) throws IllegalArgumentException;
 
     /**
+     * Add an execution step to this operation process.  Runtime operation steps are automatically added after
+     * configuration operation steps.  Since only one operation may perform runtime work at a time, this method
+     * may block until other runtime operations have completed.
+     *
+     * @param step the step to add
+     * @param stage the stage at which the operation applies
+     * @param addFirst add the handler before the others
+     * @throws IllegalArgumentException if the step handler is not valid for this controller type
+     */
+    void addStep(OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException;
+
+    /**
      * Add an execution step to this operation process, writing any output to the response object
      * associated with the current step.
      * Runtime operation steps are automatically added after configuration operation steps.  Since only one operation
@@ -78,6 +90,20 @@ public interface OperationContext {
      * @throws IllegalArgumentException if the step handler is not valid for this controller type
      */
     void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage) throws IllegalArgumentException;
+
+    /**
+     * Add an execution step to this operation process.  Runtime operation steps are automatically added after
+     * configuration operation steps.  Since only one operation may perform runtime work at a time, this method
+     * may block until other runtime operations have completed.
+     *
+     * @param response the response which the nested step should populate
+     * @param operation the operation body to pass into the added step
+     * @param step the step to add
+     * @param stage the stage at which the operation applies
+     * @param addFirst add the handler before the others
+     * @throws IllegalArgumentException if the step handler is not valid for this controller type
+     */
+    void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException;
 
     /**
      * Get a stream which is attached to the request.

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -250,6 +250,7 @@ public class ModelDescriptionConstants {
     public static final String TAIL_COMMENT_ALLOWED = "tail-comment-allowed";
     public static final String TO_REPLACE = "to-replace";
     public static final String TYPE = "type";
+    public static final String UNDEFINE_ATTRIBUTE_OPERATION = "undefine-attribute";
     public static final String UNDEPLOY = "undeploy";
     public static final String UPLOAD_DEPLOYMENT_BYTES = "upload-deployment-bytes";
     public static final String UPLOAD_DEPLOYMENT_URL = "upload-deployment-url";

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/common/CommonProviders.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/common/CommonProviders.java
@@ -150,6 +150,13 @@ public final class CommonProviders {
         }
     };
 
+    public static final DescriptionProvider UNDEFINE_ATTRIBUTE_PROVIDER = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(final Locale locale) {
+            return GlobalDescriptions.getUndefineAttributeOperationDescription(locale);
+        }
+    };
+
     public static final DescriptionProvider WRITE_ATTRIBUTE_PROVIDER = new DescriptionProvider() {
         @Override
         public ModelNode getModelDescription(Locale locale) {
@@ -223,6 +230,7 @@ public final class CommonProviders {
             return CommonDescriptions.getServiceContainerDescription(locale);
         }
     };
+
     /**
      * Provider for a resource that defines the core security vault.
      */

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/common/GlobalDescriptions.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/common/GlobalDescriptions.java
@@ -46,6 +46,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REP
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
@@ -267,6 +268,19 @@ public class GlobalDescriptions {
         return node;
     }
 
+    public static ModelNode getUndefineAttributeOperationDescription(Locale locale) {
+        ResourceBundle bundle = getResourceBundle(locale);
+
+        ModelNode node = new ModelNode();
+        node.get(OPERATION_NAME).set(UNDEFINE_ATTRIBUTE_OPERATION);
+        node.get(DESCRIPTION).set(bundle.getString("global.undefine-attribute"));
+
+        node.get(REQUEST_PROPERTIES, NAME, TYPE).set(ModelType.STRING);
+        node.get(REQUEST_PROPERTIES, NAME, DESCRIPTION).set(bundle.getString("global.undefine-attribute.name"));
+        node.get(REQUEST_PROPERTIES, NAME, NILLABLE).set(false);
+
+        return node;
+    }
 
     private static ResourceBundle getResourceBundle(Locale locale) {
         if (locale == null) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -64,6 +64,8 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
@@ -87,6 +89,7 @@ public class GlobalOperationHandlers {
     public static final OperationStepHandler READ_ATTRIBUTE = new ReadAttributeHandler();
     public static final OperationStepHandler READ_CHILDREN_NAMES = new ReadChildrenNamesOperationHandler();
     public static final OperationStepHandler READ_CHILDREN_RESOURCES = new ReadChildrenResourcesOperationHandler();
+    public static final OperationStepHandler UNDEFINE_ATTRIBUTE = new UndefineAttributeHandler();
     public static final OperationStepHandler WRITE_ATTRIBUTE = new WriteAttributeHandler();
     public static final OperationStepHandler VALIDATE_ADDRESS = new OperationStepHandler() {
 
@@ -495,6 +498,20 @@ public class GlobalOperationHandlers {
     }
 
     ;
+
+    /**
+     * The undefine-attribute handler, writing an undefined value for a single attribute.
+     */
+    public static class UndefineAttributeHandler extends WriteAttributeHandler {
+
+        @Override
+        public void execute(final OperationContext context, final ModelNode original) throws OperationFailedException {
+            final ModelNode operation = original.clone();
+            operation.get(VALUE).set(new ModelNode());
+            super.execute(context, operation);
+        }
+
+    }
 
     /**
      * {@link org.jboss.as.controller.OperationStepHandler} querying the children names of a given "child-type".

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -218,9 +218,11 @@ global.read-resource-description.operations=Whether to include descriptions of t
 global.read-resource-description.inherited=If 'operations' is true, whether to include descriptions of the resource's inherited operations. Default is true.
 global.read-resource-description.recursive=Whether to include recursively descriptions of child resources. Default is false.
 global.read-resource-description.reply=The description of the resource
+global.undefine-attribute=Sets the value of an attribute of the selected resource to 'undefined'
+global.undefine-attribute.name=The name of the attribute which should be set to 'undefined'
 global.write-attribute=Sets the value of an attribute for the selected resource
 global.write-attribute.name=The name of the attribute to set the value for under the selected resource
-global.write-attribute.value=The value of the attribute to set the value for under the selcted resource. May be null if the underlying model supports null values.
+global.write-attribute.value=The value of the attribute to set the value for under the selected resource. May be null if the underlying model supports null values.
 
 # Common Operations
 read-config-as-xml=Reads the current configuration and returns it in XML format.

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -51,6 +51,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLED_BACK;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_UPDATE_SKIPPED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.junit.Assert.assertEquals;
@@ -183,6 +184,7 @@ public class ModelControllerImplUnitTestCase {
             rootRegistration.registerOperationHandler(READ_OPERATION_NAMES_OPERATION, GlobalOperationHandlers.READ_OPERATION_NAMES, CommonProviders.READ_OPERATION_NAMES_PROVIDER, true);
             rootRegistration.registerOperationHandler(READ_OPERATION_DESCRIPTION_OPERATION, GlobalOperationHandlers.READ_OPERATION_DESCRIPTION, CommonProviders.READ_OPERATION_PROVIDER, true);
             rootRegistration.registerOperationHandler(WRITE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.WRITE_ATTRIBUTE, CommonProviders.WRITE_ATTRIBUTE_PROVIDER, true);
+            rootRegistration.registerOperationHandler(UNDEFINE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.UNDEFINE_ATTRIBUTE, CommonProviders.UNDEFINE_ATTRIBUTE_PROVIDER, true);
 
             rootRegistration.registerSubModel(PathElement.pathElement("child"), DESC_PROVIDER);
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
@@ -240,7 +240,7 @@ public class DomainModelUtil {
         serverGroups.registerOperationHandler(ADD, ServerGroupAddHandler.INSTANCE, ServerGroupAddHandler.INSTANCE, false);
         serverGroups.registerOperationHandler(REMOVE, ServerGroupRemoveHandler.INSTANCE, ServerGroupRemoveHandler.INSTANCE, false);
         serverGroups.registerReadWriteAttribute(SOCKET_BINDING_GROUP, null, WriteAttributeHandlers.WriteAttributeOperationHandler.INSTANCE, Storage.CONFIGURATION);
-        serverGroups.registerReadWriteAttribute(SOCKET_BINDING_PORT_OFFSET, null, new IntRangeValidatingHandler(0), Storage.CONFIGURATION);
+        serverGroups.registerReadWriteAttribute(SOCKET_BINDING_PORT_OFFSET, null, new IntRangeValidatingHandler(0, true), Storage.CONFIGURATION);
         DomainServerLifecycleHandlers.registerServerGroupHandlers(serverGroups);
 
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -51,6 +51,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
@@ -181,7 +182,9 @@ public class HostModelUtil {
         root.registerOperationHandler(READ_CHILDREN_RESOURCES_OPERATION, GlobalOperationHandlers.READ_CHILDREN_RESOURCES, CommonProviders.READ_CHILDREN_RESOURCES_PROVIDER, true, OperationEntry.EntryType.PUBLIC, flags);
         root.registerOperationHandler(READ_OPERATION_NAMES_OPERATION, GlobalOperationHandlers.READ_OPERATION_NAMES, CommonProviders.READ_OPERATION_NAMES_PROVIDER, true, OperationEntry.EntryType.PUBLIC, flags);
         root.registerOperationHandler(READ_OPERATION_DESCRIPTION_OPERATION, GlobalOperationHandlers.READ_OPERATION_DESCRIPTION, CommonProviders.READ_OPERATION_PROVIDER, true, OperationEntry.EntryType.PUBLIC, flags);
+        root.registerOperationHandler(UNDEFINE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.UNDEFINE_ATTRIBUTE, CommonProviders.UNDEFINE_ATTRIBUTE_PROVIDER, true);
         root.registerOperationHandler(WRITE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.WRITE_ATTRIBUTE, CommonProviders.WRITE_ATTRIBUTE_PROVIDER, true);
+
 
         // Other root resource operations
         root.registerOperationHandler(CompositeOperationHandler.NAME, CompositeOperationHandler.INSTANCE, CompositeOperationHandler.INSTANCE, false, OperationEntry.EntryType.PRIVATE);
@@ -288,7 +291,7 @@ public class HostModelUtil {
         servers.registerOperationHandler(ServerRemoveHandler.OPERATION_NAME, ServerRemoveHandler.INSTANCE, ServerRemoveHandler.INSTANCE, false);
         servers.registerReadWriteAttribute(AUTO_START, null, new WriteAttributeHandlers.ModelTypeValidatingHandler(ModelType.BOOLEAN), Storage.CONFIGURATION);
         servers.registerReadWriteAttribute(SOCKET_BINDING_GROUP, null, WriteAttributeHandlers.WriteAttributeOperationHandler.INSTANCE, Storage.CONFIGURATION);
-        servers.registerReadWriteAttribute(SOCKET_BINDING_PORT_OFFSET, null, new WriteAttributeHandlers.IntRangeValidatingHandler(0), Storage.CONFIGURATION);
+        servers.registerReadWriteAttribute(SOCKET_BINDING_PORT_OFFSET, null, new WriteAttributeHandlers.IntRangeValidatingHandler(0, true), Storage.CONFIGURATION);
         servers.registerReadWriteAttribute(PRIORITY, null, new WriteAttributeHandlers.IntRangeValidatingHandler(0), Storage.CONFIGURATION);
         servers.registerReadWriteAttribute(CPU_AFFINITY, null, new WriteAttributeHandlers.StringLengthValidatingHandler(1), Storage.CONFIGURATION);
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandlerTestCase.java
@@ -611,12 +611,22 @@ public class ApplyRemoteMasterDomainModelHandlerTestCase {
             fail("Should not have added step");
         }
 
+        @Override
+        public void addStep(OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            addStep(step, stage);
+        }
+
         public void addStep(ModelNode operation, OperationStepHandler step, OperationContext.Stage stage) throws IllegalArgumentException {
             final PathAddress opAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
             if (!expectedSteps.contains(opAddress)) {
                 fail("Should not have added step for: " + opAddress);
             }
             expectedSteps.remove(opAddress);
+        }
+
+        @Override
+        public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            addStep(operation, step, stage);
         }
 
         public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, OperationContext.Stage stage) throws IllegalArgumentException {

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/StartLevelHandler.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/StartLevelHandler.java
@@ -58,7 +58,9 @@ abstract class StartLevelHandler implements OperationStepHandler {
         ServiceController<?> svc = context.getServiceRegistry(false).getRequiredService(Services.START_LEVEL);
 
         if (svc == null || svc.getState() != ServiceController.State.UP) {
-            context.getFailureDescription().set(OSGiMessages.MESSAGES.osgiSubsystemNotActive());
+            // non-metric read-attribute handlers should not fail
+            // OSGiMessages.MESSAGES.osgiSubsystemNotActive()
+            context.getResult().set(new ModelNode());
         } else {
             StartLevel sls = (StartLevel) svc.getValue();
             invokeOperation(sls, context, operation);

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/StartLevelHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/StartLevelHandlerTestCase.java
@@ -29,6 +29,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.osgi.framework.Services;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.service.startlevel.StartLevel;
@@ -94,14 +95,14 @@ public class StartLevelHandlerTestCase {
         ServiceRegistry sr = Mockito.mock(ServiceRegistry.class);
         Mockito.when(sr.getRequiredService(Services.START_LEVEL)).thenReturn(sc);
 
-        ModelNode failureNode = new ModelNode();
+        ModelNode result = new ModelNode("test");
         OperationContext ctx = Mockito.mock(OperationContext.class);
         Mockito.when(ctx.getServiceRegistry(false)).thenReturn(sr);
-        Mockito.when(ctx.getFailureDescription()).thenReturn(failureNode);
+        Mockito.when(ctx.getResult()).thenReturn(result);
 
         StartLevelHandler handler = StartLevelHandler.READ_HANDLER;
-        Assert.assertFalse(failureNode.isDefined());
+        Assert.assertTrue(result.isDefined());
         handler.execute(ctx, new ModelNode());
-        Assert.assertTrue(failureNode.isDefined());
+        Assert.assertFalse(result.isDefined());
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
+++ b/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
@@ -49,6 +49,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
@@ -183,6 +184,7 @@ public class ServerControllerModelUtil {
         root.registerOperationHandler(READ_CHILDREN_RESOURCES_OPERATION, GlobalOperationHandlers.READ_CHILDREN_RESOURCES, CommonProviders.READ_CHILDREN_RESOURCES_PROVIDER, true);
         root.registerOperationHandler(READ_OPERATION_NAMES_OPERATION, GlobalOperationHandlers.READ_OPERATION_NAMES, CommonProviders.READ_OPERATION_NAMES_PROVIDER, true);
         root.registerOperationHandler(READ_OPERATION_DESCRIPTION_OPERATION, GlobalOperationHandlers.READ_OPERATION_DESCRIPTION, CommonProviders.READ_OPERATION_PROVIDER, true);
+        root.registerOperationHandler(UNDEFINE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.UNDEFINE_ATTRIBUTE, CommonProviders.UNDEFINE_ATTRIBUTE_PROVIDER, true);
         root.registerOperationHandler(WRITE_ATTRIBUTE_OPERATION, GlobalOperationHandlers.WRITE_ATTRIBUTE, CommonProviders.WRITE_ATTRIBUTE_PROVIDER, true);
         root.registerOperationHandler(GlobalOperationHandlers.VALIDATE_ADDRESS_OPERATION_NAME, GlobalOperationHandlers.VALIDATE_ADDRESS, CommonProviders.VALIDATE_ADDRESS_PROVIDER, true);
 
@@ -314,7 +316,6 @@ public class ServerControllerModelUtil {
 
         // The sub-deployments registry
         deployments.registerSubModel(PathElement.pathElement(SUBDEPLOYMENT), ServerDescriptionProviders.SUBDEPLOYMENT_PROVIDER);
-
 
         // Extensions
         ManagementResourceRegistration extensions = root.registerSubModel(PathElement.pathElement(EXTENSION), CommonProviders.EXTENSION_PROVIDER);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/BasicOperationsUnitTestCase.java
@@ -26,6 +26,7 @@ import static org.jboss.as.arquillian.container.Authentication.getCallbackHandle
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -34,6 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.POR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
@@ -163,6 +165,19 @@ public class BasicOperationsUnitTestCase {
             Assert.assertTrue(stepResult.get(ModelDescriptionConstants.ATTRIBUTES).hasDefined(ModelDescriptionConstants.INTERFACE));
             Assert.assertTrue(stepResult.get(ModelDescriptionConstants.ATTRIBUTES).hasDefined(ModelDescriptionConstants.PORT));
         }
+    }
+
+    @Test
+    public void testRecursiveReadIncludingRuntime() throws IOException {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE).set(true);
+        operation.get(INCLUDE_RUNTIME).set(true);
+
+        final ModelNode result = getModelControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
     }
 
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-2081: read-resource with recurse and include-runtime is broken
https://issues.jboss.org/browse/AS7-2142: Domain model usability: missing :undefine-attribute command
