### PR TITLE
[JBQA-5483] EJBTHREE->AS7: ejb2 reference - ear archive

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/ReferenceEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/ReferenceEarTestCase.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import javax.naming.InitialContext;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Migration test from EJB Testsuite (reference21_30) to AS7 [JIRA JBQA-5483]. Test for EJB3.0/EJB2.1 references
+ * 
+ * @author William DeCoste, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+public class ReferenceEarTestCase {
+    private static final Logger log = Logger.getLogger(ReferenceEarTestCase.class);
+
+    @ArquillianResource
+    InitialContext ctx;
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "multideploy-reference21_31-test.ear");
+
+        final JavaArchive jar1 = ShrinkWrap.create(JavaArchive.class, "multideploy-ejb2.jar")
+                .addClasses(
+                        Test2.class,
+                        Test2Bean.class, 
+                        Test2Home.class);
+        jar1.addClass(ReferenceEarTestCase.class);
+        jar1.addAsManifestResource(ReferenceEarTestCase.class.getPackage(), "jboss-ejb3-ejb2.xml", "jboss-ejb3.xml");
+        jar1.addAsManifestResource(ReferenceEarTestCase.class.getPackage(), "ejb-jar-ejb2.xml", "ejb-jar.xml");
+
+        final JavaArchive jar2 = ShrinkWrap.create(JavaArchive.class, "multideploy-ejb3.jar")
+                .addClasses(
+                        Test3.class,
+                        Test3Business.class, 
+                        Test3Home.class, 
+                        Test3Bean.class);
+        jar2.addAsManifestResource(ReferenceEarTestCase.class.getPackage(), "jboss-ejb3-ejb3.xml", "jboss-ejb3.xml");
+        jar2.addAsManifestResource(ReferenceEarTestCase.class.getPackage(), "ejb-jar-ejb3.xml", "ejb-jar.xml");
+
+        log.info(ear.toString(true));
+        ear.addAsModule(jar1);
+        ear.addAsModule(jar2);
+        return ear;
+    }
+
+    @Test
+    public void testEjbInjection2() throws Exception {
+
+        Test3Home test3Home = (Test3Home) ctx.lookup("java:app/multideploy-ejb3/Test3!" + Test3Home.class.getName());
+        Test3 test3 = test3Home.create();
+        Assert.assertNotNull(test3);
+        test3.testAccess();
+
+        Test2Home home = (Test2Home) ctx.lookup("java:app/multideploy-ejb2/ejb_Test2!" + Test2Home.class.getName());
+        Assert.assertNotNull(home);
+        Test2 test2 = home.create();
+        Assert.assertNotNull(test2);
+        test2.testAccess();
+    }
+
+    @Test
+    public void testEjbInjection3() throws Exception {
+
+        Test3Business test3 = (Test3Business) ctx.lookup("java:app/multideploy-ejb3/Test3!" + Test3Business.class.getName());
+        Assert.assertNotNull(test3);
+        test3.testAccess();
+
+        Test2Home home = (Test2Home) ctx.lookup("java:app/multideploy-ejb2/ejb_Test2!" + Test2Home.class.getName());
+        Assert.assertNotNull(home);
+        Test2 test2 = home.create();
+        Assert.assertNotNull(test2);
+        test2.testAccess();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test2.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import java.rmi.RemoteException;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Test2 extends javax.ejb.EJBObject {
+    void testAccess() throws RemoteException, Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test2Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test2Bean.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.SessionContext;
+import javax.naming.InitialContext;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public class Test2Bean implements javax.ejb.SessionBean {
+    private static final long serialVersionUID = -8375644698783606562L;
+
+    public void testAccess() throws RemoteException, Exception {
+        InitialContext jndiContext = new InitialContext();
+
+        Test3Business session = (Test3Business) jndiContext.lookup("java:comp/env/ejb/Test3");
+        session.testAccess();
+
+        Test3Home home = (Test3Home) jndiContext.lookup("java:comp/env/ejb/Test3Home");
+        session = home.create();
+        session.testAccess();
+    }
+
+    public void ejbCreate() {
+
+    }
+
+    public void ejbActivate() {
+
+    }
+
+    public void ejbPassivate() {
+
+    }
+
+    public void ejbRemove() {
+
+    }
+
+    public void setSessionContext(SessionContext context) {
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test2Home.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test2Home.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import javax.ejb.*;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Test2Home extends EJBHome {
+
+    public Test2 create() throws java.rmi.RemoteException, javax.ejb.CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import javax.ejb.EJBObject;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Test3 extends EJBObject, Test3Business {
+    void testAccess() throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3Bean.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import javax.ejb.EJB;
+import javax.ejb.EJBs;
+import javax.ejb.Remote;
+import javax.ejb.RemoteHome;
+import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateless(name = "Test3")
+@Remote(Test3Business.class)
+@RemoteHome(Test3Home.class)
+@EJBs({ @EJB(name = "injected/Test2", lookup = "java:app/multideploy-ejb2/ejb_Test2!org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test2Home", beanInterface = Test2Home.class) })
+public class Test3Bean implements Test3Business {
+    private static final Logger log = Logger.getLogger(Test3Bean.class);
+
+    @EJB(name = "ejb/Test2")
+    private Test2Home test2Home = null;
+
+    public void testAccess() throws Exception {
+        Test2 test2 = test2Home.create();
+
+        InitialContext jndiContext = new InitialContext();
+        Test2Home home = (Test2Home) jndiContext.lookup("java:comp/env/injected/Test2");
+        test2 = home.create();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3Business.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3Business.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Test3Business {
+    void testAccess() throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3Home.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/Test3Home.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.ejb2.reference.eararchive;
+
+import javax.ejb.*;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Test3Home extends EJBHome {
+
+    public Test3 create() throws java.rmi.RemoteException, javax.ejb.CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/ejb-jar-ejb2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/ejb-jar-ejb2.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' ?>
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" 
+                         "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<ejb-jar>
+	<enterprise-beans>
+		<session>
+        	<ejb-name>ejb_Test2</ejb-name>
+         	<home>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test2Home</home>
+         	<remote>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test2</remote>
+         	<ejb-class>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test2Bean</ejb-class>
+         	<session-type>Stateless</session-type>
+         	<transaction-type>Container</transaction-type>
+            <ejb-ref>
+				<ejb-ref-name>ejb/Test3</ejb-ref-name>
+				<ejb-ref-type>Session</ejb-ref-type>
+				<home>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test3Home</home>
+				<remote>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test3</remote>
+			</ejb-ref>
+			<ejb-ref>
+				<ejb-ref-name>ejb/Test3Home</ejb-ref-name>
+				<ejb-ref-type>Session</ejb-ref-type>
+				<home>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test3Home</home>
+				<remote>org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test3</remote>
+			</ejb-ref> 
+    	</session>
+	</enterprise-beans>
+</ejb-jar>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/ejb-jar-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/ejb-jar-ejb3.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' ?>
+<ejb-jar
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                            http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+        version="3.0">
+	<enterprise-beans>
+		<session>
+			<ejb-name>Test3</ejb-name>
+			<ejb-ref>
+				<ejb-ref-name>ejb/Test2</ejb-ref-name>
+				<ejb-ref-type>Session</ejb-ref-type>
+			</ejb-ref>            
+		</session>
+	</enterprise-beans>
+</ejb-jar>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb2.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+                  xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd
+                     http://www.jboss.org/j2ee/schema/jboss_5_0.xsd"
+                  version="3.1"
+                  impl-version="2.0">
+   <enterprise-beans>
+      <session>
+         <ejb-name>ejb_Test2</ejb-name>
+         <ejb-ref>
+		    <ejb-ref-name>ejb/Test3Home</ejb-ref-name>
+		    <jndi-name>java:app/multideploy-ejb3/Test3!org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test3Home</jndi-name>
+		 </ejb-ref>
+         <ejb-ref>
+            <ejb-ref-name>ejb/Test3</ejb-ref-name>
+            <jndi-name>java:app/multideploy-ejb3/Test3!org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test3</jndi-name>
+         </ejb-ref>
+
+         <!-- 
+         JBoss descriptor does not provide this global jnd-name binding functionality. see jira AS7-3015. 
+          <jndi-name>Test2</jndi-name>  -->
+
+      </session>
+   </enterprise-beans>
+</jboss:ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb3.xml
@@ -1,0 +1,20 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+                  xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd
+                     http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd
+                     http://www.jboss.org/j2ee/schema/jboss_5_0.xsd"
+                  version="3.1"
+                  impl-version="2.0">
+	<enterprise-beans>
+		<session>
+			<ejb-name>Test3</ejb-name>
+			<ejb-ref>
+				<ejb-ref-name>ejb/Test2</ejb-ref-name>
+				<jndi-name>java:app/multideploy-ejb2/ejb_Test2!org.jboss.as.test.integration.ejb.ejb2.reference.eararchive.Test2Home</jndi-name>
+			</ejb-ref>
+		</session>
+	</enterprise-beans>
+</jboss:ejb-jar>
+


### PR DESCRIPTION
Part of migration of EJB3 testsuite to AS7 testsuite.
Testing reference two jars of ear archive.
There was already a pull request for this test but test is not in upstream. I'm not sure whether it's ok or not.
