### PR TITLE
AS7-3260 - Fix distributed deploy for Windows DC

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerImpl.java
@@ -262,7 +262,7 @@ public class MasterDomainControllerOperationHandlerImpl extends ManagementChanne
         }
 
         private String getRelativePath(final File parent, final File child) {
-            return child.getAbsolutePath().substring(parent.getAbsolutePath().length());
+            return child.getAbsolutePath().substring(parent.getAbsolutePath().length()+1);
         }
 
         private void writeFile(final File localPath, final File file, final FlushableDataOutput output) throws IOException {


### PR DESCRIPTION
This patch fixes problem when you have Windows DC and Linux HC
File path had path separator in name and that failed deployment
