### PR TITLE
Use JBOSS_MODULEPATH instead of MODULEPATH environment variable in JBoss AS scripts

### DIFF
--- a/build/src/main/resources/bin/add-user.bat
+++ b/build/src/main/resources/bin/add-user.bat
@@ -55,13 +55,13 @@ rem Setup the java endorsed dirs
 set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
 
 rem Set default module root paths
-if "x%MODULEPATH%" == "x" (
-  set  "MODULEPATH=%JBOSS_HOME%\modules"
+if "x%JBOSS_MODULEPATH%" == "x" (
+  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
 "%JAVA%" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%MODULEPATH%" ^
+    -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.domain-add-user ^
      %*
 

--- a/build/src/main/resources/bin/add-user.sh
+++ b/build/src/main/resources/bin/add-user.sh
@@ -40,8 +40,8 @@ if [ "x$JAVA" = "x" ]; then
     fi
 fi
 
-if [ "x$MODULEPATH" = "x" ]; then
-    MODULEPATH="$JBOSS_HOME/modules"
+if [ "x$JBOSS_MODULEPATH" = "x" ]; then
+    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -50,7 +50,7 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 # Sample JPDA settings for remote socket debugging
@@ -58,7 +58,7 @@ fi
 
 eval \"$JAVA\" $JAVA_OPTS \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${MODULEPATH}\" \
+         -mp \"${JBOSS_MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          org.jboss.as.domain-add-user \
          "$@" 

--- a/build/src/main/resources/bin/appclient.bat
+++ b/build/src/main/resources/bin/appclient.bat
@@ -71,8 +71,8 @@ rem Setup the java endorsed dirs
 set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
 
 rem Set default module root paths
-if "x%MODULEPATH%" == "x" (
-  set  "MODULEPATH=%JBOSS_HOME%\modules"
+if "x%JBOSS_MODULEPATH%" == "x" (
+  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
 
@@ -80,7 +80,7 @@ if "x%MODULEPATH%" == "x" (
  "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\standalone\log\boot.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/standalone/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%MODULEPATH%" ^
+    -mp "%JBOSS_MODULEPATH%" ^
     -logmodule "org.jboss.logmanager" ^
     -jaxpmodule "javax.xml.jaxp-provider" ^
      org.jboss.as.standalone ^

--- a/build/src/main/resources/bin/appclient.sh
+++ b/build/src/main/resources/bin/appclient.sh
@@ -92,8 +92,8 @@ else
     JVM_OPTVERSION="-server $JVM_OPTVERSION"
 fi
 
-if [ "x$MODULEPATH" = "x" ]; then
-    MODULEPATH="$JBOSS_HOME/modules"
+if [ "x$JBOSS_MODULEPATH" = "x" ]; then
+    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -102,7 +102,7 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 CLASSPATH="$CLASSPATH:$JBOSS_HOME/jboss-modules.jar"
@@ -113,7 +113,7 @@ eval \"$JAVA\" $JAVA_OPTS \
  \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/appclient/log/boot.log\" \
  \"-Dlogging.configuration=file:$JBOSS_HOME/appclient/configuration/logging.properties\" \
  org.jboss.modules.Main \
- -mp \"${MODULEPATH}\" \
+ -mp \"${JBOSS_MODULEPATH}\" \
  -logmodule "org.jboss.logmanager" \
  -jaxpmodule javax.xml.jaxp-provider \
  org.jboss.as.appclient \

--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -71,8 +71,8 @@ rem Setup the java endorsed dirs
 set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
 
 rem Set default module root paths
-if "x%MODULEPATH%" == "x" (
-  set  "MODULEPATH=%JBOSS_HOME%\modules"
+if "x%JBOSS_MODULEPATH%" == "x" (
+  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
 echo ===============================================================================
@@ -93,7 +93,7 @@ echo.
  "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\domain\log\process-controller\boot.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/domain/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%MODULEPATH%" ^
+    -mp "%JBOSS_MODULEPATH%" ^
     -logmodule "org.jboss.logmanager" ^
      org.jboss.as.process-controller ^
     -jboss-home "%JBOSS_HOME%" ^

--- a/build/src/main/resources/bin/domain.sh
+++ b/build/src/main/resources/bin/domain.sh
@@ -92,8 +92,8 @@ else
     JVM_OPTVERSION="-server $JVM_OPTVERSION"
 fi
 
-if [ "x$MODULEPATH" = "x" ]; then
-    MODULEPATH="$JBOSS_HOME/modules"
+if [ "x$JBOSS_MODULEPATH" = "x" ]; then
+    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -102,7 +102,7 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 # Display our environment
@@ -126,7 +126,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/domain/log/process-controller/boot.log\" \
          \"-Dlogging.configuration=file:$JBOSS_HOME/domain/configuration/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${MODULEPATH}\" \
+         -mp \"${JBOSS_MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          org.jboss.as.process-controller \
          -jboss-home \"$JBOSS_HOME\" \
@@ -145,7 +145,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/domain/log/process-controller/boot.log\" \
          \"-Dlogging.configuration=file:$JBOSS_HOME/domain/configuration/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${MODULEPATH}\" \
+         -mp \"${JBOSS_MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          org.jboss.as.process-controller \
          -jboss-home \"$JBOSS_HOME\" \

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -71,8 +71,8 @@ rem Setup the java endorsed dirs
 set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
 
 rem Set default module root paths
-if "x%MODULEPATH%" == "x" (
-  set  "MODULEPATH=%JBOSS_HOME%\modules"
+if "x%JBOSS_MODULEPATH%" == "x" (
+  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
 echo ===============================================================================
@@ -93,7 +93,7 @@ echo.
  "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\standalone\log\boot.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/standalone/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%MODULEPATH%" ^
+    -mp "%JBOSS_MODULEPATH%" ^
     -logmodule "org.jboss.logmanager" ^
     -jaxpmodule "javax.xml.jaxp-provider" ^
     -mbeanserverbuildermodule "org.jboss.as.jmx" ^

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -92,8 +92,8 @@ else
     JVM_OPTVERSION="-server $JVM_OPTVERSION"
 fi
 
-if [ "x$MODULEPATH" = "x" ]; then
-    MODULEPATH="$JBOSS_HOME/modules"
+if [ "x$JBOSS_MODULEPATH" = "x" ]; then
+    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -102,7 +102,7 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 # Display our environment
@@ -126,7 +126,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/standalone/log/boot.log\" \
          \"-Dlogging.configuration=file:$JBOSS_HOME/standalone/configuration/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${MODULEPATH}\" \
+         -mp \"${JBOSS_MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          -jaxpmodule "javax.xml.jaxp-provider" \
          -mbeanserverbuildermodule "org.jboss.as.jmx" \
@@ -140,7 +140,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/standalone/log/boot.log\" \
          \"-Dlogging.configuration=file:$JBOSS_HOME/standalone/configuration/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${MODULEPATH}\" \
+         -mp \"${JBOSS_MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          -jaxpmodule "javax.xml.jaxp-provider" \
          -mbeanserverbuildermodule "org.jboss.as.jmx" \

--- a/build/src/main/resources/bin/util/jdr.bat
+++ b/build/src/main/resources/bin/util/jdr.bat
@@ -57,13 +57,13 @@ rem Setup the java endorsed dirs
 set JBOSS_ENDORSED_DIRS=%JBOSS_HOME%\lib\endorsed
 
 rem Set default module root paths
-if "x%MODULEPATH%" == "x" (
-  set  "MODULEPATH=%JBOSS_HOME%\modules"
+if "x%JBOSS_MODULEPATH%" == "x" (
+  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
 "%JAVA%" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%MODULEPATH%" ^
+    -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.jdr ^
     -Djboss.home.dir="%JBOSS_HOME%" ^
      %*

--- a/build/src/main/resources/bin/util/jdr.sh
+++ b/build/src/main/resources/bin/util/jdr.sh
@@ -42,8 +42,8 @@ if [ "x$JAVA" = "x" ]; then
     fi
 fi
 
-if [ "x$MODULEPATH" = "x" ]; then
-    MODULEPATH="$JBOSS_HOME/modules"
+if [ "x$JBOSS_MODULEPATH" = "x" ]; then
+    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
@@ -52,12 +52,12 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 eval \"$JAVA\" $JAVA_OPTS \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${MODULEPATH}\" \
+         -mp \"${JBOSS_MODULEPATH}\" \
          -logmodule "org.jboss.logmanager" \
          org.jboss.as.jdr \
          -Djboss.home.dir=\"$JBOSS_HOME\" \

--- a/build/src/main/resources/bin/util/vault.sh
+++ b/build/src/main/resources/bin/util/vault.sh
@@ -63,8 +63,8 @@ if [ "x$JAVA" = "x" ]; then
     fi
 fi
 
-if [ "x$MODULEPATH" = "x" ]; then
-    MODULEPATH="$JBOSS_HOME/modules"
+if [ "x$JBOSS_MODULEPATH" = "x" ]; then
+    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
 ###
@@ -72,10 +72,10 @@ fi
 ###
 
 # Shared libs
-JBOSS_VAULT_CLASSPATH="$MODULEPATH/org/picketbox/main/*"
-JBOSS_VAULT_CLASSPATH="$JBOSS_VAULT_CLASSPATH:$MODULEPATH/org/jboss/logging/main/*"
-JBOSS_VAULT_CLASSPATH="$JBOSS_VAULT_CLASSPATH:$MODULEPATH/org/jboss/common-core/main/*"
-JBOSS_VAULT_CLASSPATH="$JBOSS_VAULT_CLASSPATH:$MODULEPATH/org/jboss/as/security/main/*"
+JBOSS_VAULT_CLASSPATH="$JBOSS_MODULEPATH/org/picketbox/main/*"
+JBOSS_VAULT_CLASSPATH="$JBOSS_VAULT_CLASSPATH:$JBOSS_MODULEPATH/org/jboss/logging/main/*"
+JBOSS_VAULT_CLASSPATH="$JBOSS_VAULT_CLASSPATH:$JBOSS_MODULEPATH/org/jboss/common-core/main/*"
+JBOSS_VAULT_CLASSPATH="$JBOSS_VAULT_CLASSPATH:$JBOSS_MODULEPATH/org/jboss/as/security/main/*"
 
 export JBOSS_VAULT_CLASSPATH
 
@@ -85,7 +85,7 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
     JBOSS_ENDORSED_DIRS=`cygpath --path --windows "$JBOSS_ENDORSED_DIRS"`
-    MODULEPATH=`cygpath --path --windows "$MODULEPATH"`
+    JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
     JBOSS_VAULT_CLASSPATH=`cygpath --path --windows "$JBOSS_VAULT_CLASSPATH"`
 fi
 


### PR DESCRIPTION
More than one users on Fedora have reported that they have run into problems starting a out-of-box JBoss AS7 http://community.jboss.org/thread/175689?tstart=60. It appears that Fedora has some other application which uses (and has set) MODULEPATH environment variable. We use this environment variable in our startup scripts for pointing to the root of modules repository. The already set value (by a different application) in Fedora leads to an incorrect root for modules repository for JBoss AS.

The commit in this branch changes the usage of MODULEPATH to JBOSS_MODULEPATH (this new name also adds a bit of implicit context to that environment variable). This should prevent issues on Fedora.

P.S: Please check with David and Jason, if this change is OK, before merging this upstream.
