### PR TITLE
AS7-3114 make admin console optional

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -62,6 +62,7 @@ public class ModelDescriptionConstants {
     public static final String CONCURRENT_GROUPS = "concurrent-groups";
     public static final String CONNECTION = "connection";
     public static final String CONNECTIONS = "connections";
+    public static final String CONSOLE_ENABLED = "console-enabled";
     public static final String CONTENT = "content";
     public static final String CORE_SERVICE = "core-service";
     public static final String CPU_AFFINITY = "cpu-affinity";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -46,6 +46,7 @@ public enum Attribute {
     CODE("code"),
     CONNECTION("connection"),
     CONNECTOR("connector"),
+    CONSOLE_ENABLED("console-enabled"),
     DEFAULT_INTERFACE("default-interface"),
     DEBUG_ENABLED("debug-enabled"),
     DEBUG_OPTIONS("debug-options"),

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/HttpServerLogger.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/HttpServerLogger.java
@@ -30,6 +30,7 @@ import org.jboss.logging.Message;
 import org.jboss.logging.MessageLogger;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * Date: 05.11.2011
@@ -61,4 +62,13 @@ public interface HttpServerLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 15101, value = "Unexpected error executing deployment upload request")
     void uploadError(@Cause Throwable cause);
+
+    /**
+    * A message indicating that admin console module could not be loaded
+    *
+    * @param slot name of the console slot
+    */
+    @LogMessage(level = WARN)
+    @Message(id = 15102, value = "Unable to load console module for slot %s, disabling console")
+    void consoleModuleNotFound(String slot);
 }

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -46,6 +46,8 @@ import org.jboss.com.sun.net.httpserver.HttpsServer;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.sasl.callback.DigestHashCallback;
 
+import static org.jboss.as.domain.http.server.HttpServerMessages.MESSAGES;
+
 /**
  * The general HTTP server for handling management API requests.
  *
@@ -170,11 +172,11 @@ public class ManagementHttpServer {
         }
 
         ManagementHttpServer managementHttpServer = new ManagementHttpServer(httpServer, secureHttpServer, securityRealm);
-        ResourceHandler consoleHandler;
+        ResourceHandler consoleHandler = null;
         try {
             consoleHandler = consoleMode.createConsoleHandler(consoleSlot);
         } catch (ModuleLoadException e) {
-            throw new IOException("Unable to load resource handler", e);
+            HttpServerLogger.ROOT_LOGGER.consoleModuleNotFound(consoleSlot==null?"main":consoleSlot);
         }
         managementHttpServer.addHandler(new RootHandler(consoleHandler));
         managementHttpServer.addHandler(new DomainApiHandler(modelControllerClient, auth));

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ResourceHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ResourceHandler.java
@@ -149,7 +149,7 @@ class ResourceHandler implements ManagementHttpHandler {
             http.close();
 
             return;
-        } else if (resource.indexOf(".") == -1) {
+        } else if (!resource.contains(".")) {
             respond404(http);
         }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.ControllerMessages.MESSAGES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONSOLE_ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_CONTROLLER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
@@ -567,6 +568,12 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                         }
                         break;
                     }
+                    case CONSOLE_ENABLED:{
+                        if (http){
+                            org.jboss.as.server.mgmt.HttpManagementResourceDefinition.CONSOLE_ENABLED.parseAndSetParameter(value,addOp,reader);
+                        }
+                        break;
+                    }
                     default:
                         throw unexpectedAttribute(reader, i);
                 }
@@ -1067,6 +1074,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
 
         writer.writeStartElement(Element.HTTP_INTERFACE.getLocalName());
         HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
 
         writer.writeEmptyElement(Element.SOCKET.getLocalName());
         HttpManagementResourceDefinition.INTERFACE.marshallAsAttribute(protocol, writer);
@@ -1092,6 +1100,9 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
             }
             if (remote.hasDefined(SECURITY_REALM)) {
                 writeAttribute(writer, Attribute.SECURITY_REALM, remote.require(SECURITY_REALM).asString());
+            }
+            if (remote.get(CONSOLE_ENABLED).asBoolean(false)){
+                writeAttribute(writer, Attribute.CONSOLE_ENABLED, remote.require(CONSOLE_ENABLED).asString());
             }
             writer.writeEndElement();
         }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.host.controller.HostControllerEnvironment;
@@ -42,6 +43,7 @@ import org.jboss.as.host.controller.operations.HttpManagementAddHandler;
 import org.jboss.as.host.controller.operations.HttpManagementRemoveHandler;
 import org.jboss.as.host.controller.operations.HttpManagementWriteAttributeHandler;
 import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -72,8 +74,12 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition HTTPS_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURE_PORT, ModelType.INT, true)
             .setAllowExpression(true).setValidator(new IntRangeValidator(0, 65535, true, true))
             .build();
+    public static final SimpleAttributeDefinition CONSOLE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CONSOLE_ENABLED, ModelType.BOOLEAN, true)
+                .setXmlName(Attribute.CONSOLE_ENABLED.getLocalName())
+                .setDefaultValue(new ModelNode(true))
+                .build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM};
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM,CONSOLE_ENABLED};
 
     public HttpManagementResourceDefinition(final LocalHostControllerInfoImpl hostControllerInfo,
                                              final HostControllerEnvironment environment) {

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -78,4 +78,5 @@ core.management.http-interface.interface=Deprecated -- use 'socket-binding'. The
 core.management.http-interface.port=Deprecated -- use 'socket-binding'. The port on which the server's socket for HTTP management communication should be opened. Must be 'undefined' if the 'socket-binding' attribute is set.
 core.management.http-interface.secure-port=Deprecated -- use 'secure-socket-binding'. The port on which the server's socket for HTTPS management communication should be opened. Must be 'undefined' if the 'socket-binding' or 'secure-socket-binding' attribute is set.
 core.management.http-interface.security-realm=The security realm to use for the HTTP management interface.
+core.management.http-interface.console-enabled=Flag that indicates admin console is enabled
 

--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -41,6 +41,7 @@ import org.jboss.as.server.controller.descriptions.ServerDescriptions;
 import org.jboss.as.server.operations.HttpManagementAddHandler;
 import org.jboss.as.server.operations.HttpManagementRemoveHandler;
 import org.jboss.as.server.operations.HttpManagementWriteAttributeHandler;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -85,7 +86,12 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setAlternatives(ModelDescriptionConstants.INTERFACE)
             .build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM, SOCKET_BINDING, SECURE_SOCKET_BINDING};
+    public static final SimpleAttributeDefinition CONSOLE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CONSOLE_ENABLED, ModelType.BOOLEAN, true)
+            .setXmlName(Attribute.CONSOLE_ENABLED.getLocalName())
+            .setDefaultValue(new ModelNode(true))
+            .build();
+
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM, SOCKET_BINDING, SECURE_SOCKET_BINDING,CONSOLE_ENABLED};
 
     public static final HttpManagementResourceDefinition INSTANCE = new HttpManagementResourceDefinition();
 

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -199,8 +199,14 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
         } else {
             Logger.getLogger("org.jboss.as").warn("No security realm has been defined for the http management service; all access will be unrestricted.");
         }
+        boolean consoleEnabled = model.get(ModelDescriptionConstants.CONSOLE_ENABLED).asBoolean(true);
+        ConsoleMode consoleMode;
+        if (consoleEnabled){
+            consoleMode = context.getRunningMode() == RunningMode.ADMIN_ONLY ? ConsoleMode.ADMIN_ONLY : ConsoleMode.CONSOLE;
+        }else{
+            consoleMode = ConsoleMode.NO_CONSOLE;
+        }
 
-        ConsoleMode consoleMode = context.getRunningMode() == RunningMode.ADMIN_ONLY ? ConsoleMode.ADMIN_ONLY : ConsoleMode.CONSOLE;
         ServerEnvironment environment = (ServerEnvironment) context.getServiceRegistry(false).getRequiredService(ServerEnvironmentService.SERVICE_NAME).getValue();
         final HttpManagementService service = new HttpManagementService(consoleMode, environment.getProductConfig().getConsoleSlot());
         ServiceBuilder<HttpManagement> builder = serviceTarget.addService(HttpManagementService.SERVICE_NAME, service)

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementWriteAttributeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementWriteAttributeHandler.java
@@ -66,6 +66,7 @@ public class HttpManagementWriteAttributeHandler extends AbstractWriteAttributeH
                             HttpManagementResourceDefinition.SECURE_SOCKET_BINDING.getName()));
                     throw new OperationFailedException(failure);
                 }
+                context.completeStep();
             }
         }, OperationContext.Stage.MODEL);
 

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementWriteAttributeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementWriteAttributeHandler.java
@@ -61,6 +61,7 @@ public class NativeManagementWriteAttributeHandler extends AbstractWriteAttribut
                             NativeManagementResourceDefinition.SOCKET_BINDING.getName()));
                     throw new OperationFailedException(failure);
                 }
+                context.completeStep();
             }
         }, OperationContext.Stage.MODEL);
 

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -69,6 +69,7 @@ import java.util.concurrent.ExecutorService;
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.Attribute;
@@ -546,6 +547,12 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
                             HttpManagementResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, addOp, reader);
                         } else {
                             NativeManagementResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, addOp, reader);
+                        }
+                        break;
+                    }
+                    case CONSOLE_ENABLED:{
+                        if (http){
+                            HttpManagementResourceDefinition.CONSOLE_ENABLED.parseAndSetParameter(value,addOp,reader);
                         }
                         break;
                     }
@@ -1071,6 +1078,10 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
 
         writer.writeStartElement(Element.HTTP_INTERFACE.getLocalName());
         HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
+        boolean consoleEnabled = protocol.get(ModelDescriptionConstants.CONSOLE_ENABLED).asBoolean(true);
+        if (!consoleEnabled){
+            HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
+        }
 
         if (HttpManagementResourceDefinition.INTERFACE.isMarshallable(protocol)) {
             writer.writeEmptyElement(Element.SOCKET.getLocalName());

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -71,6 +71,7 @@ core.management.http-interface.secure-port=Deprecated -- use 'secure-socket-bind
 core.management.http-interface.security-realm=The security realm to use for the HTTP management interface.
 core.management.http-interface.socket-binding=The name of the socket binding configuration to use for the HTTP management interface's socket.
 core.management.http-interface.secure-socket-binding=The name of the socket binding configuration to use for the HTTPS management interface's socket.
+core.management.http-interface.console-enabled=Flag that indicates admin console is enabled
 core.service-container=The central container that manages all services in a running standalone server or in a host controller in a management domain.
 
 # Interfaces

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -44,7 +44,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="public" port="19999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm" console-enabled="false">
                 <socket interface="public" port="19990"/>
             </http-interface>
         </management-interfaces>


### PR DESCRIPTION
- adds console-enabled flag to http-interface that controls the console
- fails gracefully when console module is not found
