### PR TITLE
AS7-2895 Fix for windows startup scripts

### DIFF
--- a/build/src/main/resources/bin/appclient.conf.bat
+++ b/build/src/main/resources/bin/appclient.conf.bat
@@ -62,6 +62,6 @@ rem # Sample JPDA settings for shared memory debugging
 rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 rem # Use JBoss Modules lockless mode
-rem #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=true"
+rem #JAVA_OPTS="%JAVA_OPTS% -Djboss.modules.lockless=true"
 
 :JAVA_OPTS_SET

--- a/build/src/main/resources/bin/domain.conf.bat
+++ b/build/src/main/resources/bin/domain.conf.bat
@@ -56,7 +56,7 @@ rem # This is necessary to inject Byteman rules into AS7 deployments
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=org.jboss.byteman"
 
 rem # Use JBoss Modules lockless mode
-rem #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=true"
+rem #JAVA_OPTS="%JAVA_OPTS% -Djboss.modules.lockless=true"
 
 rem The ProcessController process uses its own set of java options
 set "PROCESS_CONTROLLER_JAVA_OPTS=%JAVA_OPTS%"

--- a/build/src/main/resources/bin/standalone.conf.bat
+++ b/build/src/main/resources/bin/standalone.conf.bat
@@ -62,6 +62,6 @@ rem # Sample JPDA settings for shared memory debugging
 rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 rem # Use JBoss Modules lockless mode
-rem #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=true"
+rem #JAVA_OPTS="%JAVA_OPTS% -Djboss.modules.lockless=true"
 
 :JAVA_OPTS_SET


### PR DESCRIPTION
There ware few errors in path expansion that used *nix notation instead of windows.
