### PR TITLE
AS7-3171 Fix parsing of jboss-deployment-structure.xml for 1.1 version

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser11.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser11.java
@@ -1,22 +1,5 @@
 package org.jboss.as.server.deployment.module.descriptor;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.xml.namespace.QName;
-import javax.xml.stream.Location;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.module.FilterSpecification;
@@ -35,8 +18,23 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.vfs.VFS;
 import org.jboss.vfs.VirtualFile;
 
-import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
-import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static javax.xml.stream.XMLStreamConstants.*;
 
 /**
  * @author Stuart Douglas
@@ -100,6 +98,8 @@ public class JBossDeploymentStructureParser11 implements XMLElementReader<ParseR
             elementsMap.put(new QName(NAMESPACE_1_1, "transformer"), Element.TRANSFORMER);
             elementsMap.put(new QName(NAMESPACE_1_1, "local-last"), Element.LOCAL_LAST);
             elementsMap.put(new QName(NAMESPACE_1_1, "module-alias"), Element.MODULE_ALIAS);
+            elementsMap.put(new QName(NAMESPACE_1_1, "system"), Element.SYSTEM);
+            elementsMap.put(new QName(NAMESPACE_1_1, "paths"), Element.PATHS);
             elements = elementsMap;
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/parsing/JBossDeploymentStructure11ParsingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/parsing/JBossDeploymentStructure11ParsingTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.structure.parsing;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+
+/**
+ * Tests that parsing of a jboss-deployment-structure.xml using 1.1 version xsd, works as expected
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class JBossDeploymentStructure11ParsingTestCase {
+
+    private static final Logger logger = Logger.getLogger(JBossDeploymentStructure11ParsingTestCase.class);
+
+    private static final String MODULE_NAME = "jboss-deployment-structure-11-parsing-test";
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        ejbJar.addPackage(JBossDeploymentStructure11ParsingTestCase.class.getPackage());
+        ejbJar.addAsManifestResource(JBossDeploymentStructure11ParsingTestCase.class.getPackage(), "jboss-deployment-structure_1_1.xml", "jboss-deployment-structure.xml");
+        logger.info(ejbJar.toString(true));
+        return ejbJar;
+    }
+
+    /**
+     * Tests that the deployment containing the jboss-deployment-structure.xml was parsed and deployed successfully.
+     */
+    @Test
+    public void testSuccessfulDeployment() throws Exception {
+        // just a lookup and invocation on the EJB should be fine, since it indicates that the deployment
+        // was deployed successfully.
+        final NoOpEJB noOpEJB = InitialContext.doLookup("java:module/" + NoOpEJB.class.getSimpleName() + "!" + NoOpEJB.class.getName());
+        noOpEJB.doNothing();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/parsing/NoOpEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/parsing/NoOpEJB.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.structure.parsing;
+
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+public class NoOpEJB {
+    
+    public void doNothing() {
+        return;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/parsing/jboss-deployment-structure_1_1.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/parsing/jboss-deployment-structure_1_1.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.1">
+    <deployment>
+        <dependencies>
+            <system>
+                <paths>
+                    <path name="foo.bar"/>
+                </paths>
+            </system>
+        </dependencies>
+    </deployment>
+</jboss-deployment-structure>
+
+


### PR DESCRIPTION
The commit in this branch fixes the issue reported in https://issues.jboss.org/browse/AS7-3171, which relates to parsing error being thrown for 1.1 version of jboss-deployment-structure.xml when the system and paths elements are used in the xml.
