### PR TITLE
[JBQA-5275] AS5->AS7: servlet ejbs

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/EJBServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/EJBServlet.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.ejb.EJB;
+import javax.naming.InitialContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.logging.Logger;
+import org.jboss.security.client.SecurityClient;
+import org.jboss.security.client.SecurityClientFactory;
+
+/**
+ * A servlet that accesses an EJB and tests whether the call argument is serialized.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public class EJBServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final Logger log = Logger.getLogger(EJBServlet.class);
+
+    @EJB(lookup = "java:global/ejb3-servlet-ejbs/Session30!org.jboss.as.test.integration.ejb.servlet.Session30BusinessRemote")
+    Session30BusinessRemote injectedSession;
+
+    @EJB(lookup = "java:global/ejb3-servlet-ejbs/StatelessBean!org.jboss.as.test.integration.ejb.servlet.StatelessLocal")
+    StatelessLocal injectedStateless;
+
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        SecurityClient client = null;
+        try {           
+            InitialContext ctx = new InitialContext();
+            
+            client = SecurityClientFactory.getSecurityClient();
+            client.setSimple("somebody", "password");
+            client.login();
+
+            injectedSession.hello();
+            injectedSession.goodbye();
+
+            injectedStateless.hello();
+            injectedStateless.goodbye();
+
+            String lookupString = "java:global/ejb3-servlet-ejbs/Session30!";
+            EJBServletHelper test = new EJBServletHelper();
+            test.processRequest(lookupString, ctx);
+        } catch (Exception e) {
+            log.error(e);
+            throw new ServletException("Failed to call EJBs/Session30 through remote and local interfaces", e);
+        } finally {
+            client.logout();
+        }
+        response.setContentType("text/plain");
+        PrintWriter out = response.getWriter();
+        out.print("EJBServlet OK");
+        out.close();
+    }
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/EJBServletEar.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/EJBServletEar.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.ejb.EJB;
+import javax.naming.InitialContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.logging.Logger;
+import org.jboss.security.client.SecurityClient;
+import org.jboss.security.client.SecurityClientFactory;
+
+/**
+ * A servlet that accesses an EJB and tests whether the call argument is serialized.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public class EJBServletEar extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final Logger log = Logger.getLogger(EJBServletEar.class);
+
+    @EJB(lookup = "java:app/ejb3-ear-servlet-ejbs/Session30!org.jboss.as.test.integration.ejb.servlet.Session30BusinessRemote")
+    Session30BusinessRemote injectedSession;
+
+    @EJB(lookup = "java:app/ejb3-ear-servlet-ejbs/StatelessBean!org.jboss.as.test.integration.ejb.servlet.StatelessLocal")
+    StatelessLocal injectedStateless;
+
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        SecurityClient client = null;
+        try {           
+            InitialContext ctx = new InitialContext();
+            
+            client = SecurityClientFactory.getSecurityClient();
+            client.setSimple("somebody", "password");
+            client.login();
+
+            injectedSession.hello();
+            injectedSession.goodbye();
+
+            injectedStateless.hello();
+            injectedStateless.goodbye();
+
+            String lookupString = "java:app/ejb3-ear-servlet-ejbs/Session30!";
+            EJBServletHelper test = new EJBServletHelper();
+            test.processRequest(lookupString, ctx);
+        } catch (Exception e) {
+            log.error(e);
+            throw new ServletException("Failed to call EJBs/Session30 through remote and local interfaces", e);
+        } finally {
+            client.logout();
+        }
+        response.setContentType("text/plain");
+        PrintWriter out = response.getWriter();
+        out.print("EJBServlet OK");
+        out.close();
+    }
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/EJBServletHelper.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/EJBServletHelper.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.naming.InitialContext;
+
+/**
+ * Implements processRequest method.
+ */
+public class EJBServletHelper {
+
+    protected void processRequest(String lookupString, InitialContext ctx) throws Exception {
+
+        Session30BusinessRemote remote = (Session30BusinessRemote) ctx.lookup(lookupString + Session30BusinessRemote.class.getName());
+
+        remote.hello();
+        remote.goodbye();
+
+        TestObject o = new TestObject();
+        remote.access(o);
+        o = remote.createTestObject();
+
+        Session30BusinessLocal local = (Session30BusinessLocal) ctx.lookup(lookupString + Session30BusinessLocal.class.getName());
+        o = new TestObject();
+        local.access(o);
+        o = local.createTestObject();
+        local.getWarTestObject();
+
+        Session30Home home = (Session30Home) ctx.lookup(lookupString + Session30Home.class.getName());
+        Session30Remote remote21 = home.create();
+        remote21.access(o);
+
+        Session30LocalHome localHome = (Session30LocalHome) ctx.lookup(lookupString + Session30LocalHome.class.getName());
+        Session30Local local21 = localHome.create();
+        local21.access(o);
+
+        home = (Session30Home) ctx.lookup("java:comp/env/ejb/remote/Session30");
+        remote21 = home.create();
+        remote21.access(o);
+
+        localHome = (Session30LocalHome) ctx.lookup("java:comp/env/ejb/local/Session30");
+        local21 = localHome.create();
+        local21.access(o);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/ServletUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/ServletUnitTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A servlet that accesses an EJB and tests whether the call argument is serialized.
+ * Part of migration AS5 testsuite to AS7 [JIRA JBQA-5275].
+ * 
+ * @author William DeCoste, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ServletUnitTestCase {
+    private static final Logger log = Logger.getLogger(ServletUnitTestCase.class.getName());
+
+    @Deployment(name = "ejb", order = 2)
+    public static Archive<?> deployEjbs() {
+        JavaArchive jar = getEjbs("ejb3-servlet-ejbs.jar");
+        jar.addAsManifestResource(new StringAsset("Dependencies: deployment.ejb3-servlet-client.jar \n"), "MANIFEST.MF");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    @Deployment(name = "client", order = 1)
+    public static Archive<?> deployClient() {
+        JavaArchive jar = getClient("ejb3-servlet-client.jar");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    @Deployment(name = "servlet", order = 3)
+    public static Archive<?> deployServlet() {
+        WebArchive war = getServlet("ejb3-servlet.war");
+        war.addClass(EJBServlet.class);
+        war.addAsWebInfResource(ServletUnitTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.addAsWebInfResource(ServletUnitTestCase.class.getPackage(), "web.xml", "web.xml");
+        war.addAsManifestResource(new StringAsset("Dependencies: deployment.ejb3-servlet-ejbs.jar \n"), "MANIFEST.MF");
+        log.info(war.toString(true));
+        return war;
+    }
+    
+    @Deployment(name = "ear", order = 4) 
+    public static Archive<?> deployEar() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ejb3-ear-servlet.ear");
+        
+        ear.addAsModule(getClient("ejb3-ear-servlet-client.jar"));
+        ear.addAsModule(getEjbs("ejb3-ear-servlet-ejbs.jar"));
+        
+        WebArchive war = getServlet("ejb3-ear-servlet.war");
+        war.addAsWebInfResource(ServletUnitTestCase.class.getPackage(), "jboss-web-ear.xml", "jboss-web.xml");
+        war.addAsWebInfResource(ServletUnitTestCase.class.getPackage(), "web-ear.xml", "web.xml");
+        war.addClass(EJBServletEar.class);
+        ear.addAsModule(war);
+        
+        ear.addAsManifestResource(ServletUnitTestCase.class.getPackage(), "application.xml", "application.xml");
+        log.info(ear.toString(true));
+        return ear;
+    }
+
+    private static JavaArchive getEjbs(String archiveName) {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, archiveName);
+        jar.addClasses(
+                Session30.class, 
+                Session30Bean.class, 
+                Session30BusinessLocal.class, 
+                Session30BusinessRemote.class,
+                Session30Home.class, 
+                Session30Local.class, 
+                Session30LocalHome.class, 
+                Session30Remote.class, 
+                StatefulBean.class,
+                StatefulLocal.class, 
+                StatefulRemote.class, 
+                StatelessBean.class, 
+                StatelessLocal.class,
+                TestObject.class);
+        jar.addAsResource(ServletUnitTestCase.class.getPackage(), "users.properties", "users.properties");
+        jar.addAsResource(ServletUnitTestCase.class.getPackage(), "roles.properties", "roles.properties");
+        return jar;
+    }
+
+    private static JavaArchive getClient(String archiveName) {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, archiveName);
+        jar.addClasses(WarTestObject.class);
+        return jar;
+    }
+
+    private static WebArchive getServlet(String archiveName) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, archiveName);
+        war.addClasses(EJBServletHelper.class);
+        return war;
+    }
+
+    @Test
+    public void testEJBServletEar() throws Exception {
+        String res = HttpRequest.get("http://localhost:8080/servlet/EJBServlet", 2, TimeUnit.SECONDS);
+        Assert.assertEquals("EJBServlet OK", res);
+    }
+    
+    @Test
+    public void testEJBServlet() throws Exception {
+        String res = HttpRequest.get("http://localhost:8080/ejb3-servlet/EJBServlet", 2, TimeUnit.SECONDS);
+        Assert.assertEquals("EJBServlet OK", res);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Session30 {
+    void hello();
+
+    void goodbye();
+
+    String access(TestObject o);
+
+    TestObject createTestObject();
+
+    boolean checkEqPointer(TestObject to);
+
+    WarTestObject getWarTestObject();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Bean.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.EJB;
+import javax.ejb.Local;
+import javax.ejb.LocalHome;
+import javax.ejb.Remote;
+import javax.ejb.RemoteHome;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateless(name = "Session30")
+@Remote(Session30BusinessRemote.class)
+@Local(Session30BusinessLocal.class)
+@RemoteHome(Session30Home.class)
+@LocalHome(Session30LocalHome.class)
+@SecurityDomain("other")
+public class Session30Bean implements Session30 {
+
+    @EJB
+    private StatefulRemote stateful;
+
+    private TestObject testObject;
+
+    @RolesAllowed({ "allowed" })
+    public void hello() {
+    }
+
+    @RolesAllowed({ "allowed" })
+    public void goodbye() {
+    }
+
+    public String access(TestObject o) {
+        return stateful.access(o);
+    }
+
+    public TestObject createTestObject() {
+        testObject = new TestObject();
+        return testObject;
+    }
+
+    public boolean checkEqPointer(TestObject to) {
+        return to == testObject;
+    }
+
+    public WarTestObject getWarTestObject() {
+        return new WarTestObject();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30BusinessLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30BusinessLocal.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.ejb.Local;
+
+/**
+ * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
+ */
+@Local
+public interface Session30BusinessLocal /* extends Session30 */ {
+    // FIXME: AS7-3006 - there should not be a need to define the methods here whe they're inherited from Session30    
+    void hello() ;  
+
+    void goodbye();
+
+    String access(TestObject o);
+
+    TestObject createTestObject();
+
+    boolean checkEqPointer(TestObject to);
+
+    WarTestObject getWarTestObject();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30BusinessRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30BusinessRemote.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.Remote;
+
+/**
+ * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
+ */
+@Remote
+public interface Session30BusinessRemote /* extends Session30 */ {
+    // FIXME: AS7-3006 - there should not be a need to define the methods here whe they're inherited from Session30 
+    void hello() throws RemoteException;  
+
+    void goodbye() throws RemoteException;
+
+    String access(TestObject o) throws RemoteException;
+
+    TestObject createTestObject() throws RemoteException;
+
+    boolean checkEqPointer(TestObject to) throws RemoteException;
+
+    WarTestObject getWarTestObject() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Home.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Home.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBHome;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Session30Home extends EJBHome {
+    public Session30Remote create() throws javax.ejb.CreateException,  RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Local.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Local.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.ejb.EJBLocalObject;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Session30Local extends EJBLocalObject /*, Session30 */ {
+    // FIXME: AS7-3006 - there should not be a need to define the methods here whe they're inherited from Session30    
+    void hello();  
+
+    void goodbye();
+
+    String access(TestObject o);
+
+    TestObject createTestObject();
+
+    boolean checkEqPointer(TestObject to);
+
+    WarTestObject getWarTestObject();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30LocalHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30LocalHome.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.ejb.EJBLocalHome;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Session30LocalHome extends EJBLocalHome {
+    public Session30Local create() throws javax.ejb.CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Remote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Remote.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface Session30Remote extends EJBObject /*, Session30 */ {
+    // FIXME: AS7-3006 - there should not be a need to define the methods here whe they're inherited from Session30
+    void hello() throws RemoteException;  
+
+    void goodbye() throws RemoteException;
+
+    String access(TestObject o) throws RemoteException;
+
+    TestObject createTestObject() throws RemoteException;
+
+    boolean checkEqPointer(TestObject to) throws RemoteException;
+
+    WarTestObject getWarTestObject() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulBean.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.ejb.Local;
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateful(name = "Stateful")
+@Remote(StatefulRemote.class)
+@Local(StatefulLocal.class)
+@SecurityDomain("other")
+public class StatefulBean implements StatefulRemote, StatefulLocal {
+    public String access(TestObject o) {
+        return "Session30";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulLocal.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface StatefulLocal {
+    String access(TestObject o);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulRemote.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface StatefulRemote {
+    String access(TestObject o);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatelessBean.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+import javax.ejb.Local;
+import javax.ejb.Stateful;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+@Stateful
+@Local(StatelessLocal.class)
+public class StatelessBean implements StatelessLocal {
+    public void hello() {
+    }
+
+    public void goodbye() {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatelessLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatelessLocal.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface StatelessLocal {
+    void hello();
+
+    void goodbye();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/TestObject.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/TestObject.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+
+public class TestObject implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public TestObject() {
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/WarTestObject.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/WarTestObject.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.servlet;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+
+public class WarTestObject implements java.io.Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public WarTestObject() {
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/application.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/application.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/application_5.xsd"
+    version="5" id="application-test-everything">
+
+    <display-name>EJB3 Web Container Testsuite</display-name>
+
+    <module>
+       <web>
+          <web-uri>ejb3-ear-servlet.war</web-uri>
+          <context-root>/servlet</context-root>
+       </web>
+    </module>
+ 
+   <module>
+       <ejb>ejb3-ear-servlet-client.jar</ejb>
+   </module>
+
+    <module>
+        <ejb>ejb3-ear-servlet-ejbs.jar</ejb>
+    </module>
+</application>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/jboss-web-ear.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/jboss-web-ear.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
+<!DOCTYPE jboss-web
+    PUBLIC "-//JBoss//DTD Web Application 2.3V2//EN"
+    "http://www.jboss.org/j2ee/dtd/jboss-web_4_0.dtd">
+
+<jboss-web>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/remote/Session30</ejb-ref-name>
+      <jndi-name>java:app/ejb3-ear-servlet-ejbs/Session30!org.jboss.as.test.integration.ejb.servlet.Session30Home</jndi-name>
+   </ejb-ref>
+   
+   <ejb-local-ref>
+      <ejb-ref-name>ejb/local/Session30</ejb-ref-name>
+      <jndi-name>java:app/ejb3-ear-servlet-ejbs/Session30!org.jboss.as.test.integration.ejb.servlet.Session30LocalHome</jndi-name>
+   </ejb-local-ref>
+</jboss-web>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/jboss-web.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
+<!DOCTYPE jboss-web
+    PUBLIC "-//JBoss//DTD Web Application 2.3V2//EN"
+    "http://www.jboss.org/j2ee/dtd/jboss-web_4_0.dtd">
+
+<jboss-web>
+
+   <ejb-ref>
+      <ejb-ref-name>ejb/remote/Session30</ejb-ref-name>
+      <jndi-name>java:global/ejb3-servlet-ejbs/Session30!org.jboss.as.test.integration.ejb.servlet.Session30Home</jndi-name>
+   </ejb-ref>
+   
+   <ejb-local-ref>
+      <ejb-ref-name>ejb/local/Session30</ejb-ref-name>
+      <jndi-name>java:global/ejb3-servlet-ejbs/Session30!org.jboss.as.test.integration.ejb.servlet.Session30LocalHome</jndi-name>
+   </ejb-local-ref>
+</jboss-web>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/roles.properties
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/roles.properties
@@ -1,0 +1,2 @@
+somebody=allowed
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/users.properties
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/users.properties
@@ -1,0 +1,1 @@
+somebody=password

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/web-ear.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/web-ear.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5"
+   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+   http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+ 
+   <servlet>
+      <servlet-name>EJBServlet</servlet-name>
+      <servlet-class>org.jboss.as.test.integration.ejb.servlet.EJBServletEar</servlet-class>
+   </servlet>
+
+   <!-- The servlet and jsp page mappings -->
+   <servlet-mapping>
+      <servlet-name>EJBServlet</servlet-name>
+      <url-pattern>/EJBServlet</url-pattern>
+   </servlet-mapping>
+   
+   <ejb-ref>
+      <ejb-ref-name>ejb/remote/Session30</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <home>org.jboss.as.test.integration.ejb.servlet.Session30Home</home>
+      <remote>org.jboss.as.test.integration.ejb.servlet.Session30Remote</remote>
+   </ejb-ref>
+   
+   <ejb-local-ref>
+      <ejb-ref-name>ejb/local/Session30</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <local-home>org.jboss.as.test.integration.ejb.servlet.Session30LocalHome</local-home>
+      <local>org.jboss.as.test.integration.ejb.servlet.Session30Local</local>
+   </ejb-local-ref>
+
+</web-app>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5"
+   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+   http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+ 
+   <servlet>
+      <servlet-name>EJBServlet</servlet-name>
+      <servlet-class>org.jboss.as.test.integration.ejb.servlet.EJBServlet</servlet-class>
+   </servlet>
+
+   <!-- The servlet and jsp page mappings -->
+   <servlet-mapping>
+      <servlet-name>EJBServlet</servlet-name>
+      <url-pattern>/EJBServlet</url-pattern>
+   </servlet-mapping>
+   
+   <ejb-ref>
+      <ejb-ref-name>ejb/remote/Session30</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <home>org.jboss.as.test.integration.ejb.servlet.Session30Home</home>
+      <remote>org.jboss.as.test.integration.ejb.servlet.Session30Remote</remote>
+   </ejb-ref>
+   
+   <ejb-local-ref>
+      <ejb-ref-name>ejb/local/Session30</ejb-ref-name>
+      <ejb-ref-type>Session</ejb-ref-type>
+      <local-home>org.jboss.as.test.integration.ejb.servlet.Session30LocalHome</local-home>
+      <local>org.jboss.as.test.integration.ejb.servlet.Session30Local</local>
+   </ejb-local-ref>
+
+</web-app>
+


### PR DESCRIPTION
Part of AS5->AS7 testsuite migration.
A servlet that accesses an EJB and tests whether the call argument is serialized.
