### PR TITLE
AS7-3073 Add a log message to indicate that a MDB has been deployed

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -385,4 +385,15 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 14141, value = "Channel end notification received, closing channel %s")
     void closingChannelOnChannelEnd(Channel channel);
 
+    /**
+     * Logs a message which includes the resource adapter name and the destination on which a message driven bean
+     * is listening
+     *
+     * @param mdbName     The message driven bean name
+     * @param raName      The resource adapter name
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 14142, value = "Started message driven bean '%s' with '%s' resource adapter")
+    void logMDBStart(final String mdbName, final String raName);
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
@@ -29,10 +29,13 @@ import java.util.Properties;
 
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.component.EJBComponentCreateService;
 import org.jboss.as.ejb3.component.pool.PoolConfig;
 import org.jboss.as.ejb3.deployment.ApplicationExceptions;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
 import org.jboss.msc.value.InjectedValue;
 
 /**
@@ -60,6 +63,13 @@ public class MessageDrivenComponentCreateService extends EJBComponentCreateServi
         this.messageListenerInterface = componentConfiguration.getViews().get(0).getViewClass();
 
         this.activationProps = componentDescription.getActivationProps();
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        super.start(context);
+        // AS7-3073 just log a message about the MDB being started
+        EjbLogger.ROOT_LOGGER.logMDBStart(this.getComponentName(), this.resourceAdapterName);
     }
 
     @Override


### PR DESCRIPTION
The commit in this branch add a log message to indicate that a MDB has been detected and deployed. Unlike session beans where we log the JNDI names to indicate the session bean detection, the MDBs were being silently deployed without giving any indication to the users. This takes care of https://issues.jboss.org/browse/AS7-3073 which requested for this kind of log.
