### PR TITLE
AS7-3119 recurring timer executed concurrent if execution time longer than interval

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -26,12 +26,11 @@ package org.jboss.as.ejb3;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.File;
-import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Date;
 
 import javax.ejb.Timer;
 
@@ -318,7 +317,7 @@ public interface EjbLogger extends BasicLogger {
     void discardingEntityComponent(EntityBeanComponentInstance instance, @Cause Throwable t);
 
     /**
-     * Logs an error message indicating that an invocation failred
+     * Logs an error message indicating that an invocation failed
      */
     @LogMessage(level = ERROR)
     @Message(id = 14134, value = "EJB Invocation failed on component %s for method %s")
@@ -396,4 +395,10 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 14142, value = "Started message driven bean '%s' with '%s' resource adapter")
     void logMDBStart(final String mdbName, final String raName);
 
+    /**
+     * Logs a waring message indicating an overlapped invoking timeout for timer
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 14143, value = "Timer %s is still active, skipping overlapping scheduled execution at: %s")
+    void skipOverlappingInvokeTimeout(String id, Date scheduledTime);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.ejb3.timerservice.task;
 
+import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
+import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+
 import java.util.Date;
 
 import org.jboss.as.ejb3.timerservice.TimerImpl;
@@ -28,9 +31,6 @@ import org.jboss.as.ejb3.timerservice.TimerServiceImpl;
 import org.jboss.as.ejb3.timerservice.TimerState;
 import org.jboss.as.ejb3.timerservice.spi.BeanRemovedException;
 import org.jboss.as.ejb3.timerservice.spi.TimedObjectInvoker;
-
-import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
-import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 
 /**
  * A timer task which will be invoked at appropriate intervals based on a {@link javax.ejb.Timer}
@@ -105,6 +105,14 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
             if(this.timer.getNextExpiration() != null) {
                 this.timer.scheduleTimeout();
             }
+            return;
+        }
+        // If the recurring timer running longer than the interval is, we don't want to allow another
+        // execution until the it is complete. See JIRA AS7-3119
+        if(this.timer.getState() == TimerState.IN_TIMEOUT && !this.timer.isCalendarTimer()) {
+            ROOT_LOGGER.skipOverlappingInvokeTimeout(this.timer.getId(), now);
+            this.timer.setNextTimeout(this.calculateNextTimeout());
+            this.timerService.persistTimer(this.timer);
             return;
         }
 


### PR DESCRIPTION
The execution of a interval timer timeout is suppressed if the timer is still active.
This is compatible to the former AS versions.
A WARNING message 'JBAS014143: Timer is still active, skipping overlapping scheduled execution at: ' will be logged.

Calendar timer are still executed concurrent.

This is a rebased version of pull-request #997. It is not a still merged fix as Stuart mentionend.
I checked the behaviour before and after.
