### PR TITLE
AS7-2995 schedule timer stops if timeout occour during retry

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/overlap/OverlapTimerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/overlap/OverlapTimerTestCase.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.timerservice.overlap;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@RunWith(Arquillian.class)
+public class OverlapTimerTestCase {
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "overlap-timer-test.jar");
+        ejbJar.addPackage(OverlapTimerTestCase.class.getPackage());
+        return ejbJar;
+    }
+
+    @Test
+    public void testContinuedAfterOverlap() throws Exception {
+        Assert.assertTrue("Schedule timeout method was not invoked within 3 seconds!", ScheduleRetryFailSingletonBean.startLatch().await(3, TimeUnit.SECONDS));
+        Assert.assertTrue("Schedule timer is not alive after overlapped invocation!",ScheduleRetryFailSingletonBean.aliveLatch().await(4, TimeUnit.SECONDS));
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/overlap/ScheduleRetryFailSingletonBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/overlap/ScheduleRetryFailSingletonBean.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.timerservice.overlap;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.ejb.AccessTimeout;
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+import javax.ejb.Timer;
+
+import org.jboss.logging.Logger;
+
+/**
+ * SingletonBean to test that the schedule continue after a second timeout happen
+ * during the singleton is still retrying the timeout.<br/>
+ * See JIRA AS7-2995.
+ *
+ * @author <a href="mailto:wfink@redhat.com">Wolf-Dieter Fink</a>
+ */
+@Singleton
+@AccessTimeout(unit = TimeUnit.MILLISECONDS, value = 100)  // make the test faster
+public class ScheduleRetryFailSingletonBean {
+    private static final Logger LOGGER = Logger.getLogger(ScheduleRetryFailSingletonBean.class);
+    private static CountDownLatch started = new CountDownLatch(1);
+    private static CountDownLatch alive = new CountDownLatch(4);
+
+    /**
+     * count the number of invoked timeouts
+     */
+    private static int counter;
+
+    @SuppressWarnings("unused")
+    @Schedule(second = "*", minute = "*", hour = "*", persistent = false)
+    private void timeout(final Timer timer) {
+        int wait = 0;
+        counter++;
+        LOGGER.info("Executing TimerTestBean  " + timer);
+        switch(counter) {
+            case 1:
+                started.countDown();
+                throw new RuntimeException("Force retry for test");
+            case 2:
+                // ensure that the timeout retry is running if longer than schedule
+                wait = 1300;
+                break;
+            default:
+                break;
+        }
+        alive.countDown();
+        LOGGER.info("count=" + counter + "  Sleeping "+wait+"ms");
+        try {
+            Thread.sleep(wait);
+        } catch (InterruptedException e) {}
+        LOGGER.info("Finished executing TimerTestBean nextTimeOut=" + timer.getNextTimeout());
+    }
+
+    /**
+     * Latch to test whether the first timeout is executed.
+     *
+     * @return latch which is blocked until the first schedule
+     */
+    public static CountDownLatch startLatch() {
+        return started;
+    }
+    /**
+     * Latch to test whether a timeout is fired after overlapping with a timeout retry.
+     * The test should wait a minimum of 4 seconds.
+     *
+     * @return latch which is blocked until a timeout happen after retry
+     */
+    public static CountDownLatch aliveLatch() {
+        return alive;
+    }
+}


### PR DESCRIPTION
If a timer is in retry mode and the next expiration is suppressed the timer is not longer active
