### PR TITLE
cli: added completion to the --content argument of the rollout-plan command

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
@@ -149,7 +149,7 @@ public interface ArgumentValueConverter {
             ParserUtil.parse(value, callback, initialState);
             final List<ParsedOperationRequestHeader> headers = callback.getHeaders();
             if(headers.isEmpty()) {
-                return null;
+                throw new CommandFormatException("'" + value + "' doesn't follow format {rollout server_group_list [rollback-across-groups]}");
             }
             if(headers.size() > 1) {
                 throw new CommandFormatException("Too many headers: " + headers);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
@@ -80,11 +80,12 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
     private Map<String, Map<String, CommandArgument>> propsByOp;
 
     private Map<String, ArgumentValueConverter> propConverters;
+    private Map<String, CommandLineCompleter> valueCompleters;
 
     public GenericTypeOperationHandler(CommandContext ctx, String nodeType, String idProperty) {
         this(ctx, nodeType, idProperty, Arrays.asList("read-attribute", "read-children-names", "read-children-resources",
                 "read-children-types", "read-operation-description", "read-operation-names",
-                "read-resource-description", "validate-address", "write-attribute"));
+                "read-resource-description", "validate-address", "write-attribute", "undefine-attribute"));
     }
 
     public GenericTypeOperationHandler(CommandContext ctx, String nodeType, String idProperty, List<String> excludeOperations) {
@@ -224,6 +225,13 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
         propConverters.put(propertyName, converter);
     }
 
+    public void addValueCompleter(String propertyName, CommandLineCompleter completer) {
+        if(valueCompleters == null) {
+            valueCompleters = new HashMap<String, CommandLineCompleter>();
+        }
+        valueCompleters.put(propertyName, completer);
+    }
+
     @Override
     public Collection<CommandArgument> getArguments(CommandContext ctx) {
         ParsedCommandLine args = ctx.getParsedCommandLine();
@@ -254,12 +262,17 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                         if(propConverters != null) {
                             valueConverter = propConverters.get(prop.getName());
                         }
+                        if(valueCompleters != null) {
+                            valueCompleter = valueCompleters.get(prop.getName());
+                        }
                         if(valueConverter == null) {
                             valueConverter = ArgumentValueConverter.DEFAULT;
                             if(propDescr.has(Util.TYPE)) {
                                 type = propDescr.get(Util.TYPE).asType();
                                 if(ModelType.BOOLEAN == type) {
-                                    valueCompleter = SimpleTabCompleter.BOOLEAN;
+                                    if(valueCompleter == null) {
+                                        valueCompleter = SimpleTabCompleter.BOOLEAN;
+                                    }
                                 } else if(prop.getName().endsWith("properties")) { // TODO this is bad but can't rely on proper descriptions
                                     valueConverter = ArgumentValueConverter.PROPERTIES;
                                 } else if(ModelType.LIST == type) {
@@ -307,12 +320,17 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                         if(propConverters != null) {
                             valueConverter = propConverters.get(prop.getName());
                         }
+                        if(valueCompleters != null) {
+                            valueCompleter = valueCompleters.get(prop.getName());
+                        }
                         if(valueConverter == null) {
                             valueConverter = ArgumentValueConverter.DEFAULT;
                             if(propDescr.has(Util.TYPE)) {
                                 type = propDescr.get(Util.TYPE).asType();
                                 if(ModelType.BOOLEAN == type) {
-                                    valueCompleter = SimpleTabCompleter.BOOLEAN;
+                                    if(valueCompleter == null) {
+                                        valueCompleter = SimpleTabCompleter.BOOLEAN;
+                                    }
                                 } else if(prop.getName().endsWith("properties")) { // TODO this is bad but can't rely on proper descriptions
                                     valueConverter = ArgumentValueConverter.PROPERTIES;
                                 } else if(ModelType.LIST == type) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -128,6 +128,7 @@ import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestParser;
 import org.jboss.as.cli.operation.impl.DefaultPrefixFormatter;
+import org.jboss.as.cli.operation.impl.RolloutPlanCompleter;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
@@ -304,6 +305,7 @@ class CommandContextImpl implements CommandContext {
 
         final GenericTypeOperationHandler rolloutPlan = new GenericTypeOperationHandler(this, "/management-client-content=rollout-plans/rollout-plan", null);
         rolloutPlan.addValueConverter("content", ArgumentValueConverter.ROLLOUT_PLAN);
+        rolloutPlan.addValueCompleter("content", RolloutPlanCompleter.INSTANCE);
         cmdRegistry.registerHandler(rolloutPlan, "rollout-plan");
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
@@ -403,9 +403,6 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
         lastChunkIndex = index;
         this.lastHeaderName = headerName;
         if(headerName.equals("rollout")) {
-            if(headers == null) {
-                headers = new ArrayList<ParsedOperationRequestHeader>();
-            }
             return new RolloutPlanHeaderCallbackHandler(this);
         }
         return null;

--- a/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
@@ -228,7 +228,7 @@ public class ParserUtil {
                     buffer.setLength(0);
                     inValue = false;
                 } else if (HeaderListState.ID.equals(id)) {
-                    if (ctx.getCharacter() == '}') {
+                    if (!ctx.isEndOfContent()) {
                         handler.headerListEnd(ctx.getLocation());
                     }
                 } else if (HeaderNameState.ID.equals(id)) {

--- a/cli/src/main/java/org/jboss/as/cli/parsing/operation/OperationRequestState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/operation/OperationRequestState.java
@@ -24,7 +24,6 @@ package org.jboss.as.cli.parsing.operation;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.parsing.CharacterHandler;
 import org.jboss.as.cli.parsing.DefaultParsingState;
-import org.jboss.as.cli.parsing.EnterStateCharacterHandler;
 import org.jboss.as.cli.parsing.OutputTargetState;
 import org.jboss.as.cli.parsing.ParsingContext;
 
@@ -45,7 +44,17 @@ public class OperationRequestState extends DefaultParsingState {
     public OperationRequestState(final NodeState nodeState, final AddressOperationSeparatorState addrOpSep, final PropertyListState propList,
             final HeaderListState headerList, final OutputTargetState outRedirect) {
         super(ID);
-        setDefaultHandler(new EnterStateCharacterHandler(nodeState));
+        //setDefaultHandler(new EnterStateCharacterHandler(nodeState));
+        setDefaultHandler(new CharacterHandler(){
+            @Override
+            public void handle(ParsingContext ctx) throws CommandFormatException {
+                final CharacterHandler handler = enterStateHandlers.getHandler(ctx.getCharacter());
+                if(handler == null) {
+                    ctx.enterState(nodeState);
+                } else {
+                    handler.handle(ctx);
+                }
+            }});
         enterState(':', addrOpSep);
         enterState('(', propList);
         enterState('{', headerList);

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/RolloutPlanParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/RolloutPlanParsingTestCase.java
@@ -1038,7 +1038,6 @@ public class RolloutPlanParsingTestCase extends TestCase {
     @Test
     public void testRollout() throws Exception {
 
-        //parse("/profile=default/subsystem=threads/thread-factory=mytf:do{ rollout in-series = groupA}");
         parse(":do{rollout");
 
         assertFalse(handler.hasAddress());
@@ -1058,6 +1057,26 @@ public class RolloutPlanParsingTestCase extends TestCase {
         final List<ParsedOperationRequestHeader> headers = handler.getHeaders();
         assertEquals(0, headers.size());
         assertEquals("rollout", handler.getLastHeaderName());
+    }
+
+    @Test
+    public void testOnlyHeaderListStart() throws Exception {
+
+        parse("{");
+
+        assertFalse(handler.hasAddress());
+        assertFalse(handler.hasOperationName());
+        assertFalse(handler.hasProperties());
+        assertFalse(handler.endsOnAddressOperationNameSeparator());
+        assertFalse(handler.endsOnPropertyListStart());
+        assertFalse(handler.endsOnPropertySeparator());
+        assertFalse(handler.endsOnPropertyValueSeparator());
+        assertFalse(handler.endsOnNodeSeparator());
+        assertFalse(handler.endsOnNodeTypeNameSeparator());
+        assertTrue(handler.endsOnSeparator());
+        assertTrue(handler.endsOnHeaderListStart());
+        assertFalse(handler.isRequestComplete());
+        assertFalse(handler.hasHeaders());
     }
 
     protected void parse(String opReq) throws CommandFormatException {


### PR DESCRIPTION
It's kind of related to AS7-3278 "rollout plan tab-completion". Just forgot about this argument.
It also includes a fix for AS7-3201 CLI: rollout-plan add command with malformed plan crashes CLI.

Thanks,
Alexey
