### PR TITLE
AS7-2899 JPA 2.0 section 3.8.6 (tx scoped pc in non-tx should detach entities loaded by query)

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
@@ -118,7 +118,9 @@ public class ExtendedEntityManager extends AbstractEntityManager implements Seri
     }
 
     public void containerClose() {
-        underlyingEntityManager.close();
+        if (underlyingEntityManager.isOpen()) {
+            underlyingEntityManager.close();
+        }
     }
 
     @Override

--- a/jpa/core/src/main/java/org/jboss/as/jpa/container/QueryNonTxInvocationDetacher.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/container/QueryNonTxInvocationDetacher.java
@@ -1,0 +1,241 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.container;
+
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
+import javax.persistence.LockModeType;
+import javax.persistence.Parameter;
+import javax.persistence.Query;
+import javax.persistence.TemporalType;
+
+/**
+ * for JPA 2.0 section 3.8.6
+ * used by TransactionScopedEntityManager to detach entities loaded by a query in a non-jta invocation.
+ * This could be a proxy but wrapper classes give faster performance.
+ *
+ * @author Scott Marlow
+ */
+public class QueryNonTxInvocationDetacher implements Query {
+
+    private final Query underlyingQuery;
+    private final EntityManager underlyingEntityManager;
+
+    QueryNonTxInvocationDetacher(EntityManager underlyingEntityManager, Query underlyingQuery) {
+        this.underlyingQuery = underlyingQuery;
+        this.underlyingEntityManager = underlyingEntityManager;
+    }
+
+    @Override
+    public List getResultList() {
+        List result = underlyingQuery.getResultList();
+        /**
+         * The purpose of this wrapper class is so that we can detach the returned entities from this method.
+         * Call EntityManager.clear will accomplish that.
+         */
+        underlyingEntityManager.clear();
+        return result;
+    }
+
+    @Override
+    public Object getSingleResult() {
+        Object result = underlyingQuery.getSingleResult();
+        /**
+         * The purpose of this wrapper class is so that we can detach the returned entities from this method.
+         * Call EntityManager.clear will accomplish that.
+         */
+        underlyingEntityManager.clear();
+        return result;
+    }
+
+    @Override
+    public int executeUpdate() {
+        return underlyingQuery.executeUpdate();
+    }
+
+    @Override
+    public Query setMaxResults(int maxResult) {
+        underlyingQuery.setMaxResults(maxResult);
+        return this;
+    }
+
+    @Override
+    public int getMaxResults() {
+        return underlyingQuery.getMaxResults();
+    }
+
+    @Override
+    public Query setFirstResult(int startPosition) {
+        underlyingQuery.setFirstResult(startPosition);
+        return this;
+    }
+
+    @Override
+    public int getFirstResult() {
+        return underlyingQuery.getFirstResult();
+    }
+
+    @Override
+    public Query setHint(String hintName, Object value) {
+        underlyingQuery.setHint(hintName, value);
+        return this;
+    }
+
+    @Override
+    public Map<String, Object> getHints() {
+        return underlyingQuery.getHints();
+    }
+
+    @Override
+    public <T> Query setParameter(Parameter<T> param, T value) {
+        underlyingQuery.setParameter(param, value);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType) {
+        underlyingQuery.setParameter(param, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(Parameter<Date> param, Date value, TemporalType temporalType) {
+        underlyingQuery.setParameter(param, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(String name, Object value) {
+        underlyingQuery.setParameter(name, value);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(String name, Calendar value, TemporalType temporalType) {
+        underlyingQuery.setParameter(name, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(String name, Date value, TemporalType temporalType) {
+        underlyingQuery.setParameter(name, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(int position, Object value) {
+        underlyingQuery.setParameter(position, value);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(int position, Calendar value, TemporalType temporalType) {
+        underlyingQuery.setParameter(position, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Query setParameter(int position, Date value, TemporalType temporalType) {
+        underlyingQuery.setParameter(position, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Set<Parameter<?>> getParameters() {
+        return underlyingQuery.getParameters();
+    }
+
+    @Override
+    public Parameter<?> getParameter(String name) {
+        return underlyingQuery.getParameter(name);
+    }
+
+    @Override
+    public <T> Parameter<T> getParameter(String name, Class<T> type) {
+        return underlyingQuery.getParameter(name, type);
+    }
+
+    @Override
+    public Parameter<?> getParameter(int position) {
+        return underlyingQuery.getParameter(position);
+    }
+
+    @Override
+    public <T> Parameter<T> getParameter(int position, Class<T> type) {
+        return underlyingQuery.getParameter(position, type);
+    }
+
+    @Override
+    public boolean isBound(Parameter<?> param) {
+        return underlyingQuery.isBound(param);
+    }
+
+    @Override
+    public <T> T getParameterValue(Parameter<T> param) {
+        return underlyingQuery.getParameterValue(param);
+    }
+
+    @Override
+    public Object getParameterValue(String name) {
+        return underlyingQuery.getParameterValue(name);
+    }
+
+    @Override
+    public Object getParameterValue(int position) {
+        return underlyingQuery.getParameterValue(position);
+    }
+
+    @Override
+    public Query setFlushMode(FlushModeType flushMode) {
+        underlyingQuery.setFlushMode(flushMode);
+        return this;
+    }
+
+    @Override
+    public FlushModeType getFlushMode() {
+        return underlyingQuery.getFlushMode();
+    }
+
+    @Override
+    public Query setLockMode(LockModeType lockMode) {
+        underlyingQuery.setLockMode(lockMode);
+        return this;
+    }
+
+    @Override
+    public LockModeType getLockMode() {
+        return underlyingQuery.getLockMode();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) {
+        return underlyingQuery.unwrap(cls);
+    }
+}

--- a/jpa/core/src/main/java/org/jboss/as/jpa/container/TypedQueryNonTxInvocationDetacher.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/container/TypedQueryNonTxInvocationDetacher.java
@@ -1,0 +1,240 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.container;
+
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
+import javax.persistence.LockModeType;
+import javax.persistence.Parameter;
+import javax.persistence.TemporalType;
+import javax.persistence.TypedQuery;
+
+/**
+ * for JPA 2.0 section 3.8.6
+ * used by TransactionScopedEntityManager to detach entities loaded by a query in a non-jta invocation.
+ * This could be a proxy but wrapper classes give faster performance.
+ *
+ * @author Scott Marlow
+ */
+public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
+
+    private final TypedQuery underlyingQuery;
+    private final EntityManager underlyingEntityManager;
+
+    TypedQueryNonTxInvocationDetacher(EntityManager underlyingEntityManager, TypedQuery underlyingQuery) {
+        this.underlyingQuery = underlyingQuery;
+        this.underlyingEntityManager = underlyingEntityManager;
+    }
+
+    @Override
+    public List<X> getResultList() {
+        List<X> result = underlyingQuery.getResultList();
+        /**
+         * The purpose of this wrapper class is so that we can detach the returned entities from this method.
+         * Call EntityManager.clear will accomplish that.
+         */
+        underlyingEntityManager.clear();
+        return result;
+    }
+
+    @Override
+    public X getSingleResult() {
+        X result = (X)underlyingQuery.getSingleResult();
+        /**
+         * The purpose of this wrapper class is so that we can detach the returned entities from this method.
+         * Call EntityManager.clear will accomplish that.
+         */
+        underlyingEntityManager.clear();
+        return result;
+    }
+
+    @Override
+    public int executeUpdate() {
+        return underlyingQuery.executeUpdate();
+    }
+
+    @Override
+    public TypedQuery setMaxResults(int maxResult) {
+        underlyingQuery.setMaxResults(maxResult);
+        return this;
+    }
+
+    @Override
+    public int getMaxResults() {
+        return underlyingQuery.getMaxResults();
+    }
+
+    @Override
+    public TypedQuery setFirstResult(int startPosition) {
+        underlyingQuery.setFirstResult(startPosition);
+        return this;
+    }
+
+    @Override
+    public int getFirstResult() {
+        return underlyingQuery.getFirstResult();
+    }
+
+    @Override
+    public TypedQuery setHint(String hintName, Object value) {
+        underlyingQuery.setHint(hintName, value);
+        return this;
+    }
+
+    @Override
+    public <T> TypedQuery<X> setParameter(Parameter<T> param, T value) {
+        underlyingQuery.setParameter(param, value);
+        return this;
+    }
+
+    @Override
+    public TypedQuery<X> setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType) {
+        underlyingQuery.setParameter(param, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public TypedQuery<X> setParameter(Parameter<Date> param, Date value, TemporalType temporalType) {
+        underlyingQuery.setParameter(param, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Map<String, Object> getHints() {
+        return underlyingQuery.getHints();
+    }
+    @Override
+    public TypedQuery setParameter(String name, Object value) {
+        underlyingQuery.setParameter(name, value);
+        return this;
+    }
+
+    @Override
+    public TypedQuery setParameter(String name, Calendar value, TemporalType temporalType) {
+        underlyingQuery.setParameter(name, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public TypedQuery setParameter(String name, Date value, TemporalType temporalType) {
+        underlyingQuery.setParameter(name, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public TypedQuery setParameter(int position, Object value) {
+        underlyingQuery.setParameter(position, value);
+        return this;
+    }
+
+    @Override
+    public TypedQuery setParameter(int position, Calendar value, TemporalType temporalType) {
+        underlyingQuery.setParameter(position, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public TypedQuery setParameter(int position, Date value, TemporalType temporalType) {
+        underlyingQuery.setParameter(position, value, temporalType);
+        return this;
+    }
+
+    @Override
+    public Set<Parameter<?>> getParameters() {
+        return underlyingQuery.getParameters();
+    }
+
+    @Override
+    public Parameter<?> getParameter(String name) {
+        return underlyingQuery.getParameter(name);
+    }
+
+    @Override
+    public <T> Parameter<T> getParameter(String name, Class<T> type) {
+        return underlyingQuery.getParameter(name, type);
+    }
+
+    @Override
+    public Parameter<?> getParameter(int position) {
+        return underlyingQuery.getParameter(position);
+    }
+
+    @Override
+    public <T> Parameter<T> getParameter(int position, Class<T> type) {
+        return underlyingQuery.getParameter(position, type);
+    }
+
+    @Override
+    public boolean isBound(Parameter<?> param) {
+        return underlyingQuery.isBound(param);
+    }
+
+    @Override
+    public <T> T getParameterValue(Parameter<T> param) {
+        return underlyingQuery.getParameterValue(param);
+    }
+
+    @Override
+    public Object getParameterValue(String name) {
+        return underlyingQuery.getParameterValue(name);
+    }
+
+    @Override
+    public Object getParameterValue(int position) {
+        return underlyingQuery.getParameterValue(position);
+    }
+
+    @Override
+    public TypedQuery setFlushMode(FlushModeType flushMode) {
+        underlyingQuery.setFlushMode(flushMode);
+        return this;
+    }
+
+    @Override
+    public FlushModeType getFlushMode() {
+        return underlyingQuery.getFlushMode();
+    }
+
+    @Override
+    public TypedQuery setLockMode(LockModeType lockMode) {
+        underlyingQuery.setLockMode(lockMode);
+        return this;
+    }
+
+    @Override
+    public LockModeType getLockMode() {
+        return underlyingQuery.getLockMode();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> cls) {
+        return underlyingQuery.unwrap(cls);
+    }
+}

--- a/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceException;
-import javax.transaction.RollbackException;
 import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -134,14 +133,7 @@ public class TransactionUtil {
     }
 
     private void registerSynchronization(EntityManager entityManager, String puScopedName, boolean closeEMAtTxEnd) {
-        Transaction tx = getTransaction();
-        try {
-            tx.registerSynchronization(new SessionSynchronization(entityManager, closeEMAtTxEnd, puScopedName));
-        } catch (RollbackException e) {
-            throw new RuntimeException(e);
-        } catch (SystemException e) {
-            throw new RuntimeException(e);
-        }
+        getTransactionSynchronizationRegistry().registerInterposedSynchronization(new SessionSynchronization(entityManager, closeEMAtTxEnd, puScopedName));
     }
 
     private Transaction getTransaction() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/SFSB1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/SFSB1.java
@@ -99,21 +99,21 @@ public class SFSB1 {
     }
 
     public String queryEmployeeNameNoTX(int id) {
-        Query q = em.createQuery("SELECT e.name FROM Employee e");
+        Query q = em.createQuery("SELECT e.name FROM Employee e where e.id=:id");
+        q.setParameter("id", new Integer(id));
         try {
-            String name = (String)q.getSingleResult();
+            String name = (String) q.getSingleResult();
             return name;
-        }
-        catch (NoResultException expected) {
+        } catch (NoResultException expected) {
             return "success";
-        }
-        catch (Exception unexpected) {
+        } catch (Exception unexpected) {
             return unexpected.getMessage();
         }
     }
 
     public Employee queryEmployeeNoTX(int id) {
-        TypedQuery<Employee> q = em.createQuery("SELECT e FROM Employee e", Employee.class);
+        TypedQuery<Employee> q = em.createQuery("SELECT e FROM Employee e where e.id=:id", Employee.class);
+        q.setParameter("id", new Integer(id));
         return q.getSingleResult();
     }
 
@@ -121,7 +121,8 @@ public class SFSB1 {
     // For a transaction scoped persistence context non jta-tx invocation, entities returned from Query
     // must be detached.
     public boolean isQueryEmployeeDetached(int id) {
-        TypedQuery<Employee> q = em.createQuery("SELECT e FROM Employee e", Employee.class);
+        TypedQuery<Employee> q = em.createQuery("SELECT e FROM Employee e where e.id=:id", Employee.class);
+        q.setParameter("id", new Integer(id));
         Employee employee = q.getSingleResult();
         return em.contains(employee) != true;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/TransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/TransactionTestCase.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.integration.jpa.transaction;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -105,6 +106,20 @@ public class TransactionTestCase {
         SFSB1 sfsb1 = lookup("SFSB1", SFSB1.class);
         String name = sfsb1.queryEmployeeNameNoTX(1);
         assertEquals("Query should of thrown NoResultException, which we indicate by returning 'success'", "success", name);
+    }
+
+    // Test that the queried Employee is detached as required by JPA 2.0 section 3.8.6
+    // For a transaction scoped persistence context non jta-tx invocation, entities returned from Query
+    // must be detached.
+    @Test
+    public void testQueryNonTXTransactionalDetach() throws Exception {
+        SFSB1 sfsb1 = lookup("SFSB1", SFSB1.class);
+        sfsb1.createEmployee("Jill", "54 Country Lane", 2);
+        Employee employee = sfsb1.queryEmployeeNoTX(2);
+        assertNotNull(employee);
+
+        boolean detached = sfsb1.isQueryEmployeeDetached(2);
+        assertTrue("JPA 2.0 section 3.8.6 violated, query returned entity in non-tx that wasn't detached ", detached);
     }
 
     /**


### PR DESCRIPTION
Also, close the XPC only if its still open (if EMF already closed, EM is also closed).  
Also, when closing the persistence context after a TX ends, use a TSR sync instead of TX (interposed syncs run after user code completes).
