### PR TITLE
Fix for AS7-2638 

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/CommonBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/CommonBase.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener;
+
+import javax.jms.MessageListener;
+
+/**
+ * @author Jaikiran Pai
+ */
+public abstract class CommonBase implements MessageListener {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/ConcreteMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/ConcreteMDB.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+
+/**
+ * @author Jaikiran Pai
+ */
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/queue/message-listener")
+})
+public class ConcreteMDB extends CommonBase {
+
+    private static final Logger logger = Logger.getLogger(ConcreteMDB.class);
+
+    public static final String SUCCESS_REPLY = "onMessage() method was invoked";
+
+    public static final String FAILURE_REPLY = "onMessage() method was *not* invoked";
+
+    @Resource(mappedName = "java:/JmsXA")
+    private ConnectionFactory factory;
+
+    private Connection connection;
+    private Session session;
+
+    @PreDestroy
+    protected void preDestroy() throws JMSException {
+        session.close();
+        connection.close();
+    }
+
+    @PostConstruct
+    protected void postConstruct() throws JMSException {
+        connection = factory.createConnection();
+        session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+    }
+
+    @Override
+    public void onMessage(Message message) {
+        logger.info("Received message: " + message);
+        try {
+            if (message.getJMSReplyTo() != null) {
+                logger.info("Replying to " + message.getJMSReplyTo());
+                final Destination destination = message.getJMSReplyTo();
+                final MessageProducer replyProducer = session.createProducer(destination);
+                final Message replyMsg = session.createTextMessage(SUCCESS_REPLY);
+                replyMsg.setJMSCorrelationID(message.getJMSMessageID());
+                replyProducer.send(replyMsg);
+                replyProducer.close();
+            }
+        } catch (JMSException jmse) {
+            throw new RuntimeException(jmse);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/MessageListenerInClassHierarchyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/MessageListenerInClassHierarchyTestCase.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.common.JMSAdminOperations;
+import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.integration.ejb.mdb.messagedrivencontext.SimpleMDB;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.TextMessage;
+
+/**
+ * Tests that if a message listener interface is implemented by the base class of a message driven bean, then
+ * it's taken into consideration while checking for message listener interface for the MDB.
+ *
+ * @author Jaikiran Pai
+ * @see https://issues.jboss.org/browse/AS7-2638
+ */
+@RunWith(Arquillian.class)
+public class MessageListenerInClassHierarchyTestCase {
+
+    private static JMSAdminOperations jmsAdminOperations;
+
+    private static final String QUEUE_JNDI_NAME = "java:jboss/queue/message-listener";
+    private static final String REPLY_QUEUE_JNDI_NAME = "java:jboss/queue/message-listener-reply-queue";
+
+    @EJB(mappedName = "java:module/JMSMessagingUtil")
+    private JMSMessagingUtil jmsUtil;
+
+    @Resource(mappedName = QUEUE_JNDI_NAME)
+    private Queue queue;
+
+    @Resource(mappedName = REPLY_QUEUE_JNDI_NAME)
+    private Queue replyQueue;
+
+    @Deployment
+    public static Archive createDeployment() {
+        // setup the JMS destinations
+        createJmsDestinations();
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "message-listener-in-class-hierarchy-test.jar");
+        jar.addClasses(ConcreteMDB.class, CommonBase.class, JMSMessagingUtil.class, JMSAdminOperations.class);
+        return jar;
+    }
+
+    private static void createJmsDestinations() {
+        jmsAdminOperations = new JMSAdminOperations();
+        jmsAdminOperations.createJmsQueue("messagelistener/queue", QUEUE_JNDI_NAME);
+        jmsAdminOperations.createJmsQueue("messagelistener/replyQueue", REPLY_QUEUE_JNDI_NAME);
+    }
+
+    @AfterClass
+    public static void afterTestClass() {
+        try {
+            jmsAdminOperations.removeJmsQueue("messagelistener/queue");
+            jmsAdminOperations.removeJmsQueue("messagelistener/replyQueue");
+        } finally {
+            if (jmsAdminOperations != null) {
+                jmsAdminOperations.close();
+            }
+        }
+    }
+
+    /**
+     * Test that if a {@link javax.jms.MessageListener} interface is implemented by the base class of a
+     * message driven bean, then it's taken into consideration while looking for potential message listener
+     * interface
+     *
+     * @throws Exception
+     * @see https://issues.jboss.org/browse/AS7-2638
+     */
+    @Test
+    public void testSetMessageDrivenContext() throws Exception {
+        this.jmsUtil.sendTextMessage("hello world", this.queue, this.replyQueue);
+        final Message reply = this.jmsUtil.receiveMessage(replyQueue, 5000);
+        Assert.assertNotNull("Reply message was null on reply queue: " + this.replyQueue, reply);
+        final TextMessage textMessage = (TextMessage) reply;
+        Assert.assertEquals("setMessageDrivenContext method was *not* invoked on MDB", ConcreteMDB.SUCCESS_REPLY, textMessage.getText());
+    }
+}


### PR DESCRIPTION
The commit in this branch fixes the issue reported in https://issues.jboss.org/browse/AS7-2638, where the base class of a message driven bean wasn't looked for potential message listener interface.
