### PR TITLE
[JBWS-3413] java.xml.ws.spi.Provider resolution is JVM implementation specific

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/webservices/server/integration/main/module.xml
@@ -61,7 +61,8 @@
           </exports>
         </module>
         <module name="org.jboss.ws.cxf.jbossws-cxf-server" services="export" export="true"/>
-        <module name="org.apache.cxf" services="export" export="true">
+        <!-- Do not import services from cxf module direclty, those need to come from jbossws -->
+        <module name="org.apache.cxf" export="true">
           <imports>
             <include path="META-INF/cxf"/>
             <include path="META-INF"/>

--- a/build/src/main/resources/modules/org/jboss/ws/cxf/jbossws-cxf-client/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ws/cxf/jbossws-cxf-client/main/module.xml
@@ -43,7 +43,8 @@
         <module name="org.jboss.ws.jaxws-client" export="true" services="export" />
         <!--  JBossWS configuration of Apache CXF -->
         <module name="org.jboss.ws.cxf.jbossws-cxf-factories" services="export" />
-        <module name="org.apache.cxf" export="true" services="export" />
+        <!-- Apache CXF - do not import services, those need to come from JBossWS -->
+        <module name="org.apache.cxf" export="true" />
         <module name="org.jboss.ws.cxf.jbossws-cxf-transports-httpserver" export="true" services="export" />
         <module name="org.jboss.jaxbintros" export="true"/>
     </dependencies>

--- a/build/src/main/resources/modules/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
@@ -46,7 +46,8 @@
         <module name="org.jboss.ws.common" />
         <module name="org.jboss.ws.jaxws-client" />
         <module name="org.jboss.ws.cxf.jbossws-cxf-factories" services="import"/>
-        <module name="org.apache.cxf" services="import">
+        <!-- do not import services from cxf, those need to come from jbossws -->
+        <module name="org.apache.cxf">
           <imports>
             <include path="META-INF/cxf"/> <!-- required to also pull in the bus extensions from META-INF -->
             <include path="META-INF/"/>

--- a/build/src/main/resources/modules/org/jboss/ws/jaxws-client/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ws/jaxws-client/main/module.xml
@@ -41,7 +41,8 @@
         <module name="org.jboss.ws.spi" />
         <module name="org.jboss.ws.common" />
         <module name="org.jboss.ws.cxf.jbossws-cxf-factories" services="import"/>
-        <module name="org.apache.cxf" services="import">
+        <!-- do not import services from cxf, those need to come from jbossws -->
+        <module name="org.apache.cxf">
           <imports>
             <include path="META-INF/cxf"/> <!-- required to also pull in the bus extensions from META-INF -->
             <include path="META-INF/"/>


### PR DESCRIPTION
Do not export META-INF/services declarations from org.apache.cxf module; those are to be overridden by jbossws-cxf modules, however IBM JDK messes up with resources ordering, causing wrong javax.xml.ws.spi.Provider resolution. Hence we need to avoid duplicated META-INF/services being exported.
