### PR TITLE
AS7-3286 Register InitialContextFactoryBuilder service with the OSGi layer

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/InitialContextFactoryBuilder.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContextFactoryBuilder.java
@@ -22,13 +22,14 @@
 
 package org.jboss.as.naming;
 
-import javax.naming.Context;
-import javax.naming.NamingException;
+import static org.jboss.as.naming.NamingMessages.MESSAGES;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Hashtable;
 
-import static org.jboss.as.naming.NamingMessages.MESSAGES;
+import javax.naming.Context;
+import javax.naming.NamingException;
 
 /**
  * Initial context factory builder which ensures the proper naming context factory is used if the environment
@@ -48,6 +49,9 @@ public class InitialContextFactoryBuilder implements javax.naming.spi.InitialCon
      * @throws NamingException If an error occurs loading the factroy class.
      */
     public javax.naming.spi.InitialContextFactory createInitialContextFactory(Hashtable<?, ?> environment) throws NamingException {
+        if (environment == null)
+            environment = new Hashtable<String, Object>();
+
         final String factoryClassName = (String)environment.get(Context.INITIAL_CONTEXT_FACTORY);
         if(factoryClassName == null || InitialContextFactory.class.getName().equals(factoryClassName)) {
             return DEFAULT_FACTORY;

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemAdd.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemAdd.java
@@ -28,12 +28,13 @@ import java.util.List;
 
 import javax.naming.CompositeName;
 import javax.naming.Context;
+import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.naming.InitialContextFactoryService;
+import org.jboss.as.naming.InitialContextFactoryBuilder;
 import org.jboss.as.naming.NamingContext;
 import org.jboss.as.naming.NamingStore;
 import org.jboss.as.naming.ServiceBasedNamingStore;
@@ -118,8 +119,11 @@ public class NamingSubsystemAdd extends AbstractBoottimeAddStepHandler {
             }
         });
 
-        // Provide the {@link InitialContext} as OSGi service
-        newControllers.add(InitialContextFactoryService.addService(target, verificationHandler));
+        // Register InitialContext and InitialContextFactoryBuilder as OSGi services
+        newControllers.add(NamingSubsystemOSGiService.addService(target,
+                InitialContext.class, InitialContext.class, verificationHandler));
+        newControllers.add(NamingSubsystemOSGiService.addService(target,
+                javax.naming.spi.InitialContextFactoryBuilder.class, InitialContextFactoryBuilder.class, verificationHandler));
 
         newControllers.add(target.addService(JndiViewExtensionRegistry.SERVICE_NAME, new JndiViewExtensionRegistry()).install());
 


### PR DESCRIPTION
Similar code was already in place for the InitialContext. I generalized
this into a single generic service registration class.

Also found a bug in the JBoss InitialContextFactoryBuilder in that it
didn't accept a null argument, which the spec allows. I fixed this.

The above is tested in the provided JNDITestCase integration test.
