### PR TITLE
Add support for clustering EJB interceptors 

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/BasicComponent.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/BasicComponent.java
@@ -161,8 +161,18 @@ public class BasicComponent implements Component {
                 throw MESSAGES.componentConstructionFailure(e);
             }
         }
+        componentInstanceCreated(basicComponentInstance, context);
         // return the component instance
         return basicComponentInstance;
+    }
+
+    /**
+     * Method that can be overriden to perform setup on the instance after it has been created
+     * @param basicComponentInstance The component instance
+     * @param context The interceptor factory context used to construct the instance
+     */
+    protected void componentInstanceCreated(final BasicComponentInstance basicComponentInstance, final InterceptorFactoryContext context) {
+
     }
 
 

--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentConfiguration.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentConfiguration.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,6 +81,8 @@ public class ComponentConfiguration {
     private InterceptorFactory namespaceContextInterceptorFactory;
 
     private NamespaceContextSelector namespaceContextSelector;
+
+    private final Set<Object> interceptorContextKeys = new HashSet<Object>();
 
     public ComponentConfiguration(final ComponentDescription componentDescription, final ClassIndex classIndex, final ClassLoader moduleClassLoder) {
         this.componentDescription = componentDescription;
@@ -379,5 +382,9 @@ public class ComponentConfiguration {
 
     public void setNamespaceContextSelector(final NamespaceContextSelector namespaceContextSelector) {
         this.namespaceContextSelector = namespaceContextSelector;
+    }
+
+    public Set<Object> getInterceptorContextKeys() {
+        return interceptorContextKeys;
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentDescription.java
@@ -623,6 +623,7 @@ public class ComponentDescription {
 
                 //we store the interceptor instance under the class key
                 final Object contextKey = interceptorClass.getModuleClass();
+                configuration.getInterceptorContextKeys().add(contextKey);
 
                 final ClassReflectionIndex<?> interceptorIndex = deploymentReflectionIndex.getClassIndex(interceptorClass.getModuleClass());
                 final Constructor<?> constructor = interceptorIndex.getConstructor(EMPTY_CLASS_ARRAY);

--- a/ee/src/main/java/org/jboss/as/ee/component/ManagedReferenceInterceptorFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ManagedReferenceInterceptorFactory.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.ee.component;
 
-import static org.jboss.as.ee.EeMessages.MESSAGES;
-
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.as.naming.ManagedReference;
@@ -33,10 +31,12 @@ import org.jboss.invocation.InterceptorContext;
 import org.jboss.invocation.InterceptorFactory;
 import org.jboss.invocation.InterceptorFactoryContext;
 
+import static org.jboss.as.ee.EeMessages.MESSAGES;
+
 /**
  * An interceptor factory which gets an object instance from a managed resource.  A reference to the resource will be
  * attached to the given factory context key; the resource should be retained and passed to an instance of {@link
- * org.jboss.as.ee.component.ManagedReferenceReleaseInterceptor} which is run during destruction.
+ * org.jboss.as.ee.component.ManagedReferenceReleaseInterceptorFactory} which is run during destruction.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
@@ -66,8 +66,11 @@ class ManagedReferenceInterceptorFactory implements InterceptorFactory {
      * {@inheritDoc}
      */
     public Interceptor create(final InterceptorFactoryContext context) {
-        final AtomicReference<ManagedReference> referenceReference = new AtomicReference<ManagedReference>();
-        context.getContextData().put(contextKey, referenceReference);
+        AtomicReference<ManagedReference> referenceReference = (AtomicReference<ManagedReference>) context.getContextData().get(contextKey);
+        if (referenceReference == null) {
+            referenceReference = new AtomicReference<ManagedReference>();
+            context.getContextData().put(contextKey, referenceReference);
+        }
         return new ManagedReferenceInterceptor(componentInstantiation, referenceReference);
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentCreateService.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentConfiguration;
@@ -67,6 +68,7 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
     private final InterceptorFactory ejb2XRemoveMethod;
     @SuppressWarnings("rawtypes")
     private final InjectedValue<CacheFactory> cacheFactory = new InjectedValue<CacheFactory>();
+    private final Set<Object> serializableInterceptorContextKeys;
 
     /**
      * Construct a new instance.
@@ -96,6 +98,7 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
         this.marshallingConfiguration.setClassResolver(new SimpleClassResolver(componentConfiguration.getModuleClassLoder()));
         this.marshallingConfiguration.setObjectResolver(new StatefulSessionBeanObjectResolver());
         this.marshallingConfiguration.setClassTable(new StatefulSessionBeanClassTable(componentConfiguration.getComponentClass()));
+        this.serializableInterceptorContextKeys = componentConfiguration.getInterceptorContextKeys();
     }
 
     private static Collection<InterceptorFactory> createInterceptorFactories(Collection<Method> methods, InterceptorFactory... factories) {
@@ -174,6 +177,10 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
 
     public InterceptorFactory getEjb2XRemoveMethod() {
         return ejb2XRemoveMethod;
+    }
+
+    public Set<Object> getSerializableInterceptorContextKeys() {
+        return serializableInterceptorContextKeys;
     }
 
     @SuppressWarnings("unchecked")

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentInstance.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentInstance.java
@@ -61,6 +61,7 @@ public class StatefulSessionComponentInstance extends SessionBeanComponentInstan
     private final Collection<Interceptor> prePassivate;
     private final Collection<Interceptor> postActivate;
     private final Interceptor ejb2XRemoveInterceptor;
+    private volatile Map<Object, Object> serializableInterceptors;
 
     /**
      * Construct a new instance.
@@ -163,6 +164,14 @@ public class StatefulSessionComponentInstance extends SessionBeanComponentInstan
         }
     }
 
+    public Map<Object, Object> getSerializableInterceptors() {
+        return serializableInterceptors;
+    }
+
+    public void setSerializableInterceptors(final Map<Object, Object> serializableInterceptors) {
+        this.serializableInterceptors = serializableInterceptors;
+    }
+
     @Override
     public StatefulSessionComponent getComponent() {
         return (StatefulSessionComponent) super.getComponent();
@@ -188,6 +197,6 @@ public class StatefulSessionComponentInstance extends SessionBeanComponentInstan
     }
 
     public Object writeReplace() throws ObjectStreamException {
-        return new SerializedStatefulSessionComponent(getInstance(), id, getComponent().getCreateServiceName().getCanonicalName());
+        return new SerializedStatefulSessionComponent(getInstance(), id, getComponent().getCreateServiceName().getCanonicalName(), serializableInterceptors);
     }
 }

--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -96,6 +96,29 @@
                                 <phase>none</phase>
                             </execution>
 
+
+                            <!-- Multi node clustering tests with UNMANAGED containers. -->
+                            <execution>
+                                <id>tests-clustering-multi-node-unmanaged.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/clustering/unmanaged/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>clustering-udp-unmanaged</arquillian.launch>
+                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
+                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+
                             <!-- Single node clustering tests. -->
                             <execution>
                                 <id>tests-clustering-single-node.surefire</id>
@@ -129,28 +152,6 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <arquillian.launch>clustering-udp</arquillian.launch>
-                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
-                                    </systemPropertyVariables>
-                                </configuration>
-                            </execution>
-                            
-                            <!-- Multi node clustering tests with UNMANAGED containers. -->
-                            <execution>
-                                <id>tests-clustering-multi-node-unmanaged.surefire</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <!-- Tests to execute. -->
-                                    <includes>
-                                        <include>org/jboss/as/test/clustering/unmanaged/**/*TestCase.java</include>
-                                    </includes>
-
-                                    <!-- Parameters to test cases. -->
-                                    <systemPropertyVariables>
-                                        <arquillian.launch>clustering-udp-unmanaged</arquillian.launch>
                                         <!-- Use combine.children="append" to pick up parent properties automatically. -->
                                         <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/StatefulFailoverTestCase.java
@@ -38,9 +38,11 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.unmanaged.ejb3.stateful.bean.StatefulBean;
+import org.jboss.as.test.clustering.unmanaged.ejb3.stateful.bean.StatefulCDIInterceptor;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -81,6 +83,7 @@ public class StatefulFailoverTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "stateful.war");
         war.addPackage(StatefulBean.class.getPackage());
         war.setWebXML(StatefulBean.class.getPackage(), "web.xml");
+        war.addAsWebInfResource(new StringAsset("<beans><interceptors><class>" + StatefulCDIInterceptor.class.getName() + "</class></interceptors></beans>"), "beans.xml");
         System.out.println(war.toString(true));
         return war;
     }
@@ -91,6 +94,7 @@ public class StatefulFailoverTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "stateful.war");
         war.addPackage(StatefulBean.class.getPackage());
         war.setWebXML(StatefulBean.class.getPackage(), "web.xml");
+        war.addAsWebInfResource(new StringAsset("<beans><interceptors><class>" + StatefulCDIInterceptor.class.getName() + "</class></interceptors></beans>"), "beans.xml");
         war.addAsWebInfResource(EmptyAsset.INSTANCE, "force-hashcode-change.txt");
         System.out.println(war.toString(true));
         return war;
@@ -111,42 +115,42 @@ public class StatefulFailoverTestCase {
         String url2 = "http://127.0.0.1:8180/stateful/count";
 
         try {
-            assertQueryCount(101, client, url1);
-            assertQueryCount(202, client, url1);
+            assertQueryCount(10101, client, url1);
+            assertQueryCount(20202, client, url1);
 
             controller.start(CONTAINER2);
             deployer.deploy(DEPLOYMENT2);
 
-            assertQueryCount(303, client, url1);
-            assertQueryCount(404, client, url1);
+            assertQueryCount(30303, client, url1);
+            assertQueryCount(40404, client, url1);
 
-            assertQueryCount(505, client, url2);
-            assertQueryCount(606, client, url2);
+            assertQueryCount(50505, client, url2);
+            assertQueryCount(60606, client, url2);
 
             controller.stop(CONTAINER2);
 
-            assertQueryCount(707, client, url1);
-            assertQueryCount(808, client, url1);
+            assertQueryCount(70707, client, url1);
+            assertQueryCount(80808, client, url1);
 
             controller.start(CONTAINER2);
 
-            assertQueryCount(909, client, url1);
-            assertQueryCount(1010, client, url1);
+            assertQueryCount(90909, client, url1);
+            assertQueryCount(101010, client, url1);
 
-            assertQueryCount(1111, client, url2);
-            assertQueryCount(1212, client, url2);
+            assertQueryCount(111111, client, url2);
+            assertQueryCount(121212, client, url2);
 
             controller.stop(CONTAINER1);
-            assertQueryCount(1313, client, url2);
-            assertQueryCount(1414, client, url2);
+            assertQueryCount(131313, client, url2);
+            assertQueryCount(141414, client, url2);
             
             controller.start(CONTAINER1);
 
-            assertQueryCount(1515, client, url1);
-            assertQueryCount(1616, client, url1);
+            assertQueryCount(151515, client, url1);
+            assertQueryCount(161616, client, url1);
 
-            assertQueryCount(1717, client, url1);
-            assertQueryCount(1818, client, url1);
+            assertQueryCount(171717, client, url1);
+            assertQueryCount(181818, client, url1);
         } finally {
             client.getConnectionManager().shutdown();
 
@@ -170,43 +174,43 @@ public class StatefulFailoverTestCase {
         String url2 = "http://127.0.0.1:8180/stateful/count";
 
         try {
-            assertQueryCount(101, client, url1);
-            assertQueryCount(202, client, url1);
+            assertQueryCount(10101, client, url1);
+            assertQueryCount(20202, client, url1);
 
             controller.start(CONTAINER2);
             deployer.deploy(DEPLOYMENT2);
 
-            assertQueryCount(303, client, url1);
-            assertQueryCount(404, client, url1);
+            assertQueryCount(30303, client, url1);
+            assertQueryCount(40404, client, url1);
 
-            assertQueryCount(505, client, url2);
-            assertQueryCount(606, client, url2);
+            assertQueryCount(50505, client, url2);
+            assertQueryCount(60606, client, url2);
 
             deployer.undeploy(DEPLOYMENT2);
 
-            assertQueryCount(707, client, url1);
-            assertQueryCount(808, client, url1);
+            assertQueryCount(70707, client, url1);
+            assertQueryCount(80808, client, url1);
 
             deployer.deploy(DEPLOYMENT2);
 
-            assertQueryCount(909, client, url1);
-            assertQueryCount(1010, client, url1);
+            assertQueryCount(90909, client, url1);
+            assertQueryCount(101010, client, url1);
 
-            assertQueryCount(1111, client, url2);
-            assertQueryCount(1212, client, url2);
+            assertQueryCount(111111, client, url2);
+            assertQueryCount(121212, client, url2);
 
             deployer.undeploy(DEPLOYMENT1);
 
-            assertQueryCount(1313, client, url2);
-            assertQueryCount(1414, client, url2);
+            assertQueryCount(131313, client, url2);
+            assertQueryCount(141414, client, url2);
             
             deployer.deploy(DEPLOYMENT1);
 
-            assertQueryCount(1515, client, url1);
-            assertQueryCount(1616, client, url1);
+            assertQueryCount(151515, client, url1);
+            assertQueryCount(161616, client, url1);
 
-            assertQueryCount(1717, client, url2);
-            assertQueryCount(1818, client, url2);
+            assertQueryCount(171717, client, url2);
+            assertQueryCount(181818, client, url2);
         } finally {
             client.getConnectionManager().shutdown();
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/StatefulFailoverTestCase.java
@@ -111,42 +111,42 @@ public class StatefulFailoverTestCase {
         String url2 = "http://127.0.0.1:8180/stateful/count";
 
         try {
-            assertQueryCount(1, client, url1);
-            assertQueryCount(2, client, url1);
+            assertQueryCount(101, client, url1);
+            assertQueryCount(202, client, url1);
 
             controller.start(CONTAINER2);
             deployer.deploy(DEPLOYMENT2);
 
-            assertQueryCount(3, client, url1);
-            assertQueryCount(4, client, url1);
+            assertQueryCount(303, client, url1);
+            assertQueryCount(404, client, url1);
 
-            assertQueryCount(5, client, url2);
-            assertQueryCount(6, client, url2);
+            assertQueryCount(505, client, url2);
+            assertQueryCount(606, client, url2);
 
             controller.stop(CONTAINER2);
 
-            assertQueryCount(7, client, url1);
-            assertQueryCount(8, client, url1);
+            assertQueryCount(707, client, url1);
+            assertQueryCount(808, client, url1);
 
             controller.start(CONTAINER2);
 
-            assertQueryCount(9, client, url1);
-            assertQueryCount(10, client, url1);
+            assertQueryCount(909, client, url1);
+            assertQueryCount(1010, client, url1);
 
-            assertQueryCount(11, client, url2);
-            assertQueryCount(12, client, url2);
+            assertQueryCount(1111, client, url2);
+            assertQueryCount(1212, client, url2);
 
             controller.stop(CONTAINER1);
-            assertQueryCount(13, client, url2);
-            assertQueryCount(14, client, url2);
+            assertQueryCount(1313, client, url2);
+            assertQueryCount(1414, client, url2);
             
             controller.start(CONTAINER1);
 
-            assertQueryCount(15, client, url1);
-            assertQueryCount(16, client, url1);
+            assertQueryCount(1515, client, url1);
+            assertQueryCount(1616, client, url1);
 
-            assertQueryCount(17, client, url1);
-            assertQueryCount(18, client, url1);
+            assertQueryCount(1717, client, url1);
+            assertQueryCount(1818, client, url1);
         } finally {
             client.getConnectionManager().shutdown();
 
@@ -170,43 +170,43 @@ public class StatefulFailoverTestCase {
         String url2 = "http://127.0.0.1:8180/stateful/count";
 
         try {
-            assertQueryCount(1, client, url1);
-            assertQueryCount(2, client, url1);
+            assertQueryCount(101, client, url1);
+            assertQueryCount(202, client, url1);
 
             controller.start(CONTAINER2);
             deployer.deploy(DEPLOYMENT2);
 
-            assertQueryCount(3, client, url1);
-            assertQueryCount(4, client, url1);
+            assertQueryCount(303, client, url1);
+            assertQueryCount(404, client, url1);
 
-            assertQueryCount(5, client, url2);
-            assertQueryCount(6, client, url2);
+            assertQueryCount(505, client, url2);
+            assertQueryCount(606, client, url2);
 
             deployer.undeploy(DEPLOYMENT2);
 
-            assertQueryCount(7, client, url1);
-            assertQueryCount(8, client, url1);
+            assertQueryCount(707, client, url1);
+            assertQueryCount(808, client, url1);
 
             deployer.deploy(DEPLOYMENT2);
 
-            assertQueryCount(9, client, url1);
-            assertQueryCount(10, client, url1);
+            assertQueryCount(909, client, url1);
+            assertQueryCount(1010, client, url1);
 
-            assertQueryCount(11, client, url2);
-            assertQueryCount(12, client, url2);
+            assertQueryCount(1111, client, url2);
+            assertQueryCount(1212, client, url2);
 
             deployer.undeploy(DEPLOYMENT1);
 
-            assertQueryCount(13, client, url2);
-            assertQueryCount(14, client, url2);
+            assertQueryCount(1313, client, url2);
+            assertQueryCount(1414, client, url2);
             
             deployer.deploy(DEPLOYMENT1);
 
-            assertQueryCount(15, client, url1);
-            assertQueryCount(16, client, url1);
+            assertQueryCount(1515, client, url1);
+            assertQueryCount(1616, client, url1);
 
-            assertQueryCount(17, client, url2);
-            assertQueryCount(18, client, url2);
+            assertQueryCount(1717, client, url2);
+            assertQueryCount(1818, client, url2);
         } finally {
             client.getConnectionManager().shutdown();
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/Intercepted.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/Intercepted.java
@@ -1,8 +1,8 @@
 /*
- * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
- * as indicated by the @author tags. See the copyright.txt file in the
- * distribution for a full listing of individual contributors.
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -19,26 +19,17 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.as.test.clustering.unmanaged.ejb3.stateful.bean;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
-import javax.interceptor.Interceptors;
-
-import org.jboss.ejb3.annotation.Clustered;
+import javax.interceptor.InterceptorBinding;
 
 /**
- * @author Paul Ferraro
+ * @author Stuart Douglas
  */
-@Clustered
-@javax.ejb.Stateful(name = "StatefulBean")
-@Interceptors(StatefulInterceptor.class)
-@Intercepted
-public class StatefulBean implements Stateful {
-    private AtomicInteger count = new AtomicInteger(0);
-    
-    public int increment() {
-        return this.count.incrementAndGet();
-    }
+@Retention(RetentionPolicy.RUNTIME)
+@InterceptorBinding
+public @interface Intercepted {
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/StatefulBean.java
@@ -24,6 +24,8 @@ package org.jboss.as.test.clustering.unmanaged.ejb3.stateful.bean;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.interceptor.Interceptors;
+
 import org.jboss.ejb3.annotation.Clustered;
 
 /**
@@ -31,6 +33,7 @@ import org.jboss.ejb3.annotation.Clustered;
  */
 @Clustered
 @javax.ejb.Stateful(name = "StatefulBean")
+@Interceptors(StatefulInterceptor.class)
 public class StatefulBean implements Stateful {
     private AtomicInteger count = new AtomicInteger(0);
     

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/StatefulCDIInterceptor.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/StatefulCDIInterceptor.java
@@ -4,18 +4,21 @@ import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
 /**
  * @author Stuart Douglas
  */
-
-public class StatefulInterceptor implements Serializable {
+@Intercepted
+@Interceptor
+public class StatefulCDIInterceptor implements Serializable {
 
     private final AtomicInteger count = new AtomicInteger(0);
-    
+
     @AroundInvoke
     public Object invoke(final InvocationContext context) throws Exception {
-        return ((Integer)context.proceed() ) + count.addAndGet(100);
+        return ((Integer)context.proceed() ) + count.addAndGet(10000);
     }
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/StatefulInterceptor.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/unmanaged/ejb3/stateful/bean/StatefulInterceptor.java
@@ -1,0 +1,21 @@
+package org.jboss.as.test.clustering.unmanaged.ejb3.stateful.bean;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+/**
+ * @author Stuart Douglas
+ */
+
+public class StatefulInterceptor {
+
+    private final AtomicInteger count = new AtomicInteger(0);
+    
+    
+    @AroundInvoke
+    public Object invoke(final InvocationContext context) throws Exception {
+        return ((Integer)context.proceed() ) + count.addAndGet(100);
+    }
+}


### PR DESCRIPTION
The the moment EJB interceptors are not replicated, this fixes it for both CDI and normal interceptors.
