### PR TITLE
[AS7-3057] Handle ipv6 addresses in cli

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
@@ -62,7 +62,7 @@ public class ConnectHandler extends CommandHandlerWithHelp {
             }
             final String arg = args.get(0);
             String portStr = null;
-            int colonIndex = arg.indexOf(':');
+            int colonIndex = arg.lastIndexOf(':');
             if(colonIndex < 0) {
                 // default port
                 host = arg;
@@ -70,8 +70,25 @@ public class ConnectHandler extends CommandHandlerWithHelp {
                 // default host
                 portStr = arg.substring(1).trim();
             } else {
-                host = arg.substring(0, colonIndex).trim();
-                portStr = arg.substring(colonIndex + 1).trim();
+                final boolean hasPort;
+                int closeBracket = arg.lastIndexOf(']');
+                if (closeBracket != -1) {
+                    //possible ip v6
+                    if (closeBracket > colonIndex) {
+                        hasPort = false;
+                    } else {
+                        hasPort = true;
+                    }
+                } else {
+                    //probably ip v4
+                    hasPort = true;
+                }
+                if (hasPort) {
+                    host = arg.substring(0, colonIndex).trim();
+                    portStr = arg.substring(colonIndex + 1).trim();
+                } else {
+                    host = arg;
+                }
             }
 
             if(portStr != null) {

--- a/cli/src/main/resources/help/connect.txt
+++ b/cli/src/main/resources/help/connect.txt
@@ -30,3 +30,8 @@ To connect automatically after the launch, use '--connect' switch. E.g.
  jboss-admin.sh --connect
  jboss-admin.sh --connect controller=controller-host.net
  jboss-admin.sh --connect controller=controller-host.net:1234
+ 
+ The host may be any of these formats:
+-a host name, e.g. localhost
+-an ipv4 address, e.g. 127.0.0.1
+-an ipv6 address, e.g. [::1]


### PR DESCRIPTION
To try it out

Change standalone.conf to use -Djava.net.preferIPv6Stack=true instead of -Djava.net.preferIPv4Stack=true

Change the management interface in standalone.xml
{code}

```
    <interface name="management">
        <inet-address value="::1"/>
    </interface>
```

{code}

Start CLI and connect:

[~/sourcecontrol/jboss-as7/git/jboss-as]
$./build/target/jboss-as-7.1.0.CR1-SNAPSHOT/bin/jboss-admin.sh 
You are disconnected at the moment. Type 'connect' to connect to the server or 'help' for the list of supported commands.
[disconnected /] connect [::1]:9999
host [::1]
[standalone@[::1]:9999 /] 
