### PR TITLE
Jandex-ing org.picketlink module to process annotations inside it (AS7-3106)

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1097,8 +1097,8 @@
         </module-def>
 
         <module-def name="org.picketlink">
-            <maven-resource group="org.picketlink" artifact="picketlink-fed"/>
-            <maven-resource group="org.picketlink" artifact="picketlink-bindings"/>
+            <maven-resource group="org.picketlink" artifact="picketlink-fed" jandex="true"/>
+            <maven-resource group="org.picketlink" artifact="picketlink-bindings" jandex="true"/>
             <maven-resource group="org.picketlink" artifact="picketlink-bindings-jboss"/>
             <maven-resource group="org.picketlink" artifact="picketlink-trust-jbossws"/>
         </module-def>


### PR DESCRIPTION
As the issue AS7-3116 is resolved, I would need to jandex following jars (see commit).
