### PR TITLE
Remove singleton naming convention from single-instance child resources.

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -414,9 +414,11 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
                 builder.expiration().wakeUpInterval(expiration.get(ModelKeys.INTERVAL).asLong());
             }
         }
+
+        /*
         // state transfer is a child resource
-        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
-            ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+        if (cache.hasDefined(ModelKeys.STATE_TRANSFER) && cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME).isDefined()) {
+            ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
             if (stateTransfer.hasDefined(ModelKeys.ENABLED)) {
                 builder.clustering().stateTransfer().fetchInMemoryState(stateTransfer.get(ModelKeys.ENABLED).asBoolean());
             }
@@ -427,7 +429,7 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
                 builder.clustering().stateTransfer().chunkSize(stateTransfer.get(ModelKeys.CHUNK_SIZE).asInt());
             }
         }
-
+        */
         String storeKey = this.findStoreKey(cache);
         if (storeKey != null) {
             ModelNode store = cache.get(storeKey);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -342,8 +342,8 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
         }
 
         // locking is a child resource
-        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.LOCKING).isDefined()) {
-            ModelNode locking = cache.get(ModelKeys.SINGLETON, ModelKeys.LOCKING);
+        if (cache.hasDefined(ModelKeys.LOCKING) && cache.get(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME).isDefined()) {
+            ModelNode locking = cache.get(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME);
             if (locking.hasDefined(ModelKeys.ISOLATION)) {
                 builder.locking().isolationLevel(IsolationLevel.valueOf(locking.get(ModelKeys.ISOLATION).asString()));
             }
@@ -361,8 +361,8 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
         TransactionMode txMode = TransactionMode.NONE;
         LockingMode lockingMode = LockingMode.OPTIMISTIC;
         // locking is a child resource
-        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION).isDefined()) {
-            ModelNode transaction = cache.get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
+        if (cache.hasDefined(ModelKeys.TRANSACTION) && cache.get(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME).isDefined()) {
+            ModelNode transaction = cache.get(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
             if (transaction.hasDefined(ModelKeys.STOP_TIMEOUT)) {
                 builder.transaction().cacheStopTimeout(transaction.get(ModelKeys.STOP_TIMEOUT).asLong());
             }
@@ -391,8 +391,8 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
             }
         }
         // eviction is a child resource
-        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.EVICTION).isDefined()) {
-            ModelNode eviction = cache.get(ModelKeys.SINGLETON, ModelKeys.EVICTION);
+        if (cache.hasDefined(ModelKeys.EVICTION) && cache.get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME).isDefined()) {
+            ModelNode eviction = cache.get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
 
             if (eviction.hasDefined(ModelKeys.STRATEGY)) {
                 builder.eviction().strategy(EvictionStrategy.valueOf(eviction.get(ModelKeys.STRATEGY).asString()));
@@ -402,8 +402,8 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
             }
         }
         // expiration is a child resource
-        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION).isDefined()) {
-            ModelNode expiration = cache.get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
+        if (cache.hasDefined(ModelKeys.EXPIRATION) && cache.get(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME).isDefined()) {
+            ModelNode expiration = cache.get(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
             if (expiration.hasDefined(ModelKeys.MAX_IDLE)) {
                 builder.expiration().maxIdle(expiration.get(ModelKeys.MAX_IDLE).asLong());
             }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerAdd.java
@@ -111,7 +111,7 @@ public class CacheContainerAdd extends AbstractAddStepHandler {
 
         String defaultCache = model.require(ModelKeys.DEFAULT_CACHE).asString();
 
-        boolean hasTransport = model.hasDefined(ModelKeys.SINGLETON) && model.get(ModelKeys.SINGLETON).hasDefined(ModelKeys.TRANSPORT);
+        boolean hasTransport = model.hasDefined(ModelKeys.TRANSPORT) && model.get(ModelKeys.TRANSPORT).hasDefined(ModelKeys.TRANSPORT_NAME);
         Transport transportConfig = hasTransport ? new Transport() : null;
         EmbeddedCacheManagerDependencies dependencies = new EmbeddedCacheManagerDependencies(transportConfig);
 
@@ -146,7 +146,7 @@ public class CacheContainerAdd extends AbstractAddStepHandler {
 
         if (hasTransport) {
             String stack = null;
-            ModelNode transport = model.get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+            ModelNode transport = model.get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
             if (transport.hasDefined(ModelKeys.STACK)) {
                 stack = transport.get(ModelKeys.STACK).asString();
             }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -22,7 +22,9 @@ public interface CommonAttributes {
     SimpleAttributeDefinition ACQUIRE_TIMEOUT = new SimpleAttributeDefinition(ModelKeys.ACQUIRE_TIMEOUT,
             new ModelNode().set(longDefault), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
     SimpleAttributeDefinition ALIAS = new SimpleAttributeDefinition(ModelKeys.ALIAS, ModelType.STRING, true);
-    SimpleAttributeDefinition ALIASES = new SimpleAttributeDefinition(ModelKeys.ALIASES, ModelType.LIST, true);
+    SimpleListAttributeDefinition ALIASES = SimpleListAttributeDefinition.Builder.of(ModelKeys.ALIASES, ALIAS).
+            setAllowNull(true).
+            build();
     SimpleAttributeDefinition BATCH_SIZE = new SimpleAttributeDefinition(ModelKeys.BATCH_SIZE,
             new ModelNode().set(intDefault), ModelType.INT, true);
     SimpleAttributeDefinition BATCHING = new SimpleAttributeDefinition(ModelKeys.BATCHING,
@@ -77,6 +79,9 @@ public interface CommonAttributes {
     SimpleAttributeDefinition PRELOAD = new SimpleAttributeDefinition(ModelKeys.PRELOAD,
             new ModelNode().set(booleanDefault), ModelType.BOOLEAN,  true);
     SimpleAttributeDefinition PROPERTY = new SimpleAttributeDefinition(ModelKeys.PROPERTY, ModelType.LIST, true);
+//    SimpleListAttributeDefinition PROPERTIES = SimpleListAttributeDefinition.Builder.of(ModelKeys.PROPERTIES, PROPERTY).
+//            setAllowNull(true).
+//            build();
     SimpleAttributeDefinition PURGE = new SimpleAttributeDefinition(ModelKeys.PURGE,
             new ModelNode().set(booleanDefault), ModelType.BOOLEAN,  true);
     SimpleAttributeDefinition QUEUE_FLUSH_INTERVAL = new SimpleAttributeDefinition(ModelKeys.QUEUE_FLUSH_INTERVAL,
@@ -92,7 +97,7 @@ public interface CommonAttributes {
     SimpleAttributeDefinition SHARED = new SimpleAttributeDefinition(ModelKeys.SHARED,
             new ModelNode().set(booleanDefault), ModelType.BOOLEAN,  true);
     SimpleAttributeDefinition SINGLETON = new SimpleAttributeDefinition(ModelKeys.SINGLETON,
-            new ModelNode().set(booleanDefault), ModelType.BOOLEAN,  true);
+            new ModelNode().set(booleanDefault), ModelType.BOOLEAN, true);
     SimpleAttributeDefinition SITE = new SimpleAttributeDefinition(ModelKeys.SITE, ModelType.STRING, true);
     SimpleAttributeDefinition SOCKET_TIMEOUT = new SimpleAttributeDefinition(ModelKeys.SOCKET_TIMEOUT,
             new ModelNode().set(longDefault), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
@@ -130,4 +135,11 @@ public interface CommonAttributes {
     AttributeDefinition[] REMOTE_ATTRIBUTES = { /* REMOTE_SERVER */ };
 
     AttributeDefinition[] STATE_TRANSFER_ATTRIBUTES = { ENABLED, TIMEOUT, CHUNK_SIZE };
+
+    // complex attribute definitions (helpers for now to create descriptions)
+    ObjectTypeAttributeDefinition TRANSPORT_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.TRANSPORT, TRANSPORT_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("transport").
+            build();
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -142,4 +142,25 @@ public interface CommonAttributes {
             setAllowNull(true).
             setSuffix("transport").
             build();
+
+    ObjectTypeAttributeDefinition LOCKING_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.LOCKING, LOCKING_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("locking").
+            build();
+    ObjectTypeAttributeDefinition TRANSACTION_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.TRANSACTION, TRANSACTION_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("transaction").
+            build();
+    ObjectTypeAttributeDefinition EVICTION_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.EVICTION, EVICTION_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("eviction").
+            build();
+    ObjectTypeAttributeDefinition EXPIRATION_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.EXPIRATION, EXPIRATION_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("expiration").
+            build();
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -163,4 +163,9 @@ public interface CommonAttributes {
             setAllowNull(true).
             setSuffix("expiration").
             build();
+    ObjectTypeAttributeDefinition STATE_TRANSFER_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.STATE_TRANSFER, STATE_TRANSFER_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("state-transfer").
+            build();
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
@@ -98,10 +98,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.CACHE_CONTAINER_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, keyPrefix, container);
         }
-        // need to add value type until we replace with a ListAttribute
-        ALIASES.addResourceAttributeDescription(resources, keyPrefix, container).
-                get(ModelDescriptionConstants.VALUE_TYPE).set(ModelType.STRING);
-        // information about its child "singleton=transport"
+        // information about its child "transport=TRANSPORT"
         container.get(CHILDREN, ModelKeys.TRANSPORT, DESCRIPTION).set(resources.getString(keyPrefix + ".transport"));
         container.get(CHILDREN, ModelKeys.TRANSPORT, MIN_OCCURS).set(0);
         container.get(CHILDREN, ModelKeys.TRANSPORT, MAX_OCCURS).set(1);
@@ -215,7 +212,7 @@ public class InfinispanDescriptions {
         }
         // children
         addCommonCacheChildren("infinispan.cache", cache, resources);
-        addStateTransferCacheChildren("infinispan-cache", cache, resources);
+        addStateTransferCacheChildren("infinispan.cache", cache, resources);
         return cache ;
     }
 
@@ -245,7 +242,7 @@ public class InfinispanDescriptions {
         }
         // children
         addCommonCacheChildren("infinispan.cache", cache, resources);
-        addStateTransferCacheChildren("infinispan-cache", cache, resources);
+        addStateTransferCacheChildren("infinispan.cache", cache, resources);
         return cache ;
     }
 
@@ -470,18 +467,44 @@ public class InfinispanDescriptions {
     }
 
     private static void addCommonCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
+        // information about its child "locking=LOCKING"
+        description.get(CHILDREN, ModelKeys.LOCKING, DESCRIPTION).set(resources.getString(keyPrefix+".locking"));
+        description.get(CHILDREN, ModelKeys.LOCKING, MIN_OCCURS).set(0);
+        description.get(CHILDREN, ModelKeys.LOCKING, MAX_OCCURS).set(1);
+        description.get(CHILDREN, ModelKeys.LOCKING, ALLOWED).setEmptyList();
+        description.get(CHILDREN, ModelKeys.LOCKING, ALLOWED).add(ModelKeys.LOCKING_NAME);
+        description.get(CHILDREN, ModelKeys.LOCKING, MODEL_DESCRIPTION);
+        // information about its child "transaction=TRANSACTION"
+        description.get(CHILDREN, ModelKeys.TRANSACTION, DESCRIPTION).set(resources.getString(keyPrefix+".transaction"));
+        description.get(CHILDREN, ModelKeys.TRANSACTION, MIN_OCCURS).set(0);
+        description.get(CHILDREN, ModelKeys.TRANSACTION, MAX_OCCURS).set(1);
+        description.get(CHILDREN, ModelKeys.TRANSACTION, ALLOWED).setEmptyList();
+        description.get(CHILDREN, ModelKeys.TRANSACTION, ALLOWED).add(ModelKeys.TRANSACTION_NAME);
+        description.get(CHILDREN, ModelKeys.TRANSACTION, MODEL_DESCRIPTION);
+        // information about its child "eviction=EVICTION"
+        description.get(CHILDREN, ModelKeys.EVICTION, DESCRIPTION).set(resources.getString(keyPrefix+".eviction"));
+        description.get(CHILDREN, ModelKeys.EVICTION, MIN_OCCURS).set(0);
+        description.get(CHILDREN, ModelKeys.EVICTION, MAX_OCCURS).set(1);
+        description.get(CHILDREN, ModelKeys.EVICTION, ALLOWED).setEmptyList();
+        description.get(CHILDREN, ModelKeys.EVICTION, ALLOWED).add(ModelKeys.EVICTION_NAME);
+        description.get(CHILDREN, ModelKeys.EVICTION, MODEL_DESCRIPTION);
+        // information about its child "expiration=EXPIRATION"
+        description.get(CHILDREN, ModelKeys.EXPIRATION, DESCRIPTION).set(resources.getString(keyPrefix+".expiration"));
+        description.get(CHILDREN, ModelKeys.EXPIRATION, MIN_OCCURS).set(0);
+        description.get(CHILDREN, ModelKeys.EXPIRATION, MAX_OCCURS).set(1);
+        description.get(CHILDREN, ModelKeys.EXPIRATION, ALLOWED).setEmptyList();
+        description.get(CHILDREN, ModelKeys.EXPIRATION, ALLOWED).add(ModelKeys.EXPIRATION_NAME);
+        description.get(CHILDREN, ModelKeys.EXPIRATION, MODEL_DESCRIPTION);
+     }
+
+    private static void addStateTransferCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
         // information about its child "singleton=*"
         description.get(CHILDREN, ModelKeys.SINGLETON, DESCRIPTION).set(resources.getString(keyPrefix+".singleton"));
         description.get(CHILDREN, ModelKeys.SINGLETON, MIN_OCCURS).set(0);
         description.get(CHILDREN, ModelKeys.SINGLETON, MAX_OCCURS).set(1);
         description.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).setEmptyList();
-        description.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).add("locking").add("transaction").add("eviction").add("expiration");
-        description.get(CHILDREN, ModelKeys.SINGLETON, MODEL_DESCRIPTION);
-    }
-
-    private static void addStateTransferCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
-        // information about its child "singleton=*"
         description.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).add("state-transfer");
+        description.get(CHILDREN, ModelKeys.SINGLETON, MODEL_DESCRIPTION);
     }
 
     private static void addRehashingCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
@@ -502,31 +525,12 @@ public class InfinispanDescriptions {
         BATCHING.addOperationParameterDescription(resources, keyPrefix, operation);
         INDEXING.addOperationParameterDescription(resources, keyPrefix, operation);
 
+        LOCKING_OBJECT.addOperationParameterDescription(resources, keyPrefix , operation) ;
+        TRANSACTION_OBJECT.addOperationParameterDescription(resources, keyPrefix , operation) ;
+        EVICTION_OBJECT.addOperationParameterDescription(resources, keyPrefix , operation) ;
+        EXPIRATION_OBJECT.addOperationParameterDescription(resources, keyPrefix , operation) ;
+
         ModelNode requestProperties = operation.get(ModelDescriptionConstants.REQUEST_PROPERTIES);
-        String lockingPrefix = keyPrefix + "." + "locking" ;
-        ModelNode locking = addNode(requestProperties, ModelKeys.LOCKING, resources.getString(lockingPrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
-        for (AttributeDefinition attr : CommonAttributes.LOCKING_ATTRIBUTES) {
-            addAttributeDescription(attr, resources, lockingPrefix, locking);
-        }
-
-        String transactionPrefix = keyPrefix + "." + "transaction" ;
-        ModelNode transaction = addNode(requestProperties, ModelKeys.TRANSACTION, resources.getString(transactionPrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
-        for (AttributeDefinition attr : CommonAttributes.TRANSACTION_ATTRIBUTES) {
-            addAttributeDescription(attr, resources, transactionPrefix, transaction);
-        }
-
-        String evictionPrefix = keyPrefix + "." + "eviction" ;
-        ModelNode eviction = addNode(requestProperties, ModelKeys.EVICTION, resources.getString(evictionPrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
-        for (AttributeDefinition attr : CommonAttributes.EVICTION_ATTRIBUTES) {
-            addAttributeDescription(attr, resources, evictionPrefix, eviction);
-        }
-
-        String expirationPrefix = keyPrefix + ".expiration" ;
-        ModelNode expiration = addNode(requestProperties, ModelKeys.EXPIRATION, resources.getString(expirationPrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
-        for (AttributeDefinition attr : CommonAttributes.EXPIRATION_ATTRIBUTES) {
-            addAttributeDescription(attr, resources, expirationPrefix, expiration);
-         }
-
         String storePrefix = keyPrefix + "." + "store" ;
         ModelNode store = addNode(requestProperties, ModelKeys.STORE, resources.getString(storePrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
         for (AttributeDefinition attr : CommonAttributes.STORE_ATTRIBUTES) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
@@ -102,11 +102,11 @@ public class InfinispanDescriptions {
         ALIASES.addResourceAttributeDescription(resources, keyPrefix, container).
                 get(ModelDescriptionConstants.VALUE_TYPE).set(ModelType.STRING);
         // information about its child "singleton=transport"
-        container.get(CHILDREN, ModelKeys.SINGLETON, DESCRIPTION).set(resources.getString(keyPrefix + ".singleton"));
-        container.get(CHILDREN, ModelKeys.SINGLETON, MIN_OCCURS).set(0);
-        container.get(CHILDREN, ModelKeys.SINGLETON, MAX_OCCURS).set(1);
-        container.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).setEmptyList().add("transport");
-        container.get(CHILDREN, ModelKeys.SINGLETON, MODEL_DESCRIPTION);
+        container.get(CHILDREN, ModelKeys.TRANSPORT, DESCRIPTION).set(resources.getString(keyPrefix + ".transport"));
+        container.get(CHILDREN, ModelKeys.TRANSPORT, MIN_OCCURS).set(0);
+        container.get(CHILDREN, ModelKeys.TRANSPORT, MAX_OCCURS).set(1);
+        container.get(CHILDREN, ModelKeys.TRANSPORT, ALLOWED).setEmptyList().add(ModelKeys.TRANSPORT_NAME);
+        container.get(CHILDREN, ModelKeys.TRANSPORT, MODEL_DESCRIPTION);
         // information about its child "local-cache"
         container.get(CHILDREN, ModelKeys.LOCAL_CACHE, DESCRIPTION).set(resources.getString(keyPrefix + ".local-cache"));
         container.get(CHILDREN, ModelKeys.LOCAL_CACHE, MIN_OCCURS).set(0);
@@ -138,9 +138,6 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.CACHE_CONTAINER_ATTRIBUTES) {
             attr.addOperationParameterDescription(resources, "infinispan.container", op);
         }
-        // need to add value type until we replace with a ListAttribute
-        ALIASES.addOperationParameterDescription(resources, "infinispan.container", op).
-                get(ModelDescriptionConstants.VALUE_TYPE).set(ModelType.STRING);
         return op;
     }
 
@@ -196,7 +193,6 @@ public class InfinispanDescriptions {
         }
         // children
         addCommonCacheChildren("infinispan.cache", cache, resources);
-        addStateTransferCacheChildren("infinispan-cache", cache, resources);
         return cache ;
      }
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
@@ -212,7 +212,7 @@ public class InfinispanDescriptions {
         }
         // children
         addCommonCacheChildren("infinispan.cache", cache, resources);
-        addStateTransferCacheChildren("infinispan.cache", cache, resources);
+        addStateTransferCacheChildren("infinispan.replicated-cache", cache, resources);
         return cache ;
     }
 
@@ -223,12 +223,7 @@ public class InfinispanDescriptions {
         addCommonCacheAddRequestProperties("infinispan.cache", op, resources);
         addCommonClusteredCacheAddRequestProperties("infinispan.clustered-cache", op, resources);
         // nested resource initialization
-        String keyPrefix = "infinispan.replicated-cache.state-transfer" ;
-        ModelNode requestProperties = op.get(ModelDescriptionConstants.REQUEST_PROPERTIES);
-        ModelNode stateTransfer = addNode(requestProperties, ModelKeys.STATE_TRANSFER, resources.getString(keyPrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
-        for (AttributeDefinition attr : CommonAttributes.STATE_TRANSFER_ATTRIBUTES) {
-            addAttributeDescription(attr, resources, keyPrefix, stateTransfer);
-        }
+        STATE_TRANSFER_OBJECT.addOperationParameterDescription(resources, "infinispan.replicated-cache", op);
         return op;
     }
 
@@ -242,7 +237,7 @@ public class InfinispanDescriptions {
         }
         // children
         addCommonCacheChildren("infinispan.cache", cache, resources);
-        addStateTransferCacheChildren("infinispan.cache", cache, resources);
+        addStateTransferCacheChildren("infinispan.replicated-cache", cache, resources);
         return cache ;
     }
 
@@ -255,12 +250,8 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.DISTRIBUTED_CACHE_ATTRIBUTES) {
             attr.addOperationParameterDescription(resources, "infinispan.distributed-cache", op);
         }
-        String keyPrefix = "infinispan.replicated-cache.state-transfer" ;
-        ModelNode requestProperties = op.get(ModelDescriptionConstants.REQUEST_PROPERTIES);
-        ModelNode stateTransfer = addNode(requestProperties, ModelKeys.STATE_TRANSFER, resources.getString(keyPrefix), ModelType.OBJECT, false).get(ModelDescriptionConstants.VALUE_TYPE);
-        for (AttributeDefinition attr : CommonAttributes.STATE_TRANSFER_ATTRIBUTES) {
-            addAttributeDescription(attr, resources, keyPrefix, stateTransfer);
-        }
+        // nested resource initialization
+        STATE_TRANSFER_OBJECT.addOperationParameterDescription(resources, "infinispan.replicated-cache", op);
         return op;
     }
 
@@ -499,17 +490,12 @@ public class InfinispanDescriptions {
 
     private static void addStateTransferCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
         // information about its child "singleton=*"
-        description.get(CHILDREN, ModelKeys.SINGLETON, DESCRIPTION).set(resources.getString(keyPrefix+".singleton"));
-        description.get(CHILDREN, ModelKeys.SINGLETON, MIN_OCCURS).set(0);
-        description.get(CHILDREN, ModelKeys.SINGLETON, MAX_OCCURS).set(1);
-        description.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).setEmptyList();
-        description.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).add("state-transfer");
-        description.get(CHILDREN, ModelKeys.SINGLETON, MODEL_DESCRIPTION);
-    }
-
-    private static void addRehashingCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
-        // information about its child "singleton=*"
-        description.get(CHILDREN, ModelKeys.SINGLETON, ALLOWED).add("rehashing");
+        description.get(CHILDREN, ModelKeys.STATE_TRANSFER, DESCRIPTION).set(resources.getString(keyPrefix+".state-transfer"));
+        description.get(CHILDREN, ModelKeys.STATE_TRANSFER, MIN_OCCURS).set(0);
+        description.get(CHILDREN, ModelKeys.STATE_TRANSFER, MAX_OCCURS).set(1);
+        description.get(CHILDREN, ModelKeys.STATE_TRANSFER, ALLOWED).setEmptyList();
+        description.get(CHILDREN, ModelKeys.STATE_TRANSFER, ALLOWED).add(ModelKeys.STATE_TRANSFER_NAME);
+        description.get(CHILDREN, ModelKeys.STATE_TRANSFER, MODEL_DESCRIPTION);
     }
 
     /**

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -61,7 +61,7 @@ public class InfinispanExtension implements Extension {
     private static final PathElement transactionPath = PathElement.pathElement(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
     private static final PathElement evictionPath = PathElement.pathElement(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
     private static final PathElement expirationPath = PathElement.pathElement(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
-    private static final PathElement stateTransferPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+    private static final PathElement stateTransferPath = PathElement.pathElement(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
     private static final PathElement storePropertyPath = PathElement.pathElement(ModelKeys.PROPERTY);
 
     /**

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -55,7 +55,7 @@ public class InfinispanExtension implements Extension {
     private static final PathElement invalidationCachePath = PathElement.pathElement(ModelKeys.INVALIDATION_CACHE);
     private static final PathElement replicatedCachePath = PathElement.pathElement(ModelKeys.REPLICATED_CACHE);
     private static final PathElement distributedCachePath = PathElement.pathElement(ModelKeys.DISTRIBUTED_CACHE);
-    private static final PathElement transportPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+    private static final PathElement transportPath = PathElement.pathElement(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
 
     private static final PathElement lockingPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.LOCKING);
     private static final PathElement transactionPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -57,10 +57,10 @@ public class InfinispanExtension implements Extension {
     private static final PathElement distributedCachePath = PathElement.pathElement(ModelKeys.DISTRIBUTED_CACHE);
     private static final PathElement transportPath = PathElement.pathElement(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
 
-    private static final PathElement lockingPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.LOCKING);
-    private static final PathElement transactionPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
-    private static final PathElement evictionPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.EVICTION);
-    private static final PathElement expirationPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
+    private static final PathElement lockingPath = PathElement.pathElement(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME);
+    private static final PathElement transactionPath = PathElement.pathElement(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
+    private static final PathElement evictionPath = PathElement.pathElement(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
+    private static final PathElement expirationPath = PathElement.pathElement(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
     private static final PathElement stateTransferPath = PathElement.pathElement(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
     private static final PathElement storePropertyPath = PathElement.pathElement(ModelKeys.PROPERTY);
 
@@ -108,12 +108,14 @@ public class InfinispanExtension implements Extension {
         replicated.registerOperationHandler(ADD, ReplicatedCacheAdd.INSTANCE, InfinispanSubsystemProviders.REPLICATED_CACHE_ADD, false);
         replicated.registerOperationHandler(REMOVE, CacheRemove.INSTANCE, InfinispanSubsystemProviders.CACHE_REMOVE, false);
         registerCommonCacheAttributeHandlers(replicated);
+        registerSharedStateCacheAttributeHandlers(replicated);
 
         // add /subsystem=infinispan/cache-container=*/distributed-cache=*
         ManagementResourceRegistration distributed = container.registerSubModel(distributedCachePath, InfinispanSubsystemProviders.DISTRIBUTED_CACHE);
         distributed.registerOperationHandler(ADD, DistributedCacheAdd.INSTANCE, InfinispanSubsystemProviders.DISTRIBUTED_CACHE_ADD, false);
         distributed.registerOperationHandler(REMOVE, CacheRemove.INSTANCE, InfinispanSubsystemProviders.CACHE_REMOVE, false);
         registerCommonCacheAttributeHandlers(distributed);
+        registerSharedStateCacheAttributeHandlers(distributed);
     }
 
     /**
@@ -131,36 +133,39 @@ public class InfinispanExtension implements Extension {
     }
 
     private void registerCommonCacheAttributeHandlers(ManagementResourceRegistration resource) {
-        // register the singleton=locking handlers
+        // register the locking=LOCKING handlers
         final ManagementResourceRegistration locking = resource.registerSubModel(lockingPath, InfinispanSubsystemProviders.LOCKING);
         locking.registerOperationHandler(ADD, CacheConfigOperationHandlers.LOCKING_ADD, InfinispanSubsystemProviders.LOCKING_ADD);
         locking.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.LOCKING_REMOVE);
         CacheConfigOperationHandlers.LOCKING_ATTR.registerAttributes(locking);
 
-        // register the singleton=transaction handlers
+        // register the transaction=TRANSACTION handlers
         final ManagementResourceRegistration transaction = resource.registerSubModel(transactionPath, InfinispanSubsystemProviders.TRANSACTION);
         transaction.registerOperationHandler(ADD, CacheConfigOperationHandlers.TRANSACTION_ADD, InfinispanSubsystemProviders.TRANSACTION_ADD);
         transaction.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.TRANSACTION_REMOVE);
         CacheConfigOperationHandlers.TRANSACTION_ATTR.registerAttributes(transaction);
 
-        // register the singleton=eviction handlers
+        // register the eviction=EVICTION handlers
         final ManagementResourceRegistration eviction = resource.registerSubModel(evictionPath, InfinispanSubsystemProviders.EVICTION);
         eviction.registerOperationHandler(ADD, CacheConfigOperationHandlers.EVICTION_ADD, InfinispanSubsystemProviders.EVICTION_ADD);
         eviction.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.EVICTION_REMOVE);
         CacheConfigOperationHandlers.EVICTION_ATTR.registerAttributes(eviction);
 
-        // register the singleton=expiration handlers
+        // register the expiration=EXPIRATION handlers
         final ManagementResourceRegistration expiration = resource.registerSubModel(expirationPath, InfinispanSubsystemProviders.EXPIRATION);
         expiration.registerOperationHandler(ADD, CacheConfigOperationHandlers.EXPIRATION_ADD, InfinispanSubsystemProviders.EXPIRATION_ADD);
         expiration.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.EXPIRATION_REMOVE);
         CacheConfigOperationHandlers.LOCKING_ATTR.registerAttributes(expiration);
+    }
 
-        // register the singleton=state-transfer handlers
+    private void registerSharedStateCacheAttributeHandlers(ManagementResourceRegistration resource) {
+        // register the state-transfer=STATE_TRANSFER handlers
         final ManagementResourceRegistration stateTransfer = resource.registerSubModel(stateTransferPath, InfinispanSubsystemProviders.STATE_TRANSFER);
         stateTransfer.registerOperationHandler(ADD, CacheConfigOperationHandlers.STATE_TRANSFER_ADD, InfinispanSubsystemProviders.STATE_TRANSFER_ADD);
         stateTransfer.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STATE_TRANSFER_REMOVE);
         CacheConfigOperationHandlers.STATE_TRANSFER_ATTR.registerAttributes(stateTransfer);
     }
+
 
     static void createPropertyRegistration(final ManagementResourceRegistration parent) {
         final ManagementResourceRegistration registration = parent.registerSubModel(storePropertyPath, InfinispanSubsystemProviders.STORE_PROPERTY);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
@@ -180,14 +180,12 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
      */
     private void addSharedStateCacheConfigCommands(Property cache, ModelNode address, ModelNode result) throws OperationFailedException {
 
-        if (cache.getValue().hasDefined(ModelKeys.SINGLETON)) {
-            // command to recreate the state transfer configuration
-            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
-                ModelNode stateTransfer = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
-                ModelNode stateTransferAddress = address.clone();
-                stateTransferAddress.add(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
-                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.STATE_TRANSFER_ATTRIBUTES, stateTransferAddress, stateTransfer));
-            }
+        // command to recreate the state transfer configuration
+        if (cache.getValue().get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME).isDefined()) {
+            ModelNode stateTransfer = cache.getValue().get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
+            ModelNode stateTransferAddress = address.clone();
+            stateTransferAddress.add(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
+            result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.STATE_TRANSFER_ATTRIBUTES, stateTransferAddress, stateTransfer));
         }
     }
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
@@ -88,6 +88,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
                             result.add(ReplicatedCacheAdd.createOperation(cacheAddress, cache.getValue()));
 
                             addCacheConfigCommands(cache, cacheAddress, result);
+                            addSharedStateCacheConfigCommands(cache, cacheAddress, result);
                         }
                     // add commands for distributed caches
                     } else if (cacheTypeList.getName().equals(ModelKeys.DISTRIBUTED_CACHE)) {
@@ -97,6 +98,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
                             result.add(DistributedCacheAdd.createOperation(cacheAddress, cache.getValue()));
 
                             addCacheConfigCommands(cache, cacheAddress, result);
+                            addSharedStateCacheConfigCommands(cache, cacheAddress, result);
                         }
                     }
                 }
@@ -117,12 +119,12 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
     private void addCacheContainerConfigCommands(Property container, ModelNode address, ModelNode result) throws OperationFailedException {
 
         // add operation to create the transport for the container
-        if (container.getValue().hasDefined(ModelKeys.SINGLETON)) {
+        if (container.getValue().hasDefined(ModelKeys.TRANSPORT)) {
             // command to recreate the transport configuration
-            if (container.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT).isDefined()) {
-                ModelNode transport = container.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+            if (container.getValue().get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME).isDefined()) {
+                ModelNode transport = container.getValue().get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
                 ModelNode transportAddress = address.clone() ;
-                transportAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSPORT) ;
+                transportAddress.add(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME) ;
                 result.add(TransportAdd.createOperation(transportAddress, transport));
             }
         }
@@ -167,6 +169,20 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
                 expirationAddress.add(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
                 result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EXPIRATION_ATTRIBUTES, expirationAddress, expiration));
             }
+        }
+    }
+
+    /**
+     * Creates commands to recreate existing cache configuration elements
+     *
+     * @param cache  the cache Property containing the configuration elements
+     * @param address the cache address
+     * @param result  the list of operations
+     * @throws OperationFailedException
+     */
+    private void addSharedStateCacheConfigCommands(Property cache, ModelNode address, ModelNode result) throws OperationFailedException {
+
+        if (cache.getValue().hasDefined(ModelKeys.SINGLETON)) {
             // command to recreate the state transfer configuration
             if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
                 ModelNode stateTransfer = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
@@ -176,4 +192,5 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             }
         }
     }
+
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
@@ -140,35 +140,33 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
      */
     private void addCacheConfigCommands(Property cache, ModelNode address, ModelNode result) throws OperationFailedException {
 
-        if (cache.getValue().hasDefined(ModelKeys.SINGLETON)) {
-            // command to recreate the locking configuration
-            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.LOCKING).isDefined()) {
-                ModelNode locking = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.LOCKING);
-                ModelNode lockingAddress = address.clone();
-                lockingAddress.add(ModelKeys.SINGLETON, ModelKeys.LOCKING);
-                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.LOCKING_ATTRIBUTES, lockingAddress, locking));
-            }
-            // command to recreate the transaction configuration
-            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION).isDefined()) {
-                ModelNode transaction = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
-                ModelNode transactionAddress = address.clone();
-                transactionAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
-                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.TRANSACTION_ATTRIBUTES, transactionAddress, transaction));
-            }
-            // command to recreate the eviction configuration
-            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EVICTION).isDefined()) {
-                ModelNode eviction = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EVICTION);
-                ModelNode evictionAddress = address.clone();
-                evictionAddress.add(ModelKeys.SINGLETON, ModelKeys.EVICTION);
-                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EVICTION_ATTRIBUTES, evictionAddress, eviction));
-            }
-            // command to recreate the expiration configuration
-            if (cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION).isDefined()) {
-                ModelNode expiration = cache.getValue().get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
-                ModelNode expirationAddress = address.clone();
-                expirationAddress.add(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
-                result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EXPIRATION_ATTRIBUTES, expirationAddress, expiration));
-            }
+        // command to recreate the locking configuration
+        if (cache.getValue().get(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME).isDefined()) {
+            ModelNode locking = cache.getValue().get(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME);
+            ModelNode lockingAddress = address.clone();
+            lockingAddress.add(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME);
+            result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.LOCKING_ATTRIBUTES, lockingAddress, locking));
+        }
+        // command to recreate the transaction configuration
+        if (cache.getValue().get(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME).isDefined()) {
+            ModelNode transaction = cache.getValue().get(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
+            ModelNode transactionAddress = address.clone();
+            transactionAddress.add(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
+            result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.TRANSACTION_ATTRIBUTES, transactionAddress, transaction));
+        }
+        // command to recreate the eviction configuration
+        if (cache.getValue().get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME).isDefined()) {
+            ModelNode eviction = cache.getValue().get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
+            ModelNode evictionAddress = address.clone();
+            evictionAddress.add(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
+            result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EVICTION_ATTRIBUTES, evictionAddress, eviction));
+        }
+        // command to recreate the expiration configuration
+        if (cache.getValue().get(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME).isDefined()) {
+            ModelNode expiration = cache.getValue().get(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
+            ModelNode expirationAddress = address.clone();
+            expirationAddress.add(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
+            result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.EXPIRATION_ATTRIBUTES, expirationAddress, expiration));
         }
     }
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
@@ -564,7 +564,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
 
         // ModelNode for the cache add operation
         ModelNode lockingAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
-        lockingAddress.add(ModelKeys.SINGLETON,ModelKeys.LOCKING) ;
+        lockingAddress.add(ModelKeys.LOCKING,ModelKeys.LOCKING_NAME) ;
         lockingAddress.protect();
         ModelNode locking = Util.getEmptyOperation(ModelDescriptionConstants.ADD, lockingAddress);
 
@@ -606,7 +606,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
 
         // ModelNode for the transaction add operation
         ModelNode transactionAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
-        transactionAddress.add(ModelKeys.SINGLETON,ModelKeys.TRANSACTION) ;
+        transactionAddress.add(ModelKeys.TRANSACTION,ModelKeys.TRANSACTION_NAME) ;
         transactionAddress.protect();
         ModelNode transaction = Util.getEmptyOperation(ModelDescriptionConstants.ADD, transactionAddress);
 
@@ -650,7 +650,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
     private void parseEviction(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
         // ModelNode for the eviction add operation
         ModelNode evictionAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
-        evictionAddress.add(ModelKeys.SINGLETON,ModelKeys.EVICTION) ;
+        evictionAddress.add(ModelKeys.EVICTION,ModelKeys.EVICTION_NAME) ;
         evictionAddress.protect();
         ModelNode eviction = Util.getEmptyOperation(ModelDescriptionConstants.ADD, evictionAddress);
 
@@ -688,7 +688,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
 
         // ModelNode for the expiration add operation
         ModelNode expirationAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
-        expirationAddress.add(ModelKeys.SINGLETON,ModelKeys.EXPIRATION) ;
+        expirationAddress.add(ModelKeys.EXPIRATION,ModelKeys.EXPIRATION_NAME) ;
         expirationAddress.protect();
         ModelNode expiration = Util.getEmptyOperation(ModelDescriptionConstants.ADD, expirationAddress);
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
@@ -502,7 +502,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
 
         // ModelNode for the rehashing add operation
         ModelNode rehashingAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
-        rehashingAddress.add(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER) ;
+        rehashingAddress.add(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME) ;
         rehashingAddress.protect();
         ModelNode rehashing = Util.getEmptyOperation(ModelDescriptionConstants.ADD, rehashingAddress);
 
@@ -531,7 +531,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
     private void parseStateTransfer(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
         // ModelNode for the state transfer add operation
         ModelNode stateTransferAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone() ;
-        stateTransferAddress.add(ModelKeys.SINGLETON,ModelKeys.STATE_TRANSFER) ;
+        stateTransferAddress.add(ModelKeys.STATE_TRANSFER,ModelKeys.STATE_TRANSFER_NAME) ;
         stateTransferAddress.protect();
         ModelNode stateTransfer = Util.getEmptyOperation(ModelDescriptionConstants.ADD, stateTransferAddress);
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
@@ -205,7 +205,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
 
         // setup the transport address
         ModelNode transportAddress = containerAddress.clone() ;
-        transportAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+        transportAddress.add(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
         transportAddress.protect() ;
         transport.get(ModelDescriptionConstants.OP_ADDR).set(transportAddress);
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -495,7 +495,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
     private void parseStateTransfer(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
         // ModelNode for the state transfer add operation
         ModelNode stateTransferAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone();
-        stateTransferAddress.add(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+        stateTransferAddress.add(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
         stateTransferAddress.protect();
         ModelNode stateTransfer = Util.getEmptyOperation(ModelDescriptionConstants.ADD, stateTransferAddress);
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -196,7 +196,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
 
         // setup the transport address
         ModelNode transportAddress = containerAddress.clone() ;
-        transportAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+        transportAddress.add(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
         transportAddress.protect() ;
         transport.get(ModelDescriptionConstants.OP_ADDR).set(transportAddress);
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -528,7 +528,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
 
         // ModelNode for the cache add operation
         ModelNode lockingAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone();
-        lockingAddress.add(ModelKeys.SINGLETON,ModelKeys.LOCKING);
+        lockingAddress.add(ModelKeys.LOCKING,ModelKeys.LOCKING_NAME);
         lockingAddress.protect();
         ModelNode locking = Util.getEmptyOperation(ModelDescriptionConstants.ADD, lockingAddress);
 
@@ -570,7 +570,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
 
         // ModelNode for the transaction add operation
         ModelNode transactionAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone();
-        transactionAddress.add(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
+        transactionAddress.add(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
         transactionAddress.protect();
         ModelNode transaction = Util.getEmptyOperation(ModelDescriptionConstants.ADD, transactionAddress);
 
@@ -610,7 +610,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
     private void parseEviction(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
         // ModelNode for the eviction add operation
         ModelNode evictionAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone();
-        evictionAddress.add(ModelKeys.SINGLETON, ModelKeys.EVICTION);
+        evictionAddress.add(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
         evictionAddress.protect();
         ModelNode eviction = Util.getEmptyOperation(ModelDescriptionConstants.ADD, evictionAddress);
 
@@ -648,7 +648,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
 
         // ModelNode for the expiration add operation
         ModelNode expirationAddress = cache.get(ModelDescriptionConstants.OP_ADDR).clone();
-        expirationAddress.add(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
+        expirationAddress.add(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
         expirationAddress.protect();
         ModelNode expiration = Util.getEmptyOperation(ModelDescriptionConstants.ADD, expirationAddress);
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -157,8 +157,8 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeEndElement();
                     }
 
-                    if (cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
-                        ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+                    if (cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME).isDefined()) {
+                        ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
                         writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
                         this.writeOptional(writer, Attribute.ENABLED, stateTransfer, ModelKeys.ENABLED);
                         this.writeOptional(writer, Attribute.TIMEOUT, stateTransfer, ModelKeys.TIMEOUT);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -121,53 +121,49 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                     this.writeOptional(writer, Attribute.INDEXING, cache, ModelKeys.INDEXING);
                     this.writeOptional(writer, Attribute.JNDI_NAME, cache, ModelKeys.JNDI_NAME);
 
-                    // all child elements can be governed by this
-                    if (cache.hasDefined(ModelKeys.SINGLETON)) {
+                    if (cache.get(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME).isDefined()) {
+                        writer.writeStartElement(Element.LOCKING.getLocalName());
+                        ModelNode locking = cache.get(ModelKeys.LOCKING, ModelKeys.LOCKING_NAME);
+                        this.writeOptional(writer, Attribute.ISOLATION, locking, ModelKeys.ISOLATION);
+                        this.writeOptional(writer, Attribute.STRIPING, locking, ModelKeys.STRIPING);
+                        this.writeOptional(writer, Attribute.ACQUIRE_TIMEOUT, locking, ModelKeys.ACQUIRE_TIMEOUT);
+                        this.writeOptional(writer, Attribute.CONCURRENCY_LEVEL, locking, ModelKeys.CONCURRENCY_LEVEL);
+                        writer.writeEndElement();
+                    }
 
-                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.LOCKING).isDefined()) {
-                            writer.writeStartElement(Element.LOCKING.getLocalName());
-                            ModelNode locking = cache.get(ModelKeys.SINGLETON, ModelKeys.LOCKING);
-                            this.writeOptional(writer, Attribute.ISOLATION, locking, ModelKeys.ISOLATION);
-                            this.writeOptional(writer, Attribute.STRIPING, locking, ModelKeys.STRIPING);
-                            this.writeOptional(writer, Attribute.ACQUIRE_TIMEOUT, locking, ModelKeys.ACQUIRE_TIMEOUT);
-                            this.writeOptional(writer, Attribute.CONCURRENCY_LEVEL, locking, ModelKeys.CONCURRENCY_LEVEL);
-                            writer.writeEndElement();
-                        }
+                    if (cache.get(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME).isDefined()) {
+                        writer.writeStartElement(Element.TRANSACTION.getLocalName());
+                        ModelNode transaction = cache.get(ModelKeys.TRANSACTION, ModelKeys.TRANSACTION_NAME);
+                        this.writeOptional(writer, Attribute.STOP_TIMEOUT, transaction, ModelKeys.STOP_TIMEOUT);
+                        this.writeOptional(writer, Attribute.MODE, transaction, ModelKeys.MODE);
+                        this.writeOptional(writer, Attribute.LOCKING, transaction, ModelKeys.LOCKING);
+                        writer.writeEndElement();
+                    }
 
-                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION).isDefined()) {
-                            writer.writeStartElement(Element.TRANSACTION.getLocalName());
-                            ModelNode transaction = cache.get(ModelKeys.SINGLETON, ModelKeys.TRANSACTION);
-                            this.writeOptional(writer, Attribute.STOP_TIMEOUT, transaction, ModelKeys.STOP_TIMEOUT);
-                            this.writeOptional(writer, Attribute.MODE, transaction, ModelKeys.MODE);
-                            this.writeOptional(writer, Attribute.LOCKING, transaction, ModelKeys.LOCKING);
-                            writer.writeEndElement();
-                        }
+                    if (cache.get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME).isDefined()) {
+                        writer.writeStartElement(Element.EVICTION.getLocalName());
+                        ModelNode eviction = cache.get(ModelKeys.EVICTION, ModelKeys.EVICTION_NAME);
+                        this.writeOptional(writer, Attribute.STRATEGY, eviction, ModelKeys.STRATEGY);
+                        this.writeOptional(writer, Attribute.MAX_ENTRIES, eviction, ModelKeys.MAX_ENTRIES);
+                        writer.writeEndElement();
+                    }
 
-                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.EVICTION).isDefined()) {
-                            writer.writeStartElement(Element.EVICTION.getLocalName());
-                            ModelNode eviction = cache.get(ModelKeys.SINGLETON, ModelKeys.EVICTION);
-                            this.writeOptional(writer, Attribute.STRATEGY, eviction, ModelKeys.STRATEGY);
-                            this.writeOptional(writer, Attribute.MAX_ENTRIES, eviction, ModelKeys.MAX_ENTRIES);
-                            writer.writeEndElement();
-                        }
+                    if (cache.get(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME).isDefined()) {
+                        writer.writeStartElement(Element.EXPIRATION.getLocalName());
+                        ModelNode expiration = cache.get(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
+                        this.writeOptional(writer, Attribute.MAX_IDLE, expiration, ModelKeys.MAX_IDLE);
+                        this.writeOptional(writer, Attribute.LIFESPAN, expiration, ModelKeys.LIFESPAN);
+                        this.writeOptional(writer, Attribute.INTERVAL, expiration, ModelKeys.INTERVAL);
+                        writer.writeEndElement();
+                    }
 
-                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION).isDefined()) {
-                            writer.writeStartElement(Element.EXPIRATION.getLocalName());
-                            ModelNode expiration = cache.get(ModelKeys.SINGLETON, ModelKeys.EXPIRATION);
-                            this.writeOptional(writer, Attribute.MAX_IDLE, expiration, ModelKeys.MAX_IDLE);
-                            this.writeOptional(writer, Attribute.LIFESPAN, expiration, ModelKeys.LIFESPAN);
-                            this.writeOptional(writer, Attribute.INTERVAL, expiration, ModelKeys.INTERVAL);
-                            writer.writeEndElement();
-                        }
-
-                        if (cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
-                            ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
-                            writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
-                            this.writeOptional(writer, Attribute.ENABLED, stateTransfer, ModelKeys.ENABLED);
-                            this.writeOptional(writer, Attribute.TIMEOUT, stateTransfer, ModelKeys.TIMEOUT);
-                            this.writeOptional(writer, Attribute.CHUNK_SIZE, stateTransfer, ModelKeys.CHUNK_SIZE);
-                            writer.writeEndElement();
-                        }
+                    if (cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
+                        ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+                        writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
+                        this.writeOptional(writer, Attribute.ENABLED, stateTransfer, ModelKeys.ENABLED);
+                        this.writeOptional(writer, Attribute.TIMEOUT, stateTransfer, ModelKeys.TIMEOUT);
+                        this.writeOptional(writer, Attribute.CHUNK_SIZE, stateTransfer, ModelKeys.CHUNK_SIZE);
+                        writer.writeEndElement();
                     }
 
                     if (cache.hasDefined(ModelKeys.STORE)) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -68,9 +68,9 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                 this.writeOptional(writer, Attribute.EVICTION_EXECUTOR, container, ModelKeys.EVICTION_EXECUTOR);
                 this.writeOptional(writer, Attribute.REPLICATION_QUEUE_EXECUTOR, container, ModelKeys.REPLICATION_QUEUE_EXECUTOR);
 
-                if (container.hasDefined(ModelKeys.SINGLETON)) {
+                if (container.hasDefined(ModelKeys.TRANSPORT)) {
                     writer.writeStartElement(Element.TRANSPORT.getLocalName());
-                    ModelNode transport = container.get(ModelKeys.SINGLETON, ModelKeys.TRANSPORT);
+                    ModelNode transport = container.get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
                     this.writeOptional(writer, Attribute.STACK, transport, ModelKeys.STACK);
                     this.writeOptional(writer, Attribute.EXECUTOR, transport, ModelKeys.EXECUTOR);
                     this.writeOptional(writer, Attribute.LOCK_TIMEOUT, transport, ModelKeys.LOCK_TIMEOUT);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -47,9 +47,11 @@ public class ModelKeys {
     static final String ENABLED = "enabled";
     static final String ENTRY_TABLE = "entry-table";
     static final String EVICTION = "eviction";
+    static final String EVICTION_NAME = "EVICTION";
     static final String EVICTION_EXECUTOR = "eviction-executor";
     static final String EXECUTOR = "executor";
     static final String EXPIRATION = "expiration";
+    static final String EXPIRATION_NAME = "EXPIRATION";
     static final String FETCH_SIZE = "fetch-size";
     static final String FETCH_STATE = "fetch-state";
     static final String FILE_STORE = "file-store";
@@ -66,6 +68,7 @@ public class ModelKeys {
     static final String LOCAL_CACHE = "local-cache";
     static final String LOCK_TIMEOUT = "lock-timeout";
     static final String LOCKING = "locking";
+    static final String LOCKING_NAME = "LOCKING";
     static final String MACHINE = "machine";
     static final String MAX_ENTRIES = "max-entries";
     static final String MAX_IDLE = "max-idle";
@@ -103,6 +106,7 @@ public class ModelKeys {
     static final String TIMEOUT = "timeout";
     static final String TIMESTAMP_COLUMN = "timestamp-column";
     static final String TRANSACTION = "transaction";
+    static final String TRANSACTION_NAME = "TRANSACTION";
     static final String TRANSPORT = "transport";
     static final String TRANSPORT_NAME = "TRANSPORT";
     static final String TYPE = "type";

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -104,6 +104,7 @@ public class ModelKeys {
     static final String TIMESTAMP_COLUMN = "timestamp-column";
     static final String TRANSACTION = "transaction";
     static final String TRANSPORT = "transport";
+    static final String TRANSPORT_NAME = "TRANSPORT";
     static final String TYPE = "type";
     static final String VIRTUAL_NODES = "virtual-nodes";
     static final String WAIT = "wait";

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -98,6 +98,7 @@ public class ModelKeys {
     static final String STACK = "stack";
     static final String START = "start";
     static final String STATE_TRANSFER = "state-transfer";
+    static final String STATE_TRANSFER_NAME = "STATE_TRANSFER";
     static final String STOP_TIMEOUT = "stop-timeout";
     static final String STORE = "store";
     static final String STRATEGY = "strategy";

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ObjectTypeAttributeDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ObjectTypeAttributeDefinition.java
@@ -1,0 +1,243 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat, Inc., and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import java.util.List;
+import java.util.ResourceBundle;
+
+import org.jboss.as.clustering.infinispan.subsystem.validators.ObjectTypeValidator;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ParameterCorrector;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
+import org.jboss.as.controller.operations.validation.MinMaxValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+* Date: 15.11.2011
+*
+* @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+* @author Richard Achmatowicz (c) 2012 RedHat Inc.
+*/
+public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
+    private final AttributeDefinition[] valueTypes;
+    private final String suffix;
+
+    private ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull, final ParameterCorrector corrector, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
+        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, new ObjectTypeValidator(allowNull, valueTypes), alternatives, requires, flags);
+        this.valueTypes = valueTypes;
+        if (suffix == null) {
+            this.suffix = "";
+        } else {
+            this.suffix = suffix;
+        }
+    }
+
+
+    @Override
+    public ModelNode parse(final String value, final XMLStreamReader reader) throws XMLStreamException {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public ModelNode addResourceAttributeDescription(ResourceBundle bundle, String prefix, ModelNode resourceDescription) {
+        final ModelNode result = super.addResourceAttributeDescription(bundle, prefix, resourceDescription);
+        addValueTypeDescription(result, prefix, bundle);
+        return result;
+    }
+
+    @Override
+    public ModelNode addOperationParameterDescription(ResourceBundle bundle, String prefix, ModelNode operationDescription) {
+        final ModelNode result = super.addOperationParameterDescription(bundle, prefix, operationDescription);
+        addValueTypeDescription(result, prefix, bundle);
+        return result;
+    }
+
+    protected void addValueTypeDescription(final ModelNode node, final String prefix, final ResourceBundle bundle) {
+        for (AttributeDefinition valueType : valueTypes) {
+            final ModelNode valueTypeDesc = getValueTypeDescription(valueType, false);
+            final String p = (prefix == null || prefix.isEmpty()) ? suffix : String.format("%s.%s", prefix, suffix);
+            valueTypeDesc.get(DESCRIPTION).set(valueType.getAttributeTextDescription(bundle, p));
+            final ModelNode childType = node.get(VALUE_TYPE, valueType.getName()).set(valueTypeDesc);
+            if (valueType instanceof ObjectTypeAttributeDefinition) {
+                ObjectTypeAttributeDefinition.class.cast(valueType).addValueTypeDescription(childType, prefix, bundle);
+            }
+        }
+    }
+
+    @Override
+    public void marshallAsElement(final ModelNode resourceModel, final XMLStreamWriter writer) throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            writer.writeStartElement(getXmlName());
+            for (AttributeDefinition valueType : valueTypes) {
+                for (ModelNode handler : resourceModel.get(getName()).asList()) {
+                    valueType.marshallAsElement(handler, writer);
+                }
+            }
+            writer.writeEndElement();
+        }
+    }
+
+    private ModelNode getValueTypeDescription(final AttributeDefinition valueType, final boolean forOperation) {
+        final ModelNode result = new ModelNode();
+        result.get(ModelDescriptionConstants.TYPE).set(valueType.getType());
+        result.get(ModelDescriptionConstants.DESCRIPTION); // placeholder
+        result.get(ModelDescriptionConstants.EXPRESSIONS_ALLOWED).set(valueType.isAllowExpression());
+        if (forOperation) {
+            result.get(ModelDescriptionConstants.REQUIRED).set(!valueType.isAllowNull());
+        }
+        result.get(ModelDescriptionConstants.NILLABLE).set(isAllowNull());
+        final ModelNode defaultValue = valueType.getDefaultValue();
+        if (!forOperation && defaultValue != null && defaultValue.isDefined()) {
+            result.get(ModelDescriptionConstants.DEFAULT).set(defaultValue);
+        }
+        MeasurementUnit measurementUnit = valueType.getMeasurementUnit();
+        if (measurementUnit != null && measurementUnit != MeasurementUnit.NONE) {
+            result.get(ModelDescriptionConstants.UNIT).set(measurementUnit.getName());
+        }
+        final String[] alternatives = valueType.getAlternatives();
+        if (alternatives != null) {
+            for (final String alternative : alternatives) {
+                result.get(ModelDescriptionConstants.ALTERNATIVES).add(alternative);
+            }
+        }
+        final String[] requires = valueType.getRequires();
+        if (requires != null) {
+            for (final String required : requires) {
+                result.get(ModelDescriptionConstants.REQUIRES).add(required);
+            }
+        }
+        final ParameterValidator validator = valueType.getValidator();
+        if (validator instanceof MinMaxValidator) {
+            MinMaxValidator minMax = (MinMaxValidator) validator;
+            Long min = minMax.getMin();
+            if (min != null) {
+                switch (valueType.getType()) {
+                    case STRING:
+                    case LIST:
+                    case OBJECT:
+                        result.get(ModelDescriptionConstants.MIN_LENGTH).set(min);
+                        break;
+                    default:
+                        result.get(ModelDescriptionConstants.MIN).set(min);
+                }
+            }
+            Long max = minMax.getMax();
+            if (max != null) {
+                switch (valueType.getType()) {
+                    case STRING:
+                    case LIST:
+                    case OBJECT:
+                        result.get(ModelDescriptionConstants.MAX_LENGTH).set(max);
+                        break;
+                    default:
+                        result.get(ModelDescriptionConstants.MAX).set(max);
+                }
+            }
+        }
+        if (validator instanceof AllowedValuesValidator) {
+            AllowedValuesValidator avv = (AllowedValuesValidator) validator;
+            List<ModelNode> allowed = avv.getAllowedValues();
+            if (allowed != null) {
+                for (ModelNode ok : allowed) {
+                    result.get(ModelDescriptionConstants.ALLOWED).add(ok);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static class Builder {
+        private final String name;
+        private String suffix;
+        private final AttributeDefinition[] valueTypes;
+        private ParameterCorrector corrector;
+        private String xmlName;
+        private boolean allowNull;
+        private String[] alternatives;
+        private String[] requires;
+        private AttributeAccess.Flag[] flags;
+
+        public Builder(final String name, final AttributeDefinition... valueTypes) {
+            this.name = name;
+            this.valueTypes = valueTypes;
+            this.allowNull = true;
+        }
+
+        public static Builder of(final String name, final AttributeDefinition... valueTypes) {
+            return new Builder(name, valueTypes);
+        }
+
+        public ObjectTypeAttributeDefinition build() {
+            if (xmlName == null) xmlName = name;
+            return new ObjectTypeAttributeDefinition(name, xmlName, suffix, valueTypes, allowNull, corrector, alternatives, requires, flags);
+        }
+
+        public Builder setAllowNull(final boolean allowNull) {
+            this.allowNull = allowNull;
+            return this;
+        }
+
+        public Builder setAlternates(final String... alternates) {
+            this.alternatives = alternates;
+            return this;
+        }
+
+        public Builder setCorrector(final ParameterCorrector corrector) {
+            this.corrector = corrector;
+            return this;
+        }
+
+        public Builder setFlags(final AttributeAccess.Flag... flags) {
+            this.flags = flags;
+            return this;
+        }
+
+        public Builder setRequires(final String... requires) {
+            this.requires = requires;
+            return this;
+        }
+
+        public Builder setSuffix(final String suffix) {
+            this.suffix = suffix;
+            return this;
+        }
+
+        public Builder setXmlName(final String xmlName) {
+            this.xmlName = xmlName;
+            return this;
+        }
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheAdd.java
@@ -43,8 +43,8 @@ public abstract class SharedStateCacheAdd extends ClusteredCacheAdd {
         super.processModelNode(cache, builder, dependencies);
 
         // state transfer is a child resource
-        if (cache.hasDefined(ModelKeys.SINGLETON) && cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER).isDefined()) {
-            ModelNode stateTransfer = cache.get(ModelKeys.SINGLETON, ModelKeys.STATE_TRANSFER);
+        if (cache.hasDefined(ModelKeys.STATE_TRANSFER) && cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME).isDefined()) {
+            ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
 
             if (stateTransfer.hasDefined(ModelKeys.ENABLED)) {
                 builder.clustering().stateTransfer().fetchInMemoryState(stateTransfer.get(ModelKeys.ENABLED).asBoolean());

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SimpleListAttributeDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SimpleListAttributeDefinition.java
@@ -1,0 +1,241 @@
+  /*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
+import org.jboss.as.controller.operations.validation.MinMaxValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Date: 13.10.2011
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ * @author Richard Achmatowicz (c) 2012 RedHat Inc.
+ */
+public class SimpleListAttributeDefinition extends ListAttributeDefinition {
+    private final SimpleAttributeDefinition valueType;
+
+    private SimpleListAttributeDefinition(final String name, final String xmlName, final SimpleAttributeDefinition valueType, final boolean allowNull, final int minSize, final int maxSize, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
+        super(name, xmlName, allowNull, minSize, maxSize, valueType.getValidator(), alternatives, requires, flags);
+        this.valueType = valueType;
+    }
+
+    @Override
+    public ModelNode addResourceAttributeDescription(ResourceBundle bundle, String prefix, ModelNode resourceDescription) {
+        final ModelNode result = super.addResourceAttributeDescription(bundle, prefix, resourceDescription);
+        addValueTypeDescription(result, prefix, bundle);
+        return result;
+    }
+
+    @Override
+    public ModelNode addOperationParameterDescription(ResourceBundle bundle, String prefix, ModelNode operationDescription) {
+        final ModelNode result = super.addOperationParameterDescription(bundle, prefix, operationDescription);
+        addValueTypeDescription(result, prefix, bundle);
+        return result;
+    }
+
+
+    @Override
+    protected void addValueTypeDescription(final ModelNode node, final ResourceBundle bundle) {
+        node.get(VALUE_TYPE, valueType.getName()).set(getValueTypeDescription(false));
+    }
+
+
+    protected void addValueTypeDescription(final ModelNode node, final String prefix, final ResourceBundle bundle) {
+        final ModelNode valueTypeDesc = getValueTypeDescription(false);
+        valueTypeDesc.get(DESCRIPTION).set(valueType.getAttributeTextDescription(bundle, prefix));
+        node.get(VALUE_TYPE, valueType.getName()).set(valueTypeDesc);
+    }
+
+    @Override
+    protected void addAttributeValueTypeDescription(final ModelNode node, final ResourceDescriptionResolver resolver, final Locale locale, final ResourceBundle bundle) {
+        final ModelNode valueTypeDesc = getValueTypeDescription(false);
+        valueTypeDesc.get(DESCRIPTION).set(resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, valueType.getName()));
+        node.get(VALUE_TYPE, valueType.getName()).set(valueTypeDesc);
+    }
+
+    @Override
+    protected void addOperationParameterValueTypeDescription(final ModelNode node, final String operationName, final ResourceDescriptionResolver resolver, final Locale locale, final ResourceBundle bundle) {
+        final ModelNode valueTypeDesc = getValueTypeDescription(true);
+        valueTypeDesc.get(DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, valueType.getName()));
+        node.get(VALUE_TYPE, valueType.getName()).set(valueTypeDesc);
+    }
+
+    @Override
+    public void marshallAsElement(final ModelNode resourceModel, final XMLStreamWriter writer) throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            writer.writeStartElement(getXmlName());
+            for (ModelNode handler : resourceModel.get(getName()).asList()) {
+                valueType.marshallAsElement(handler, writer);
+            }
+            writer.writeEndElement();
+        }
+    }
+
+    private ModelNode getValueTypeDescription(boolean forOperation) {
+        final ModelNode result = new ModelNode();
+        result.get(ModelDescriptionConstants.TYPE).set(valueType.getType());
+        result.get(ModelDescriptionConstants.DESCRIPTION); // placeholder
+        result.get(ModelDescriptionConstants.EXPRESSIONS_ALLOWED).set(valueType.isAllowExpression());
+        if (forOperation) {
+            result.get(ModelDescriptionConstants.REQUIRED).set(!valueType.isAllowNull());
+        }
+        result.get(ModelDescriptionConstants.NILLABLE).set(isAllowNull());
+        final ModelNode defaultValue = valueType.getDefaultValue();
+        if (!forOperation && defaultValue != null && defaultValue.isDefined()) {
+            result.get(ModelDescriptionConstants.DEFAULT).set(defaultValue);
+        }
+        MeasurementUnit measurementUnit = valueType.getMeasurementUnit();
+        if (measurementUnit != null && measurementUnit != MeasurementUnit.NONE) {
+            result.get(ModelDescriptionConstants.UNIT).set(measurementUnit.getName());
+        }
+        final String[] alternatives = valueType.getAlternatives();
+        if (alternatives != null) {
+            for (final String alternative : alternatives) {
+                result.get(ModelDescriptionConstants.ALTERNATIVES).add(alternative);
+            }
+        }
+        final String[] requires = valueType.getRequires();
+        if (requires != null) {
+            for (final String required : requires) {
+                result.get(ModelDescriptionConstants.REQUIRES).add(required);
+            }
+        }
+        final ParameterValidator validator = valueType.getValidator();
+        if (validator instanceof MinMaxValidator) {
+            MinMaxValidator minMax = (MinMaxValidator) validator;
+            Long min = minMax.getMin();
+            if (min != null) {
+                switch (valueType.getType()) {
+                    case STRING:
+                    case LIST:
+                    case OBJECT:
+                        result.get(ModelDescriptionConstants.MIN_LENGTH).set(min);
+                        break;
+                    default:
+                        result.get(ModelDescriptionConstants.MIN).set(min);
+                }
+            }
+            Long max = minMax.getMax();
+            if (max != null) {
+                switch (valueType.getType()) {
+                    case STRING:
+                    case LIST:
+                    case OBJECT:
+                        result.get(ModelDescriptionConstants.MAX_LENGTH).set(max);
+                        break;
+                    default:
+                        result.get(ModelDescriptionConstants.MAX).set(max);
+                }
+            }
+        }
+        if (validator instanceof AllowedValuesValidator) {
+            AllowedValuesValidator avv = (AllowedValuesValidator) validator;
+            List<ModelNode> allowed = avv.getAllowedValues();
+            if (allowed != null) {
+                for (ModelNode ok : allowed) {
+                    result.get(ModelDescriptionConstants.ALLOWED).add(ok);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static class Builder {
+        private final String name;
+        private final SimpleAttributeDefinition valueType;
+        private String xmlName;
+        private boolean allowNull;
+        private int minSize;
+        private int maxSize;
+        private String[] alternatives;
+        private String[] requires;
+        private AttributeAccess.Flag[] flags;
+
+        public Builder(final String name, final SimpleAttributeDefinition valueType) {
+            this.name = name;
+            this.valueType = valueType;
+        }
+
+        public static Builder of(final String name, final SimpleAttributeDefinition valueType) {
+            return new Builder(name, valueType);
+        }
+
+        public SimpleListAttributeDefinition build() {
+            if (xmlName == null) xmlName = name;
+            if (maxSize < 1) maxSize = Integer.MAX_VALUE;
+            return new SimpleListAttributeDefinition(name, xmlName, valueType, allowNull, minSize, maxSize, alternatives, requires, flags);
+        }
+
+        public Builder setAllowNull(final boolean allowNull) {
+            this.allowNull = allowNull;
+            return this;
+        }
+
+        public Builder setAlternates(final String... alternates) {
+            this.alternatives = alternates;
+            return this;
+        }
+
+        public Builder setFlags(final AttributeAccess.Flag... flags) {
+            this.flags = flags;
+            return this;
+        }
+
+        public Builder setMaxSize(final int maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public Builder setMinSize(final int minSize) {
+            this.minSize = minSize;
+            return this;
+        }
+
+        public Builder setRequires(final String... requires) {
+            this.requires = requires;
+            return this;
+        }
+
+        public Builder setXmlName(final String xmlName) {
+            this.xmlName = xmlName;
+            return this;
+        }
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/validators/ObjectTypeValidator.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/validators/ObjectTypeValidator.java
@@ -1,0 +1,89 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat, Inc., and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+
+package org.jboss.as.clustering.infinispan.subsystem.validators;
+
+// import static org.jboss.as.clustering.ClusteringMessages.MESSAGES;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+* Date: 16.11.2011
+*
+* @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+*/
+public class ObjectTypeValidator extends ModelTypeValidator implements AllowedValuesValidator {
+    private final Map<String, AttributeDefinition> allowedValues;
+    private final List<ModelNode> nodeValues;
+
+    public ObjectTypeValidator(final boolean nullable, final AttributeDefinition... attributes) {
+        super(nullable, false, false, ModelType.OBJECT, findModelTypes(attributes));
+        allowedValues = new HashMap<String, AttributeDefinition>(attributes.length);
+        nodeValues = new ArrayList<ModelNode>(attributes.length);
+        for (AttributeDefinition attribute : attributes) {
+            allowedValues.put(attribute.getName(), attribute);
+            nodeValues.add(new ModelNode().set(attribute.getName()));
+        }
+    }
+
+    @Override
+    public void validateParameter(final String parameterName, final ModelNode value) throws OperationFailedException {
+        super.validateParameter(parameterName, value);
+        if (value.isDefined()) {
+            for (String key : value.keys()) {
+                if (allowedValues.containsKey(key)) {
+                    allowedValues.get(key).getValidator().validateParameter(key, value.get(key));
+                } else {
+                    // create and pass a two parameter message about this error
+                    // throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidValueTypeKey(key, allowedValues.keySet())));
+                    throw new OperationFailedException(new ModelNode().set("invalid type key"));
+                }
+            }
+        }
+    }
+
+    @Override
+    public List<ModelNode> getAllowedValues() {
+        return nodeValues;
+    }
+
+    private static ModelType[] findModelTypes(final AttributeDefinition... attributes) {
+        final Set<ModelType> result = new HashSet<ModelType>();
+        for (AttributeDefinition attr : attributes) {
+            if (attr.getType() != ModelType.OBJECT)
+                result.add(attr.getType());
+        }
+        return result.toArray(new ModelType[]{});
+    }
+}

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -57,8 +57,6 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest {
         super(InfinispanExtension.SUBSYSTEM_NAME, new InfinispanExtension(), xmlFile);
         this.xmlFile = xmlFile ;
         this.operations = operations ;
-
-        System.out.println("xmlFile = " + xmlFile + ", operations = " + operations);
     }
 
     @Parameters


### PR DESCRIPTION
This change replaces naming of singleton child resources as /subsystem=infinispan/cache-container=X/singleton=transport with  /subsystem=infinispan/cache-container=X/transport=TRANSPORT.
Also adds in the use of SimpleListAttributeDefinition and ObjectTypeAttributeDefinition to simplify descriptions.
