### PR TITLE
AS7-3331 Changed SSL config attributes to use an enumeration of strings

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-jacorb_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jacorb_1_1.xsd
@@ -82,11 +82,11 @@
             <xs:element name="initializers" minOccurs="0" maxOccurs="1" type="orbInitializersConfigType"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="optional" default="JBoss"/>
-        <xs:attribute name="print-version" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="use-imr" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="use-bom" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="cache-typecodes" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="cache-poa-names" type="xs:string" use="optional" default="off"/>
+        <xs:attribute name="print-version" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="use-imr" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="use-bom" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="cache-typecodes" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="cache-poa-names" type="onOffType" use="optional" default="off"/>
         <xs:attribute name="giop-minor-version" type="xs:integer" use="optional" default="2"/>
     </xs:complexType>
 
@@ -136,7 +136,7 @@
                         ]]>
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="security" type="securityEnabledType" use="optional" default="off"/>
+        <xs:attribute name="security" type="onOffType" use="optional" default="off"/>
         <xs:attribute name="transactions" type="transactionEnabledType" use="optional" default="off"/>
     </xs:complexType>
 
@@ -161,8 +161,8 @@
         <xs:sequence>
             <xs:element name="request-processors" minOccurs="0" maxOccurs="1" type="poaRequestProcessorsConfigType"/>
         </xs:sequence>
-        <xs:attribute name="monitoring" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="queue-wait" type="xs:string" use="optional" default="off"/>
+        <xs:attribute name="monitoring" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="queue-wait" type="onOffType" use="optional" default="off"/>
         <xs:attribute name="queue-min" type="xs:integer" use="optional" default="10"/>
         <xs:attribute name="queue-max" type="xs:integer" use="optional" default="100"/>
     </xs:complexType>
@@ -198,7 +198,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="root-context" type="xs:string" use="optional" default="JBoss/Naming/root"/>
-        <xs:attribute name="export-corbaloc" type="xs:string" use="optional" default="on"/>
+        <xs:attribute name="export-corbaloc" type="onOffType" use="optional" default="on"/>
     </xs:complexType>
 
     <xs:complexType name="interopConfigType">
@@ -221,13 +221,13 @@
                         ]]>
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="sun" type="xs:string" use="optional" default="on"/>
-        <xs:attribute name="comet" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="iona" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="chunk-custom-rmi-valuetypes" type="xs:string" use="optional" default="on"/>
-        <xs:attribute name="lax-boolean-encoding" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="indirection-encoding-disable" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="strict-check-on-tc-creation" type="xs:string" use="optional" default="off"/>
+        <xs:attribute name="sun" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="comet" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="iona" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="chunk-custom-rmi-valuetypes" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="lax-boolean-encoding" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="indirection-encoding-disable" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="strict-check-on-tc-creation" type="onOffType" use="optional" default="off"/>
     </xs:complexType>
 
     <xs:complexType name="securityConfigType">
@@ -241,30 +241,24 @@
                                    to establish SSL connections.
                 * add-component-via-interceptor: indicates whether SSL components should be added by an IOR interceptor
                                                  (on) or not (off).
-                * client-supports: value that indicates the client SSL supported parameters (EstablishTrustInTarget=20,
-                                   EstablishTrustInClient=40, MutualAuth=60).
-                * client-requires: value that indicates the client SSL required parameters (EstablishTrustInTarget=20,
-                                   EstablishTrustInClient=40, MutualAuth=60).
-                * server-supports: value that indicates the server SSL supported parameters (EstablishTrustInTarget=20,
-                                   EstablishTrustInClient=40, MutualAuth=60).
-                * server-requires: value that indicates the server SSL required parameters (EstablishTrustInTarget=20,
-                                   EstablishTrustInClient=40, MutualAuth=60).
-                * use-domain-socket-factory: indicates whether the JBoss domain socket factory should be used (on) or
-                                             not (off).
-                * use-domain-server-socket-factory: indicates whether the JBoss domain server socket factory should be
-                                                    used (on) or not (off).
+                * client-supports: value that indicates the client SSL supported parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * client-requires: value that indicates the client SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * server-supports: value that indicates the server SSL supported parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * server-requires: value that indicates the server SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
                         ]]>
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="support-ssl" type="xs:string" use="optional" default="off"/>
+        <xs:attribute name="support-ssl" type="onOffType" use="optional" default="off"/>
         <xs:attribute name="security-domain" type="xs:string" use="optional"/>
-        <xs:attribute name="add-component-via-interceptor" type="xs:string" use="optional" default="on"/>
-        <xs:attribute name="client-supports" type="xs:integer" use="optional" default="60"/>
-        <xs:attribute name="client-requires" type="xs:integer" use="optional" default="0"/>
-        <xs:attribute name="server-supports" type="xs:integer" use="optional" default="60"/>
-        <xs:attribute name="server-requires" type="xs:integer" use="optional" default="0"/>
-        <xs:attribute name="use-domain-socket-factory" type="xs:string" use="optional" default="off"/>
-        <xs:attribute name="use-domain-server-socket-factory" type="xs:string" use="optional" default="off"/>
+        <xs:attribute name="add-component-via-interceptor" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="client-supports" type="sslConfigType" use="optional" default="MutualAuth"/>
+        <xs:attribute name="client-requires" type="sslConfigType" use="optional" default="None"/>
+        <xs:attribute name="server-supports" type="sslConfigType" use="optional" default="MutualAuth"/>
+        <xs:attribute name="server-requires" type="sslConfigType" use="optional" default="None"/>
     </xs:complexType>
 
     <xs:complexType name="genericPropertiesType">
@@ -293,10 +287,12 @@
         <xs:attribute name="value" type="xs:string" use="required"/>
     </xs:complexType>
 
-    <xs:simpleType name="securityEnabledType">
+    <xs:simpleType name="onOffType">
         <xs:annotation>
             <xs:documentation>
-                Enumeration for the security interceptor config.
+                <![CDATA[
+                    Enumeration of allowed values for the standard JacORB attributes.
+                ]]>
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:token">
@@ -308,13 +304,27 @@
     <xs:simpleType name="transactionEnabledType">
         <xs:annotation>
             <xs:documentation>
-                Enumeration for the transaction interceptor config.
+                Enumeration of allowed values for the transaction interceptor config.
             </xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:token">
             <xs:enumeration value="on"/>
             <xs:enumeration value="off"/>
             <xs:enumeration value="spec"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sslConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the SSL config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="None"/>
+            <xs:enumeration value="ServerAuth"/>
+            <xs:enumeration value="ClientAuth"/>
+            <xs:enumeration value="MutualAuth"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBExtension.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBExtension.java
@@ -22,9 +22,10 @@
 
 package org.jboss.as.jacorb;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -32,10 +33,6 @@ import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 
 /**
  * <p>
@@ -61,13 +58,6 @@ public class JacORBExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0);
         final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(JacORBSubsystemResource.INSTANCE);
         subsystemRegistration.registerOperationHandler(DESCRIBE, GenericSubsystemDescribeHandler.INSTANCE, GenericSubsystemDescribeHandler.INSTANCE, false, OperationEntry.EntryType.PRIVATE);
-
-        /*final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(JacORBSubsystemProviders.SUBSYSTEM);
-        registration.registerOperationHandler(ADD, JacORBSubsystemAdd.INSTANCE,JacORBSubsystemProviders.SUBSYSTEM_ADD, false);
-        registration.registerOperationHandler(REMOVE, ReloadRequiredRemoveStepHandler.INSTANCE, JacORBSubsystemProviders.SUBSYSTEM_REMOVE, false);
-        registration.registerOperationHandler(DESCRIBE, GenericSubsystemDescribeHandler.INSTANCE, JacORBSubsystemProviders.SUBSYSTEM_DESCRIBE, false, OperationEntry.EntryType.PRIVATE);*/
-
-
         subsystem.registerXMLElementWriter(PARSER);
     }
 

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
@@ -22,21 +22,6 @@
 
 package org.jboss.as.jacorb;
 
-import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.MapAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.operations.validation.IntRangeValidator;
-import org.jboss.as.controller.operations.validation.ModelTypeValidator;
-import org.jboss.as.controller.parsing.Attribute;
-import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -44,6 +29,24 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.MapAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.parsing.Attribute;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 
 /**
  * <p>
@@ -58,6 +61,17 @@ class JacORBSubsystemDefinitions {
 
     private static final ModelNode DEFAULT_ENABLED_PROPERTY = new ModelNode().set("on");
 
+    private static final ParameterValidator SSL_CONFIG_VALIDATOR =
+            new EnumValidator<SSLConfigValue>(SSLConfigValue.class, true, false);
+
+    // enum and validator for the standard jacorb attributes that use on/off strings to enable and disable properties.
+    private enum OnOffValue {OFF, ON}
+
+    private static final ParameterValidator ON_OFF_VALIDATOR = new EnumValidator<OnOffValue>(OnOffValue.class, true, false);
+
+    // enum for the tx initializer configuration.
+    private enum TxInitializerValue {ON, OFF, SPEC}
+
     // orb attribute definitions.
     public static final SimpleAttributeDefinition ORB_NAME = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.NAME, ModelType.STRING, true)
@@ -68,30 +82,35 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition ORB_PRINT_VERSION = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_PRINT_VERSION, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition ORB_USE_IMR = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_USE_IMR, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition ORB_USE_BOM = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_USE_BOM, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition ORB_CACHE_TYPECODES = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_CACHE_TYPECODES, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition ORB_CACHE_POA_NAMES = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_CACHE_POA_NAMES, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -163,12 +182,14 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition ORB_INIT_SECURITY = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_INIT_SECURITY, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition ORB_INIT_TX = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_INIT_TRANSACTIONS, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(new EnumValidator<TxInitializerValue>(TxInitializerValue.class, true, false))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -176,12 +197,14 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition POA_MONITORING = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.POA_MONITORING, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition POA_QUEUE_WAIT = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.POA_QUEUE_WAIT, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -224,6 +247,7 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition NAMING_EXPORT_CORBALOC = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.NAMING_EXPORT_CORBALOC, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_ENABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -231,42 +255,49 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition INTEROP_SUN = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_SUN, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_ENABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition INTEROP_COMET = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_COMET, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition INTEROP_IONA = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_IONA, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition INTEROP_CHUNK_RMI_VALUETYPES = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_CHUNK_RMI_VALUETYPES, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_ENABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition INTEROP_LAX_BOOLEAN_ENCODING = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_LAX_BOOLEAN_ENCODING, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition INTEROP_INDIRECT_ENCODING_DISABLE = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_INDIRECTION_ENCODING_DISABLE, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition INTEROP_STRICT_CHECK_ON_TC_CREATION = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.INTEROP_STRICT_CHECK_ON_TC_CREATION, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -274,6 +305,7 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition SECURITY_SUPPORT_SSL = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.SECURITY_SUPPORT_SSL, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -285,48 +317,38 @@ class JacORBSubsystemDefinitions {
     public static final SimpleAttributeDefinition SECURITY_ADD_COMPONENT_INTERCEPTOR = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.SECURITY_ADD_COMP_VIA_INTERCEPTOR, ModelType.STRING, true)
             .setDefaultValue(DEFAULT_ENABLED_PROPERTY)
+            .setValidator(ON_OFF_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition SECURITY_CLIENT_SUPPORTS = new SimpleAttributeDefinitionBuilder(
-            JacORBSubsystemConstants.SECURITY_CLIENT_SUPPORTS, ModelType.INT, true)
-            .setDefaultValue(new ModelNode().set(60))
-            .setValidator(new IntRangeValidator(0, 60, true, false))
+            JacORBSubsystemConstants.SECURITY_CLIENT_SUPPORTS, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode().set("MutualAuth"))
+            .setValidator(SSL_CONFIG_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition SECURITY_CLIENT_REQUIRES = new SimpleAttributeDefinitionBuilder(
-            JacORBSubsystemConstants.SECURITY_CLIENT_REQUIRES, ModelType.INT, true)
-            .setDefaultValue(new ModelNode().set(0))
-            .setValidator(new IntRangeValidator(0, 60, true, false))
+            JacORBSubsystemConstants.SECURITY_CLIENT_REQUIRES, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode().set("None"))
+            .setValidator(SSL_CONFIG_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition SECURITY_SERVER_SUPPORTS = new SimpleAttributeDefinitionBuilder(
-            JacORBSubsystemConstants.SECURITY_SERVER_SUPPORTS, ModelType.INT, true)
-            .setDefaultValue(new ModelNode().set(60))
-            .setValidator(new IntRangeValidator(0, 60, true, false))
+            JacORBSubsystemConstants.SECURITY_SERVER_SUPPORTS, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode().set("MutualAuth"))
+            .setValidator(SSL_CONFIG_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
     public static final SimpleAttributeDefinition SECURITY_SERVER_REQUIRES = new SimpleAttributeDefinitionBuilder(
-            JacORBSubsystemConstants.SECURITY_SERVER_REQUIRES, ModelType.INT, true)
-            .setDefaultValue(new ModelNode().set(0))
-            .setValidator(new IntRangeValidator(0, 60, true, false))
+            JacORBSubsystemConstants.SECURITY_SERVER_REQUIRES, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode().set("None"))
+            .setValidator(SSL_CONFIG_VALIDATOR)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
-    public static final SimpleAttributeDefinition SECURITY_USE_DOMAIN_SF = new SimpleAttributeDefinitionBuilder(
-            JacORBSubsystemConstants.SECURITY_USE_DOMAIN_SF, ModelType.STRING, true)
-            .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .build();
-
-    public static final SimpleAttributeDefinition SECURITY_USE_DOMAIN_SSF = new SimpleAttributeDefinitionBuilder(
-            JacORBSubsystemConstants.SECURITY_USE_DOMAIN_SSF, ModelType.STRING, true)
-            .setDefaultValue(DEFAULT_DISABLED_PROPERTY)
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .build();
     public static final PropertiesAttributeDefinition PROPERTIES =
             new PropertiesAttributeDefinition(JacORBSubsystemConstants.PROPERTIES,
                     JacORBSubsystemConstants.PROPERTIES, true);
@@ -364,8 +386,10 @@ class JacORBSubsystemDefinitions {
     // list that contains the security attribute definitions.
     static final List<SimpleAttributeDefinition> SECURITY_ATTRIBUTES = Arrays.asList(SECURITY_SUPPORT_SSL,
             SECURITY_SECURITY_DOMAIN, SECURITY_ADD_COMPONENT_INTERCEPTOR, SECURITY_CLIENT_SUPPORTS,
-            SECURITY_CLIENT_REQUIRES, SECURITY_SERVER_SUPPORTS, SECURITY_SERVER_REQUIRES, SECURITY_USE_DOMAIN_SF,
-            SECURITY_USE_DOMAIN_SSF);
+            SECURITY_CLIENT_REQUIRES, SECURITY_SERVER_SUPPORTS, SECURITY_SERVER_REQUIRES);
+
+    static final List<SimpleAttributeDefinition> SSL_CONFIG_ATTRIBUTES = Arrays.asList(SECURITY_CLIENT_SUPPORTS,
+            SECURITY_CLIENT_REQUIRES, SECURITY_SERVER_SUPPORTS, SECURITY_SERVER_REQUIRES);
 
     // list that contains all attribute definitions.
     static final List<AttributeDefinition> SUBSYSTEM_ATTRIBUTES;
@@ -386,7 +410,9 @@ class JacORBSubsystemDefinitions {
         SUBSYSTEM_ATTRIBUTES.add(PROPERTIES);
 
         Map<String, AttributeDefinition> map = new HashMap<String, AttributeDefinition>();
-        for (AttributeDefinition attribute : SUBSYSTEM_ATTRIBUTES) { map.put(attribute.getName(), attribute); }
+        for (AttributeDefinition attribute : SUBSYSTEM_ATTRIBUTES) {
+            map.put(attribute.getName(), attribute);
+        }
         ATTRIBUTES_BY_NAME = map;
     }
 

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemResource.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemResource.java
@@ -1,5 +1,10 @@
 package org.jboss.as.jacorb;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+
+import java.util.EnumSet;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
@@ -10,14 +15,8 @@ import org.jboss.as.controller.descriptions.DefaultResourceRemoveDescriptionProv
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-
-import java.util.EnumSet;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 
 /**
  * @author Tomaz Cerar

--- a/jacorb/src/main/java/org/jboss/as/jacorb/SSLConfigValue.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/SSLConfigValue.java
@@ -1,0 +1,63 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat, Inc., and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+
+package org.jboss.as.jacorb;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>
+ * Enumeration of the SSL configuration values. Each enum contains the corresponding JacORB value, which is represented
+ * as an int.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+enum SSLConfigValue {
+
+    NONE("0"), SERVERAUTH("20"), CLIENTAUTH("40"), MUTUALAUTH("60");
+
+    private String jacorbValue;
+
+    SSLConfigValue(String jacorbValue) {
+        this.jacorbValue = jacorbValue;
+    }
+
+    public String getJacorbValue() {
+        return this.jacorbValue;
+    }
+
+    private static Map<String, SSLConfigValue> MAP;
+
+    static {
+        final Map<String, SSLConfigValue> map = new HashMap<String, SSLConfigValue>();
+        for (SSLConfigValue configValue : values()) {
+            map.put(configValue.getJacorbValue(), configValue);
+        }
+        MAP = map;
+    }
+
+    public static SSLConfigValue fromValue(String value) {
+        return MAP.get(value);
+    }
+}

--- a/jacorb/src/main/resources/org/jboss/as/jacorb/LocalDescriptions.properties
+++ b/jacorb/src/main/resources/org/jboss/as/jacorb/LocalDescriptions.properties
@@ -1,109 +1,62 @@
 jacorb=The JacORB subsystem configuration.
 jacorb.add=Adds the JacORB subsystem.
 jacorb.remove=Removes the JacORB subsystem.
-jacorb.transactions=Indicates whether the transactions interceptors are to be installed (on) or not (off).
-jacorb.support-ssl=Does it support SSL
-jacorb.pool-size=Pool size
-jacorb.cache-poa-names=Cache POA names
-jacorb.add-component-via-interceptor=Add component via interceptor
-jacorb.max-managed-buf-size=Max managed buffer size
-jacorb.client-timeout=Client timeout
-jacorb.server-timeout=Server timeout
-jacorb.server-supports=Server supports
-jacorb.client-supports=Client supports
-jacorb.client-requires=Client requires
-jacorb.queue-wait=Queue wait
-jacorb.giop-minor-version=GIOP minor version
-jacorb.monitoring=Monitoring enabled?
-jacorb.use-domain-server-socket-factory=Use domain server socket factory
-jacorb.use-domain-socket-factory=Use domain socket factory
-jacorb.server-requires=Server requires
-jacorb.properties=Properties
-jacorb.root-context=Root context
-jacorb.comet=Use comet
-jacorb.max-server-connections=Maximum server connections
-jacorb.iona=Iona
-jacorb.chunk-custom-rmi-valuetypes=Chunk custom rmi value types
-jacorb.queue-max=Max queue size
-jacorb.queue-min=Min queue size
-jacorb.print-version=Print version?
-jacorb.security=Security
-jacorb.sun=Sun
-jacorb.lax-boolean-encoding=Lax boolean ending
-jacorb.strict-check-on-tc-creation=Strict check on tc creation
-jacorb.use-imr=Use IMR
-jacorb.use-bom=Use BOM
-jacorb.name=JacORB
-jacorb.max-threads=Max threads
-jacorb.cache-typecodes=Cache typecodes
-jacorb.indirection-encoding-disable=Indirection encoding disable
-jacorb.retry-interval=Retry interval
-jacorb.retries=Retries
-jacorb.outbuf-cache-timeout=Out buffer cache timeout
-jacorb.outbuf-size=Out buffer size
-jacorb.security-domain=Security domain
-jacorb.export-corbaloc=Export corba location
 
 # orb configuration properties.
-orb.name=The name of the running ORB.
-orb.print-version=Indicates whether the version number should be printed during ORB startup (on) or not (off).
-orb.use-imr=Indicates whether the implementation repository should be used (on) or not (off).
-orb.use-bom=Indicates whether GIOP 1.2 byte order markers should be used (on) or not (off).
-orb.cache-typecodes=Indicates whether typecodes should be cached (on) or not (off).
-orb.cache-poa-names=Indicates whether POA names should be cached (on) or not (off).
-orb.giop-minor-version=The GIOP minor version to be used.
+jacorb.name=The name of the running ORB.
+jacorb.print-version=Indicates whether the version number should be printed during ORB startup (on) or not (off).
+jacorb.use-imr=Indicates whether the implementation repository should be used (on) or not (off).
+jacorb.use-bom=Indicates whether GIOP 1.2 byte order markers should be used (on) or not (off).
+jacorb.cache-typecodes=Indicates whether typecodes should be cached (on) or not (off).
+jacorb.cache-poa-names=Indicates whether POA names should be cached (on) or not (off).
+jacorb.giop-minor-version=The GIOP minor version to be used.
 
 # orb connection configuration properties.
-orb.conn.retries=The number of retries if connections cannot be promptly established.
-orb.conn.retry-interval=The interval in milliseconds between retries.
-orb.conn.client-timeout=The client-side connection timeout value in milliseconds. A value of zero indicates that the connection never times out.
-orb.conn.server-timeout=The server-side connection timeout value in milliseconds. A value of zero indicates that the connection never times out.
-orb.conn.max-server-connections=The maximum number of connections accepted by the server.
-orb.conn.max-managed-buf-size=The log2 of maximum size managed by the internal buffer manager.
-orb.conn.outbuf-size=The size of the network buffers for outgoing messages.
-orb.conn.outbuf-cache-timeout=The buffer cache timeout in milliseconds.
+jacorb.retries=The number of retries if connections cannot be promptly established.
+jacorb.retry-interval=The interval in milliseconds between retries.
+jacorb.client-timeout=The client-side connection timeout value in milliseconds. A value of zero indicates that the connection never times out.
+jacorb.server-timeout=The server-side connection timeout value in milliseconds. A value of zero indicates that the connection never times out.
+jacorb.max-server-connections=The maximum number of connections accepted by the server.
+jacorb.max-managed-buf-size=The log2 of maximum size managed by the internal buffer manager.
+jacorb.outbuf-size=The size of the network buffers for outgoing messages.
+jacorb.outbuf-cache-timeout=The buffer cache timeout in milliseconds.
 
 # orb initializers configuration properties.
-orb.init.codebase=Indicates whether the codebase interceptor is to be installed (on) or not (off).
-orb.init.security=Indicates whether the security interceptors are to be installed (on) or not (off).
-orb.init.transactions=Indicates whether the transactions interceptors are to be installed (on) or not (off).
+jacorb.security=Indicates whether the security interceptors are to be installed (on) or not (off).
+jacorb.transactions=Indicates whether the transactions interceptors are to be installed (on) or not (off).
 
 
 # poa configuration properties.
-poa.monitoring=Indicates whether the monitoring GUI should be displayed (on) or not (off).
-poa.queue-wait=Indicates whether requests that exceed the maximum queue size should wait (on) or not (off). When disabled, a TRANSIENT exception is thrown if the queue is full.
-poa.queue-min=The size of the queue for notifying waiting requests. In other words, blocked requests are only notified when the queue has no more than queue-min requests.
-poa.queue-max=The maximum number of requests that can be queued.
+jacorb.monitoring=Indicates whether the monitoring GUI should be displayed (on) or not (off).
+jacorb.queue-wait=Indicates whether requests that exceed the maximum queue size should wait (on) or not (off). When disabled, a TRANSIENT exception is thrown if the queue is full.
+jacorb.queue-min=The size of the queue for notifying waiting requests. In other words, blocked requests are only notified when the queue has no more than queue-min requests.
+jacorb.queue-max=The maximum number of requests that can be queued.
 
 # poa request-processors configuration properties.
-poa.request-processors.pool-size=The size of the request processors thread-pool. Threads that finish processing a request are placed back in the pool if the pool is not full and discarded otherwise.
-poa.request-processors.max-threads=The maximum number of active request processor threads. Threads are first obtained from the pool and once the pool is exhausted new threads are created until the number of threads reaches this limit. New requests will wait until an active thread finishes its job.
+jacorb.pool-size=The size of the request processors thread-pool. Threads that finish processing a request are placed back in the pool if the pool is not full and discarded otherwise.
+jacorb.max-threads=The maximum number of active request processor threads. Threads are first obtained from the pool and once the pool is exhausted new threads are created until the number of threads reaches this limit. New requests will wait until an active thread finishes its job.
 
 # naming configuration properties.
-naming.root-context=The naming service root context.
-naming.export-corbaloc=Indicates whether the root context should be exported as corbaloc::address:port/NameService (on) or not (off).
+jacorb.root-context=The naming service root context.
+jacorb.export-corbaloc=Indicates whether the root context should be exported as corbaloc::address:port/NameService (on) or not (off).
 
 # interop configuration properties.
-interop.sun=Indicates whether interoperability with Sun's ORB is enabled (on) or not (off).
-interop.comet=Indicates whether interoperability with Comet's ORB is enabled (on) or not (off).
-interop.iona=Indicates whether interoperability with IONA's ASP is enabled (on) or not (off).
-interop.chunk-custom-rmi-valuetypes=Indicates whether custom RMI valuetypes should be encoded as chunks (on) or not (off).
-interop.lax-boolean-encoding=Indicates whether any non-zero CDR encoded boolean value should be interpreted as true (on) or not (off).
-interop.indirection-encoding-disable=Indicates whether indirection encoding for repeated typecodes should be disabled (on) or not (off).
-interop.strict-check-on-tc-creation=Indicates whether the method create_abstract_interface_tc should perform a validation check on the name parameter (on) or not (off).
+jacorb.sun=Indicates whether interoperability with Sun's ORB is enabled (on) or not (off).
+jacorb.comet=Indicates whether interoperability with Comet's ORB is enabled (on) or not (off).
+jacorb.iona=Indicates whether interoperability with IONA's ASP is enabled (on) or not (off).
+jacorb.chunk-custom-rmi-valuetypes=Indicates whether custom RMI valuetypes should be encoded as chunks (on) or not (off).
+jacorb.lax-boolean-encoding=Indicates whether any non-zero CDR encoded boolean value should be interpreted as true (on) or not (off).
+jacorb.indirection-encoding-disable=Indicates whether indirection encoding for repeated typecodes should be disabled (on) or not (off).
+jacorb.strict-check-on-tc-creation=Indicates whether the method create_abstract_interface_tc should perform a validation check on the name parameter (on) or not (off).
 
 # security configuration properties.
-security.support-ssl=Indicates whether SSL is to be supported (on) or not (off).
-security.security-domain=The name of the security domain that holds the key and trust stores that will be used to establish SSL connections.
-security.add-component-via-interceptor=Indicates whether SSL components should be added by an IOR interceptor (on) or not (off).
-security.client-supports=Value that indicates the client SSL supported parameters (EstablishTrustInTarget=20,EstablishTrustInClient=40,MutualAuth=60).
-security.client-requires=Value that indicates the client SSL required parameters (EstablishTrustInTarget=20,EstablishTrustInClient=40,MutualAuth=60).
-security.server-supports=Value that indicates the server SSL supported parameters (EstablishTrustInTarget=20,EstablishTrustInClient=40,MutualAuth=60).
-security.server-requires=Value that indicates the server SSL required parameters (EstablishTrustInTarget=20,EstablishTrustInClient=40,MutualAuth=60).
-security.use-domain-socket-factory=Indicates whether the JBoss domain socket factory should be used (on) or not (off).
-security.use-domain-server-socket-factory=Indicates whether the JBoss domain server socket factory should be used (on) or not (off).
+jacorb.support-ssl=Indicates whether SSL is to be supported (on) or not (off).
+jacorb.security-domain=The name of the security domain that holds the key and trust stores that will be used to establish SSL connections.
+jacorb.add-component-via-interceptor=Indicates whether SSL components should be added by an IOR interceptor (on) or not (off).
+jacorb.client-supports=Value that indicates the client SSL supported parameters (None, ServerAuth, ClientAuth, MutualAuth).
+jacorb.client-requires=Value that indicates the client SSL required parameters (None, ServerAuth, ClientAuth, MutualAuth).
+jacorb.server-supports=Value that indicates the server SSL supported parameters (None, ServerAuth, ClientAuth, MutualAuth).
+jacorb.server-requires=Value that indicates the server SSL required parameters (None, ServerAuth, ClientAuth, MutualAuth).
 
 # generic properties.
-properties=A list of generic key/value properties.
-properties.name=The name (key) of the property.
-properties.value=The value of the property.
+jacorb.properties=A list of generic key/value properties.

--- a/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
+++ b/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
@@ -66,7 +66,7 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
         "        <connection retries=\"5\" retry-interval=\"500\" client-timeout=\"0\" server-timeout=\"0\" " +
         "            max-server-connections=\"500\" max-managed-buf-size=\"24\" outbuf-size=\"2048\" " +
         "            outbuf-cache-timeout=\"-1\"/>" +
-        "        <initializers security=\"on\" transactions=\"on\"/>" +
+        "        <initializers security=\"on\" transactions=\"spec\"/>" +
         "    </orb>" +
         "    <poa monitoring=\"off\" queue-wait=\"on\" queue-min=\"10\" queue-max=\"100\">" +
         "        <request-processors pool-size=\"10\" max-threads=\"32\"/>" +
@@ -74,9 +74,8 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
         "    <naming root-context=\"JBoss/Naming/root\" export-corbaloc=\"on\"/>" +
         "    <interop sun=\"on\" comet=\"off\" iona=\"off\" chunk-custom-rmi-valuetypes=\"on\" " +
         "        lax-boolean-encoding=\"off\" indirection-encoding-disable=\"off\" strict-check-on-tc-creation=\"off\"/>" +
-        "    <security support-ssl=\"off\" add-component-via-interceptor=\"on\" client-supports=\"60\"" +
-        "        client-requires=\"0\" server-supports=\"60\" server-requires=\"0\" use-domain-socket-factory=\"off\"" +
-        "        use-domain-server-socket-factory=\"off\"/>" +
+        "    <security support-ssl=\"off\" add-component-via-interceptor=\"on\" client-supports=\"mutualAuth\"" +
+        "        client-requires=\"none\" server-supports=\"mutualAuth\" server-requires=\"none\"/>" +
         "    <properties>" +
         "        <property name=\"some_property\" value=\"some_value\"/>" +
         "    </properties>" +
@@ -195,7 +194,8 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
         "        <request-processors pool-size=\"10\" max-threads=\"32\"/>" +
         "    </poa>" +
         "    <interop sun=\"on\" comet=\"off\" chunk-custom-rmi-valuetypes=\"on\"/>" +
-        "    <security support-ssl=\"off\" use-domain-socket-factory=\"off\" use-domain-server-socket-factory=\"off\"/>" +
+        "    <security support-ssl=\"off\" use-domain-socket-factory=\"off\" use-domain-server-socket-factory=\"off\"" +
+        "              client-supports=\"60\" client-requires=\"0\"/>" +
         "    <property key=\"a\" value=\"va\"/>" +
         "    <property key=\"b\" value=\"vb\"/>" +
         "    <initializers>security,transactions</initializers>" +


### PR DESCRIPTION
JacORB SSL config attributes are now available as a string enum (None, ServerAuth, ClientAuth, MutualAuth) instead of non-intuitive integers (0, 20, 40 and 60).
Added an EnumValidator to all attributes that have an specific list of allowed values.
Updated version 1.1 of the schema to use restriction where necessary and removed attributes that were never used by the subsystem. Subsystem parser has been updated as well so that subsystem configs that use the 1.0 schema don't fail if the user provides one of the removed attributes.
Fixed description messages and cleaned up commented out code from previous commit.
