### PR TITLE
AS7-3297 allow setting jboss.domain.master.port as the host.xml example shows

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2353,4 +2353,16 @@ public interface ControllerMessages {
      */
     @Message(id = 14835, value = "The '%s' attribute of the '%s' parameter can not be converted to an integer in the description of the operation at %s: %s")
     String invalidDescriptionMinMaxLengthForParameterHasWrongType(String minOrMaxLength, String paramName, PathAddress address, ModelNode description);
+
+    /**
+     * Creates an exception indicating the {@code value} for the {@code name} must be a valid port number.
+     *
+     * @param name     the name for the value that must be a port number.
+     * @param value    the invalid value.
+     * @param location the location of the error.
+     *
+     * @return a {@link XMLStreamException} for the error.
+     */
+    @Message(id = 14836, value = "Illegal '%s' value %s -- must be a valid port number")
+    XMLStreamException invalidPort(String name, String value, @Param Location location);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -83,6 +83,7 @@ import org.jboss.as.domain.management.parsing.ManagementXml;
 import org.jboss.as.host.controller.resources.HttpManagementResourceDefinition;
 import org.jboss.as.host.controller.resources.NativeManagementResourceDefinition;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -738,7 +739,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
             final List<ModelNode> list) throws XMLStreamException {
         // Handle attributes
         String host = null;
-        Integer port = null;
+        ModelNode port = null;
         String securityRealm = null;
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
@@ -753,9 +754,16 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                         break;
                     }
                     case PORT: {
-                        port = Integer.valueOf(value);
-                        if (port.intValue() < 1) {
-                            throw MESSAGES.invalidValueGreaterThan(attribute.getLocalName(), port, 0, reader.getLocation());
+                        port = parsePossibleExpression(value);
+                        if(port.getType() != ModelType.EXPRESSION) {
+                            try {
+                                Integer portNo = Integer.valueOf(value);
+                                if (portNo.intValue() < 1) {
+                                    throw MESSAGES.invalidPort(attribute.getLocalName(), value, reader.getLocation());
+                                }
+                            }catch(NumberFormatException e) {
+                                throw MESSAGES.invalidPort(attribute.getLocalName(), value, reader.getLocation());
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
Acept 'jboss.domain.master.port' startup property as the host.xml example for remote domain controller.
Throw a JBAS014836 message if the attribute is not a portnumber or an expression.
