### PR TITLE
https://issues.jboss.org/browse/AS7-2983

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsIntegrationProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsIntegrationProcessor.java
@@ -39,6 +39,7 @@ public class JaxrsIntegrationProcessor implements DeploymentUnitProcessor {
     private static final String SERVLET_INIT_PARAM = "javax.ws.rs.Application";
     public static final String RESTEASY_SCAN = "resteasy.scan";
     public static final String RESTEASY_SCAN_RESOURCES = "resteasy.scan.resources";
+    public static final String RESTEASY_SCAN_PROVIDERS = "resteasy.scan.providers";
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
@@ -76,6 +77,9 @@ public class JaxrsIntegrationProcessor implements DeploymentUnitProcessor {
                 } else if (param.getParamName().equals(RESTEASY_SCAN_RESOURCES)) {
                     it.remove();
                     JAXRS_LOGGER.resteasyScanWarning(RESTEASY_SCAN_RESOURCES);
+                } else if (param.getParamName().equals(RESTEASY_SCAN_PROVIDERS)) {
+                    it.remove();
+                    JAXRS_LOGGER.resteasyScanWarning(RESTEASY_SCAN_PROVIDERS);
                 }
             }
         }


### PR DESCRIPTION
AS7-2983

RESTEasy: Cfg. params resteasy.scan.providers and resteasy.scan.resources should provide the same warning as resteasy.scan

AS7 does its own annotation scanning, this is correct and true, so resteasy.scan is useless and stays only for backward compatibility. If an application is used with parameters resteasy.scan.providers or resteasy.scan.resources deployer is silent and I think better behavior is producing the same warning as when parameter resteasy.scan is used.
