### PR TITLE
AS7-3284

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/LegacyGlobalConfigurationAdapter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/LegacyGlobalConfigurationAdapter.java
@@ -142,7 +142,7 @@ public class LegacyGlobalConfigurationAdapter {
         ;
 
         for (AdvancedExternalizerConfig externalizerConfig : legacy.getExternalizers()) {
-            builder.serialization().addAdvancedExternalizer(externalizerConfig.getAdvancedExternalizer());
+            builder.serialization().addAdvancedExternalizer(externalizerConfig.getId(), externalizerConfig.getAdvancedExternalizer());
         }
 
         builder.asyncTransportExecutor()


### PR DESCRIPTION
AS7-3284: When copying advancedexternalizer from the legacy configuration, use the id coming from the externalizerconfig, since it may have been assigned by a module lifecycle and not overridden from AbstractExternalizer
