### PR TITLE
AS7-3025

### DIFF
--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineArgument.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineArgument.java
@@ -469,6 +469,7 @@ enum CommandLineArgument {
     };
 
     private static String USAGE;
+    static final String NEW_LINE = String.format("%n");
 
     /**
      * The command line argument.
@@ -497,10 +498,10 @@ enum CommandLineArgument {
         segmentInstructions(instructions(), instructions);
         StringBuilder sb = new StringBuilder(String.format("    %-35s %s", argumentExample(), instructions.get(0)));
         for (int i = 1; i < instructions.size(); i++) {
-            sb.append("\n");
+            sb.append(NEW_LINE);
             sb.append(String.format("%-40s%s", " ", instructions.get(i)));
         }
-        sb.append('\n');
+        sb.append(NEW_LINE);
         return sb.toString();
     }
 
@@ -526,9 +527,9 @@ enum CommandLineArgument {
     public static String usage() {
         if (USAGE == null) {
             final StringBuilder sb = new StringBuilder();
-            sb.append(MESSAGES.argUsage()).append("\n");
+            sb.append(MESSAGES.argUsage()).append(NEW_LINE);
             for (CommandLineArgument arg : CommandLineArgument.values()) {
-                sb.append(arg.toString()).append("\n");
+                sb.append(arg.toString()).append(NEW_LINE);
             }
             USAGE = sb.toString();
         }

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessMessages.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessMessages.java
@@ -167,13 +167,37 @@ interface ProcessMessages {
     String argDefaultMulticastAddress();
 
     /**
+     * Instructions for the {@link CommandLineArgument#ADMIN_ONLY} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set the host controller's running type to ADMIN_ONLY causing it to open administrative interfaces and accept management requests but not start servers or, if this host controller is the master for the domain, accept incoming connections from slave host controllers.")
+    String argAdminOnly();
+
+    /**
+     * Instructions for the {@link CommandLineArgument#ADMIN_ONLY} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set system property jboss.domain.master.address to the given value. In a default slave Host Controller config, this is used to configure the address of the master Host Controller.")
+    String argMasterAddress();
+
+    /**
+     * Instructions for the {@link CommandLineArgument#ADMIN_ONLY} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set system property jboss.domain.master.port to the given value. In a default slave Host Controller config, this is used to configure the port used for native management communication by the master Host Controller.")
+    String argMasterPort();
+
+    /**
      * Instructions for the {@link CommandLineArgument#INTERFACE_BIND_ADDRESS} command line argument.
      *
      * @param argument the name of the argument
      *
      * @return the message.
      */
-    @Message(id = 12056, value = "No value was provided for argument %s")
+    @Message(id = 12050, value = "No value was provided for argument %s")
     String noArgValue(String argument);
 
     /**
@@ -183,7 +207,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalStateException} for the error.
      */
-    @Message(id = 12057, value = "Could not find java executable under %s.")
+    @Message(id = 12051, value = "Could not find java executable under %s.")
     IllegalStateException cannotFindJavaExe(String binDir);
 
     /**
@@ -191,7 +215,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 12058, value = "Authentication key must be 16 bytes long")
+    @Message(id = 12052, value = "Authentication key must be 16 bytes long")
     IllegalArgumentException invalidAuthKeyLen();
 
     /**
@@ -199,7 +223,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 12059, value = "cmd must have at least one entry")
+    @Message(id = 12053, value = "cmd must have at least one entry")
     IllegalArgumentException invalidCommandLen();
 
     /**
@@ -209,7 +233,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalStateException} for the error.
      */
-    @Message(id = 12060, value = "Java home '%s' does not exist.")
+    @Message(id = 12054, value = "Java home '%s' does not exist.")
     IllegalStateException invalidJavaHome(String dir);
 
     /**
@@ -220,7 +244,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalStateException} for the error.
      */
-    @Message(id = 12061, value = "Java home's bin '%s' does not exist. The home directory was determined to be %s.")
+    @Message(id = 12055, value = "Java home's bin '%s' does not exist. The home directory was determined to be %s.")
     IllegalStateException invalidJavaHomeBin(String binDir, String javaHomeDir);
 
     /**
@@ -230,7 +254,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 12062, value = "%s length is invalid")
+    @Message(id = 12056, value = "%s length is invalid")
     IllegalArgumentException invalidLength(String parameterName);
 
     /**
@@ -240,7 +264,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 12063, value = "Invalid option: %s")
+    @Message(id = 12057, value = "Invalid option: %s")
     IllegalArgumentException invalidOption(String option);
 
     /**
@@ -248,7 +272,7 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 12064, value = "Command contains a null component")
+    @Message(id = 12058, value = "Command contains a null component")
     IllegalArgumentException nullCommandComponent();
 
     /**
@@ -258,30 +282,6 @@ interface ProcessMessages {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 12065, value = "%s is null")
+    @Message(id = 12059, value = "%s is null")
     IllegalArgumentException nullVar(String varName);
-
-    /**
-     * Instructions for the {@link CommandLineArgument#ADMIN_ONLY} command line argument.
-     *
-     * @return the message.
-     */
-    @Message(id = 12066, value = "Set the host controller's running type to ADMIN_ONLY causing it to open administrative interfaces and accept management requests but not start servers or, if this host controller is the master for the domain, accept incoming connections from slave host controllers.")
-    String argAdminOnly();
-
-    /**
-     * Instructions for the {@link CommandLineArgument#ADMIN_ONLY} command line argument.
-     *
-     * @return the message.
-     */
-    @Message(id = 12067, value = "Set system property jboss.domain.master.address to the given value. In a default slave Host Controller config, this is used to configure the address of the master Host Controller.")
-    String argMasterAddress();
-
-    /**
-     * Instructions for the {@link CommandLineArgument#ADMIN_ONLY} command line argument.
-     *
-     * @return the message.
-     */
-    @Message(id = 12068, value = "Set system property jboss.domain.master.port to the given value. In a default slave Host Controller config, this is used to configure the port used for native management communication by the master Host Controller.")
-    String argMasterPort();
 }

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessMessages.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessMessages.java
@@ -43,7 +43,7 @@ interface ProcessMessages {
      */
     ProcessMessages MESSAGES = Messages.getBundle(ProcessMessages.class);
 
-    @Message(id = 12040, value = "Usage: ./domain.sh [args...]\nwhere args include:")
+    @Message(id = Message.NONE, value = "Usage: ./domain.sh [args...]%nwhere args include:")
     String argUsage();
 
     /**
@@ -51,7 +51,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12041, value = "Keep a copy of the persistent domain configuration even if this host is not the Domain Controller")
+    @Message(id = Message.NONE, value = "Keep a copy of the persistent domain configuration even if this host is not the Domain Controller")
     String argBackup();
 
     /**
@@ -59,7 +59,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12042, value = "If this host is not the Domain Controller and cannot contact the Domain Controller at boot, boot using a locally cached copy of the domain configuration (see --backup)")
+    @Message(id = Message.NONE, value = "If this host is not the Domain Controller and cannot contact the Domain Controller at boot, boot using a locally cached copy of the domain configuration (see --backup)")
     String argCachedDc();
 
     /**
@@ -67,7 +67,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12043, value = "Name of the domain configuration file to use (default is \"domain.xml\")")
+    @Message(id = Message.NONE, value = "Name of the domain configuration file to use (default is \"domain.xml\")")
     String argDomainConfig();
 
     /**
@@ -75,7 +75,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12044, value = "Display this message and exit")
+    @Message(id = Message.NONE, value = "Display this message and exit")
     String argHelp();
 
     /**
@@ -83,7 +83,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12045, value = "Address on which the host controller should listen for communication from the process controller")
+    @Message(id = Message.NONE, value = "Address on which the host controller should listen for communication from the process controller")
     String argInterProcessHcAddress();
 
     /**
@@ -91,7 +91,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12046, value = "Port on which the host controller should listen for communication from the process controller")
+    @Message(id = Message.NONE, value = "Port on which the host controller should listen for communication from the process controller")
     String argInterProcessHcPort();
 
     /**
@@ -99,7 +99,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12047, value = "Name of the host configuration file to use (default is \"host.xml\")")
+    @Message(id = Message.NONE, value = "Name of the host configuration file to use (default is \"host.xml\")")
     String argHostConfig();
 
     /**
@@ -107,7 +107,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12048, value = "Address on which the process controller listens for communication from processes it controls")
+    @Message(id = Message.NONE, value = "Address on which the process controller listens for communication from processes it controls")
     String argPcAddress();
 
     /**
@@ -115,7 +115,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12049, value = "Port on which the process controller listens for communication from processes it controls")
+    @Message(id = Message.NONE, value = "Port on which the process controller listens for communication from processes it controls")
     String argPcPort();
 
     /**
@@ -123,7 +123,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12050, value = "Load system properties from the given url")
+    @Message(id = Message.NONE, value = "Load system properties from the given url")
     String argProperties();
 
     /**
@@ -131,7 +131,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12051, value = "Set a system property")
+    @Message(id = Message.NONE, value = "Set a system property")
     String argSystem();
 
     /**
@@ -139,7 +139,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12052, value = "Print version and exit")
+    @Message(id = Message.NONE, value = "Print version and exit")
     String argVersion();
 
     /**
@@ -147,7 +147,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12053, value = "Set system property jboss.bind.address to the given value")
+    @Message(id = Message.NONE, value = "Set system property jboss.bind.address to the given value")
     String argPublicBindAddress();
 
     /**
@@ -155,7 +155,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12054, value = "Set system property jboss.bind.address.<interface> to the given value")
+    @Message(id = Message.NONE, value = "Set system property jboss.bind.address.<interface> to the given value")
     String argInterfaceBindAddress();
 
     /**
@@ -163,7 +163,7 @@ interface ProcessMessages {
      *
      * @return the message.
      */
-    @Message(id = 12055, value = "Set system property jboss.default.multicast.address to the given value")
+    @Message(id = Message.NONE, value = "Set system property jboss.default.multicast.address to the given value")
     String argDefaultMulticastAddress();
 
     /**

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgument.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgument.java
@@ -1,0 +1,396 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.server;
+
+import static org.jboss.as.server.ServerMessages.MESSAGES;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.process.CommandLineConstants;
+
+/**
+ * Command line arguments for standalone mode.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+enum CommandLineArgument {
+
+    ADMIN_ONLY {
+        @Override
+        public String argument() {
+            return CommandLineConstants.ADMIN_ONLY;
+        }
+
+        @Override
+        public String argumentExample() {
+            return argument();
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argAdminOnly();
+        }
+    },
+    PUBLIC_BIND_ADDRESS {
+        @Override
+        public String argument() {
+            return CommandLineConstants.PUBLIC_BIND_ADDRESS;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s=<value>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argPublicBindAddress();
+        }
+    },
+    LEGACY_PUBLIC_BIND_ADDRESS {
+        @Override
+        public String argument() {
+            return CommandLineConstants.PUBLIC_BIND_ADDRESS;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s <value>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argPublicBindAddress();
+        }
+    },
+    INTERFACE_BIND_ADDRESS {
+        @Override
+        public String argument() {
+            return CommandLineConstants.PUBLIC_BIND_ADDRESS;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s<interface>=<value>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argInterfaceBindAddress();
+        }
+    },
+    SHORT_SERVER_CONFIG {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SHORT_SERVER_CONFIG;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s=<config>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argServerConfig();
+        }
+    },
+    LEGACY_SHORT_SERVER_CONFIG {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SHORT_SERVER_CONFIG;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s <config>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argServerConfig();
+        }
+    },
+    SYSTEM_PROPERTY {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SYS_PROP;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s<name>[=<value>]", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argSystem();
+        }
+    },
+    SHORT_HELP {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SHORT_HELP;
+        }
+
+        @Override
+        public String argumentExample() {
+            return argument();
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argHelp();
+        }
+    },
+    HELP {
+        @Override
+        public String argument() {
+            return CommandLineConstants.HELP;
+        }
+
+        @Override
+        public String argumentExample() {
+            return argument();
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argHelp();
+        }
+    },
+    SHORT_PROPERTIES {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SHORT_PROPERTIES;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s=<url>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argProperties();
+        }
+    },
+    LEGACY_SHORT_PROPERTIES {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SHORT_PROPERTIES;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s <url>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argProperties();
+        }
+    },
+    PROPERTIES {
+        @Override
+        public String argument() {
+            return CommandLineConstants.PROPERTIES;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s=<url>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argProperties();
+        }
+    },
+    SERVER_CONFIG {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SERVER_CONFIG;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("--%s=<config>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argServerConfig();
+        }
+    },
+    DEFAULT_MULTICAST_ADDRESS {
+        @Override
+        public String argument() {
+            return CommandLineConstants.DEFAULT_MULTICAST_ADDRESS;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s=<value>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argDefaultMulticastAddress();
+        }
+    },
+    LEGACY_DEFAULT_MULTICAST_ADDRESS {
+        @Override
+        public String argument() {
+            return CommandLineConstants.DEFAULT_MULTICAST_ADDRESS;
+        }
+
+        @Override
+        public String argumentExample() {
+            return String.format("%s <value>", argument());
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argDefaultMulticastAddress();
+        }
+    },
+    LEGACY_SHORT_VERSION {
+        @Override
+        public String argument() {
+            return CommandLineConstants.OLD_SHORT_VERSION;
+        }
+
+        @Override
+        public String argumentExample() {
+            return argument();
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argVersion();
+        }
+    },
+    SHORT_VERSION {
+        @Override
+        public String argument() {
+            return CommandLineConstants.SHORT_VERSION;
+        }
+
+        @Override
+        public String argumentExample() {
+            return argument();
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argVersion();
+        }
+    },
+    VERSION {
+        @Override
+        public String argument() {
+            return CommandLineConstants.VERSION;
+        }
+
+        @Override
+        public String argumentExample() {
+            return argument();
+        }
+
+        @Override
+        public String instructions() {
+            return MESSAGES.argVersion();
+        }
+    };
+
+    private static String USAGE;
+    static final String NEW_LINE = String.format("%n");
+
+    /**
+     * The command line argument.
+     *
+     * @return the argument.
+     */
+    public abstract String argument();
+
+    /**
+     * An example of how the argument is used.
+     *
+     * @return the example.
+     */
+    public abstract String argumentExample();
+
+    /**
+     * The argument instructions.
+     *
+     * @return the instructions.
+     */
+    public abstract String instructions();
+
+    @Override
+    public String toString() {
+        final List<String> instructions = new ArrayList<String>();
+        segmentInstructions(instructions(), instructions);
+        StringBuilder sb = new StringBuilder(String.format("    %-35s %s", argumentExample(), instructions.get(0)));
+        for (int i = 1; i < instructions.size(); i++) {
+            sb.append(NEW_LINE);
+            sb.append(String.format("%-40s%s", " ", instructions.get(i)));
+        }
+        sb.append(NEW_LINE);
+        return sb.toString();
+    }
+
+    private static void segmentInstructions(String instructions, List<String> segments) {
+        if (instructions.length() <= 40) {
+            segments.add(instructions);
+        } else {
+            String testFragment = instructions.substring(0, 40);
+            int lastSpace = testFragment.lastIndexOf(' ');
+            if (lastSpace < 0) {
+                // degenerate case; we just have to chop not at a space
+                lastSpace = 39;
+            }
+            segments.add(instructions.substring(0, lastSpace + 1));
+            segmentInstructions(instructions.substring(lastSpace + 1), segments);
+        }
+    }
+
+    public static void printUsage(final PrintStream out) {
+        out.print(usage());
+    }
+
+    public static String usage() {
+        if (USAGE == null) {
+            final StringBuilder sb = new StringBuilder();
+            sb.append(MESSAGES.argUsage()).append(NEW_LINE);
+            for (CommandLineArgument arg : CommandLineArgument.values()) {
+                sb.append(arg.toString()).append(NEW_LINE);
+            }
+            USAGE = sb.toString();
+        }
+        return USAGE;
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -55,27 +55,7 @@ import org.jboss.stdio.StdioContext;
 public final class Main {
 
     public static void usage() {
-        System.out.println("Usage: ./standalone.sh [args...]\n");
-        System.out.println("where args include:");
-        System.out.println("    --admin-only                       Set the server's running type to ADMIN_ONLY causing it to open administrative interfaces ");
-        System.out.println("                                       and accept management requests but not start other runtime services or accept end user requests.\n");
-        System.out.println("    -b=<value>                         Set system property jboss.bind.address to the given value\n");
-        System.out.println("    -b <value>                         Set system property jboss.bind.address to the given value\n");
-        System.out.println("    -b<interface>=<value>              Set system property jboss.bind.address.<interface> to the given value\n");
-        System.out.println("    -c=<config>                        Name of the server configuration file to use (default is \"standalone.xml\")\n");
-        System.out.println("    -c <config>                        Name of the server configuration file to use (default is \"standalone.xml\")\n");
-        System.out.println("    -D<name>[=<value>]                 Set a system property\n");
-        System.out.println("    -h                                 Display this message and exit\n");
-        System.out.println("    --help                             Display this message and exit");
-        System.out.println("    -P=<url>                           Load system properties from the given url\n");
-        System.out.println("    -P <url>                           Load system properties from the given url\n");
-        System.out.println("    --properties=<url>                 Load system properties from the given url\n");
-        System.out.println("    --server-config=<config>           Name of the server configuration file to use (default is \"standalone.xml\")\n");
-        System.out.println("    -u=<value>                         Set system property jboss.default.multicast.address to the given value\n");
-        System.out.println("    -u <value>                         Set system property jboss.default.multicast.address to the given value\n");
-        System.out.println("    -V                                 Print version and exit\n");
-        System.out.println("    -v                                 Print version and exit\n");
-        System.out.println("    --version                          Print version and exit\n");
+        CommandLineArgument.printUsage(System.out);
     }
 
     private Main() {
@@ -205,7 +185,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.printf("Argument expected for option %s\n", arg);
+                        System.err.printf(ServerMessages.MESSAGES.noArgValue(arg));
                         usage();
                         return null;
                     }
@@ -241,13 +221,11 @@ public final class Main {
                     runningMode = RunningMode.ADMIN_ONLY;
                 } else {
                     System.err.printf(ServerMessages.MESSAGES.invalidCommandLineOption(arg));
-                    System.err.println();
                     usage();
                     return null;
                 }
             } catch (IndexOutOfBoundsException e) {
                 System.err.printf(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(arg));
-                System.err.println();
                 usage();
                 return null;
             }

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -211,4 +211,103 @@ public interface ServerMessages {
 
     @Message(id = 15833, value = "Failed to create VFSResourceLoader for root [%s]")
     DeploymentUnitProcessingException failedToCreateVFSResourceLoader(String resourceRoot, @Cause IOException cause);
+
+    /**
+     * Instructions for the usage of standalone.sh.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Usage: ./standalone.sh [args...]%nwhere args include:")
+    String argUsage();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#DOMAIN_CONFIG} and {@link
+     * org.jboss.as.process.CommandLineArgument#SHORT_DOMAIN_CONFIG} command line arguments.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Name of the server configuration file to use (default is \"standalone.xml\")")
+    String argServerConfig();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#SHORT_HELP} or {@link
+     * org.jboss.as.process.CommandLineArgument#HELP} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(value = "Display this message and exit")
+    String argHelp();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#SHORT_PROPERTIES} or {@link
+     * org.jboss.as.process.CommandLineArgument#PROPERTIES} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Load system properties from the given url")
+    String argProperties();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#SYSTEM_PROPERTY} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set a system property")
+    String argSystem();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#SHORT_VERSION}, {@link
+     * org.jboss.as.process.CommandLineArgument#LEGACY_SHORT_VERSION} or {@link org.jboss.as.process.CommandLineArgument#VERSION}
+     * command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Print version and exit")
+    String argVersion();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#PUBLIC_BIND_ADDRESS} or {@link
+     * org.jboss.as.process.CommandLineArgument#LEGACY_PUBLIC_BIND_ADDRESS} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set system property jboss.bind.address to the given value")
+    String argPublicBindAddress();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#INTERFACE_BIND_ADDRESS} command line
+     * argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set system property jboss.bind.address.<interface> to the given value")
+    String argInterfaceBindAddress();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#DEFAULT_MULTICAST_ADDRESS} command line
+     * argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set system property jboss.default.multicast.address to the given value")
+    String argDefaultMulticastAddress();
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#INTERFACE_BIND_ADDRESS} command line
+     * argument.
+     *
+     * @param argument the name of the argument
+     *
+     * @return the message.
+     */
+    @Message(value = "No value was provided for argument %s%n")
+    String noArgValue(String argument);
+
+    /**
+     * Instructions for the {@link org.jboss.as.process.CommandLineArgument#ADMIN_ONLY} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Set the server's running type to ADMIN_ONLY causing it to open administrative interfaces and accept management requests but not start other runtime services or accept end user requests.")
+    String argAdminOnly();
 }

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -235,7 +235,7 @@ public interface ServerMessages {
      *
      * @return the message.
      */
-    @Message(value = "Display this message and exit")
+    @Message(id = Message.NONE, value = "Display this message and exit")
     String argHelp();
 
     /**
@@ -300,7 +300,7 @@ public interface ServerMessages {
      *
      * @return the message.
      */
-    @Message(value = "No value was provided for argument %s%n")
+    @Message(id = 18534, value = "No value was provided for argument %s%n")
     String noArgValue(String argument);
 
     /**


### PR DESCRIPTION
Fix the standalone help/usage text and make i18n compliant.

Make the help text for the process-controller use platform independent new line characters.

Fix logging in the server and process-controller modules. The help next should not use id's.
