### PR TITLE
Added processing of description in load-group in jbosscmp-jdbc.xml Processing

### DIFF
--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/JDBCMetaDataParser.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/JDBCMetaDataParser.java
@@ -1140,6 +1140,10 @@ public class JDBCMetaDataParser extends MetaDataElementParser {
                     fields.add(getElementText(reader));
                     break;
                 }
+                case DESCRIPTION: {
+                    getElementText(reader);
+                    break;
+                }                
                 default: {
                     throw unexpectedElement(reader);
                 }


### PR DESCRIPTION
Hello Collegues,

there seems to be a little discrepancy between the DTD and the Processing of jbosscmp-jdbc files in the following item:

In an EAR file i have a JAR with EJB2-Beans and a corresponding jbosscmp-jdbc.xml file (see attachment).
## The follwing part caused the deployment to fail:

```
 <entity>
      ...
     <load-groups>
           <load-group>
                 <description/>
                ...
      ...
  </entity>
```

---
## In this snippet, the line "<description/>" was not expected, although the DTD contains the following rule:
## <!ELEMENT load-group (description?, load-group-name, field-name+)>

(line 346)
## The respective error show is as follows:

10:29:33,597 ERROR [org.jboss.msc.service.fail](MSC service thread 1-1) MSC00001: Failed to start service jboss.deploym
ent.subunit."BasisWebServer7.ear"."BasisWebEJB.jar".POST_MODULE: org.jboss.msc.service.StartException in service jboss.d
eployment.subunit."BasisWebServer7.ear"."BasisWebEJB.jar".POST_MODULE: Failed to process phase POST_MODULE of subdeploym
ent "BasisWebEJB.jar" of deployment "BasisWebServer7.ear"
        at org.jboss.as.server.deployment.DeploymentUnitPhaseService.start(DeploymentUnitPhaseService.java:121) [jboss-a
s-server-7.1.0.CR1-SNAPSHOT.jar:]
        at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1824) [jboss-ms
c-1.0.1.GA.jar:]
        at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1759) [jboss-msc-1.0.1.G
A.jar:]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110) [:1.7.0_02]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603) [:1.7.0_02]
        at java.lang.Thread.run(Thread.java:722) [:1.7.0_02]
Caused by: org.jboss.as.server.deployment.DeploymentUnitProcessingException: Failed to parse jbosscmp-jdbc.xml: /C:/p/gi
t/blue61-jboss-as-58d59cd/build/target/jboss-as-7.1.0.CR1-SNAPSHOT/bin/content/BasisWebServer7.ear/BasisWebEJB.jar/META-
INF/jbosscmp-jdbc.xml
        at org.jboss.as.cmp.processors.CmpParsingProcessor.deploy(CmpParsingProcessor.java:90)
        at org.jboss.as.server.deployment.DeploymentUnitPhaseService.start(DeploymentUnitPhaseService.java:115) [jboss-a
s-server-7.1.0.CR1-SNAPSHOT.jar:]
        ... 5 more
Caused by: javax.xml.stream.XMLStreamException: ParseError at [row,col]:[271,22]
Message: Unexpected element 'description' encountered
        at org.jboss.metadata.parser.util.MetaDataElementParser.unexpectedElement(MetaDataElementParser.java:108)
        at org.jboss.as.cmp.jdbc.metadata.parser.JDBCMetaDataParser.parseLoadGroup(JDBCMetaDataParser.java:1144)
        at org.jboss.as.cmp.jdbc.metadata.parser.JDBCMetaDataParser.parseLoadGroups(JDBCMetaDataParser.java:1119)
        at org.jboss.as.cmp.jdbc.metadata.parser.JDBCMetaDataParser.parseEntity(JDBCMetaDataParser.java:796)
        at org.jboss.as.cmp.jdbc.metadata.parser.JDBCMetaDataParser.parseEnterpriseBeans(JDBCMetaDataParser.java:710)
        at org.jboss.as.cmp.jdbc.metadata.parser.JDBCMetaDataParser.parse(JDBCMetaDataParser.java:71)
        at org.jboss.as.cmp.processors.CmpParsingProcessor.deploy(CmpParsingProcessor.java:88)
        ... 6 more

---

If i delete the offending lines it works, but these xml files are generated by XDOCLET and I would rather not change them manually in every build 

So I inserted a missing case-label to at least ignore the offending descriptions.
