### PR TITLE
AS7-3061, JBPAPP-7428,AS7-2440: Logging Subsystem Fixes

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -170,7 +170,7 @@ public interface CommonAttributes {
             setAllowNull(true).
             build();
 
-    SimpleAttributeDefinition SUFFIX = SimpleAttributeDefinitionBuilder.create("suffix", ModelType.STRING, true).build();
+    SimpleAttributeDefinition SUFFIX = SimpleAttributeDefinitionBuilder.create("suffix", ModelType.STRING).build();
 
     SimpleAttributeDefinition TARGET = SimpleAttributeDefinitionBuilder.create("target", ModelType.STRING, true).
             setDefaultValue(new ModelNode().set(Target.SYSTEM_OUT.toString())).

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -49,6 +49,7 @@ import org.jboss.as.logging.handlers.AbstractLogHandlerWriteAttributeHandler;
 import org.jboss.as.logging.handlers.HandlerDisable;
 import org.jboss.as.logging.handlers.HandlerEnable;
 import org.jboss.as.logging.handlers.HandlerLevelChange;
+import org.jboss.as.logging.handlers.LoggerFileHandlerRemove;
 import org.jboss.as.logging.handlers.LoggerHandlerRemove;
 import org.jboss.as.logging.handlers.async.AsyncHandlerAdd;
 import org.jboss.as.logging.handlers.async.AsyncHandlerAssignSubhandler;
@@ -74,7 +75,6 @@ import org.jboss.as.logging.handlers.file.SizeRotatingHandlerWriteAttributeHandl
 import org.jboss.as.logging.loggers.AbstractLoggerWriteAttributeHandler;
 import org.jboss.as.logging.loggers.LoggerAdd;
 import org.jboss.as.logging.loggers.LoggerAssignHandler;
-import org.jboss.as.logging.loggers.LoggerFileHandlerRemove;
 import org.jboss.as.logging.loggers.LoggerLevelChange;
 import org.jboss.as.logging.loggers.LoggerRemove;
 import org.jboss.as.logging.loggers.LoggerUnassignHandler;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -128,6 +128,28 @@ public interface LoggingMessages {
     String handlerAlreadyDefined(String name);
 
     /**
+     * A message indicating the handler is attached to the handlers.
+     *
+     * @param handlerName the name of tha attached handler.
+     * @param handlers    a collection of the handler names.
+     *
+     * @return the message.
+     */
+    @Message(value = "Handler %s is attached to the following handlers and cannot be removed; %s")
+    String handlerAttachedToHandlers(String handlerName, Collection<String> handlers);
+
+    /**
+     * A message indicating the handler is attached to the loggers.
+     *
+     * @param handlerName the name of tha attached handler.
+     * @param loggers     a collection of the logger names.
+     *
+     * @return the message.
+     */
+    @Message(value = "Handler %s is attached to the following loggers and cannot be removed; %s")
+    String handlerAttachedToLoggers(String handlerName, Collection<String> loggers);
+
+    /**
      * A message indicating the handler, represented by the {@code name} parameter, was not found.
      *
      * @param name the handler name.

--- a/logging/src/main/java/org/jboss/as/logging/handlers/LoggerFileHandlerRemove.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/LoggerFileHandlerRemove.java
@@ -20,10 +20,9 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.logging.loggers;
+package org.jboss.as.logging.handlers;
 
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.logging.handlers.LoggerHandlerRemove;
 import org.jboss.as.logging.util.LogServices;
 
 /**


### PR DESCRIPTION
Require the suffix attribute for periodic rotating file handlers.

Throw an exception if a handler is attempting to be removed and attached to a logger or an asynchronous log handler.
