### PR TITLE
Upgrade Infinispan from 5.1.0.CR1 to 5.1.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.2.7.Final</version.org.hornetq>
-        <version.org.infinispan>5.1.0.CR1</version.org.infinispan>
+        <version.org.infinispan>5.1.0.CR2</version.org.infinispan>
         <version.org.javassist>3.15.0-GA</version.org.javassist>
         <version.org.jdom>1.1.2</version.org.jdom>
         <version.org.jboss.arquillian.core>1.0.0.CR7</version.org.jboss.arquillian.core>
@@ -3199,6 +3199,14 @@
                     <exclusion>
                         <groupId>org.jboss</groupId>
                         <artifactId>jandex</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core-asl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>stax2-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
An upgrade of infinispan from 5.1.0.CR1 to 5.1.0.CR2.

All smoke+basic integration tests passed.
Failures of clustering web tests, but these also occur in master without the changes.

I'm putting the pull request up in the case that Paul and Jason agree that it should go in.
