### PR TITLE
[JBQA-5275] AS6->AS7: jndi module name lookup

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/ear/ClassLoadingEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/ear/ClassLoadingEJB.java
@@ -23,6 +23,8 @@
 package org.jboss.as.test.integration.deployment.structure.ear;
 
 import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 /**
  * User: jpai
@@ -40,5 +42,10 @@ public class ClassLoadingEJB {
 
     public boolean hasResource(String resource) {
         return this.getClass().getResource(resource) != null;
+    }
+    
+    public String query(String name) throws NamingException
+    {
+       return new InitialContext().lookup(name).toString();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/ear/EarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/ear/EarJBossDeploymentStructureTestCase.java
@@ -1,5 +1,7 @@
 package org.jboss.as.test.integration.deployment.structure.ear;
 
+import static org.junit.Assert.assertEquals;
+
 import javax.ejb.EJB;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -100,4 +102,13 @@ public class EarJBossDeploymentStructureTestCase {
         Assert.assertTrue(this.ejb.hasResource("/META-INF/" + METAINF_RESOURCE_TXT));
     }
 
+    /**
+     * EE.5.15, part of testsuite migration AS6->AS7 (jbas7556)
+     */
+    @Test
+    public void testModuleName() throws Exception
+    {
+       String result = ejb.query("java:module/ModuleName");
+       assertEquals("ejb", result);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/ClassLoadingEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/ClassLoadingEJB.java
@@ -23,6 +23,8 @@
 package org.jboss.as.test.integration.deployment.structure.jar;
 
 import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 /**
  * User: jpai
@@ -36,5 +38,10 @@ public class ClassLoadingEJB {
             throw new RuntimeException("Classname parameter cannot be null or empty");
         }
         return this.getClass().getClassLoader().loadClass(className);
+    }
+    
+    public String query(String name) throws NamingException
+    {
+       return new InitialContext().lookup(name).toString();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/JarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/JarJBossDeploymentStructureTestCase.java
@@ -1,5 +1,7 @@
 package org.jboss.as.test.integration.deployment.structure.jar;
 
+import static org.junit.Assert.assertEquals;
+
 import javax.ejb.EJB;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -76,4 +78,13 @@ public class JarJBossDeploymentStructureTestCase {
         Assert.assertTrue(ClassLoadingEJB.class.getProtectionDomain().getCodeSource().getLocation().getProtocol().equals("jar"));
     }
 
+    /**
+     * EE.5.15, part of testsuite migration AS6->AS7 (jbas7556)
+     */
+    @Test
+    public void testModuleName() throws Exception
+    {
+       String result = ejb.query("java:module/ModuleName");
+       assertEquals("deployment-structure", result);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/ClassLoadingEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/ClassLoadingEJB.java
@@ -23,6 +23,8 @@
 package org.jboss.as.test.integration.deployment.structure.war;
 
 import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 /**
  * User: jpai
@@ -36,5 +38,10 @@ public class ClassLoadingEJB {
             throw new RuntimeException("Classname parameter cannot be null or empty");
         }
         return this.getClass().getClassLoader().loadClass(className);
+    }
+    
+    public String query(String name) throws NamingException
+    {
+       return new InitialContext().lookup(name).toString();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
@@ -1,5 +1,7 @@
 package org.jboss.as.test.integration.deployment.structure.war;
 
+import static org.junit.Assert.assertEquals;
+
 import javax.ejb.EJB;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -77,4 +79,13 @@ public class WarJBossDeploymentStructureTestCase {
         Assert.assertTrue(ClassLoadingEJB.class.getProtectionDomain().getCodeSource().getLocation().getProtocol().equals("file"));
     }
 
+    /**
+     * EE.5.15, part of testsuite migration AS6->AS7 (jbas7556)
+     */
+    @Test
+    public void testModuleName() throws Exception
+    {
+       String result = ejb.query("java:module/ModuleName");
+       assertEquals("deployment-structure", result);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/DeploymentWithBindTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/DeploymentWithBindTestCase.java
@@ -32,6 +32,8 @@ import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Part of migration of AS6 testsuite to AS7 testsuite.
Testing of ability of lookup module name via jndi.
