### PR TITLE
AS7-3118 Fix exit code of "jboss-as-standlone.sh status" when proc not running

### DIFF
--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -144,9 +144,13 @@ status() {
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
       echo "$prog is running (pid $ppid)"
       return 0
+    else
+      echo "$prog dead but pid file exists"
+      return 1
     fi
   fi
   echo "$prog is not running"
+  return 3
 }
 
 case "$1" in


### PR DESCRIPTION
Now follows LSB behaviour.
