### PR TITLE
Improve AS-2695

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -805,6 +805,7 @@
             <maven-resource group="org.jboss.as" artifact="jboss-as-web"/>
             <maven-resource group="org.jboss.web" artifact="jasper-jdt"/>
             <maven-resource group="org.jboss.web" artifact="jbossweb"/>
+            <extract-native-jar group="org.jboss.as" artifact="jbossweb-native"/>
         </module-def>
 
         <module-def name="org.jboss.as.webservices">

--- a/build/lib.xml
+++ b/build/lib.xml
@@ -169,6 +169,17 @@
         </sequential>
     </macrodef>
 
+    <macrodef name="extract-native-jar" >
+        <attribute name="group"/>
+        <attribute name="artifact"/>
+        <sequential>
+        <unzip src="${@{group}:@{artifact}:jar}" dest="${module.repo.output.dir}/${current.module.path}">
+           <patternset>
+               <include name="lib/**"/>
+           </patternset>
+       </unzip>
+        </sequential>
+    </macrodef>
 
     <scriptdef name="define-resource-root" language="javascript">
         <attribute name="path"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -115,6 +115,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jbossweb-native</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.invocation</groupId>
             <artifactId>jboss-invocation</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
         <version.org.jboss.arquillian.core>1.0.0.CR6</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.osgi>1.0.0.CR4</version.org.jboss.arquillian.osgi>
         <version.org.jboss.as.console>1.0.0.Beta25</version.org.jboss.as.console>
+        <version.org.jboss.as.jbossweb-native>2.0.10.Beta1</version.org.jboss.as.jbossweb-native>
         <version.org.jboss.classfilewriter>1.0.0.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.common-core>2.2.17.GA</version.org.jboss.common-core>
         <version.org.jboss.com.sun.httpserver>1.0.0.Beta3</version.org.jboss.com.sun.httpserver>
@@ -4998,6 +4999,13 @@
                 <artifactId>jbossweb</artifactId>
                 <version>${version.org.jboss.web}</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jbossweb-native</artifactId>
+                <version>${version.org.jboss.as.jbossweb-native}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>org.jboss.weld</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <version.org.jboss.staxmapper>1.0.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.1.GA</version.org.jboss.stdio>
         <version.org.jboss.threads>2.0.0.GA</version.org.jboss.threads>
-        <version.org.jboss.web>7.0.5.Final</version.org.jboss.web>
+        <version.org.jboss.web>7.0.6.Final</version.org.jboss.web>
         <version.org.jboss.web.jasper-jdt>7.0.3.Final</version.org.jboss.web.jasper-jdt>
         <version.org.jboss.weld.weld>1.1.4.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>1.1.Final</version.org.jboss.weld.weld-api>


### PR DESCRIPTION
Improve AS-2695: Allows to bundle jbossweb-native for most used platforms (macosx,, linux and windows).
