### PR TITLE
[AS7-3250] fix parse fail when jboss-ejb-client.xml has multiple

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor10Parser.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor10Parser.java
@@ -246,6 +246,11 @@ class EJBClientDescriptor10Parser implements XMLElementReader<EJBClientDescripto
         if (!required.isEmpty()) {
             missingAttributes(reader.getLocation(), required);
         }
+        // This element is just composed of attributes which we already processed, so no more content
+        // is expected
+        if (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            unexpectedContent(reader);
+        }
     }
 
     private static void unexpectedEndOfDocument(final Location location) throws XMLStreamException {


### PR DESCRIPTION
remote-ejb-receiver element
