### PR TITLE
Add read and write access to all cache attributes (except store) for Infinispan.

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AddAliasCommand.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AddAliasCommand.java
@@ -21,7 +21,7 @@ import org.jboss.logging.Logger;
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class AddAliasCommand implements OperationStepHandler, DescriptionProvider {
+public class AddAliasCommand implements OperationStepHandler {
 
     private static final Logger log = Logger.getLogger(AddAliasCommand.class.getPackage().getName());
     public static final AddAliasCommand INSTANCE = new AddAliasCommand();
@@ -101,16 +101,6 @@ public class AddAliasCommand implements OperationStepHandler, DescriptionProvide
             newList.add().set(alias);
         }
         return newList ;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.as.controller.descriptions.DescriptionProvider#getModelDescription(java.util.Locale)
-     */
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getAddAliasCommandDescription(locale);
     }
 
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigOperationHandlers.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigOperationHandlers.java
@@ -1,0 +1,218 @@
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Common code for handling the following cache configuration elements
+ * {locking, transaction, eviction, expiration, state-transfer, rehashing, store, file-store, jdbc-store, remote-store}
+ *
+ * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ */
+public class CacheConfigOperationHandlers {
+
+
+    /** The cache locking config add operation handler. */
+    static final OperationStepHandler LOCKING_ADD = new BasicCacheConfigAdd(CommonAttributes.LOCKING_ATTRIBUTES) {
+       public void process(ModelNode submodel , ModelNode operation){
+          // override locking stuff here
+       }
+    };
+    static final SelfRegisteringAttributeHandler LOCKING_ATTR = new AttributeWriteHandler(CommonAttributes.LOCKING_ATTRIBUTES);
+
+    /** The cache transaction config add operation handler. */
+    static final OperationStepHandler TRANSACTION_ADD = new BasicCacheConfigAdd(CommonAttributes.TRANSACTION_ATTRIBUTES);
+    static final SelfRegisteringAttributeHandler TRANSACTION_ATTR = new AttributeWriteHandler(CommonAttributes.TRANSACTION_ATTRIBUTES);
+
+    /** The cache eviction config add operation handler. */
+    static final OperationStepHandler EVICTION_ADD = new BasicCacheConfigAdd(CommonAttributes.EVICTION_ATTRIBUTES);
+    static final SelfRegisteringAttributeHandler EVICTION_ATTR = new AttributeWriteHandler(CommonAttributes.EVICTION_ATTRIBUTES);
+
+    /** The cache expiration config add operation handler. */
+    static final OperationStepHandler EXPIRATION_ADD = new BasicCacheConfigAdd(CommonAttributes.EXPIRATION_ATTRIBUTES);
+    static final SelfRegisteringAttributeHandler EXPIRATION_ATTR = new AttributeWriteHandler(CommonAttributes.EXPIRATION_ATTRIBUTES);
+
+    /** The cache state transfer config add operation handler. */
+    static final OperationStepHandler STATE_TRANSFER_ADD = new BasicCacheConfigAdd(CommonAttributes.STATE_TRANSFER_ATTRIBUTES);
+    static final SelfRegisteringAttributeHandler STATE_TRANSFER_ATTR = new AttributeWriteHandler(CommonAttributes.STATE_TRANSFER_ATTRIBUTES);
+
+    /** The cache rehashing config add operation handler. */
+    static final OperationStepHandler REHASHING_ADD = new BasicCacheConfigAdd(CommonAttributes.REHASHING_ATTRIBUTES);
+    static final SelfRegisteringAttributeHandler REHASHING_ATTR = new AttributeWriteHandler(CommonAttributes.REHASHING_ATTRIBUTES);
+
+    /** The cache store config add operation handler. */
+    static final OperationStepHandler STORE_ADD = new BasicCacheConfigAdd(CommonAttributes.STORE_ATTRIBUTES);
+    static final SelfRegisteringAttributeHandler STORE_ATTR = new AttributeWriteHandler(CommonAttributes.STORE_ATTRIBUTES);
+
+    /** The cache config remove operation handler. */
+    static final OperationStepHandler REMOVE = new OperationStepHandler() {
+        @Override
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            final Resource resource = context.removeResource(PathAddress.EMPTY_ADDRESS);
+            reloadRequiredStep(context);
+            context.completeStep();
+        }
+    };
+
+    /** The cache config property add operation handler. */
+    static final OperationStepHandler STORE_PROPERTY_ADD = new OperationStepHandler() {
+        @Override
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            final Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
+            CommonAttributes.VALUE.validateAndSet(operation, resource.getModel());
+            reloadRequiredStep(context);
+            context.completeStep();
+        }
+    };
+
+    static final OperationStepHandler STORE_PROPERTY_ATTR = new OperationStepHandler() {
+        @Override
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
+            CommonAttributes.VALUE.validateAndSet(operation, resource.getModel());
+            reloadRequiredStep(context);
+            context.completeStep();
+        }
+    };
+
+    /**
+     * Helper class to process adding nested cache configuration elements to the cache parent resource.
+     * Override the process method in order to process configuration specific elements.
+     *
+     */
+    private static class BasicCacheConfigAdd implements OperationStepHandler, DescriptionProvider {
+        private final AttributeDefinition[] attributes;
+
+        BasicCacheConfigAdd(final AttributeDefinition[] attributes) {
+            this.attributes = attributes;
+        }
+
+        @Override
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            final Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
+            final ModelNode subModel = resource.getModel();
+
+            // Process attributes
+            for(final AttributeDefinition attribute : attributes) {
+                attribute.validateAndSet(operation, subModel);
+            }
+
+            // Process acceptor/connector type specific properties
+            process(subModel, operation);
+
+            // The cache config parameters  <property name=>value</property>
+            if(operation.hasDefined(ModelKeys.PROPERTY)) {
+                for(Property property : operation.get(ModelKeys.PROPERTY).asPropertyList()) {
+                    // create a new property=name resource
+                    final Resource param = context.createResource(PathAddress.pathAddress(PathElement.pathElement(ModelKeys.PROPERTY, property.getName())));
+                    final ModelNode value = property.getValue();
+                    if(! value.isDefined()) {
+                        throw new OperationFailedException(new ModelNode().set("property " + property.getName() + " not defined"));
+                    }
+                    // set the value of the property
+                    param.getModel().get(ModelDescriptionConstants.VALUE).set(value);
+                }
+            }
+            // This needs a reload
+            reloadRequiredStep(context);
+            context.completeStep();
+        }
+
+        void process(ModelNode subModel, ModelNode operation) {
+            //
+        };
+
+        public ModelNode getModelDescription(Locale locale) {
+            return new ModelNode().set(DESCRIPTION);
+        }
+
+    }
+
+    interface SelfRegisteringAttributeHandler extends OperationStepHandler {
+        void registerAttributes(final ManagementResourceRegistration registry);
+    }
+
+    /**
+     * Helper class to handle write access as well as register attributes.
+     */
+    static class AttributeWriteHandler extends ReloadRequiredWriteAttributeHandler implements SelfRegisteringAttributeHandler {
+        final AttributeDefinition[] attributes;
+
+        private AttributeWriteHandler(AttributeDefinition[] attributes) {
+            super(attributes);
+            this.attributes = attributes;
+        }
+
+        public void registerAttributes(final ManagementResourceRegistration registry) {
+            final EnumSet<AttributeAccess.Flag> flags = EnumSet.of(AttributeAccess.Flag.RESTART_ALL_SERVICES);
+            for (AttributeDefinition attr : attributes) {
+                registry.registerReadWriteAttribute(attr.getName(), null, this, flags);
+            }
+        }
+    }
+
+    static ModelNode createOperation(AttributeDefinition[] attributes, ModelNode address, ModelNode existing) throws OperationFailedException {
+        ModelNode operation = Util.getEmptyOperation(ADD, address);
+        for(final AttributeDefinition attribute : attributes) {
+            attribute.validateAndSet(existing, operation);
+        }
+        return operation;
+    }
+
+    /**
+     * Add a step triggering the {@linkplain org.jboss.as.controller.OperationContext#reloadRequired()} in case the
+     * the cache service is installed, since the transport-config operations need a reload/restart and can't be
+     * applied to the runtime directly.
+     *
+     * @param context the operation context
+     */
+    static void reloadRequiredStep(final OperationContext context) {
+        if(context.getType() == OperationContext.Type.SERVER) {
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+
+                    // shorten this by providing static getServiceName methods which take an OP_ADDR
+                    PathAddress elementAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
+                    PathAddress cacheAddress = elementAddress.subAddress(0, elementAddress.size() - 1);
+                    PathAddress containerAddress = cacheAddress.subAddress(0, cacheAddress.size() - 2);
+                    String cacheName = cacheAddress.getLastElement().getValue();
+                    String containerName = containerAddress.getLastElement().getValue();
+                    ServiceName cacheConfigurationServiceName = CacheConfigurationService.getServiceName(containerName, cacheName);
+
+                    final ServiceController<?> controller = context.getServiceRegistry(false).getService(cacheConfigurationServiceName);
+                    if(controller != null) {
+                        context.reloadRequired();
+                    }
+                     context.completeStep();
+                }
+            }, OperationContext.Stage.RUNTIME);
+        }
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
@@ -32,6 +32,8 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.transaction.tm.BatchModeTransactionManager;
 import org.jboss.as.clustering.infinispan.TransactionManagerProvider;
 import org.jboss.as.clustering.infinispan.TransactionSynchronizationRegistryProvider;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerAdd.java
@@ -30,7 +30,6 @@ import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -44,7 +43,6 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.ManagedReferenceFactory;
@@ -73,7 +71,7 @@ import org.jgroups.Channel;
  * @author Tristan Tarrant
  * @author Richard Achmatowicz
  */
-public class CacheContainerAdd extends AbstractAddStepHandler implements DescriptionProvider {
+public class CacheContainerAdd extends AbstractAddStepHandler {
 
     private static final Logger log = Logger.getLogger(CacheContainerAdd.class.getPackage().getName());
 
@@ -222,16 +220,6 @@ public class CacheContainerAdd extends AbstractAddStepHandler implements Descrip
 
         log.debugf("Cache container %s installed", name);
      }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.as.controller.descriptions.DescriptionProvider#getModelDescription(java.util.Locale)
-     */
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getCacheContainerAddDescription(locale);
-    }
 
     private void addExecutorDependency(ServiceBuilder<CacheContainer> builder, ModelNode model, String key, Injector<Executor> injector) {
         if (model.hasDefined(key)) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemove.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemove.java
@@ -21,26 +21,18 @@
  */
 
 package org.jboss.as.clustering.infinispan.subsystem;
-import java.util.Locale;
-
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 
 /**
  * @author Paul Ferraro
  */
-public class CacheContainerRemove extends AbstractRemoveStepHandler implements DescriptionProvider {
+public class CacheContainerRemove extends AbstractRemoveStepHandler {
 
     public static final CacheContainerRemove INSTANCE = new CacheContainerRemove();
-
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getCacheContainerRemoveDescription(locale);
-    }
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
         final PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemove.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemove.java
@@ -2,19 +2,16 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import java.util.Locale;
-
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 
 /**
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class CacheRemove extends AbstractRemoveStepHandler implements DescriptionProvider {
+public class CacheRemove extends AbstractRemoveStepHandler {
 
     private static final Logger log = Logger.getLogger(CacheRemove.class.getPackage().getName());
     static final CacheRemove INSTANCE = new CacheRemove();
@@ -37,9 +34,4 @@ public class CacheRemove extends AbstractRemoveStepHandler implements Descriptio
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {
         // TODO:  RE-ADD SERVICES
     }
-
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getCacheRemoveDescription(locale);
-    }
-
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheAdd.java
@@ -47,7 +47,7 @@ public abstract class ClusteredCacheAdd extends CacheAdd {
     /**
      * Create a Configuration object initialized from the data in the operation.
      *
-     * @param model data representing cache configuration
+     * @param cache data representing cache configuration
      * @param configuration Configuration to add the data to
      * @return initialised Configuration object
      */

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -9,6 +9,8 @@ import org.jboss.dmr.ModelType;
 /**
  * Attributes used in setting up Infinispan configurations
  *
+ * To mark an attribute as required, mark it as not allowing null.
+ *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
 public interface CommonAttributes {
@@ -28,8 +30,8 @@ public interface CommonAttributes {
     SimpleAttributeDefinition CONCURRENCY_LEVEL = new SimpleAttributeDefinition(ModelKeys.CONCURRENCY_LEVEL,
             new ModelNode().set(intDefault), ModelType.INT, true);
     SimpleAttributeDefinition DATA_SOURCE = new SimpleAttributeDefinition(ModelKeys.DATASOURCE, ModelType.STRING, true);
-    SimpleAttributeDefinition DEFAULT_CACHE = new SimpleAttributeDefinition(ModelKeys.DEFAULT_CACHE, ModelType.STRING, true);
-    SimpleAttributeDefinition DEFAULT_CACHE_CONTAINER = new SimpleAttributeDefinition(ModelKeys.DEFAULT_CACHE_CONTAINER, ModelType.STRING, true);
+    SimpleAttributeDefinition DEFAULT_CACHE = new SimpleAttributeDefinition(ModelKeys.DEFAULT_CACHE, ModelType.STRING, false);
+    SimpleAttributeDefinition DEFAULT_CACHE_CONTAINER = new SimpleAttributeDefinition(ModelKeys.DEFAULT_CACHE_CONTAINER, ModelType.STRING, false);
     SimpleAttributeDefinition EAGER_LOCKING = new SimpleAttributeDefinition(ModelKeys.EAGER_LOCKING,
             new ModelNode().set(booleanDefault), ModelType.BOOLEAN,  true);
     // enabled (used in state transfer, rehashing)
@@ -91,7 +93,7 @@ public interface CommonAttributes {
     SimpleAttributeDefinition SITE = new SimpleAttributeDefinition(ModelKeys.SITE, ModelType.STRING, true);
     SimpleAttributeDefinition SOCKET_TIMEOUT = new SimpleAttributeDefinition(ModelKeys.SOCKET_TIMEOUT,
             new ModelNode().set(longDefault), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
-    SimpleAttributeDefinition STACK = new SimpleAttributeDefinition(ModelKeys.STACK, ModelType.STRING, true);
+    SimpleAttributeDefinition STACK = new SimpleAttributeDefinition(ModelKeys.STACK, ModelType.STRING, false);
     SimpleAttributeDefinition START = new SimpleAttributeDefinition(ModelKeys.START, ModelType.STRING, true);
     SimpleAttributeDefinition STOP_TIMEOUT = new SimpleAttributeDefinition(ModelKeys.STOP_TIMEOUT,
             new ModelNode().set(longDefault), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
@@ -104,24 +106,29 @@ public interface CommonAttributes {
     SimpleAttributeDefinition TIMEOUT = new SimpleAttributeDefinition(ModelKeys.TIMEOUT,
             new ModelNode().set(longDefault), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
     SimpleAttributeDefinition TYPE = new SimpleAttributeDefinition(ModelKeys.TYPE, ModelType.STRING, true);
+    SimpleAttributeDefinition VALUE = new SimpleAttributeDefinition("value", ModelType.STRING, false);
     SimpleAttributeDefinition VIRTUAL_NODES = new SimpleAttributeDefinition(ModelKeys.VIRTUAL_NODES,
             new ModelNode().set(intDefault), ModelType.INT, true);
+    SimpleAttributeDefinition WAIT = new SimpleAttributeDefinition(ModelKeys.WAIT,
+            new ModelNode().set(longDefault), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
 
     AttributeDefinition[] CACHE_CONTAINER_ATTRIBUTES = { DEFAULT_CACHE, JNDI_NAME, LISTENER_EXECUTOR, EVICTION_EXECUTOR, REPLICATION_QUEUE_EXECUTOR, ALIAS };
     AttributeDefinition[] TRANSPORT_ATTRIBUTES = { STACK, EXECUTOR, LOCK_TIMEOUT, SITE, RACK, MACHINE  };
 
-    AttributeDefinition[] CACHE_ATTRIBUTES = { STACK, EXECUTOR, LOCK_TIMEOUT, SITE, RACK, MACHINE  };
+    AttributeDefinition[] CACHE_ATTRIBUTES = { /* NAME, */ START, BATCHING, INDEXING };
+    AttributeDefinition[] CLUSTERED_CACHE_ATTRIBUTES = { MODE,  QUEUE_SIZE, QUEUE_FLUSH_INTERVAL, REMOTE_TIMEOUT };
+    AttributeDefinition[] DISTRIBUTED_CACHE_ATTRIBUTES = { OWNERS, VIRTUAL_NODES, L1_LIFESPAN };
+
     AttributeDefinition[] LOCKING_ATTRIBUTES = { ISOLATION, STRIPING, ACQUIRE_TIMEOUT, CONCURRENCY_LEVEL  };
     AttributeDefinition[] TRANSACTION_ATTRIBUTES = { MODE, STOP_TIMEOUT, EAGER_LOCKING  };
     AttributeDefinition[] EVICTION_ATTRIBUTES = { STRATEGY, MAX_ENTRIES };
     AttributeDefinition[] EXPIRATION_ATTRIBUTES = { MAX_IDLE, LIFESPAN, INTERVAL };
-
     AttributeDefinition[] STORE_ATTRIBUTES = { SHARED, PRELOAD, PASSIVATION, FETCH_STATE, PURGE, SINGLETON /* PROPERTY */};
     AttributeDefinition[] FILESTORE_ATTRIBUTES = { RELATIVE_TO, PATH };
     AttributeDefinition[] JDBC_STORE_ATTRIBUTES = { DATA_SOURCE };
     AttributeDefinition[] REMOTE_ATTRIBUTES = { /* REMOTE_SERVER */ };
 
     AttributeDefinition[] STATE_TRANSFER_ATTRIBUTES = { ENABLED, TIMEOUT, FLUSH_TIMEOUT };
-    AttributeDefinition[] REHASHING_ATTRIBUTES = { ENABLED, TIMEOUT };
+    AttributeDefinition[] REHASHING_ATTRIBUTES = { ENABLED, TIMEOUT, WAIT };
 
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
@@ -3,19 +3,17 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
 import java.util.List;
-import java.util.Locale;
 
 import org.infinispan.config.Configuration;
 import org.infinispan.config.Configuration.CacheMode;
 import org.infinispan.config.FluentConfiguration;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
 /**
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class DistributedCacheAdd extends ClusteredCacheAdd implements DescriptionProvider {
+public class DistributedCacheAdd extends ClusteredCacheAdd {
 
     static final DistributedCacheAdd INSTANCE = new DistributedCacheAdd();
 
@@ -43,10 +41,6 @@ public class DistributedCacheAdd extends ClusteredCacheAdd implements Descriptio
         }
         if (fromModel.hasDefined(ModelKeys.L1_LIFESPAN)) {
             toModel.get(ModelKeys.L1_LIFESPAN).set(fromModel.get(ModelKeys.L1_LIFESPAN));
-        }
-        // child node
-        if (fromModel.hasDefined(ModelKeys.REHASHING)) {
-            toModel.get(ModelKeys.REHASHING).set(fromModel.get(ModelKeys.REHASHING));
         }
     }
 
@@ -79,9 +73,11 @@ public class DistributedCacheAdd extends ClusteredCacheAdd implements Descriptio
                 fluent.l1().disable();
             }
         }
-        // process child node
-        if (cache.hasDefined(ModelKeys.REHASHING)) {
-            ModelNode rehashing = cache.get(ModelKeys.REHASHING);
+
+        // rehashing is a child resource
+        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.REHASHING).isDefined()) {
+            ModelNode rehashing = cache.get(ModelKeys.SINGLETON, ModelKeys.REHASHING);
+
             FluentConfiguration.HashConfig fluentHash = fluent.hash();
             if (rehashing.hasDefined(ModelKeys.ENABLED)) {
                 fluentHash.rehashEnabled(rehashing.get(ModelKeys.ENABLED).asBoolean());
@@ -93,10 +89,5 @@ public class DistributedCacheAdd extends ClusteredCacheAdd implements Descriptio
                 fluentHash.rehashWait(rehashing.get(ModelKeys.WAIT).asLong());
             }
         }
-    }
-
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getDistributedCacheAddDescription(locale);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemAdd.java
@@ -22,13 +22,14 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import static org.jboss.as.clustering.infinispan.InfinispanLogger.ROOT_LOGGER;
+
 import java.util.List;
-import java.util.Locale;
+
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
@@ -38,12 +39,10 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.InjectedValue;
 
-import static org.jboss.as.clustering.infinispan.InfinispanLogger.ROOT_LOGGER;
-
 /**
  * @author Paul Ferraro
  */
-public class InfinispanSubsystemAdd extends AbstractAddStepHandler implements DescriptionProvider {
+public class InfinispanSubsystemAdd extends AbstractAddStepHandler {
 
     private static final Logger log = Logger.getLogger(InfinispanSubsystemAdd.class.getPackage().getName());
 
@@ -58,16 +57,6 @@ public class InfinispanSubsystemAdd extends AbstractAddStepHandler implements De
     private static void populate(ModelNode source, ModelNode target) {
         target.get(ModelKeys.DEFAULT_CACHE_CONTAINER).set(source.require(ModelKeys.DEFAULT_CACHE_CONTAINER));
         target.get(ModelKeys.CACHE_CONTAINER).setEmptyObject();
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.as.controller.descriptions.DescriptionProvider#getModelDescription(java.util.Locale)
-     */
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getSubsystemAddDescription(locale);
     }
 
     protected void populateModel(ModelNode operation, ModelNode model) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
@@ -22,12 +22,10 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import java.util.Locale;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
@@ -37,20 +35,11 @@ import org.jboss.dmr.Property;
  * Returns a ModelNode LIST of operations which can re-create the subsystem.
  *
  * @author Paul Ferraro
+ * @author Richard Achmatowicz
  */
-public class InfinispanSubsystemDescribe implements OperationStepHandler, DescriptionProvider {
+public class InfinispanSubsystemDescribe implements OperationStepHandler {
 
     public static final InfinispanSubsystemDescribe INSTANCE = new InfinispanSubsystemDescribe();
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.as.controller.descriptions.DescriptionProvider#getModelDescription(java.util.Locale)
-     */
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getSubsystemDescribeDescription(locale);
-    }
 
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         ModelNode result = context.getResult();
@@ -65,47 +54,49 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler, Descri
         if (subModel.hasDefined(ModelKeys.CACHE_CONTAINER)) {
             // list of (cacheContainerName, containerModel)
             for (Property container : subModel.get(ModelKeys.CACHE_CONTAINER).asPropertyList()) {
-                ModelNode address = rootAddress.toModelNode();
-                address.add(ModelKeys.CACHE_CONTAINER, container.getName());
-                result.add(CacheContainerAdd.createOperation(address, container.getValue()));
+                ModelNode containerAddress = rootAddress.toModelNode();
+                containerAddress.add(ModelKeys.CACHE_CONTAINER, container.getName());
+                result.add(CacheContainerAdd.createOperation(containerAddress, container.getValue()));
 
-                // add operation to create the transport for the container
-                if (container.getValue().hasDefined(ModelKeys.SINGLETON)) {
-                    ModelNode transport = container.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
-                    ModelNode transportAddress = address.clone() ;
-                    transportAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSPORT) ;
-                    result.add(TransportAdd.createOperation(transportAddress, transport));
-                }
+                addCacheContainerConfigCommands(container, containerAddress, result);
 
                 // list of (cacheType, OBJECT)
                 for (Property cacheTypeList : container.getValue().asPropertyList()) {
                     // add commands for local caches
                     if (cacheTypeList.getName().equals(ModelKeys.LOCAL_CACHE)) {
                         for (Property cache : cacheTypeList.getValue().asPropertyList()) {
-                            ModelNode cacheAddress = address.clone() ;
+                            ModelNode cacheAddress = containerAddress.clone() ;
                             cacheAddress.add(ModelKeys.LOCAL_CACHE, cache.getName()) ;
                             result.add(LocalCacheAdd.createOperation(cacheAddress, cache.getValue()));
+
+                            addCacheConfigCommands(cache, cacheAddress, result);
                         }
                     // add commands for invalidation caches
                     } else if (cacheTypeList.getName().equals(ModelKeys.INVALIDATION_CACHE)) {
                         for (Property cache : cacheTypeList.getValue().asPropertyList()) {
-                            ModelNode cacheAddress = address.clone() ;
+                            ModelNode cacheAddress = containerAddress.clone() ;
                             cacheAddress.add(ModelKeys.INVALIDATION_CACHE, cache.getName()) ;
                             result.add(InvalidationCacheAdd.createOperation(cacheAddress, cache.getValue()));
+
+                            addCacheConfigCommands(cache, cacheAddress, result);
                         }
                     // add commands for distributed caches
                     } else if (cacheTypeList.getName().equals(ModelKeys.REPLICATED_CACHE)) {
                         for (Property cache : cacheTypeList.getValue().asPropertyList()) {
-                            ModelNode cacheAddress = address.clone() ;
+                            ModelNode cacheAddress = containerAddress.clone() ;
                             cacheAddress.add(ModelKeys.REPLICATED_CACHE, cache.getName()) ;
                             result.add(ReplicatedCacheAdd.createOperation(cacheAddress, cache.getValue()));
+
+                            addCacheConfigCommands(cache, cacheAddress, result);
                         }
                     // add commands for distributed caches
                     } else if (cacheTypeList.getName().equals(ModelKeys.DISTRIBUTED_CACHE)) {
                         for (Property cache : cacheTypeList.getValue().asPropertyList()) {
-                            ModelNode cacheAddress = address.clone() ;
+                            ModelNode cacheAddress = containerAddress.clone() ;
                             cacheAddress.add(ModelKeys.DISTRIBUTED_CACHE, cache.getName()) ;
                             result.add(DistributedCacheAdd.createOperation(cacheAddress, cache.getValue()));
+
+                            addCacheConfigCommands(cache, cacheAddress, result);
                         }
                     }
                 }
@@ -113,5 +104,83 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler, Descri
         }
 
         context.completeStep();
+    }
+
+    /**
+     * Creates commands to recreate existing cache container configuration elements
+     *
+     * @param container  the cache container Property containing the configuration elements
+     * @param address the cache container address
+     * @param result  the list of operations
+     * @throws OperationFailedException
+     */
+    private void addCacheContainerConfigCommands(Property container, ModelNode address, ModelNode result) throws OperationFailedException {
+
+        // add operation to create the transport for the container
+        if (container.getValue().hasDefined(ModelKeys.SINGLETON)) {
+            // command to recreate the transport configuration
+            if (container.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT).isDefined()) {
+                ModelNode transport = container.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+                ModelNode transportAddress = address.clone() ;
+                transportAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSPORT) ;
+                result.add(TransportAdd.createOperation(transportAddress, transport));
+            }
+        }
+    }
+
+    /**
+     * Creates commands to recreate existing cache configuration elements
+     *
+     * @param cache  the cache Property containing the configuration elements
+     * @param address the cache address
+     * @param result  the list of operations
+     * @throws OperationFailedException
+     */
+    private void addCacheConfigCommands(Property cache, ModelNode address, ModelNode result) throws OperationFailedException {
+
+        if (cache.getValue().hasDefined(ModelKeys.SINGLETON)) {
+            // command to recreate the locking configuration
+            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.LOCKING).isDefined()) {
+                ModelNode locking = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.LOCKING);
+                ModelNode lockingAddress = address.clone();
+                lockingAddress.add(ModelKeys.SINGLETON, ModelKeys.LOCKING);
+                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.LOCKING_ATTRIBUTES, lockingAddress, locking));
+            }
+            // command to recreate the transaction configuration
+            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION).isDefined()) {
+                ModelNode transaction = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
+                ModelNode transactionAddress = address.clone();
+                transactionAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
+                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.TRANSACTION_ATTRIBUTES, transactionAddress, transaction));
+            }
+            // command to recreate the eviction configuration
+            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EVICTION).isDefined()) {
+                ModelNode eviction = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EVICTION);
+                ModelNode evictionAddress = address.clone();
+                evictionAddress.add(ModelKeys.SINGLETON, ModelKeys.EVICTION);
+                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EVICTION_ATTRIBUTES, evictionAddress, eviction));
+            }
+            // command to recreate the expiration configuration
+            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION).isDefined()) {
+                ModelNode expiration = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
+                ModelNode expirationAddress = address.clone();
+                expirationAddress.add(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
+                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EXPIRATION_ATTRIBUTES, expirationAddress, expiration));
+            }
+            // command to recreate the state transfer configuration
+            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
+                ModelNode stateTransfer = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+                ModelNode stateTransferAddress = address.clone();
+                stateTransferAddress.add(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.STATE_TRANSFER_ATTRIBUTES, stateTransferAddress, stateTransfer));
+            }
+            // command to recreate the rehashing configuration
+            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.REHASHING).isDefined()) {
+                ModelNode rehashing = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.REHASHING);
+                ModelNode rehashingAddress = address.clone();
+                rehashingAddress.add(ModelKeys.SINGLETON, ModelKeys.REHASHING);
+                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.REHASHING_ATTRIBUTES, rehashingAddress, rehashing));
+            }
+        }
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemParser_1_0.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemParser_1_0.java
@@ -294,6 +294,7 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         // set the cache mode to local
         // cache.get(ModelKeys.MODE).set(Configuration.CacheMode.LOCAL.name());
@@ -308,28 +309,27 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             throw ParseUtils.missingRequired(reader, EnumSet.of(Attribute.NAME));
         }
 
+        // update the cache address with the cache name
+        addCacheNameToAddress(cache, containerAddress, ModelKeys.LOCAL_CACHE) ;
+
         while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
             Element element = Element.forName(reader.getLocalName());
-            this.parseCacheElement(reader, element, cache);
+            this.parseCacheElement(reader, element, cache, additionalConfigurationOperations);
         }
 
-        String name = cache.get(ModelKeys.NAME).asString();
-        // setup the cache address
-        ModelNode cacheAddress = containerAddress.clone() ;
-        cacheAddress.add(ModelKeys.LOCAL_CACHE, name);
-        cacheAddress.protect() ;
-        cache.get(ModelDescriptionConstants.OP_ADDR).set(cacheAddress);
-
-        // get rid of NAME now that we are finished with it
-        cache.remove(ModelKeys.NAME);
-
         operations.add(cache);
+        // add operations to create configuration resources
+        for (ModelNode additionalOperation : additionalConfigurationOperations) {
+            operations.add(additionalOperation);
+        }
+
     }
 
     private void parseDistributedCache(XMLExtendedStreamReader reader, ModelNode containerAddress, List<ModelNode> operations) throws XMLStreamException {
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -360,36 +360,34 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             throw ParseUtils.missingRequired(reader, EnumSet.of(Attribute.MODE));
         }
 
+        // update the cache address with the cache name
+        addCacheNameToAddress(cache, containerAddress, ModelKeys.DISTRIBUTED_CACHE) ;
+
         while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
             Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case REHASHING: {
-                    this.parseRehashing(reader, cache.get(ModelKeys.REHASHING).setEmptyObject());
+                    this.parseRehashing(reader, cache, additionalConfigurationOperations);
                     break;
                 }
                 default: {
-                    this.parseCacheElement(reader, element, cache);
+                    this.parseCacheElement(reader, element, cache, additionalConfigurationOperations);
                 }
             }
         }
 
-        String name = cache.get(ModelKeys.NAME).asString();
-        // setup the cache address
-        ModelNode cacheAddress = containerAddress.clone() ;
-        cacheAddress.add(ModelKeys.DISTRIBUTED_CACHE, name);
-        cacheAddress.protect() ;
-        cache.get(ModelDescriptionConstants.OP_ADDR).set(cacheAddress);
-
-        // get rid of NAME now that we are finished with it
-        cache.remove(ModelKeys.NAME);
-
         operations.add(cache);
+        // add operations to create configuration resources
+        for (ModelNode additionalOperation : additionalConfigurationOperations) {
+            operations.add(additionalOperation);
+        }
     }
 
     private void parseReplicatedCache(XMLExtendedStreamReader reader, ModelNode containerAddress, List<ModelNode> operations) throws XMLStreamException {
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -404,35 +402,34 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             throw ParseUtils.missingRequired(reader, EnumSet.of(Attribute.MODE));
         }
 
+        // update the cache address with the cache name
+        addCacheNameToAddress(cache, containerAddress, ModelKeys.REPLICATED_CACHE) ;
+
         while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
             Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case STATE_TRANSFER: {
-                    this.parseStateTransfer(reader, cache.get(ModelKeys.STATE_TRANSFER).setEmptyObject());
+                    this.parseStateTransfer(reader, cache, additionalConfigurationOperations);
                     break;
                 }
                 default: {
-                    this.parseCacheElement(reader, element, cache);
+                    this.parseCacheElement(reader, element, cache, additionalConfigurationOperations);
                 }
             }
         }
-        String name = cache.get(ModelKeys.NAME).asString();
-        // setup the cache address
-        ModelNode cacheAddress = containerAddress.clone() ;
-        cacheAddress.add(ModelKeys.REPLICATED_CACHE, name);
-        cacheAddress.protect() ;
-        cache.get(ModelDescriptionConstants.OP_ADDR).set(cacheAddress);
-
-        // get rid of NAME now that we are finished with it
-        cache.remove(ModelKeys.NAME);
 
         operations.add(cache);
+        // add operations to create configuration resources
+        for (ModelNode additionalOperation : additionalConfigurationOperations) {
+            operations.add(additionalOperation);
+        }
     }
 
     private void parseInvalidationCache(XMLExtendedStreamReader reader, ModelNode containerAddress, List<ModelNode> operations) throws XMLStreamException {
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -447,47 +444,59 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             throw ParseUtils.missingRequired(reader, EnumSet.of(Attribute.MODE));
         }
 
+        // update the cache address with the cache name
+        addCacheNameToAddress(cache, containerAddress, ModelKeys.INVALIDATION_CACHE) ;
+
         while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
             Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case STATE_TRANSFER: {
-                    this.parseStateTransfer(reader, cache.get(ModelKeys.STATE_TRANSFER).setEmptyObject());
+                    this.parseStateTransfer(reader, cache, additionalConfigurationOperations);
                     break;
                 }
                 default: {
-                    this.parseCacheElement(reader, element, cache);
+                    this.parseCacheElement(reader, element, cache, additionalConfigurationOperations);
                 }
             }
         }
+
+        operations.add(cache);
+        // add operations to create configuration resources
+        for (ModelNode additionalOperation : additionalConfigurationOperations) {
+            operations.add(additionalOperation);
+        }
+    }
+
+    private void addCacheNameToAddress(ModelNode cache, ModelNode containerAddress, String cacheType) {
+
         String name = cache.get(ModelKeys.NAME).asString();
         // setup the cache address
         ModelNode cacheAddress = containerAddress.clone() ;
-        cacheAddress.add(ModelKeys.INVALIDATION_CACHE, name);
+        cacheAddress.add(cacheType, name);
         cacheAddress.protect() ;
         cache.get(ModelDescriptionConstants.OP_ADDR).set(cacheAddress);
 
         // get rid of NAME now that we are finished with it
         cache.remove(ModelKeys.NAME);
-
-        operations.add(cache);
     }
 
-    private void parseCacheElement(XMLExtendedStreamReader reader, Element element, ModelNode cache) throws XMLStreamException {
+
+    private void parseCacheElement(XMLExtendedStreamReader reader, Element element, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
         switch (element) {
             case LOCKING: {
-                this.parseLocking(reader, cache.get(ModelKeys.LOCKING).setEmptyObject());
+                this.parseLocking(reader, cache, operations);
                 break;
             }
             case TRANSACTION: {
-                this.parseTransaction(reader, cache.get(ModelKeys.TRANSACTION).setEmptyObject());
+                this.parseTransaction(reader, cache, operations);
                 break;
             }
             case EVICTION: {
-                this.parseEviction(reader, cache.get(ModelKeys.EVICTION).setEmptyObject());
+                this.parseEviction(reader, cache, operations);
                 break;
             }
             case EXPIRATION: {
-                this.parseExpiration(reader, cache.get(ModelKeys.EXPIRATION).setEmptyObject());
+                this.parseExpiration(reader, cache, operations);
                 break;
             }
             case STORE: {
@@ -512,7 +521,14 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
         }
     }
 
-    private void parseRehashing(XMLExtendedStreamReader reader, ModelNode rehashing) throws XMLStreamException {
+    private void parseRehashing(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
+
+        // ModelNode for the rehashing add operation
+        ModelNode rehashingAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        rehashingAddress.add(ModelKeys.SINGLETON,ModelKeys.REHASHING) ;
+        rehashingAddress.protect();
+        ModelNode rehashing = Util.getEmptyOperation(ModelDescriptionConstants.ADD, rehashingAddress);
+
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
@@ -535,9 +551,16 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             }
         }
         ParseUtils.requireNoContent(reader);
+        operations.add(rehashing);
     }
 
-    private void parseStateTransfer(XMLExtendedStreamReader reader, ModelNode stateTransfer) throws XMLStreamException {
+    private void parseStateTransfer(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
+        // ModelNode for the state transfer add operation
+        ModelNode stateTransferAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        stateTransferAddress.add(ModelKeys.SINGLETON,ModelKeys.STATE_TRANSFER) ;
+        stateTransferAddress.protect();
+        ModelNode stateTransfer = Util.getEmptyOperation(ModelDescriptionConstants.ADD, stateTransferAddress);
+
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
@@ -560,9 +583,17 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             }
         }
         ParseUtils.requireNoContent(reader);
+        operations.add(stateTransfer);
     }
 
-    private void parseLocking(XMLExtendedStreamReader reader, ModelNode locking) throws XMLStreamException {
+    private void parseLocking(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
+
+        // ModelNode for the cache add operation
+        ModelNode lockingAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        lockingAddress.add(ModelKeys.SINGLETON,ModelKeys.LOCKING) ;
+        lockingAddress.protect();
+        ModelNode locking = Util.getEmptyOperation(ModelDescriptionConstants.ADD, lockingAddress);
+
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
@@ -594,9 +625,17 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             }
         }
         ParseUtils.requireNoContent(reader);
+        operations.add(locking);
     }
 
-    private void parseTransaction(XMLExtendedStreamReader reader, ModelNode transaction) throws XMLStreamException {
+    private void parseTransaction(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
+
+        // ModelNode for the transaction add operation
+        ModelNode transactionAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        transactionAddress.add(ModelKeys.SINGLETON,ModelKeys.TRANSACTION) ;
+        transactionAddress.protect();
+        ModelNode transaction = Util.getEmptyOperation(ModelDescriptionConstants.ADD, transactionAddress);
+
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
@@ -631,9 +670,16 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             }
         }
         ParseUtils.requireNoContent(reader);
+        operations.add(transaction);
     }
 
-    private void parseEviction(XMLExtendedStreamReader reader, ModelNode eviction) throws XMLStreamException {
+    private void parseEviction(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
+        // ModelNode for the eviction add operation
+        ModelNode evictionAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        evictionAddress.add(ModelKeys.SINGLETON,ModelKeys.EVICTION) ;
+        evictionAddress.protect();
+        ModelNode eviction = Util.getEmptyOperation(ModelDescriptionConstants.ADD, evictionAddress);
+
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
@@ -661,9 +707,17 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             }
         }
         ParseUtils.requireNoContent(reader);
+        operations.add(eviction);
     }
 
-    private void parseExpiration(XMLExtendedStreamReader reader, ModelNode expiration) throws XMLStreamException {
+    private void parseExpiration(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
+
+        // ModelNode for the expiration add operation
+        ModelNode expirationAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        expirationAddress.add(ModelKeys.SINGLETON,ModelKeys.EXPIRATION) ;
+        expirationAddress.protect();
+        ModelNode expiration = Util.getEmptyOperation(ModelDescriptionConstants.ADD, expirationAddress);
+
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
@@ -686,6 +740,7 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
             }
         }
         ParseUtils.requireNoContent(reader);
+        operations.add(expiration);
     }
 
     private void parseCustomStore(XMLExtendedStreamReader reader, ModelNode store) throws XMLStreamException {
@@ -1046,40 +1101,64 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
                     this.writeOptional(writer, Attribute.START, cache, ModelKeys.START);
                     this.writeOptional(writer, Attribute.BATCHING, cache, ModelKeys.BATCHING);
                     this.writeOptional(writer, Attribute.INDEXING, cache, ModelKeys.INDEXING);
-                    if (cache.hasDefined(ModelKeys.LOCKING)) {
-                        writer.writeStartElement(Element.LOCKING.getLocalName());
-                        ModelNode locking = cache.get(ModelKeys.LOCKING);
-                        this.writeOptional(writer, Attribute.ISOLATION, locking, ModelKeys.ISOLATION);
-                        this.writeOptional(writer, Attribute.STRIPING, locking, ModelKeys.STRIPING);
-                        this.writeOptional(writer, Attribute.ACQUIRE_TIMEOUT, locking, ModelKeys.ACQUIRE_TIMEOUT);
-                        this.writeOptional(writer, Attribute.CONCURRENCY_LEVEL, locking, ModelKeys.CONCURRENCY_LEVEL);
-                        writer.writeEndElement();
-                    }
 
-                    if (cache.hasDefined(ModelKeys.TRANSACTION)) {
-                        writer.writeStartElement(Element.TRANSACTION.getLocalName());
-                        ModelNode transaction = cache.get(ModelKeys.TRANSACTION);
-                        this.writeOptional(writer, Attribute.STOP_TIMEOUT, transaction, ModelKeys.STOP_TIMEOUT);
-                        this.writeOptional(writer, Attribute.MODE, transaction, ModelKeys.MODE);
-                        this.writeOptional(writer, Attribute.LOCKING, transaction, ModelKeys.LOCKING);
-                        writer.writeEndElement();
-                    }
 
-                    if (cache.hasDefined(ModelKeys.EVICTION)) {
-                        writer.writeStartElement(Element.EVICTION.getLocalName());
-                        ModelNode eviction = cache.get(ModelKeys.EVICTION);
-                        this.writeOptional(writer, Attribute.STRATEGY, eviction, ModelKeys.STRATEGY);
-                        this.writeOptional(writer, Attribute.MAX_ENTRIES, eviction, ModelKeys.MAX_ENTRIES);
-                        writer.writeEndElement();
-                    }
+                    // all child elements can be governed by this
+                    if (cache.hasDefined(ModelKeys.SINGLETON)) {
 
-                    if (cache.hasDefined(ModelKeys.EXPIRATION)) {
-                        writer.writeStartElement(Element.EXPIRATION.getLocalName());
-                        ModelNode expiration = cache.get(ModelKeys.EXPIRATION);
-                        this.writeOptional(writer, Attribute.MAX_IDLE, expiration, ModelKeys.MAX_IDLE);
-                        this.writeOptional(writer, Attribute.LIFESPAN, expiration, ModelKeys.LIFESPAN);
-                        this.writeOptional(writer, Attribute.INTERVAL, expiration, ModelKeys.INTERVAL);
-                        writer.writeEndElement();
+                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.LOCKING).isDefined()) {
+                            writer.writeStartElement(Element.LOCKING.getLocalName());
+                            ModelNode locking = cache.get(ModelKeys.SINGLETON, ModelKeys.LOCKING);
+                            this.writeOptional(writer, Attribute.ISOLATION, locking, ModelKeys.ISOLATION);
+                            this.writeOptional(writer, Attribute.STRIPING, locking, ModelKeys.STRIPING);
+                            this.writeOptional(writer, Attribute.ACQUIRE_TIMEOUT, locking, ModelKeys.ACQUIRE_TIMEOUT);
+                            this.writeOptional(writer, Attribute.CONCURRENCY_LEVEL, locking, ModelKeys.CONCURRENCY_LEVEL);
+                            writer.writeEndElement();
+                        }
+
+                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION).isDefined()) {
+                            writer.writeStartElement(Element.TRANSACTION.getLocalName());
+                            ModelNode transaction = cache.get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
+                            this.writeOptional(writer, Attribute.STOP_TIMEOUT, transaction, ModelKeys.STOP_TIMEOUT);
+                            this.writeOptional(writer, Attribute.MODE, transaction, ModelKeys.MODE);
+                            this.writeOptional(writer, Attribute.LOCKING, transaction, ModelKeys.LOCKING);
+                            writer.writeEndElement();
+                        }
+
+                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.EVICTION).isDefined()) {
+                            writer.writeStartElement(Element.EVICTION.getLocalName());
+                            ModelNode eviction = cache.get(ModelKeys.SINGLETON, ModelKeys.EVICTION);
+                            this.writeOptional(writer, Attribute.STRATEGY, eviction, ModelKeys.STRATEGY);
+                            this.writeOptional(writer, Attribute.MAX_ENTRIES, eviction, ModelKeys.MAX_ENTRIES);
+                            writer.writeEndElement();
+                        }
+
+                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION).isDefined()) {
+                            writer.writeStartElement(Element.EXPIRATION.getLocalName());
+                            ModelNode expiration = cache.get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
+                            this.writeOptional(writer, Attribute.MAX_IDLE, expiration, ModelKeys.MAX_IDLE);
+                            this.writeOptional(writer, Attribute.LIFESPAN, expiration, ModelKeys.LIFESPAN);
+                            this.writeOptional(writer, Attribute.INTERVAL, expiration, ModelKeys.INTERVAL);
+                            writer.writeEndElement();
+                        }
+
+                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
+                            ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+                            writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
+                            this.writeOptional(writer, Attribute.ENABLED, stateTransfer, ModelKeys.ENABLED);
+                            this.writeOptional(writer, Attribute.TIMEOUT, stateTransfer, ModelKeys.TIMEOUT);
+                            this.writeOptional(writer, Attribute.FLUSH_TIMEOUT, stateTransfer, ModelKeys.FLUSH_TIMEOUT);
+                            writer.writeEndElement();
+                        }
+
+                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.REHASHING).isDefined()) {
+                            ModelNode rehashing = cache.get(ModelKeys.SINGLETON, ModelKeys.REHASHING);
+                            writer.writeStartElement(Element.REHASHING.getLocalName());
+                            this.writeOptional(writer, Attribute.ENABLED, rehashing, ModelKeys.ENABLED);
+                            this.writeOptional(writer, Attribute.TIMEOUT, rehashing, ModelKeys.TIMEOUT);
+                            this.writeOptional(writer, Attribute.WAIT, rehashing, ModelKeys.WAIT);
+                            writer.writeEndElement();
+                        }
                     }
 
                     if (cache.hasDefined(ModelKeys.STORE)) {
@@ -1125,24 +1204,6 @@ public class InfinispanSubsystemParser_1_0 implements XMLElementReader<List<Mode
                             writer.writeEndElement();
                         }
                         this.writeStoreProperties(writer, store);
-                        writer.writeEndElement();
-                    }
-
-                    if (cache.hasDefined(ModelKeys.STATE_TRANSFER)) {
-                        ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER);
-                        writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
-                        this.writeOptional(writer, Attribute.ENABLED, stateTransfer, ModelKeys.ENABLED);
-                        this.writeOptional(writer, Attribute.TIMEOUT, stateTransfer, ModelKeys.TIMEOUT);
-                        this.writeOptional(writer, Attribute.FLUSH_TIMEOUT, stateTransfer, ModelKeys.FLUSH_TIMEOUT);
-                        writer.writeEndElement();
-                    }
-
-                    if (cache.hasDefined(ModelKeys.REHASHING)) {
-                        ModelNode rehashing = cache.get(ModelKeys.REHASHING);
-                        writer.writeStartElement(Element.REHASHING.getLocalName());
-                        this.writeOptional(writer, Attribute.ENABLED, rehashing, ModelKeys.ENABLED);
-                        this.writeOptional(writer, Attribute.TIMEOUT, rehashing, ModelKeys.TIMEOUT);
-                        this.writeOptional(writer, Attribute.WAIT, rehashing, ModelKeys.WAIT);
                         writer.writeEndElement();
                     }
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
@@ -1,0 +1,275 @@
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import java.util.Locale;
+
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ */
+public class InfinispanSubsystemProviders {
+
+    static final DescriptionProvider SUBSYSTEM = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getSubsystemDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider SUBSYSTEM_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getSubsystemAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider SUBSYSTEM_REMOVE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getSubsystemRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider SUBSYSTEM_DESCRIBE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getSubsystemDescribeDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider CACHE_CONTAINER = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheContainerDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider CACHE_CONTAINER_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheContainerAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider CACHE_CONTAINER_REMOVE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheContainerRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider REMOVE_ALIAS = new DescriptionProvider() {
+    public ModelNode getModelDescription(Locale locale) {
+        return InfinispanDescriptions.getRemoveAliasCommandDescription(locale);
+    }
+    };
+
+    static final DescriptionProvider ADD_ALIAS = new DescriptionProvider() {
+    public ModelNode getModelDescription(Locale locale) {
+        return InfinispanDescriptions.getAddAliasCommandDescription(locale);
+    }
+    };
+
+    static final DescriptionProvider LOCAL_CACHE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getLocalCacheDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider LOCAL_CACHE_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getLocalCacheAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider INVALIDATION_CACHE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getInvalidationCacheDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider INVALIDATION_CACHE_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getInvalidationCacheAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider REPLICATED_CACHE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getReplicatedCacheDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider REPLICATED_CACHE_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getReplicatedCacheAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider DISTRIBUTED_CACHE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getDistributedCacheDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider DISTRIBUTED_CACHE_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getDistributedCacheAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider CACHE_REMOVE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider TRANSPORT = new DescriptionProvider() {
+         public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getTransportDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider TRANSPORT_ADD = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getTransportAddDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider TRANSPORT_REMOVE = new DescriptionProvider() {
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getTransportRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider LOCKING = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getLockingDescription(locale);
+        }
+    };
+    static final DescriptionProvider LOCKING_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getLockingAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider LOCKING_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getLockingRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider TRANSACTION = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getTransactionDescription(locale);
+        }
+    };
+    static final DescriptionProvider TRANSACTION_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getTransactionAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider TRANSACTION_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getTransactionRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider EVICTION = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getEvictionDescription(locale);
+        }
+    };
+    static final DescriptionProvider EVICTION_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getEvictionAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider EVICTION_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getEvictionRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider EXPIRATION = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getExpirationDescription(locale);
+        }
+    };
+    static final DescriptionProvider EXPIRATION_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getExpirationAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider EXPIRATION_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getExpirationRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider STATE_TRANSFER = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getStateTransferDescription(locale);
+        }
+    };
+    static final DescriptionProvider STATE_TRANSFER_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getStateTransferAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider STATE_TRANSFER_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getStateTransferRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider REHASHING = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getRehashingDescription(locale);
+        }
+    };
+    static final DescriptionProvider REHASHING_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getRehashingAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider REHASHING_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getRehashingRemoveDescription(locale);
+        }
+    };
+
+
+
+    public static final DescriptionProvider STORE_PROPERTY = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheStorePropertyDescription(locale);
+        }
+    };
+    public static final DescriptionProvider STORE_PROPERTY_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheStorePropertyAddDescription(locale);
+        }
+    };
+    public static final DescriptionProvider STORE_PROPERTY_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheStorePropertyRemoveDescription(locale);
+        }
+    };
+
+
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheAdd.java
@@ -3,19 +3,17 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
 import java.util.List;
-import java.util.Locale;
 
 import org.infinispan.config.Configuration;
 import org.infinispan.config.Configuration.CacheMode;
 import org.infinispan.config.FluentConfiguration;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
 /**
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class InvalidationCacheAdd extends ClusteredCacheAdd implements DescriptionProvider {
+public class InvalidationCacheAdd extends ClusteredCacheAdd {
 
     static final InvalidationCacheAdd INSTANCE = new InvalidationCacheAdd();
 
@@ -35,9 +33,11 @@ public class InvalidationCacheAdd extends ClusteredCacheAdd implements Descripti
     void populate(ModelNode fromModel, ModelNode toModel) {
         super.populate(fromModel, toModel);
         // additional child node
+        /*
         if (fromModel.hasDefined(ModelKeys.STATE_TRANSFER)) {
             toModel.get(ModelKeys.STATE_TRANSFER).set(fromModel.get(ModelKeys.STATE_TRANSFER)) ;
         }
+        */
     }
 
     /**
@@ -55,8 +55,11 @@ public class InvalidationCacheAdd extends ClusteredCacheAdd implements Descripti
 
         // process the invalidation-cache attributes and elements
         FluentConfiguration fluent = configuration.fluent();
-        if (cache.hasDefined(ModelKeys.STATE_TRANSFER)) {
-            ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER) ;
+
+        // state transfer is a child resource
+        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
+            ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+
             FluentConfiguration.StateRetrievalConfig fluentStateTransfer = fluent.stateRetrieval();
             if (stateTransfer.hasDefined(ModelKeys.ENABLED)) {
                 fluentStateTransfer.fetchInMemoryState(stateTransfer.get(ModelKeys.ENABLED).asBoolean());
@@ -68,10 +71,5 @@ public class InvalidationCacheAdd extends ClusteredCacheAdd implements Descripti
                 fluentStateTransfer.logFlushTimeout(stateTransfer.get(ModelKeys.FLUSH_TIMEOUT).asLong());
             }
         }
-    }
-
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getInvalidationCacheAddDescription(locale);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheAdd.java
@@ -2,11 +2,8 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
-import java.util.Locale;
-
 import org.infinispan.config.Configuration.CacheMode;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
@@ -15,7 +12,7 @@ import org.jboss.dmr.ModelNode;
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class LocalCacheAdd extends CacheAdd implements DescriptionProvider {
+public class LocalCacheAdd extends CacheAdd {
 
     static final LocalCacheAdd INSTANCE = new LocalCacheAdd();
 
@@ -29,9 +26,5 @@ public class LocalCacheAdd extends CacheAdd implements DescriptionProvider {
     @Override
     void populateCacheMode(ModelNode fromModel, ModelNode toModel) throws OperationFailedException {
         toModel.get(ModelKeys.CACHE_MODE).set(CacheMode.LOCAL.name());
-    }
-
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getLocalCacheAddDescription(locale);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoveAliasCommand.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoveAliasCommand.java
@@ -21,7 +21,7 @@ import org.jboss.logging.Logger;
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class RemoveAliasCommand implements OperationStepHandler, DescriptionProvider {
+public class RemoveAliasCommand implements OperationStepHandler {
 
     private static final Logger log = Logger.getLogger(RemoveAliasCommand.class.getPackage().getName());
     public static final RemoveAliasCommand INSTANCE = new RemoveAliasCommand();
@@ -98,15 +98,4 @@ public class RemoveAliasCommand implements OperationStepHandler, DescriptionProv
         }
         return newList ;
     }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @see org.jboss.as.controller.descriptions.DescriptionProvider#getModelDescription(java.util.Locale)
-     */
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getRemoveAliasCommandDescription(locale);
-    }
-
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheAdd.java
@@ -3,19 +3,17 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
 import java.util.List;
-import java.util.Locale;
 
 import org.infinispan.config.Configuration;
 import org.infinispan.config.Configuration.CacheMode;
 import org.infinispan.config.FluentConfiguration;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
 /**
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class ReplicatedCacheAdd extends ClusteredCacheAdd implements DescriptionProvider {
+public class ReplicatedCacheAdd extends ClusteredCacheAdd {
 
     static final ReplicatedCacheAdd INSTANCE = new ReplicatedCacheAdd();
 
@@ -35,9 +33,11 @@ public class ReplicatedCacheAdd extends ClusteredCacheAdd implements Description
     void populate(ModelNode fromModel, ModelNode toModel) {
         super.populate(fromModel, toModel);
         // additional child node
+        /*
         if (fromModel.hasDefined(ModelKeys.STATE_TRANSFER)) {
             toModel.get(ModelKeys.STATE_TRANSFER).set(fromModel.get(ModelKeys.STATE_TRANSFER)) ;
         }
+        */
     }
 
     /**
@@ -55,8 +55,11 @@ public class ReplicatedCacheAdd extends ClusteredCacheAdd implements Description
 
         // process the replicated-cache attributes and elements
         FluentConfiguration fluent = configuration.fluent();
-        if (cache.hasDefined(ModelKeys.STATE_TRANSFER)) {
-            ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER) ;
+
+        // state transfer is a child resource
+        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
+            ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+
             FluentConfiguration.StateRetrievalConfig fluentStateTransfer = fluent.stateRetrieval();
             if (stateTransfer.hasDefined(ModelKeys.ENABLED)) {
                 fluentStateTransfer.fetchInMemoryState(stateTransfer.get(ModelKeys.ENABLED).asBoolean());
@@ -68,10 +71,5 @@ public class ReplicatedCacheAdd extends ClusteredCacheAdd implements Description
                 fluentStateTransfer.logFlushTimeout(stateTransfer.get(ModelKeys.FLUSH_TIMEOUT).asLong());
             }
         }
-    }
-
-    @Override
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getReplicatedCacheAddDescription(locale);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportAdd.java
@@ -4,14 +4,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 
 import java.util.List;
-import java.util.Locale;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
@@ -20,7 +18,7 @@ import org.jboss.msc.service.ServiceController;
 /**
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class TransportAdd extends AbstractAddStepHandler implements DescriptionProvider {
+public class TransportAdd extends AbstractAddStepHandler {
 
     private static final Logger log = Logger.getLogger(TransportAdd.class.getPackage().getName());
     public static final TransportAdd INSTANCE = new TransportAdd();
@@ -55,10 +53,6 @@ public class TransportAdd extends AbstractAddStepHandler implements DescriptionP
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         //
         context.reloadRequired();
-    }
-
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getTransportAddDescription(locale) ;
     }
 
     private static void populate(ModelNode operation, ModelNode model) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportRemove.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportRemove.java
@@ -1,18 +1,15 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import java.util.Locale;
-
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 
 /**
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class TransportRemove extends AbstractRemoveStepHandler implements DescriptionProvider {
+public class TransportRemove extends AbstractRemoveStepHandler {
 
     private static final Logger log = Logger.getLogger(TransportRemove.class.getPackage().getName());
     public static final TransportRemove INSTANCE = new TransportRemove();
@@ -25,9 +22,5 @@ public class TransportRemove extends AbstractRemoveStepHandler implements Descri
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         // need to set reload-required on the server
         context.reloadRequired();
-    }
-
-    public ModelNode getModelDescription(Locale locale) {
-        return InfinispanDescriptions.getTransportRemoveDescription(locale) ;
     }
 }

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -26,6 +26,7 @@ infinispan.container.transport.rack=A rack identifier for the transport
 infinispan.container.transport.site=A site identifier for the transport
 infinispan.container.transport.stack=The jgroups stack to use for the transport
 infinispan.container.cache=The list of caches available to this cache container
+infinispan.container.singleton=A set of single-instance configuration elements of the cache container.
 #
 infinispan.container.local-cache=A local cache
 infinispan.container.local-cache.add=Add a local cache to this cache container
@@ -41,26 +42,36 @@ infinispan.cache.mode=The cache mode. Internal use only.
 infinispan.cache.start=The cache start mode, which can be EAGER (immediate start) or LAZY (on-demand start).
 infinispan.cache.batching=If enabled, the invocation batching API will be made available for this cache.
 infinispan.cache.indexing=If enabled, entries will be indexed when they are added to the cache. Indexes will be updated as entries change or are removed.
+
+infinispan.cache.singleton=A set of single-instance configuration elements of the cache (locking, transaction, eviction, expiration, store, file-store, jdbc-store, remote-store).
 #
 infinispan.cache.locking=The locking configuration of the cache.
 infinispan.cache.locking.isolation=Sets the cache locking isolation level.
 infinispan.cache.locking.striping=If true, a pool of shared locks is maintained for all entries that need to be locked. Otherwise, a lock is created per entry in the cache. Lock striping helps control memory footprint but may reduce concurrency in the system.
 infinispan.cache.locking.acquire-timeout=Maximum time to attempt a particular lock acquisition.
 infinispan.cache.locking.concurrency-level=Concurrency level for lock containers. Adjust this value according to the number of concurrent threads interacting with Infinispan.
+infinispan.cache.locking.add=Adds a locking configuration element to the cache.
+infinispan.cache.locking.remove=Removes a locking configuration element from the cache.
 #
 infinispan.cache.transaction=The cache transaction configuration.
 infinispan.cache.transaction.mode=Sets the cache transaction mode to one of NONE, NON_XA, NON_DURABLE_XA, FULL_XA.
 infinispan.cache.transaction.stop-timeout=If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing remote and local transactions to finish. The amount of time to wait for is defined by the cache stop timeout.
 infinispan.cache.transaction.eager-locking=Only has effect for DIST mode and when useEagerLocking is set to true. When this is enabled, then only one node is locked in the cluster, disregarding numOwners config.
+infinispan.cache.transaction.add=Adds a transaction configuration element to the cache.
+infinispan.cache.transaction.remove=Removes a transcation configuration element from the cache.
 #
 infinispan.cache.eviction=The cache eviction configuration.
 infinispan.cache.eviction.strategy=Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).
 infinispan.cache.eviction.max-entries=Maximum number of entries in a cache instance. If selected value is not a power of two the actual value will default to the least power of two larger than selected value. -1 means no limit.
+infinispan.cache.eviction.add=Adds an eviction configuration element to the cache.
+infinispan.cache.eviction.remove=Removes an eviction configuration element from the cache.
 #
 infinispan.cache.expiration=The cache expiration configuration.
 infinispan.cache.expiration.max-idle=Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.
 infinispan.cache.expiration.lifespan=Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.
 infinispan.cache.expiration.interval=Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set wakeupInterval to -1.
+infinispan.cache.expiration.add=Adds an expiration configuration element to the cache.
+infinispan.cache.expiration.remove=Removes an expiration configuration element from the cache.
 
 infinispan.cache.store=The cache store configuration.
 infinispan.cache.store.shared=This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.
@@ -69,7 +80,10 @@ infinispan.cache.store.passivation=If true, data is only written to the cache st
 infinispan.cache.store.fetch-state=If true, fetch persistent state when joining a cluster. If multiple cache stores are chained, only one of them can have this property enabled.
 infinispan.cache.store.purge=If true, purges this cache store when it starts up.
 infinispan.cache.store.singleton=If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store.
-infinispan.cache.store.property=Sets a cache store property.
+infinispan.cache.store.property=A cache store property with name and value.
+infinispan.cache.store.property.add=Adds a cache store property.
+infinispan.cache.store.property.remove=Removes a cache store property.
+infinispan.cache.store.property.value=The value of the cache store property.
 
 infinispan.cache.file-store=The cache file store configuration.
 infinispan.cache.file-store.relative-to=Description
@@ -85,6 +99,8 @@ infinispan.clustered-cache.queue-flush-interval=In ASYNC mode, this attribute co
 infinispan.clustered-cache.remote-timeout=In SYNC mode, the timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.
 
 infinispan.replicated-cache.state-transfer=The state transfer configuration for invalidation and replicated caches.
+infinispan.replicated-cache.state-transfer.add=Add a state transfer configuration.
+infinispan.replicated-cache.state-transfer.remove=Remove a state transfer configuration.
 infinispan.replicated-cache.state-transfer.enabled=If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.
 infinispan.replicated-cache.state-transfer.timeout=The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.
 infinispan.replicated-cache.state-transfer.flush-timeout=This is the maximum amount of time to run a cluster-wide flush, to allow for syncing of transaction logs.
@@ -94,8 +110,11 @@ infinispan.distributed-cache.owners=Number of cluster-wide replicas for each cac
 infinispan.distributed-cache.virtual-nodes=Controls the number of virtual nodes per "real" node. If numVirtualNodes is 1, then virtual nodes are disabled. The topology aware consistent hash must be used if you wish to take advantage of virtual nodes. A default of 1 is used.
 infinispan.distributed-cache.l1-lifespan=Maximum lifespan of an entry placed in the L1 cache. This element configures the L1 cache behavior in 'distributed' caches instances. In any other cache modes, this element is ignored.
 infinispan.distributed-cache.rehashing=The distributed cache rehashing configuration, only used with 'distributed' caches, and otherwise ignored.
+infinispan.distributed-cache.rehashing.add=Add a distributed cache rehashing configuration.
+infinispan.distributed-cache.rehashing.remove=Remove a distributed cache rehashing configuration.
 infinispan.distributed-cache.rehashing.enabled=If false, no rebalancing or rehashing will take place when a new node joins the cluster or a node leaves.
 infinispan.distributed-cache.rehashing.timeout=Sets the rehashing timeout.
+infinispan.distributed-cache.rehashing.wait=Sets the rehashing wait period.
 
 #infinispan.local-cache.add=Add a local cache to the Infinispan subsystem
 #infinispan.invalidation-cache.add=Add a invalidation cache to the Infinispan subsystem

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -62,16 +62,16 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest {
        // Parse the subsystem xml into operations
        List<ModelNode> operations = super.parse(getSubsystemXml());
 
-        /*
+       /*
        // print the operations
        System.out.println("List of operations");
        for (ModelNode op : operations) {
            System.out.println("operation = " + op.toString());
        }
        */
-
        // Check that we have the expected number of operations
-       Assert.assertEquals(9, operations.size());
+       // one for each resource instance
+       Assert.assertEquals(28, operations.size());
 
        // Check that each operation has the correct content
        ModelNode addSubsystem = operations.get(0);


### PR DESCRIPTION
This pull request does the following:
(i) makes cache configuration elements locking,transport,eviction,expiration,state transfer, rehashing addressable resources with read-attribute,write-attribute, add and remove operations
(ii) reorganizes DescriptionProviders into a single class
