### PR TITLE
AS7-3306 Make commons-lang, commons-io and commons-codec available in tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <version.commons-collections>3.2.1</version.commons-collections>
         <version.commons-io>2.1</version.commons-io>
         <version.commons-lang>2.4</version.commons-lang>
-        <version.commons-lang3>3.1</version.commons-lang3>
         <version.commons-pool>1.5.6</version.commons-pool>
         <version.com.google.guava>10.0.1</version.com.google.guava>
         <version.com.h2database>1.3.161</version.com.h2database>
@@ -1222,12 +1221,6 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${version.commons-lang}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${version.commons-lang3}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <version.commons-collections>3.2.1</version.commons-collections>
         <version.commons-io>2.1</version.commons-io>
         <version.commons-lang>2.4</version.commons-lang>
+        <version.commons-lang3>3.1</version.commons-lang3>
         <version.commons-pool>1.5.6</version.commons-pool>
         <version.com.google.guava>10.0.1</version.com.google.guava>
         <version.com.h2database>1.3.161</version.com.h2database>
@@ -1221,6 +1222,12 @@
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
                 <version>${version.commons-lang}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${version.commons-lang3}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -168,8 +168,8 @@
         </dependency>
         
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -166,6 +166,20 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        
         <dependency>
             <groupId>org.projectodd.stilts</groupId>
             <artifactId>stilts-stomp-client</artifactId>
@@ -174,11 +188,13 @@
             <groupId>org.projectodd.stilts</groupId>
             <artifactId>stilts-stomplet-server-core</artifactId>
         </dependency>
+        
         <!-- Needed for @Resource(lookup=). -->
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.1_spec</artifactId>
         </dependency>
+        
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>


### PR DESCRIPTION
Follow-up of https://github.com/jbossas/jboss-as/pull/1106 .
Uses commons-lang 2.x instead of 3.x.
