### PR TITLE
Update on IIOP context propagation tests in AS7 - JBQA-5190

### DIFF
--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/ClientEjb.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/ClientEjb.java
@@ -71,9 +71,35 @@ public class ClientEjb {
                 userTransaction.rollback();
             }
         }
-        if (succeeded) {
-            Assert.assertTrue(remote.isBeforeCompletion());
-        }
+        Assert.assertEquals(succeeded, remote.isBeforeCompletion());
         Assert.assertEquals((Boolean) succeeded, remote.getCommitSuceeded());
     }
+
+    public void testRollbackOnly() throws RemoteException, SystemException, NotSupportedException {
+        final IIOPTransactionalStatefulRemote remote = statefulHome.create();
+        userTransaction.begin();
+        try {
+            Assert.assertEquals(Status.STATUS_ACTIVE, remote.transactionStatus());
+            remote.rollbackOnly();
+            Assert.assertEquals(Status.STATUS_MARKED_ROLLBACK, remote.transactionStatus());
+        } finally {
+            userTransaction.rollback();
+        }
+        Assert.assertFalse(remote.isBeforeCompletion());
+        Assert.assertFalse(remote.getCommitSuceeded());
+    }
+
+    public void testRollbackOnlyBeforeCompletion() throws RemoteException, SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException {
+        final IIOPTransactionalStatefulRemote remote = statefulHome.create();
+        userTransaction.begin();
+        try {
+            Assert.assertEquals(Status.STATUS_ACTIVE, remote.transactionStatus());
+            remote.setRollbackOnlyBeforeCompletion(true);
+            userTransaction.commit();
+        } catch (RollbackException expected) {
+        }
+        Assert.assertFalse(remote.getCommitSuceeded());
+        Assert.assertEquals(Status.STATUS_NO_TRANSACTION, remote.transactionStatus());
+    }
+
 }

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/IIOPTransactionalStatefulRemote.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/IIOPTransactionalStatefulRemote.java
@@ -19,4 +19,8 @@ public interface IIOPTransactionalStatefulRemote extends EJBObject {
 
     public void sameTransaction(boolean first) throws RemoteException;
 
+    void rollbackOnly() throws RemoteException;
+
+    public void setRollbackOnlyBeforeCompletion(boolean rollbackOnlyInBeforeCompletion) throws RemoteException;
+
 }

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/TransactionIIOPInvocationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/TransactionIIOPInvocationTestCase.java
@@ -80,6 +80,22 @@ public class TransactionIIOPInvocationTestCase {
 
     @Test
     @OperateOnDeployment("client")
+    public void testRollbackOnly() throws IOException, NamingException, NotSupportedException, SystemException {
+        final InitialContext context = new InitialContext();
+        final ClientEjb ejb = (ClientEjb) context.lookup("java:module/" + ClientEjb.class.getSimpleName());
+        ejb.testRollbackOnly();
+    }
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testRollbackOnlyBeforeCompletion() throws IOException, NamingException, NotSupportedException, SystemException, HeuristicMixedException, HeuristicRollbackException {
+        final InitialContext context = new InitialContext();
+        final ClientEjb ejb = (ClientEjb) context.lookup("java:module/" + ClientEjb.class.getSimpleName());
+        ejb.testRollbackOnlyBeforeCompletion();
+    }
+
+    @Test
+    @OperateOnDeployment("client")
     public void testSameTransactionEachCall() throws IOException, NamingException, NotSupportedException, SystemException {
         final InitialContext context = new InitialContext();
         final ClientEjb ejb = (ClientEjb) context.lookup("java:module/" + ClientEjb.class.getSimpleName());


### PR DESCRIPTION
This update covers rollback invoked on the remote server side and also
ensures that beforeCompletion method is not called in case of the
transaction marked for rollback-only.
