### PR TITLE
cli exit code

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -70,6 +70,20 @@ public interface CommandContext {
     void printColumns(Collection<String> col);
 
     /**
+     * Prints an error message to the CLI's output and passes the error code
+     * which in non-interactive mode will be used as the program's exit code.
+     * @param message the error message
+     * @param code the error code (should be greater than 0)
+     */
+    void error(String message, int code);
+
+    /**
+     * This method invokes error(message, 1).
+     * @param message the error message
+     */
+    void error(String message);
+
+    /**
      * Clears the screen.
      */
     void clearScreen();
@@ -227,4 +241,10 @@ public interface CommandContext {
      * @param listener  the listener
      */
     void addEventListener(CliEventListener listener);
+
+    /**
+     * Returns value that should be used as the exit code of the JVM process.
+     * @return  JVM exit code
+     */
+    int getExitCode();
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
@@ -182,12 +182,12 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
         try {
             request = buildRequest(ctx);
         } catch (CommandFormatException e1) {
-            ctx.printLine(e1.getLocalizedMessage());
+            ctx.error(e1.getLocalizedMessage());
             return;
         }
 
         if(request == null) {
-            ctx.printLine("Operation request wasn't built.");
+            ctx.error("Operation request wasn't built.");
             return;
         }
 
@@ -196,7 +196,7 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
         try {
             response = client.execute(request);
         } catch (Exception e) {
-            ctx.printLine("Failed to perform operation: " + e.getLocalizedMessage());
+            ctx.error("Failed to perform operation: " + e.getLocalizedMessage());
             return;
         }
         handleResponse(ctx, response, Util.COMPOSITE.equals(request.get(Util.OPERATION).asString()));
@@ -204,7 +204,7 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
 
     protected void handleResponse(CommandContext ctx, ModelNode response, boolean composite) {
         if (!Util.isSuccess(response)) {
-            ctx.printLine(Util.getFailureDescription(response));
+            ctx.error(Util.getFailureDescription(response));
             return;
         }
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
@@ -166,7 +166,7 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
         final ParsedCommandLine args = ctx.getParsedCommandLine();
         final String action = this.action.getValue(args);
         if(action == null) {
-            ctx.printLine("Command is missing.");
+            ctx.error("Command is missing.");
             return;
         }
 
@@ -185,7 +185,7 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
             }
 
             if(cmdRegistry.getCommandHandler(cmdName) != null) {
-                ctx.printLine("Command '" + cmdName + "' already registered.");
+                ctx.error("Command '" + cmdName + "' already registered.");
                 return;
             }
             cmdRegistry.registerHandler(new GenericTypeOperationHandler(ctx, nodePath, propName), cmdName);
@@ -196,14 +196,14 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
             final String cmdName = this.commandName.getValue(args, true);
             CommandHandler handler = cmdRegistry.getCommandHandler(cmdName);
             if(!(handler instanceof GenericTypeOperationHandler)) {
-                ctx.printLine("Command '" + cmdName + "' is not a generic type command.");
+                ctx.error("Command '" + cmdName + "' is not a generic type command.");
                 return;
             }
             cmdRegistry.remove(cmdName);
             return;
         }
 
-        ctx.printLine("Unexpected action: " + action);
+        ctx.error("Unexpected action: " + action);
     }
 
     protected List<String> getExistingCommands() {
@@ -281,13 +281,13 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
         try {
             ParserUtil.parseOperationRequest(typePath, callback);
         } catch (CommandFormatException e) {
-            ctx.printLine("Failed to validate input: " + e.getLocalizedMessage());
+            ctx.error("Failed to validate input: " + e.getLocalizedMessage());
             return false;
         }
 
         OperationRequestAddress typeAddress = callback.getAddress();
         if(!typeAddress.endsOnType()) {
-            ctx.printLine("Node path '" + typePath + "' doesn't appear to end on a type.");
+            ctx.error("Node path '" + typePath + "' doesn't appear to end on a type.");
             return false;
         }
 
@@ -302,11 +302,11 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
         try {
             result = ctx.getModelControllerClient().execute(request);
         } catch (IOException e) {
-            ctx.printLine("Failed to validate input: " + e.getLocalizedMessage());
+            ctx.error("Failed to validate input: " + e.getLocalizedMessage());
             return false;
         }
         if(!result.hasDefined(Util.RESULT)) {
-            ctx.printLine("Failed to validate input: operation response doesn't contain result info.");
+            ctx.error("Failed to validate input: operation response doesn't contain result info.");
             return false;
         }
 
@@ -318,7 +318,7 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
             }
         }
         if(!pathValid) {
-            ctx.printLine("Type '" + typeName + "' not found amoung child types of '" + ctx.getPrefixFormatter().format(typeAddress) + "'");
+            ctx.error("Type '" + typeName + "' not found amoung child types of '" + ctx.getPrefixFormatter().format(typeAddress) + "'");
             return false;
         }
 
@@ -328,16 +328,16 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
         try {
             result = ctx.getModelControllerClient().execute(request);
         } catch (IOException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
             return false;
         }
         if(!result.hasDefined(Util.RESULT)) {
-            ctx.printLine("Failed to validate input: operation response doesn't contain result info.");
+            ctx.error("Failed to validate input: operation response doesn't contain result info.");
             return false;
         }
         result = result.get(Util.RESULT);
         if(!result.hasDefined("attributes")) {
-            ctx.printLine("Failed to validate input: description of attributes is missing for " + typePath);
+            ctx.error("Failed to validate input: description of attributes is missing for " + typePath);
             return false;
         }
 
@@ -348,14 +348,14 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
                     if(value.has(Util.ACCESS_TYPE) && Util.READ_ONLY.equals(value.get(Util.ACCESS_TYPE).asString())) {
                         return true;
                     }
-                    ctx.printLine("Property " + propertyName + " is not read-only.");
+                    ctx.error("Property " + propertyName + " is not read-only.");
                     return false;
                 }
             }
         } else {
             return true;
         }
-        ctx.printLine("Property '" + propertyName + "' wasn't found among the properties of " + typePath);
+        ctx.error("Property '" + propertyName + "' wasn't found among the properties of " + typePath);
         return false;
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/CommandHandlerWithHelp.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/CommandHandlerWithHelp.java
@@ -77,7 +77,7 @@ public abstract class CommandHandlerWithHelp extends CommandHandlerWithArguments
         }
 
         if(!isAvailable(ctx)) {
-            ctx.printLine("The command is not available in the current context (e.g. required subsystems or connection to the controller might be unavailable).");
+            ctx.error("The command is not available in the current context (e.g. required subsystems or connection to the controller might be unavailable).");
             return;
         }
 
@@ -95,12 +95,12 @@ public abstract class CommandHandlerWithHelp extends CommandHandlerWithArguments
                     helpLine = reader.readLine();
                 }
             } catch(java.io.IOException e) {
-                ctx.printLine("Failed to read help/help.txt: " + e.getLocalizedMessage());
+                ctx.error("Failed to read help/help.txt: " + e.getLocalizedMessage());
             } finally {
                 StreamUtils.safeClose(reader);
             }
         } else {
-            ctx.printLine("Failed to locate command description " + filename);
+            ctx.error("Failed to locate command description " + filename);
         }
         return;
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
@@ -57,7 +57,7 @@ public class ConnectHandler extends CommandHandlerWithHelp {
 
         if(!args.isEmpty()) {
             if(args.size() != 1) {
-                ctx.printLine("The command expects only one argument but got " + args);
+                ctx.error("The command expects only one argument but got " + args);
                 return;
             }
             final String arg = args.get(0);
@@ -95,12 +95,12 @@ public class ConnectHandler extends CommandHandlerWithHelp {
                 try {
                     port = Integer.parseInt(portStr);
                 } catch(NumberFormatException e) {
-                    ctx.printLine("The port must be a valid non-negative integer: '" + args + "'");
+                    ctx.error("The port must be a valid non-negative integer: '" + args + "'");
                     return;
                 }
 
                 if(port < 0) {
-                    ctx.printLine("The port must be a valid non-negative integer: '" + args + "'");
+                    ctx.error("The port must be a valid non-negative integer: '" + args + "'");
                     return;
                 }
             }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -236,11 +236,11 @@ public class DeployHandler extends BatchModeCommandHandler {
         if(path != null) {
             f = new File(path);
             if(!f.exists()) {
-                ctx.printLine("Path " + f.getAbsolutePath() + " doesn't exist.");
+                ctx.error("Path " + f.getAbsolutePath() + " doesn't exist.");
                 return;
             }
             if(f.isDirectory()) {
-                ctx.printLine(f.getAbsolutePath() + " is a directory.");
+                ctx.error(f.getAbsolutePath() + " is a directory.");
                 return;
             }
         } else {
@@ -250,7 +250,7 @@ public class DeployHandler extends BatchModeCommandHandler {
         String name = this.name.getValue(args);
         if(name == null) {
             if(f == null) {
-                ctx.printLine("Either path or --name is requied.");
+                ctx.error("Either path or --name is requied.");
                 return;
             }
             name = f.getName();
@@ -265,11 +265,11 @@ public class DeployHandler extends BatchModeCommandHandler {
 
         if(force) {
             if(f == null) {
-                ctx.printLine(this.force.getFullName() + " requires a filesystem path of the deployment to be added to the deployment repository.");
+                ctx.error(this.force.getFullName() + " requires a filesystem path of the deployment to be added to the deployment repository.");
                 return;
             }
             if(disabled || serverGroups != null || allServerGroups) {
-                ctx.printLine(this.force.getFullName() +
+                ctx.error(this.force.getFullName() +
                         " only replaces the content in the deployment repository and can't be used in combination with any of " +
                         this.disabled.getFullName() + ", " + this.serverGroups.getFullName() + " or " + this.allServerGroups.getFullName() + '.');
                 return;
@@ -289,18 +289,18 @@ public class DeployHandler extends BatchModeCommandHandler {
 
         if(disabled) {
             if(f == null) {
-                ctx.printLine(this.disabled.getFullName() + " requires a filesystem path of the deployment to be added to the deployment repository.");
+                ctx.error(this.disabled.getFullName() + " requires a filesystem path of the deployment to be added to the deployment repository.");
                 return;
             }
 
             if(serverGroups != null || allServerGroups) {
-                ctx.printLine(this.serverGroups.getFullName() + " and " + this.allServerGroups.getFullName() +
+                ctx.error(this.serverGroups.getFullName() + " and " + this.allServerGroups.getFullName() +
                         " can't be used in combination with " + this.disabled.getFullName() + '.');
                 return;
             }
 
             if(Util.isDeploymentInRepository(name, client)) {
-                ctx.printLine("'" + name + "' already exists in the deployment repository (use " +
+                ctx.error("'" + name + "' already exists in the deployment repository (use " +
                 this.force.getFullName() + " to replace the existing content in the repository).");
                 return;
             }
@@ -318,12 +318,12 @@ public class DeployHandler extends BatchModeCommandHandler {
             final List<String> sgList;
             if(allServerGroups) {
                 if(serverGroups != null) {
-                    ctx.printLine(this.serverGroups.getFullName() + " can't appear in the same command with " + this.allServerGroups.getFullName());
+                    ctx.error(this.serverGroups.getFullName() + " can't appear in the same command with " + this.allServerGroups.getFullName());
                     return;
                 }
                 sgList = Util.getServerGroups(client);
                 if(sgList.isEmpty()) {
-                    ctx.printLine("No server group is available.");
+                    ctx.error("No server group is available.");
                     return;
                 }
             } else if(serverGroups == null) {
@@ -333,12 +333,12 @@ public class DeployHandler extends BatchModeCommandHandler {
                     buf.append(this.disabled.getFullName()).append(", ");
                 }
                 buf.append(this.allServerGroups.getFullName() + " or " + this.serverGroups.getFullName() + " is missing.");
-                ctx.printLine(buf.toString());
+                ctx.error(buf.toString());
                 return;
             } else {
                 sgList = Arrays.asList(serverGroups.split(","));
                 if(sgList.isEmpty()) {
-                    ctx.printLine("Couldn't locate server group name in '" + this.serverGroups.getFullName() + "=" + serverGroups + "'.");
+                    ctx.error("Couldn't locate server group name in '" + this.serverGroups.getFullName() + "=" + serverGroups + "'.");
                     return;
                 }
             }
@@ -355,7 +355,7 @@ public class DeployHandler extends BatchModeCommandHandler {
             }
         } else {
             if(serverGroups != null || allServerGroups) {
-                ctx.printLine(this.serverGroups.getFullName() + " and " + this.allServerGroups.getFullName() +
+                ctx.error(this.serverGroups.getFullName() + " and " + this.allServerGroups.getFullName() +
                         " can't appear in standalone mode.");
                 return;
             }
@@ -366,7 +366,7 @@ public class DeployHandler extends BatchModeCommandHandler {
 
         if(f != null) {
             if(Util.isDeploymentInRepository(name, client)) {
-                ctx.printLine("'" + name + "' already exists in the deployment repository (use " +
+                ctx.error("'" + name + "' already exists in the deployment repository (use " +
                 this.force.getFullName() + " to replace the existing content in the repository).");
                 return;
             }
@@ -379,18 +379,18 @@ public class DeployHandler extends BatchModeCommandHandler {
             execute(ctx, request, f);
             return;
         } else if(!Util.isDeploymentInRepository(name, client)) {
-            ctx.printLine("'" + name + "' is not found among the registered deployments.");
+            ctx.error("'" + name + "' is not found among the registered deployments.");
             return;
         }
 
         try {
             final ModelNode result = client.execute(deployRequest);
             if (!Util.isSuccess(result)) {
-                ctx.printLine(Util.getFailureDescription(result));
+                ctx.error(Util.getFailureDescription(result));
                 return;
             }
         } catch (Exception e) {
-            ctx.printLine("Failed to deploy: " + e.getLocalizedMessage());
+            ctx.error("Failed to deploy: " + e.getLocalizedMessage());
             return;
         }
     }
@@ -581,13 +581,13 @@ public class DeployHandler extends BatchModeCommandHandler {
             request.get(Util.CONTENT).get(0).get(Util.INPUT_STREAM_INDEX).set(0);
             result = ctx.getModelControllerClient().execute(op.build());
         } catch (Exception e) {
-            ctx.printLine("Failed to add the deployment content to the repository: " + e.getLocalizedMessage());
+            ctx.error("Failed to add the deployment content to the repository: " + e.getLocalizedMessage());
             return;
         } finally {
             StreamUtils.safeClose(is);
         }
         if (!Util.isSuccess(result)) {
-            ctx.printLine(Util.getFailureDescription(result));
+            ctx.error(Util.getFailureDescription(result));
             return;
         }
     }
@@ -663,7 +663,7 @@ public class DeployHandler extends BatchModeCommandHandler {
                 table.nextRow();
             }
         }
-        ctx.printLine(table.toString());
+        ctx.error(table.toString());
     }
 
     protected ModelNode getDeploymentDescriptions(CommandContext ctx, List<String> names) throws CommandFormatException {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
@@ -380,7 +380,7 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
     protected void handleResponse(CommandContext ctx, ModelNode opResponse, boolean composite) {
         //System.out.println(opResponse);
         if (!Util.isSuccess(opResponse)) {
-            ctx.printLine(Util.getFailureDescription(opResponse));
+            ctx.error(Util.getFailureDescription(opResponse));
             return;
         }
         final StringBuilder buf = formatResponse(ctx, opResponse, composite, null);
@@ -399,7 +399,7 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
             try {
                 keys = result.keys();
             } catch(Exception e) {
-                ctx.printLine("Failed to get step results from a composite operation response " + opResponse);
+                ctx.error("Failed to get step results from a composite operation response " + opResponse);
                 e.printStackTrace();
                 return null;
             }
@@ -544,13 +544,13 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                 try {
                     printProperties(ctx, getNodeProperties(ctx));
                 } catch(Exception e) {
-                    ctx.printLine("Failed to obtain the list or properties: " + e.getLocalizedMessage());
+                    ctx.error("Failed to obtain the list or properties: " + e.getLocalizedMessage());
                     return;
                 }
                 return;
             }
         } catch (CommandFormatException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
             return;
         }
 
@@ -560,7 +560,7 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                 return;
             }
         } catch (CommandFormatException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
             return;
         }
 
@@ -572,14 +572,14 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
 
         try {
             ModelNode result = getOperationDescription(ctx, operationName);
-            if(!result.hasDefined("description")) {
-                ctx.printLine("Operation description is not available.");
+            if(!result.hasDefined(Util.DESCRIPTION)) {
+                ctx.error("Operation description is not available.");
                 return;
             }
 
             final StringBuilder buf = new StringBuilder();
             buf.append("\nDESCRIPTION:\n\n");
-            buf.append(result.get("description").asString());
+            buf.append(result.get(Util.DESCRIPTION).asString());
             ctx.printLine(buf.toString());
 
             if(result.hasDefined(Util.REQUEST_PROPERTIES)) {
@@ -705,12 +705,12 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
             try {
                 result = ctx.getModelControllerClient().execute(request);
                 if(!result.hasDefined(Util.RESULT)) {
-                    ctx.printLine("Node description is not available.");
+                    ctx.error("Node description is not available.");
                     return;
                 }
                 result = result.get(Util.RESULT);
                 if(!result.hasDefined(Util.DESCRIPTION)) {
-                    ctx.printLine("Node description is not available.");
+                    ctx.error("Node description is not available.");
                     return;
                 }
             } catch (Exception e) {
@@ -765,8 +765,8 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
         request.get(Util.OPERATION).set(Util.READ_OPERATION_NAMES);
         try {
             ModelNode result = ctx.getModelControllerClient().execute(request);
-            if(!result.hasDefined("result")) {
-                ctx.printLine("Operation names aren't available.");
+            if(!result.hasDefined(Util.RESULT)) {
+                ctx.error("Operation names aren't available.");
                 return;
             }
             final List<String> list = Util.getList(result);
@@ -821,7 +821,7 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
         if(isDependsOnProfile() && ctx.isDomainMode()) {
             final String profileName = profile.getValue(ctx.getParsedCommandLine());
             if(profileName == null) {
-                ctx.printLine("--profile argument is required to get the node description.");
+                ctx.error("--profile argument is required to get the node description.");
                 return null;
             }
             address.add(Util.PROFILE, profileName);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/HelpHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/HelpHandler.java
@@ -58,7 +58,7 @@ public class HelpHandler extends CommandHandlerWithHelp {
         try {
             printCommands = commands.isPresent(ctx.getParsedCommandLine());
         } catch (CommandFormatException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
             return;
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/HistoryHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/HistoryHandler.java
@@ -72,7 +72,7 @@ public class HistoryHandler extends CommandHandlerWithHelp {
         } else if(enable.isPresent(args)) {
             ctx.getHistory().setUseHistory(true);
         } else {
-            ctx.printLine("Unexpected argument '" + ctx.getArgumentsString() + '\'');
+            ctx.error("Unexpected argument '" + ctx.getArgumentsString() + '\'');
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
@@ -87,7 +87,7 @@ public class LsHandler extends CommandHandlerWithHelp {
             try {
                 ctx.getCommandLineParser().parse(nodePath, handler);
             } catch (CommandFormatException e) {
-                ctx.printLine(e.getLocalizedMessage());
+                ctx.error(e.getLocalizedMessage());
             }
         } else {
             address = new DefaultOperationRequestAddress(ctx.getPrefix());
@@ -197,10 +197,10 @@ public class LsHandler extends CommandHandlerWithHelp {
                                         childDescriptions = descrResult.get(Util.CHILDREN);
                                     }
                                 } else {
-                                    ctx.printLine("Result is not available for read-resource-description request: " + outcome);
+                                    ctx.error("Result is not available for read-resource-description request: " + outcome);
                                 }
                             } else {
-                                ctx.printLine("Failed to get resource description: " + outcome);
+                                ctx.error("Failed to get resource description: " + outcome);
                             }
                         }
 
@@ -221,13 +221,13 @@ public class LsHandler extends CommandHandlerWithHelp {
                                         }
                                     }
                                 } else {
-                                    ctx.printLine("Result is not available for read-children-types request: " + outcome);
+                                    ctx.error("Result is not available for read-children-types request: " + outcome);
                                 }
                             } else {
-                                ctx.printLine("Failed to fetch type names: " + outcome);
+                                ctx.error("Failed to fetch type names: " + outcome);
                             }
                         } else {
-                            ctx.printLine("The result for children type names is not available: " + outcome);
+                            ctx.error("The result for children type names is not available: " + outcome);
                         }
 
                         if(resultNode.hasDefined(Util.STEP_2)) {
@@ -325,17 +325,17 @@ public class LsHandler extends CommandHandlerWithHelp {
                                         }
                                     }
                                 } else {
-                                    ctx.printLine("Result is not available for read-resource request: " + outcome);
+                                    ctx.error("Result is not available for read-resource request: " + outcome);
                                 }
                             } else {
-                                ctx.printLine("Failed to fetch attributes: " + outcome);
+                                ctx.error("Failed to fetch attributes: " + outcome);
                             }
                         } else {
-                            ctx.printLine("The result for attributes is not available: " + outcome);
+                            ctx.error("The result for attributes is not available: " + outcome);
                         }
                     }
                 } else {
-                    ctx.printLine("Failed to fetch the list of children: " + outcome);
+                    ctx.error("Failed to fetch the list of children: " + outcome);
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
@@ -58,7 +58,7 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
 
         ModelControllerClient client = ctx.getModelControllerClient();
         if(client == null) {
-            ctx.printLine("You are disconnected at the moment." +
+            ctx.error("You are disconnected at the moment." +
                     " Type 'connect' to connect to the server" +
                     " or 'help' for the list of supported commands.");
             return;
@@ -66,14 +66,14 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
 
         ModelNode request = (ModelNode) ctx.get("OP_REQ");
         if(request == null) {
-            ctx.printLine("Parsed request isn't available.");
+            ctx.error("Parsed request isn't available.");
             return;
         }
 
         try {
             validateRequest(ctx, request);
         } catch(CommandFormatException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
             return;
         }
 
@@ -81,11 +81,11 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
             ModelNode result = client.execute(request);
             ctx.printLine(result.toString());
         } catch(NoSuchElementException e) {
-            ctx.printLine("ModelNode request is incomplete: " + e.getMessage());
+            ctx.error("ModelNode request is incomplete: " + e.getMessage());
         } catch (CancellationException e) {
-            ctx.printLine("The result couldn't be retrieved (perhaps the task was cancelled: " + e.getLocalizedMessage());
+            ctx.error("The result couldn't be retrieved (perhaps the task was cancelled: " + e.getLocalizedMessage());
         } catch (IOException e) {
-            ctx.printLine("Communication error: " + e.getLocalizedMessage());
+            ctx.error("Communication error: " + e.getLocalizedMessage());
             ctx.disconnectController();
         } catch (RuntimeException e) {
             throw e;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/PrefixHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/PrefixHandler.java
@@ -62,7 +62,7 @@ public class PrefixHandler extends CommandHandlerWithHelp {
         try {
             ctx.getCommandLineParser().parse(ctx.getArgumentsString(), handler);
         } catch (CommandFormatException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
         }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReadAttributeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReadAttributeHandler.java
@@ -103,7 +103,7 @@ public class ReadAttributeHandler extends BaseOperationCommand {
                         e.printStackTrace();
                     }
                 } catch (CommandFormatException e) {
-                    ctx.printLine(e.getLocalizedMessage());
+                    ctx.error(e.getLocalizedMessage());
                     return Collections.emptyList();
                 }
                 return Collections.emptyList();
@@ -150,7 +150,7 @@ public class ReadAttributeHandler extends BaseOperationCommand {
 
     protected void handleResponse(CommandContext ctx, ModelNode response, boolean composite) {
         if (!Util.isSuccess(response)) {
-            ctx.printLine(Util.getFailureDescription(response));
+            ctx.error(Util.getFailureDescription(response));
             return;
         }
         if(!response.hasDefined(Util.RESULT)) {
@@ -174,7 +174,7 @@ public class ReadAttributeHandler extends BaseOperationCommand {
                     }
                     table.addLine(new String[]{"value", valueBuf.toString()});
                 } else {
-                    ctx.printLine("Failed to get resource description: " + response);
+                    ctx.error("Failed to get resource description: " + response);
                 }
             }
 
@@ -187,23 +187,23 @@ public class ReadAttributeHandler extends BaseOperationCommand {
                             ModelNode attributes = descrResult.get(Util.ATTRIBUTES);
                             final String name = this.name.getValue(ctx.getParsedCommandLine());
                             if(name == null) {
-                                ctx.printLine("Attribute name is not available in handleResponse.");
+                                ctx.error("Attribute name is not available in handleResponse.");
                             } else if(attributes.hasDefined(name)) {
                                 final ModelNode descr = attributes.get(name);
                                 for(String prop : descr.keys()) {
                                     table.addLine(new String[]{prop, descr.get(prop).asString()});
                                 }
                             } else {
-                                ctx.printLine("Attribute description is not available.");
+                                ctx.error("Attribute description is not available.");
                             }
                         } else {
-                            ctx.printLine("The resource doesn't provide attribute descriptions.");
+                            ctx.error("The resource doesn't provide attribute descriptions.");
                         }
                     } else {
-                        ctx.printLine("Result is not available for read-resource-description request: " + response);
+                        ctx.error("Result is not available for read-resource-description request: " + response);
                     }
                 } else {
-                    ctx.printLine("Failed to get resource description: " + response);
+                    ctx.error("Failed to get resource description: " + response);
                 }
             }
             ctx.printLine(table.toString(true));
@@ -225,7 +225,7 @@ public class ReadAttributeHandler extends BaseOperationCommand {
             try {
                 keys = result.keys();
             } catch(Exception e) {
-                ctx.printLine("Failed to get step results from a composite operation response " + opResponse);
+                ctx.error("Failed to get step results from a composite operation response " + opResponse);
                 e.printStackTrace();
                 return null;
             }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
@@ -199,7 +199,7 @@ public class UndeployHandler extends BatchModeCommandHandler {
         try {
             request = buildRequest(ctx);
         } catch (OperationFormatException e) {
-            ctx.printLine(e.getLocalizedMessage());
+            ctx.error(e.getLocalizedMessage());
             return;
         }
 
@@ -207,11 +207,11 @@ public class UndeployHandler extends BatchModeCommandHandler {
         try {
             result = client.execute(request);
         } catch (Exception e) {
-            ctx.printLine("Undeploy failed: " + e.getLocalizedMessage());
+            ctx.error("Undeploy failed: " + e.getLocalizedMessage());
             return;
         }
         if (!Util.isSuccess(result)) {
-            ctx.printLine("Undeploy failed: " + Util.getFailureDescription(result));
+            ctx.error("Undeploy failed: " + Util.getFailureDescription(result));
             return;
         }
     }
@@ -220,9 +220,9 @@ public class UndeployHandler extends BatchModeCommandHandler {
     public ModelNode buildRequest(CommandContext ctx) throws OperationFormatException {
 
         ModelNode composite = new ModelNode();
-        composite.get("operation").set("composite");
-        composite.get("address").setEmptyList();
-        ModelNode steps = composite.get("steps");
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+        ModelNode steps = composite.get(Util.STEPS);
 
         final ParsedCommandLine args = ctx.getParsedCommandLine();
         final String name = this.name.getValue(args);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/VersionHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/VersionHandler.java
@@ -99,7 +99,7 @@ public class VersionHandler implements CommandHandler {
                 }
                 buf.append('\n');
             } catch (IOException e) {
-                ctx.printLine("Failed to get the AS release info: " + e.getLocalizedMessage());
+                ctx.error("Failed to get the AS release info: " + e.getLocalizedMessage());
                 e.printStackTrace();
             }
         }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchClearHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchClearHandler.java
@@ -52,7 +52,7 @@ public class BatchClearHandler extends CommandHandlerWithHelp {
 
         Batch batch = ctx.getBatchManager().getActiveBatch();
         if(batch == null) {
-            ctx.printLine("No active batch.");
+            ctx.error("No active batch.");
             return;
         }
         batch.clear();

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchDiscardHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchDiscardHandler.java
@@ -50,7 +50,7 @@ public class BatchDiscardHandler extends CommandHandlerWithHelp {
 
         boolean result = ctx.getBatchManager().discardActiveBatch();
         if(!result) {
-            ctx.printLine("There is no active batch to discard.");
+            ctx.error("There is no active batch to discard.");
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchEditLineHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchEditLineHandler.java
@@ -128,20 +128,20 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
 
         BatchManager batchManager = ctx.getBatchManager();
         if(!batchManager.isBatchActive()) {
-            ctx.printLine("No active batch.");
+            ctx.error("No active batch.");
             return;
         }
 
         Batch batch = batchManager.getActiveBatch();
         final int batchSize = batch.size();
         if(batchSize == 0) {
-            ctx.printLine("The batch is empty.");
+            ctx.error("The batch is empty.");
             return;
         }
 
         String argsStr = ctx.getArgumentsString();
         if(argsStr == null) {
-            ctx.printLine("Missing line number.");
+            ctx.error("Missing line number.");
             return;
         }
 
@@ -154,7 +154,7 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
         }
 
         if(i == argsStr.length()) {
-            ctx.printLine("Missing the new command line after the index.");
+            ctx.error("Missing the new command line after the index.");
             return;
         }
 
@@ -163,18 +163,18 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
         try {
             lineNumber = Integer.parseInt(intStr);
         } catch(NumberFormatException e) {
-            ctx.printLine("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
+            ctx.error("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
             return;
         }
 
         if(lineNumber < 1 || lineNumber > batchSize) {
-            ctx.printLine(lineNumber + " isn't in range [1.." + batchSize + "].");
+            ctx.error(lineNumber + " isn't in range [1.." + batchSize + "].");
             return;
         }
 
         String editedLine = argsStr.substring(i).trim();
         if(editedLine.length() == 0) {
-            ctx.printLine("Missing the new command line after the index.");
+            ctx.error("Missing the new command line after the index.");
             return;
         }
 
@@ -189,7 +189,7 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
             batch.set(lineNumber - 1, newCmd);
             ctx.printLine("#" + lineNumber + " " + newCmd.getCommand());
         } catch (CommandFormatException e) {
-            ctx.printLine("Failed to process command line '" + editedLine + "': " + e.getLocalizedMessage());
+            ctx.error("Failed to process command line '" + editedLine + "': " + e.getLocalizedMessage());
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
@@ -105,7 +105,7 @@ public class BatchHandler extends CommandHandlerWithHelp {
         }
 
         if(batchManager.isBatchActive()) {
-            ctx.printLine("Can't start a new batch while in batch mode.");
+            ctx.error("Can't start a new batch while in batch mode.");
             return;
         }
 
@@ -126,7 +126,7 @@ public class BatchHandler extends CommandHandlerWithHelp {
                 }
             }
         } else if(name != null) {
-            ctx.printLine("'" + name + "' not found among the held back batches.");
+            ctx.error("'" + name + "' not found among the held back batches.");
             return;
         } else {
             activated = batchManager.activateNewBatch();
@@ -134,7 +134,7 @@ public class BatchHandler extends CommandHandlerWithHelp {
 
         if(!activated) {
             // that's more like illegal state
-            ctx.printLine("Failed to activate batch.");
+            ctx.error("Failed to activate batch.");
         }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHoldbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHoldbackHandler.java
@@ -53,7 +53,7 @@ public class BatchHoldbackHandler extends CommandHandlerWithHelp {
 
         BatchManager batchManager = ctx.getBatchManager();
         if(!batchManager.isBatchActive()) {
-            ctx.printLine("No active batch to holdback.");
+            ctx.error("No active batch to holdback.");
             return;
         }
 
@@ -64,12 +64,12 @@ public class BatchHoldbackHandler extends CommandHandlerWithHelp {
         }
 
         if(batchManager.isHeldback(name)) {
-            ctx.printLine("There already is " + (name == null ? "unnamed" : "'" + name + "'") + " batch held back.");
+            ctx.error("There already is " + (name == null ? "unnamed" : "'" + name + "'") + " batch held back.");
             return;
         }
 
         if(!batchManager.holdbackActiveBatch(name)) {
-            ctx.printLine("Failed to holdback the batch.");
+            ctx.error("Failed to holdback the batch.");
         }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchListHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchListHandler.java
@@ -54,7 +54,7 @@ public class BatchListHandler extends CommandHandlerWithHelp {
     protected void doHandle(CommandContext ctx) {
         BatchManager batchManager = ctx.getBatchManager();
         if(!batchManager.isBatchActive()) {
-            ctx.printLine("No active batch.");
+            ctx.error("No active batch.");
             return;
         }
         Batch activeBatch = batchManager.getActiveBatch();

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchMoveLineHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchMoveLineHandler.java
@@ -55,25 +55,25 @@ public class BatchMoveLineHandler extends CommandHandlerWithHelp {
 
         BatchManager batchManager = ctx.getBatchManager();
         if(!batchManager.isBatchActive()) {
-            ctx.printLine("No active batch.");
+            ctx.error("No active batch.");
             return;
         }
 
         Batch batch = batchManager.getActiveBatch();
         final int batchSize = batch.size();
         if(batchSize == 0) {
-            ctx.printLine("The batch is empty.");
+            ctx.error("The batch is empty.");
             return;
         }
 
         List<String> arguments = ctx.getParsedCommandLine().getOtherProperties();
         if(arguments.isEmpty()) {
-            ctx.printLine("Missing line number.");
+            ctx.error("Missing line number.");
             return;
         }
 
         if(arguments.size() != 2) {
-            ctx.printLine("Expected two arguments but received: " + arguments);
+            ctx.error("Expected two arguments but received: " + arguments);
             return;
         }
 
@@ -82,12 +82,12 @@ public class BatchMoveLineHandler extends CommandHandlerWithHelp {
         try {
             lineNumber = Integer.parseInt(intStr);
         } catch(NumberFormatException e) {
-            ctx.printLine("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
+            ctx.error("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
             return;
         }
 
         if(lineNumber < 1 || lineNumber > batchSize) {
-            ctx.printLine(lineNumber + " isn't in range [1.." + batchSize + "].");
+            ctx.error(lineNumber + " isn't in range [1.." + batchSize + "].");
             return;
         }
 
@@ -96,12 +96,12 @@ public class BatchMoveLineHandler extends CommandHandlerWithHelp {
         try {
             toLineNumber = Integer.parseInt(intStr);
         } catch(NumberFormatException e) {
-            ctx.printLine("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
+            ctx.error("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
             return;
         }
 
         if(toLineNumber < 1 || toLineNumber > batchSize) {
-            ctx.printLine(toLineNumber + " isn't in range [1.." + batchSize + "].");
+            ctx.error(toLineNumber + " isn't in range [1.." + batchSize + "].");
             return;
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRemoveLineHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRemoveLineHandler.java
@@ -55,25 +55,25 @@ public class BatchRemoveLineHandler extends CommandHandlerWithHelp {
 
         BatchManager batchManager = ctx.getBatchManager();
         if(!batchManager.isBatchActive()) {
-            ctx.printLine("No active batch.");
+            ctx.error("No active batch.");
             return;
         }
 
         Batch batch = batchManager.getActiveBatch();
         final int batchSize = batch.size();
         if(batchSize == 0) {
-            ctx.printLine("The batch is empty.");
+            ctx.error("The batch is empty.");
             return;
         }
 
         List<String> arguments = ctx.getParsedCommandLine().getOtherProperties();
         if(arguments.isEmpty()) {
-            ctx.printLine("Missing line number.");
+            ctx.error("Missing line number.");
             return;
         }
 
         if(arguments.size() != 1) {
-            ctx.printLine("Expected only one argument - the line number but received: " + arguments);
+            ctx.error("Expected only one argument - the line number but received: " + arguments);
             return;
         }
 
@@ -82,12 +82,12 @@ public class BatchRemoveLineHandler extends CommandHandlerWithHelp {
         try {
             lineNumber = Integer.parseInt(intStr);
         } catch(NumberFormatException e) {
-            ctx.printLine("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
+            ctx.error("Failed to parse line number '" + intStr + "': " + e.getLocalizedMessage());
             return;
         }
 
         if(lineNumber < 1 || lineNumber > batchSize) {
-            ctx.printLine(lineNumber + " isn't in range [1.." + batchSize + "].");
+            ctx.error(lineNumber + " isn't in range [1.." + batchSize + "].");
             return;
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -57,22 +57,22 @@ public class BatchRunHandler extends CommandHandlerWithHelp {
 
         BatchManager batchManager = ctx.getBatchManager();
         if(!batchManager.isBatchActive()) {
-            ctx.printLine("No active batch.");
+            ctx.error("No active batch.");
             return;
         }
 
         Batch batch = batchManager.getActiveBatch();
         List<BatchedCommand> currentBatch = batch.getCommands();
         if(currentBatch.isEmpty()) {
-            ctx.printLine("The batch is empty.");
+            ctx.error("The batch is empty.");
             batchManager.discardActiveBatch();
             return;
         }
 
         ModelNode composite = new ModelNode();
-        composite.get("operation").set("composite");
-        composite.get("address").setEmptyList();
-        ModelNode steps = composite.get("steps");
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+        ModelNode steps = composite.get(Util.STEPS);
 
         for(BatchedCommand cmd : currentBatch) {
             steps.add(cmd.getRequest());
@@ -84,10 +84,10 @@ public class BatchRunHandler extends CommandHandlerWithHelp {
                 batchManager.discardActiveBatch();
                 ctx.printLine("The batch executed successfully.");
             } else {
-                ctx.printLine("Failed to execute batch: " + Util.getFailureDescription(result));
+                ctx.error("Failed to execute batch: " + Util.getFailureDescription(result));
             }
         } catch (Exception e) {
-            ctx.printLine("Failed to execute batch: " + e.getLocalizedMessage());
+            ctx.error("Failed to execute batch: " + e.getLocalizedMessage());
         }
     }
 }

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -59,6 +59,8 @@ public class MockCommandContext implements CommandContext {
 
     private DefaultCallbackHandler parsedCmd = new DefaultCallbackHandler();
 
+    private int exitCode;
+
     public void parseCommandLine(String buffer) throws CommandFormatException {
         try {
             parsedCmd.parse(prefix, buffer);
@@ -268,5 +270,21 @@ public class MockCommandContext implements CommandContext {
     @Override
     public CliConfig getConfig() {
         return config;
+    }
+
+    @Override
+    public void error(String message, int code) {
+        exitCode = code;
+        printLine(message);
+    }
+
+    @Override
+    public void error(String message) {
+        error(message, 1);
+    }
+
+    @Override
+    public int getExitCode() {
+        return exitCode;
     }
 }


### PR DESCRIPTION
AS7-3368 jboss-admin tool doesn't return non zero code when command fails to execute

It spreads across many handlers. The idea is to have a separate method on the CommandContext to log errors and keep track of the error code. So, now every error message logging has changed from

ctx. printLine(msg)

to

ctx.error(msg).

There is also ctx.error(msg, exitCode) but it's not used yet. ctx.error(msg) will call ctx.error(msg, 1).

Thanks,
Alexey
