### PR TITLE
As7 2409

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
@@ -23,9 +23,11 @@
 package org.jboss.as.controller;
 
 import static org.jboss.as.controller.ControllerLogger.MGMT_OP_LOGGER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
@@ -38,9 +40,16 @@ import org.jboss.dmr.ModelNode;
  */
 public abstract class AbstractRemoveStepHandler implements OperationStepHandler {
 
-    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+    private ModelNode model;
 
-        final ModelNode model = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        try {
+            model = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+        } catch (NoSuchElementException e) {
+            ModelNode description = new ModelNode();
+            description.set("Unknown deployment: " + operation.get(OP_ADDR));
+            throw new OperationFailedException("Unknown deployment", description);
+        }
 
         performRemove(context, operation, model);
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostIdentifier.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostIdentifier.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.host.controller.parsing;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+/**
+ * A class that represents host identifier.
+ *
+ * There exist three variants of the identifier:
+ * <ul>
+ *  <li>explicit human name</li>
+ *  <li>system variable<li>
+ *  <li>an immutable universally unique identifier</li>
+ * </ul>
+ *
+ * @author kulikov
+ */
+public class HostIdentifier {
+    private String name;
+
+    /**
+     * Constructs host identifier follow to the offer.
+     *
+     *
+     * @param offer user's offer for generating identifier. Possible values are:
+     * - ${system.property} indicates that system.property will be used as identifier
+     * - Text 'abc' indicates that this value will be used as identifier
+     * - Null or ${jboss.domain.guid} generates unique identifier.
+     */
+    public HostIdentifier(String offer) {
+        InetAddress localhost = null;
+        try {
+            localhost = InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            //never happen
+        }
+
+        if (offer == null) {
+            name = UUID.nameUUIDFromBytes(localhost.getAddress()).toString();
+        } else if (offer.startsWith("${") && offer.endsWith("}")) {
+            String val = offer.substring(2, offer.length() - 1);
+            if (val.equalsIgnoreCase("jboss.domain.guid")) {
+                name = UUID.nameUUIDFromBytes(localhost.getAddress()).toString();
+            } else {
+                name = System.getProperty(val);
+            }
+        } else {
+            name = offer;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -208,7 +208,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                     final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
                     switch (attribute) {
                         case NAME: {
-                            hostName = value;
+                            hostName = new HostIdentifier(value).toString();
                             break;
                         }
                         default:
@@ -306,7 +306,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                     final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
                     switch (attribute) {
                         case NAME: {
-                            hostName = value;
+                            hostName = new HostIdentifier(value).toString();
                             break;
                         }
                         default:

--- a/host-controller/src/test/java/org/jboss/as/host/controller/parsing/HostIdentifierTest.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/parsing/HostIdentifierTest.java
@@ -1,0 +1,62 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.host.controller.parsing;
+
+import org.junit.*;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author kulikov
+ */
+public class HostIdentifierTest {
+
+    private HostIdentifier hostName;
+
+    public HostIdentifierTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of toString method, of class HostName.
+     */
+    @Test
+    public void testSimpleName() {
+        hostName = new HostIdentifier("name");
+        assertEquals("name", hostName.toString());
+    }
+
+    @Test
+    public void testSystemVariable() {
+        System.setProperty("jboss.host.name", "localhost");
+        hostName = new HostIdentifier("${jboss.host.name}");
+        assertEquals("localhost", hostName.toString());
+    }
+
+    @Test
+    public void testGUID() throws InterruptedException {
+        System.setProperty("jboss.domain.guid", "localhost");
+        hostName = new HostIdentifier("${jboss.domain.guid}");
+        assertTrue("GUID was not generated", hostName.toString().length() > 0);
+        assertFalse("Varibale recognized as name", hostName.toString().equals("jboss.domain.guid"));
+        assertFalse("System varibale overrides global ID", hostName.toString().equals("jboss.domain.guid"));
+    }
+
+}


### PR DESCRIPTION
Added class for generating host name. The class allows to:
- specify human name as it is now
- specify host name as system varibale (${jboss.host.name}, etc)
- generate global unique name value based on host IP address for dynamicaly registered servers in large domains/cloud. 

Generated name is unique and immutable. GUID value is default for host name or can be explicitly triggered as varibale ${jboss.domain.guid}
