### PR TITLE
AS7-2980 Upgrade JBoss transaction manager to 4.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,9 +158,9 @@
         <version.org.jboss.jandex>1.0.3.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.1.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.0.0.CR1</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.jbossts.jbossjts>4.16.0.Beta1</version.org.jboss.jbossts.jbossjts>
-        <version.org.jboss.jbossts.jbossjts-integration>4.16.0.Beta1</version.org.jboss.jbossts.jbossjts-integration>
-        <version.org.jboss.jbossts.jbossxts>4.16.0.Beta1</version.org.jboss.jbossts.jbossxts>
+        <version.org.jboss.jbossts.jbossjts>4.16.0.Final</version.org.jboss.jbossts.jbossjts>
+        <version.org.jboss.jbossts.jbossjts-integration>4.16.0.Final</version.org.jboss.jbossts.jbossjts-integration>
+        <version.org.jboss.jbossts.jbossxts>4.16.0.Final</version.org.jboss.jbossts.jbossxts>
         <version.org.jboss.jboss-vfs>3.1.0.CR1</version.org.jboss.jboss-vfs>
         <version.org.jboss.jsfunit>2.0.0.Beta1</version.org.jboss.jsfunit>
         <version.org.jboss.logging.jboss-logging>3.1.0.CR2</version.org.jboss.logging.jboss-logging>


### PR DESCRIPTION
Although AS7-2980 was closed, I do not believe it is fixed and I commented as such on the Jira. Looking at the root pom.xml it appears as though AS7 is still using JBossTS 4.16.0.beta1 which this commit contains
