### PR TITLE
Fix for AS7-3353

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentCreateService.java
@@ -75,15 +75,9 @@ public class MessageDrivenComponentCreateService extends EJBComponentCreateServi
     @Override
     protected BasicComponent createComponent() {
         final ActivationSpec activationSpec = getEndpointDeployer().createActivationSpecs(resourceAdapterName, messageListenerInterface, activationProps, getDeploymentClassLoader());
-        //final ActivationSpec activationSpec = null;
         final MessageDrivenComponent component = new MessageDrivenComponent(this, messageListenerInterface, activationSpec);
         final ResourceAdapter resourceAdapter = this.resourceAdapterInjectedValue.getValue();
         component.setResourceAdapter(resourceAdapter);
-        try {
-            activationSpec.setResourceAdapter(resourceAdapter);
-        } catch (ResourceException e) {
-            throw new RuntimeException(e);
-        }
         return component;
     }
 


### PR DESCRIPTION
The commit in this branch fixes https://issues.jboss.org/browse/AS7-3353 and no longer calls ActivationSpec.setResourceAdapter() from EJB3 subsystem and instead lets the JCA SPI handle it.
