### PR TITLE
AS7-3295: make SingletonService call election policy for single-node clusters too

### DIFF
--- a/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/SingletonService.java
+++ b/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/SingletonService.java
@@ -144,7 +144,7 @@ public class SingletonService<T extends Serializable> implements Service<T>, Ser
 
         if (nodes.isEmpty()) return null;
 
-        return (this.electionPolicy == null) || (nodes.size() == 1) ? nodes.get(0) : this.electionPolicy.elect(nodes);
+        return (this.electionPolicy == null) ? nodes.get(0) : this.electionPolicy.elect(nodes);
     }
 
     private void startNewMaster() {


### PR DESCRIPTION
This removes the code fragment which returns the node if there is only one the cluster view, and instead delegates to the election policy. This allows a policy to indicate there should be no master in the cluster.
