### PR TITLE
Support of -Djava.rmi.server.hostname system property (in a privileged block)

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/JMXConnectorService.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXConnectorService.java
@@ -195,6 +195,13 @@ public class JMXConnectorService implements Service<Void> {
     }
 
     private void setRmiServerProperty(final String address) {
+        // if the RMI server hostname is already set, don't change it
+        // So that AS 7 do support the -Djava.rmi.server.hostname system property
+        // Really useful behind a firewall, with NAT
+        if (System.getProperty(SERVER_HOSTNAME) != null) {
+            return ;
+        }
+
         SecurityManager sm = System.getSecurityManager();
         if(sm != null) {
             AccessController.doPrivileged(new PrivilegedAction<Void>() {

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXConnectorService.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXConnectorService.java
@@ -199,12 +199,20 @@ public class JMXConnectorService implements Service<Void> {
         if(sm != null) {
             AccessController.doPrivileged(new PrivilegedAction<Void>() {
                 public Void run() {
-                    System.setProperty(SERVER_HOSTNAME, address);
+                    // if the RMI server hostname is already set, don't change it
+                    // So that AS 7 do support the -Djava.rmi.server.hostname system property
+                    // Really useful behind a firewall, with NAT
+                    if (System.getProperty(SERVER_HOSTNAME) == null) {
+                        System.setProperty(SERVER_HOSTNAME, address);
+                    }
                     return null;
                 }
             });
         } else {
-            System.setProperty(SERVER_HOSTNAME, address);
+            // Same comment as above
+            if (System.getProperty(SERVER_HOSTNAME) == null) {
+                System.setProperty(SERVER_HOSTNAME, address);
+            }
         }
     }
 }


### PR DESCRIPTION
I check if the java.rmi.server.hostname system property is already set before changing it, in the org.jboss.as.jmx.JMXConnectorService class.
It helps running JBoss AS 7 behind a firewall or proxy and access to JMX with jconsole.
