### PR TITLE
AS7-3342, point welcome screen documentation to the 7.1.x docs

### DIFF
--- a/build/src/main/resources/welcome-content/documentation.html
+++ b/build/src/main/resources/welcome-content/documentation.html
@@ -40,28 +40,28 @@
 
       <h2>Administrator Guides</h2>
 
-      <p><a href="https://docs.jboss.org/author/display/AS7/Getting+Started+Guide" target="_blank">Getting Started Guide</a> Introduces
+      <p><a href="https://docs.jboss.org/author/display/AS71/Getting+Started+Guide" target="_blank">Getting Started Guide</a> Introduces
       you to installing and running the server in standalone and domain modes, how to deploy a data source, and
       how to use the Web Management Interface and Command Line interface to manage the server.</p>
 
-      <p><a href="https://docs.jboss.org/author/display/AS7/Admin+Guide" target="_blank">Admin Guide</a> A complete guide to
+      <p><a href="https://docs.jboss.org/author/display/AS71/Admin+Guide" target="_blank">Admin Guide</a> A complete guide to
       configuring and administering the application server.</p>
 
-      <p><a href="https://docs.jboss.org/author/display/AS7/High+Availability+Guide" target="_blank">High Availability Guide</a> A guide
+      <p><a href="https://docs.jboss.org/author/display/AS71/High+Availability+Guide" target="_blank">High Availability Guide</a> A guide
       to how to create a cluster, how configure the web container and EJB container for clustering, and show to configure load balancing
       and failover.</p>
 
       <h2>Developer Guides</h2>
 
-      <p><a href="https://docs.jboss.org/author/display/AS7/Getting+Started+Developing+Applications+Guide" target="_blank">Getting Started
+      <p><a href="https://docs.jboss.org/author/display/AS71/Getting+Started+Developing+Applications+Guide" target="_blank">Getting Started
       Developing Applications Guide</a> Introduces you to writing simple Java EE 6 applications and deploying them to the
       application server. Each tutorial is accompanied by a quick-start sample application. Finally the guide shows you
       how to create your own application skeleton.</p>
 
-      <p><a href="https://docs.jboss.org/author/display/AS7/Developer+Guide" target="_blank">Developer Guide</a> A
+      <p><a href="https://docs.jboss.org/author/display/AS71/Developer+Guide" target="_blank">Developer Guide</a> A
       complete guide to all deployment descriptors and APIs available in the application server.</p>
 
-      <p><a href="https://docs.jboss.org/author/display/AS7/Java+EE+Tutorial" target="_blank">Java EE Tutorial</a> A complete guide
+      <p><a href="https://docs.jboss.org/author/display/AS71/JavaEE+6+Tutorial#" target="_blank">Java EE Tutorial</a> A complete guide
       to developing Java EE 6 applications for JBoss AS.</p>
 
       <p class="logos"><a href="http://jboss.org"><img src="jboss_community.png" alt="JBoss and JBoss Community" width=


### PR DESCRIPTION
The documentation.html page linked by the welcome screen still points to the older AS7.0 docs. It should point to the newer AS7.1 docs.

We need to remember switch that everytime the docs are forked into a newer version.
