### PR TITLE
[JBQA-5275] AS5->AS7: enventry async test

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/AbstractStatefulSessionAction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/AbstractStatefulSessionAction.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import javax.ejb.Handle;
+
+/**
+ * A AbstractStatefulSessionAction.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public abstract class AbstractStatefulSessionAction implements Action {
+    private static final long serialVersionUID = 1L;
+    private final Handle handle;
+
+    public AbstractStatefulSessionAction(Handle handle) {
+        this.handle = handle;
+    }
+
+    public String execute() throws Exception {
+        StatefulSession session = (StatefulSession) handle.getEJBObject();
+        return execute(session);
+    }
+
+    protected abstract String execute(StatefulSession session) throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/Action.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/Action.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.io.Serializable;
+
+/**
+ * A Action.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public interface Action extends Serializable {
+    String execute() throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ActionExecutor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ActionExecutor.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * A ActionExecutor.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public interface ActionExecutor extends EJBObject {
+    String execute(Action action) throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ActionExecutorBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ActionExecutorBean.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+
+/**
+ * A ActionExecutorBean.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public class ActionExecutorBean implements SessionBean {
+    /** The serialVersionUID */
+    private static final long serialVersionUID = 1L;
+
+    public String execute(Action action) throws EJBException {
+        try {
+            return action.execute();
+        } catch (Exception e) {
+            throw new EJBException(e);
+        }
+    }
+
+    public void ejbCreate() throws CreateException {
+    }
+
+    public void ejbActivate() throws EJBException, RemoteException {
+    }
+
+    public void ejbPassivate() throws EJBException, RemoteException {
+    }
+
+    public void ejbRemove() throws EJBException, RemoteException {
+    }
+
+    public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ActionExecutorHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ActionExecutorHome.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * A ActionExecutorHome.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public interface ActionExecutorHome extends EJBHome {
+    ActionExecutor create() throws CreateException, RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/CompEnvInSessionSyncCallbacksUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/CompEnvInSessionSyncCallbacksUnitTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A CompEnvInSessionSyncCallbacksUnitTestCase.
+ * Part of migration AS5 testsuite to AS7 testsuite (JBQA-5275). 
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+@RunWith(Arquillian.class)
+public class CompEnvInSessionSyncCallbacksUnitTestCase {
+
+    @ArquillianResource
+    InitialContext ctx;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "compenv-sessionsync.jar").addPackage(
+                CompEnvInSessionSyncCallbacksUnitTestCase.class.getPackage());
+        jar.addAsManifestResource(CompEnvInSessionSyncCallbacksUnitTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        return jar;
+    }
+
+    /**
+     * This test is based on command pattern and calling methods on the target stateful session bean from a delegating stateless
+     * session bean instead of direct method invocations on the target stateful session bean. This is done on purpose to make
+     * sure the container sets up comp/env properly in the transaction synchronization implementation before invoking
+     * SessionSynchronization callbacks.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testBeforeCompletion() throws Exception {
+        ActionExecutorHome executorHome = (ActionExecutorHome) ctx.lookup("java:module/ActionExecutor!"
+                + ActionExecutorHome.class.getName());
+        ActionExecutor executor = executorHome.create();
+
+        StatefulSessionHome sessionHome = (StatefulSessionHome) ctx.lookup("java:module/StatefulSession!"
+                + StatefulSessionHome.class.getName());
+        final StatefulSession session = sessionHome.create();
+        try {
+            Assert.assertEquals("after-begin", executor.execute(new GetAfterBeginEntryAction(session.getHandle())));
+            Assert.assertEquals("before-completion", executor.execute(new GetBeforeCompletionEntryAction(session.getHandle())));
+            Assert.assertEquals("after-completion", executor.execute(new GetAfterCompletionEntryAction(session.getHandle())));
+        } finally {
+            if (session != null) {
+                session.remove();
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/GetAfterBeginEntryAction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/GetAfterBeginEntryAction.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import javax.ejb.Handle;
+
+/**
+ * A GetAfterBeginEntryAction.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public class GetAfterBeginEntryAction extends AbstractStatefulSessionAction {
+    public GetAfterBeginEntryAction(Handle handle) {
+        super(handle);
+    }
+
+    /** The serialVersionUID */
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected String execute(StatefulSession session) throws Exception {
+        return session.getAfterBeginEntry();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/GetAfterCompletionEntryAction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/GetAfterCompletionEntryAction.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import javax.ejb.Handle;
+
+/**
+ * A GetAfterBeginEntryAction.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public class GetAfterCompletionEntryAction extends AbstractStatefulSessionAction {
+    public GetAfterCompletionEntryAction(Handle handle) {
+        super(handle);
+    }
+
+    /** The serialVersionUID */
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected String execute(StatefulSession session) throws Exception {
+        return session.getAfterCompletionEntry();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/GetBeforeCompletionEntryAction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/GetBeforeCompletionEntryAction.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import javax.ejb.Handle;
+
+/**
+ * A GetAfterBeginEntryAction.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public class GetBeforeCompletionEntryAction extends AbstractStatefulSessionAction {
+    public GetBeforeCompletionEntryAction(Handle handle) {
+        super(handle);
+    }
+
+    /** The serialVersionUID */
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected String execute(StatefulSession session) throws Exception {
+        return session.getBeforeCompletionEntry();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/StatefulSession.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/StatefulSession.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+/**
+ * A StatefulSession.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public interface StatefulSession extends EJBObject {
+    String getAfterBeginEntry() throws RemoteException;
+
+    String getBeforeCompletionEntry() throws RemoteException;
+
+    String getAfterCompletionEntry() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/StatefulSessionBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/StatefulSessionBean.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.ejb.SessionSynchronization;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * A StatefulSessionBean.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public class StatefulSessionBean implements SessionBean, SessionSynchronization {
+    /** The serialVersionUID */
+    private static final long serialVersionUID = 1L;
+
+    private InitialContext ic;
+    private String afterBeginEntry;
+    private String beforeCompletionEntry;
+    private String afterCompletionEntry;
+
+    public String getAfterBeginEntry() throws RemoteException {
+        return afterBeginEntry;
+    }
+
+    public String getBeforeCompletionEntry() throws RemoteException {
+        return beforeCompletionEntry;
+    }
+
+    public String getAfterCompletionEntry() throws RemoteException {
+        return afterCompletionEntry;
+    }
+
+    public void ejbCreate() throws EJBException, RemoteException {
+    }
+
+    public void ejbActivate() throws EJBException, RemoteException {
+    }
+
+    public void ejbPassivate() throws EJBException, RemoteException {
+        ic = null;
+        afterBeginEntry = null;
+        beforeCompletionEntry = null;
+        afterCompletionEntry = null;
+    }
+
+    public void ejbRemove() throws EJBException, RemoteException {
+    }
+
+    public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+    }
+
+    public void afterBegin() throws EJBException, RemoteException {
+        afterBeginEntry = lookupCompEnv("afterBegin");
+    }
+
+    public void afterCompletion(boolean committed) throws EJBException, RemoteException {
+        afterCompletionEntry = lookupCompEnv("afterCompletion");
+    }
+
+    public void beforeCompletion() throws EJBException, RemoteException {
+        beforeCompletionEntry = lookupCompEnv("beforeCompletion");
+    }
+
+    private String lookupCompEnv(String name) {
+        if (ic == null) {
+            try {
+                ic = new InitialContext();
+            } catch (NamingException e) {
+                throw new EJBException("Failed to create initial context.", e);
+            }
+        }
+
+        try {
+            return (String) ic.lookup("java:comp/env/" + name);
+        } catch (NamingException e) {
+            throw new EJBException("Failed to lookup java:comp/env/" + name, e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/StatefulSessionHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/StatefulSessionHome.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.enventry.async;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * A StatefulSessionHome.
+ * 
+ * @author <a href="alex@jboss.com">Alexey Loubyansky</a>
+ */
+public interface StatefulSessionHome extends EJBHome {
+    StatefulSession create() throws CreateException, RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/enventry/async/ejb-jar.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+
+<ejb-jar >
+   <enterprise-beans>
+   
+     <session>
+        <ejb-name>StatefulSession</ejb-name>
+        <home>org.jboss.as.test.integration.ee.injection.resource.enventry.async.StatefulSessionHome</home>
+        <remote>org.jboss.as.test.integration.ee.injection.resource.enventry.async.StatefulSession</remote>
+        <ejb-class>org.jboss.as.test.integration.ee.injection.resource.enventry.async.StatefulSessionBean</ejb-class>
+        <session-type>Stateful</session-type>
+        <transaction-type>Container</transaction-type>
+
+         <env-entry>
+            <description></description>
+            <env-entry-name>afterBegin</env-entry-name>
+            <env-entry-type>java.lang.String</env-entry-type>
+            <env-entry-value>after-begin</env-entry-value>
+         </env-entry>
+         <env-entry>
+            <description></description>
+            <env-entry-name>beforeCompletion</env-entry-name>
+            <env-entry-type>java.lang.String</env-entry-type>
+            <env-entry-value>before-completion</env-entry-value>
+         </env-entry>
+         <env-entry>
+            <description></description>
+            <env-entry-name>afterCompletion</env-entry-name>
+            <env-entry-type>java.lang.String</env-entry-type>
+            <env-entry-value>after-completion</env-entry-value>
+         </env-entry>
+     </session>
+
+     <session>
+        <ejb-name>ActionExecutor</ejb-name>
+        <home>org.jboss.as.test.integration.ee.injection.resource.enventry.async.ActionExecutorHome</home>
+        <remote>org.jboss.as.test.integration.ee.injection.resource.enventry.async.ActionExecutor</remote>
+        <ejb-class>org.jboss.as.test.integration.ee.injection.resource.enventry.async.ActionExecutorBean</ejb-class>
+        <session-type>Stateless</session-type>
+        <transaction-type>Container</transaction-type>
+     </session>
+          
+   </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
Part of migration AS5 testsuite to AS7.
Test to make sure the container sets up comp/env properly in the transaction synchronization implementation before invoking SessionSynchronization callbacks.
