### PR TITLE
cli updates

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.cli;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -59,8 +60,9 @@ public class Util {
     public static final String INCLUDE_DEFAULTS = "include-defaults";
     public static final String INCLUDE_RUNTIME = "include-runtime";
     public static final String INPUT_STREAM_INDEX = "input-stream-index";
-    public static final String MIN_OCCURS = "min-occurs";
+    public static final String MANAGEMENT_CLIENT_CONTENT = "management-client-content";
     public static final String MAX_OCCURS = "max-occurs";
+    public static final String MIN_OCCURS = "min-occurs";
     public static final String NAME = "name";
     public static final String NILLABLE = "nillable";
     public static final String OPERATION = "operation";
@@ -81,6 +83,7 @@ public class Util {
     public static final String RESTART_REQUIRED = "restart-required";
     public static final String RESULT = "result";
     public static final String ROLLOUT_PLAN = "rollout-plan";
+    public static final String ROLLOUT_PLANS = "rollout-plans";
     public static final String RUNTIME_NAME = "runtime-name";
     public static final String SERVER_GROUP = "server-group";
     public static final String STEP_1 = "step-1";
@@ -597,5 +600,30 @@ public class Util {
             }
         }
         return request;
+    }
+
+    public static ModelNode getRolloutPlan(ModelControllerClient client, String name) throws CommandFormatException {
+        final ModelNode request = new ModelNode();
+        request.get(OPERATION).set(READ_ATTRIBUTE);
+        final ModelNode addr = request.get(ADDRESS);
+        addr.add(MANAGEMENT_CLIENT_CONTENT, ROLLOUT_PLANS);
+        addr.add(ROLLOUT_PLAN, name);
+        request.get(NAME).set(CONTENT);
+        final ModelNode response;
+        try {
+            response = client.execute(request);
+        } catch(IOException e) {
+            throw new CommandFormatException("Failed to execute request: " + e.getMessage(), e);
+        }
+        if(!response.hasDefined(OUTCOME)) {
+            throw new CommandFormatException("Operation response if missing outcome: " + response);
+        }
+        if(!response.get(OUTCOME).asString().equals(SUCCESS)) {
+            throw new CommandFormatException("Failed to load rollout plan: " + response);
+        }
+        if(!response.hasDefined(RESULT)) {
+            throw new CommandFormatException("Operation response is missing result.");
+        }
+        return response.get(RESULT);
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
@@ -302,7 +302,7 @@ public class LsHandler extends CommandHandlerWithHelp {
                                                             maxOccurs == null ? "n/a" : (maxOccurs == Integer.MAX_VALUE ? "unbounded" : maxOccurs.toString())
                                                             });
                                                 } else {
-                                                    attrTable.addLine(new String[]{prop.getName(), "n/a", "n/a"});
+                                                    childrenTable.addLine(new String[]{prop.getName(), "n/a", "n/a"});
                                                 }
                                             }
                                         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -41,6 +41,7 @@ import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
 import javax.security.sasl.SaslException;
 
+import org.jboss.as.cli.ArgumentValueConverter;
 import org.jboss.as.cli.CliConfig;
 import org.jboss.as.cli.CliEvent;
 import org.jboss.as.cli.CliEventListener;
@@ -276,6 +277,10 @@ class CommandContextImpl implements CommandContext {
         // these are used for the cts setup
         cmdRegistry.registerHandler(new CreateJmsResourceHandler(this), false, "create-jms-resource");
         cmdRegistry.registerHandler(new DeleteJmsResourceHandler(this), false, "delete-jms-resource");
+
+        final GenericTypeOperationHandler rolloutPlan = new GenericTypeOperationHandler(this, "/management-client-content=rollout-plans/rollout-plan", null);
+        rolloutPlan.addValueConverter("content", ArgumentValueConverter.ROLLOUT_PLAN);
+        cmdRegistry.registerHandler(rolloutPlan, "rollout-plan");
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/RolloutPlanHeader.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/RolloutPlanHeader.java
@@ -139,11 +139,14 @@ public class RolloutPlanHeader implements OperationRequestHeader {
     public void addTo(CommandContext ctx, ModelNode headers) throws CommandFormatException {
 
         if(planRef != null) {
-            final OperationRequestHeader rolloutPlan = ctx.getConfig().getRolloutPlan(planRef);
+/*            final OperationRequestHeader rolloutPlan = ctx.getConfig().getRolloutPlan(planRef);
             if(rolloutPlan == null) {
                 throw new CommandFormatException("Rollout plan with id '" + planRef + "' could not be found.");
             }
             rolloutPlan.addTo(ctx, headers);
+*/
+            ModelNode rolloutPlan = Util.getRolloutPlan(ctx.getModelControllerClient(), planRef);
+            headers.set(rolloutPlan);
             return;
         }
         ModelNode header = headers.get(HEADER_NAME);

--- a/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
@@ -69,6 +69,14 @@ public class ParserUtil {
         StateParser.parse(commandLine, callbackHandler, ArgumentListState.INSTANCE);
     }
 
+    public static void parse(String str, final CommandLineParser.CallbackHandler handler, ParsingState initialState) throws CommandFormatException {
+        if(str == null) {
+            return;
+        }
+        final ParsingStateCallbackHandler callbackHandler = getCallbackHandler(handler);
+        StateParser.parse(str, callbackHandler, initialState);
+    }
+
     protected static ParsingStateCallbackHandler getCallbackHandler(final CommandLineParser.CallbackHandler handler) {
 
         return new ParsingStateCallbackHandler() {

--- a/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/ConcurrentSignState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/ConcurrentSignState.java
@@ -41,6 +41,7 @@ public class ConcurrentSignState extends DefaultParsingState {
 
     ConcurrentSignState(ServerGroupState sg) {
         super(ID);
+        setIgnoreWhitespaces(true);
         setDefaultHandler(new EnterStateCharacterHandler(sg));
         setReturnHandler(GlobalCharacterHandlers.LEAVE_STATE_HANDLER);
     }

--- a/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/RolloutPlanState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/RolloutPlanState.java
@@ -68,7 +68,9 @@ public class RolloutPlanState extends DefaultParsingState {
                 final char ch = ctx.getCharacter();
                 if(ch == '}' || ch == ';') {
                     ctx.leaveState();
+                    return;
                 }
+                ctx.enterState(props);
                 //ctx.leaveState();
             }});
     }

--- a/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/ServerGroupListState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/ServerGroupListState.java
@@ -42,10 +42,14 @@ public class ServerGroupListState extends DefaultParsingState {
         this(ServerGroupState.INSTANCE, ServerGroupSeparatorState.INSTANCE, ConcurrentSignState.INSTANCE);
     }
 
-    ServerGroupListState(ServerGroupState sg, ServerGroupSeparatorState gs, ConcurrentSignState cs) {
+    ServerGroupListState(final ServerGroupState sg, final ServerGroupSeparatorState gs, final ConcurrentSignState cs) {
         super(ID);
         this.setIgnoreWhitespaces(true);
-        //setDefaultHandler(new EnterStateCharacterHandler(sg));
+        setDefaultHandler(new CharacterHandler(){
+            @Override
+            public void handle(ParsingContext ctx) throws CommandFormatException {
+                ctx.leaveState();
+            }});
         setEnterHandler(new EnterStateCharacterHandler(sg));
         putHandler('^', new EnterStateCharacterHandler(cs));
         putHandler(',', new EnterStateCharacterHandler(gs));
@@ -57,10 +61,29 @@ public class ServerGroupListState extends DefaultParsingState {
                 if(ctx.isEndOfContent()) {
                     return;
                 }
-                if(Character.isWhitespace(ctx.getCharacter())) {
+/*                if(Character.isWhitespace(ctx.getCharacter())) {
                     ctx.leaveState();
                 } else {
                     getHandler(ctx.getCharacter()).handle(ctx);
+                }
+*/
+                if(Character.isWhitespace(ctx.getCharacter())) {
+                    return;
+                }
+
+                switch(ctx.getCharacter()) {
+                case '^':
+                    ctx.enterState(cs);
+                    break;
+                case ',':
+                    ctx.enterState(gs);
+                    break;
+                case '}':
+                case ';':
+                    ctx.leaveState();
+                    break;
+                default:
+                    ctx.leaveState();
                 }
             }});
     }

--- a/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/ServerGroupSeparatorState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/operation/header/ServerGroupSeparatorState.java
@@ -41,6 +41,7 @@ public class ServerGroupSeparatorState extends DefaultParsingState {
 
     ServerGroupSeparatorState(ServerGroupState sg) {
         super(ID);
+        setIgnoreWhitespaces(true);
         setDefaultHandler(new EnterStateCharacterHandler(sg));
         setReturnHandler(GlobalCharacterHandlers.LEAVE_STATE_HANDLER);
     }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/RolloutPlanParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/RolloutPlanParsingTestCase.java
@@ -593,6 +593,8 @@ public class RolloutPlanParsingTestCase extends TestCase {
     @Test
     public void testRolloutId() throws Exception {
 
+/* the plans are not in the config any more, just test the parsing of the reference
+
         RolloutPlanHeader myPlan = new RolloutPlanHeader("myplan");
 
         ConcurrentRolloutPlanGroup concurrent = new ConcurrentRolloutPlanGroup();
@@ -615,7 +617,7 @@ public class RolloutPlanParsingTestCase extends TestCase {
         myPlan.addProperty("rollback-across-groups", "true");
 
         ((MockCliConfig)ctx.getConfig()).addRolloutPlan(myPlan);
-
+*/
         //parse("/profile=default/subsystem=threads/thread-factory=mytf:do{ rollout in-series = groupA}");
         parse("/profile=default/subsystem=threads/thread-factory=mytf:do{ rollout id = myplan}");
 
@@ -641,7 +643,7 @@ public class RolloutPlanParsingTestCase extends TestCase {
         final RolloutPlanHeader rollout = (RolloutPlanHeader) header;
         assertEquals("myplan", rollout.getPlanRef());
 
-        final ModelNode op = handler.toOperationRequest(ctx);
+/*        final ModelNode op = handler.toOperationRequest(ctx);
         assertTrue(op.hasDefined(Util.OPERATION_HEADERS));
         final ModelNode headersNode = op.get(Util.OPERATION_HEADERS);
 
@@ -670,7 +672,7 @@ public class RolloutPlanParsingTestCase extends TestCase {
         rolloutPlan.get("rollback-across-groups").set("true");
 
         assertEquals(expectedHeaders, headersNode);
-    }
+*/    }
 
     @Test
     public void testArgumentValueConverter() throws Exception {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
@@ -97,7 +97,7 @@ public interface DomainControllerMessages {
      * @param parentSpec  the complete string representation of the parent element
      * @return  the error message
      */
-    @Message(id = 10979, value = "%s recognized only %s as children: %s")
+    @Message(id = 10979, value = "%s recognizes only %s as children: %s")
     String unrecognizedChildren(String parent, String children, String parentSpec);
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
@@ -22,14 +22,14 @@
 
 package org.jboss.as.domain.controller;
 
-import javax.xml.stream.Location;
-import javax.xml.stream.XMLStreamException;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONCURRENT_GROUPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_SERIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 
 import org.jboss.as.controller.RunningMode;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageBundle;
 import org.jboss.logging.Messages;
-import org.jboss.logging.Param;
 
 /**
  * This module is using message IDs in the range 10900-10999.
@@ -76,4 +76,56 @@ public interface DomainControllerMessages {
      */
     @Message(id = 10977, value = "There is already a registered host named '%s'")
     String slaveAlreadyRegistered(String slaveName);
+
+    /**
+     * Creates an exception message indicating that a parent is missing a required child.
+     *
+     * @param parent  the name of the parent element
+     * @param child   the name of the missing child element
+     * @param parentSpec   the complete string representation of the parent element
+     * @return  the error message
+     */
+    @Message(id = 10978, value = "%s is missing %s: %s")
+    String requiredChildIsMissing(String parent, String child, String parentSpec);
+
+    /**
+     * Creates an exception message indicating that a parent recognizes only
+     * the specified children.
+     *
+     * @param parent  the name of the parent element
+     * @param children  recognized children
+     * @param parentSpec  the complete string representation of the parent element
+     * @return  the error message
+     */
+    @Message(id = 10979, value = "%s recognized only %s as children: %s")
+    String unrecognizedChildren(String parent, String children, String parentSpec);
+
+    /**
+     * Creates an exception message indicating that in-series is missing groups.
+     *
+     * @param rolloutPlan  string representation of a rollout plan
+     * @return  the error message
+     */
+    @Message(id = 10980, value = IN_SERIES + " is missing groups: %s")
+    String inSeriesIsMissingGroups(String rolloutPlan);
+
+    /**
+     * Creates an exception message indicating that server-group expects one
+     * and only one child.
+     *
+     * @param rolloutPlan  string representation of a rollout plan
+     * @return  the error message
+     */
+    @Message(id = 10981, value = SERVER_GROUP + " expects one and only one child: %s")
+    String serverGroupExpectsSingleChild(String rolloutPlan);
+
+    /**
+     * Creates an exception message indicating that one of the groups in
+     * rollout plan does not define neither server-group nor concurrent-groups.
+     *
+     * @param rolloutPlan  string representation of a rollout plan
+     * @return  the error message
+     */
+    @Message(id = 10982, value = "One of the groups does not define neither " + SERVER_GROUP + " nor " + CONCURRENT_GROUPS + ": %s")
+    String unexpectedInSeriesGroup(String rolloutPlan);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
@@ -302,36 +302,36 @@ public class DomainModelUtil {
         return extensionContext;
     }
 
-    public static void validateRolloutPlanStructure(ModelNode rolloutPlan) throws OperationFailedException {
-        if(rolloutPlan == null) {
+    public static void validateRolloutPlanStructure(ModelNode plan) throws OperationFailedException {
+        if(plan == null) {
             throw new OperationFailedException("rolloutPlan argument is null.");
         }
-        if(!rolloutPlan.hasDefined(ROLLOUT_PLAN)) {
-            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, ROLLOUT_PLAN, rolloutPlan.toString()));
+        if(!plan.hasDefined(ROLLOUT_PLAN)) {
+            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, ROLLOUT_PLAN, plan.toString()));
         }
-        rolloutPlan = rolloutPlan.get(ROLLOUT_PLAN);
+        ModelNode rolloutPlan1 = plan.get(ROLLOUT_PLAN);
 
         final Set<String> keys;
         try {
-            keys = rolloutPlan.keys();
+            keys = rolloutPlan1.keys();
         } catch (IllegalArgumentException e) {
-            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, IN_SERIES, rolloutPlan.toString()));
+            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, IN_SERIES, plan.toString()));
         }
         if(!keys.contains(IN_SERIES)) {
-            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, IN_SERIES, rolloutPlan.toString()));
+            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, IN_SERIES, plan.toString()));
         }
         if(keys.size() > 2 || keys.size() == 2 && !keys.contains(ROLLBACK_ACROSS_GROUPS)) {
-            throw new OperationFailedException(MESSAGES.unrecognizedChildren(ROLLOUT_PLAN, IN_SERIES + ", " + ROLLBACK_ACROSS_GROUPS, rolloutPlan.toString()));
+            throw new OperationFailedException(MESSAGES.unrecognizedChildren(ROLLOUT_PLAN, IN_SERIES + ", " + ROLLBACK_ACROSS_GROUPS, plan.toString()));
         }
 
-        final ModelNode inSeries = rolloutPlan.get(IN_SERIES);
+        final ModelNode inSeries = rolloutPlan1.get(IN_SERIES);
         if(!inSeries.isDefined()) {
-            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, IN_SERIES, rolloutPlan.toString()));
+            throw new OperationFailedException(MESSAGES.requiredChildIsMissing(ROLLOUT_PLAN, IN_SERIES, plan.toString()));
         }
 
         final List<ModelNode> groups = inSeries.asList();
         if(groups.isEmpty()) {
-            throw new OperationFailedException(MESSAGES.inSeriesIsMissingGroups(rolloutPlan.toString()));
+            throw new OperationFailedException(MESSAGES.inSeriesIsMissingGroups(plan.toString()));
         }
 
         for(ModelNode group : groups) {
@@ -341,10 +341,10 @@ public class DomainModelUtil {
                 try {
                     groupKeys = serverGroup.keys();
                 } catch(IllegalArgumentException e) {
-                    throw new OperationFailedException(MESSAGES.serverGroupExpectsSingleChild(rolloutPlan.toString()));
+                    throw new OperationFailedException(MESSAGES.serverGroupExpectsSingleChild(plan.toString()));
                 }
                 if(groupKeys.size() != 1) {
-                    throw new OperationFailedException(MESSAGES.serverGroupExpectsSingleChild(rolloutPlan.toString()));
+                    throw new OperationFailedException(MESSAGES.serverGroupExpectsSingleChild(plan.toString()));
                 }
                 validateInSeriesServerGroup(serverGroup.asProperty().getValue());
             } else if(group.hasDefined(CONCURRENT_GROUPS)) {
@@ -353,7 +353,7 @@ public class DomainModelUtil {
                     validateInSeriesServerGroup(child.asProperty().getValue());
                 }
             } else {
-                throw new OperationFailedException(MESSAGES.unexpectedInSeriesGroup(rolloutPlan.toString()));
+                throw new OperationFailedException(MESSAGES.unexpectedInSeriesGroup(plan.toString()));
             }
         }
     }


### PR DESCRIPTION
Rollout plans:
- added commands to add/remove/modify rollout plans stored in the domain model;
- dmr and cli-specific syntax;
- support for referencing stored rollout plans from operations.

A few other fixes.

Thanks,
Alexey
