### PR TITLE
AS7-3119 recurring timer executed concurrent if execution time longer than interval

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -26,12 +26,11 @@ package org.jboss.as.ejb3;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.File;
-import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Date;
 
 import javax.ejb.Timer;
 
@@ -318,7 +317,7 @@ public interface EjbLogger extends BasicLogger {
     void discardingEntityComponent(EntityBeanComponentInstance instance, @Cause Throwable t);
 
     /**
-     * Logs an error message indicating that an invocation failred
+     * Logs an error message indicating that an invocation failed
      */
     @LogMessage(level = ERROR)
     @Message(id = 14134, value = "EJB Invocation failed on component %s for method %s")
@@ -385,4 +384,10 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 14141, value = "Channel end notification received, closing channel %s")
     void closingChannelOnChannelEnd(Channel channel);
 
+    /**
+     * Logs a waring message indicating an overlapped invoking timeout for timer
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 14142, value = "Timer %s is still active, skipping overlapping scheduled execution at: %s")
+    void skipOverlappingInvokeTimeout(String id, Date scheduledTime);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.ejb3.timerservice.task;
 
+import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
+import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+
 import java.util.Date;
 
 import org.jboss.as.ejb3.timerservice.TimerImpl;
@@ -28,9 +31,6 @@ import org.jboss.as.ejb3.timerservice.TimerServiceImpl;
 import org.jboss.as.ejb3.timerservice.TimerState;
 import org.jboss.as.ejb3.timerservice.spi.BeanRemovedException;
 import org.jboss.as.ejb3.timerservice.spi.TimedObjectInvoker;
-
-import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
-import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 
 /**
  * A timer task which will be invoked at appropriate intervals based on a {@link javax.ejb.Timer}
@@ -105,6 +105,14 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
             if(this.timer.getNextExpiration() != null) {
                 this.timer.scheduleTimeout();
             }
+            return;
+        }
+        // If the recurring timer running longer than the interval is, we don't want to allow another
+        // execution until the it is complete. See JIRA AS7-3119
+        if(this.timer.getState() == TimerState.IN_TIMEOUT && !this.timer.isCalendarTimer()) {
+            ROOT_LOGGER.skipOverlappingInvokeTimeout(this.timer.getId(), now);
+            this.timer.setNextTimeout(this.calculateNextTimeout());
+            this.timerService.persistTimer(this.timer);
             return;
         }
 
@@ -182,7 +190,8 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
         TimerState timerState = this.timer.getState();
         if (timerState != TimerState.CANCELED
                 && timerState != TimerState.EXPIRED) {
-            if (this.timer.getInterval() == 0) {
+        //if (timerState == TimerState.IN_TIMEOUT || timerState == TimerState.RETRY_TIMEOUT) {
+            if (this.timer.getInterval() == 0 || this.timer.isCalendarTimer()) {
                 this.timer.expireTimer();
             } else {
                 this.timer.setTimerState(TimerState.ACTIVE);


### PR DESCRIPTION
The execution of a interval timer timeout is suppressed if the timer is still active.
This is compatible to the former AS versions.
A WARNING message 'JBAS014142: Timer <id> is still active, skipping overlapping scheduled execution at: <time>' will be logged.

Calendar timer are still executed concurrent.
