### PR TITLE
Primitive types don't need to be cloned in LocalEjbReceiver

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
@@ -203,7 +203,7 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
             return null;
         }
 
-        if (allowPassByReference && target.isAssignableFrom(object.getClass())) {
+        if (allowPassByReference && (target.isPrimitive() || target.isAssignableFrom(object.getClass()))) {
             return object;
         }
         return clone(cloner, object);


### PR DESCRIPTION
If 'pass-by-value' is disabled for the ejb client, then no cloning should be performed for parameters of primitive types. Current version of code still tries to clone them, as declared parameter class (primitive type) is not equal to runtime parameter value used during the invocation ('boxed' class for primitive type), this results a lot of cloning requests in case of remote methods with primitive types.

See AS7-3435 for more details.
