### PR TITLE
Minor logging fix in PropertiesCallbackHandler

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesCallbackHandler.java
@@ -126,7 +126,7 @@ public class PropertiesCallbackHandler implements Service<DomainCallbackHandler>
                 long fileLastModified = propertiesFile.lastModified();
                 boolean loadReallyRequired = userProperties == null || fileUpdated != fileLastModified;
                 if (loadReallyRequired) {
-                    ROOT_LOGGER.debugf("Reloading properties file '%s%", propertiesFile.getAbsolutePath());
+                    ROOT_LOGGER.debugf("Reloading properties file '%s'", propertiesFile.getAbsolutePath());
                     Properties props = new Properties();
                     InputStream is = new FileInputStream(propertiesFile);
                     try {


### PR DESCRIPTION
This commit includes a minor change to a logging statement in the PropertiesCallbackHandler. It fixes the logging message which used to result in a format exception (reported here http://community.jboss.org/thread/176671?tstart=0)
