### PR TITLE
AS7-3416 Register javax.naming.spi.ObjectFactory from OSGi Service Layer with AS7 Naming

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -49,10 +49,36 @@ public class InitialContext extends NamingContext {
      */
     private static volatile Map<String, ObjectFactory> urlContextFactories = Collections.emptyMap();
 
+    /**
+     * Add an ObjectFactory to handle requests for a specific URL scheme.
+     * @param scheme The URL scheme to handle.
+     * @param factory The ObjectFactory that can handle the requests.
+     */
     public static synchronized void addUrlContextFactory(final String scheme, ObjectFactory factory) {
         Map<String, ObjectFactory> factories = new HashMap<String, ObjectFactory>(urlContextFactories);
         factories.put(scheme, factory);
         urlContextFactories = Collections.unmodifiableMap(factories);
+    }
+
+    /**
+     * Remove an ObjectFactory from the map of registered ones. To make sure that not anybody can remove an
+     * ObjectFactory both the scheme as well as the actual object factory itself need to be supplied. So you
+     * can only remove the factory if you have the factory object.
+     * @param scheme The URL scheme for which the handler is registered.
+     * @param factory The factory object associated with the scheme
+     * @throws IllegalArgumentException if the requested scheme/factory combination is not registered.
+     */
+    public static synchronized void removeUrlContextFactory(final String scheme, ObjectFactory factory) {
+        Map<String, ObjectFactory> factories = new HashMap<String, ObjectFactory>(urlContextFactories);
+
+        ObjectFactory f = factories.get(scheme);
+        if (f == factory) {
+            factories.remove(scheme);
+            urlContextFactories = Collections.unmodifiableMap(factories);
+            return;
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
 
     public InitialContext(Hashtable<String, Object> environment) {

--- a/naming/src/test/java/org/jboss/as/naming/InitialContextTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/InitialContextTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NamingException;
+import javax.naming.spi.ObjectFactory;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * @author David Bosschaert
+ */
+public class InitialContextTestCase {
+    @Test
+    public void testRegisterURLSchemeHandler() throws Exception {
+        InitialContext ictx = new InitialContext(null);
+
+        try {
+            ictx.lookup("foobar:something");
+            Assert.fail("Precondition: the foobar: scheme should not yet be registered");
+        } catch (NamingException ne) {
+            // good
+        }
+
+        ObjectFactory tof = new TestObjectFactory();
+        InitialContext.addUrlContextFactory("foobar", tof);
+        String something = (String) ictx.lookup("foobar:something");
+        Assert.assertTrue("The object should now be provided by our TestObjectFactory", something.startsWith("TestObject:"));
+
+        try {
+            InitialContext.removeUrlContextFactory("foobar:", new TestObjectFactory());
+            Assert.fail("Should throw an IllegalArgumentException since the associated factory object doesn't match the registration");
+        } catch (IllegalArgumentException iae) {
+            // good;
+        }
+
+        Assert.assertEquals("The foobar: scheme should still be registered", something, ictx.lookup("foobar:something"));
+
+        InitialContext.removeUrlContextFactory("foobar", tof);
+        try {
+            ictx.lookup("foobar:something");
+            Assert.fail("The foobar: scheme should not be registered any more");
+        } catch (NamingException ne) {
+            // good
+        }
+    }
+
+    private class TestObjectFactory implements ObjectFactory {
+        @Override
+        public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) throws Exception {
+            return new InitialContext(new Hashtable<String, Object>()) {
+                @Override
+                public Object lookup(Name name) throws NamingException {
+                    return "TestObject: " + name;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
The main changes of this commit are in the OSGi/AS7 integration layer
(the FrameworkBootstrapService). However I also added an
InitialContext.removeUrlContextFactory() to complement the existing
InitialContext.addUrlContextFactory().
Tests included.
