### PR TITLE
Fix for setting ca-revocation-url attribute value for JSSE configuration in the web subsystem

### DIFF
--- a/web/src/main/java/org/jboss/as/web/WebConnectorService.java
+++ b/web/src/main/java/org/jboss/as/web/WebConnectorService.java
@@ -253,6 +253,10 @@ class WebConnectorService implements Service<Connector> {
                             Method m = connector.getProtocolHandler().getClass().getMethod("setKeytype", String.class);
                             m.invoke(connector.getProtocolHandler(), ssl.get(Constants.KEYSTORE_TYPE).asString());
                         }
+                        if (ssl.hasDefined(Constants.CA_REVOCATION_URL)) {
+                            Method m = connector.getProtocolHandler().getClass().getMethod("setAttribute", String.class, Object.class);
+                            m.invoke(connector.getProtocolHandler(), "crlFile", ssl.get(Constants.CA_REVOCATION_URL).asString());
+                        }
 
                     } catch (NoSuchMethodException e) {
                         throw new StartException(e);


### PR DESCRIPTION
The commit in this branch fixes a issue where the ca-revocation-url attribute value wasn't being used while setting up the JSSE SSL configurations. A user reported this issue in the forum and proposed the fix http://community.jboss.org/message/641606#641606 that's been included in this commit. 

Have run this past Jean-Frederic and Remy.
