### PR TITLE
AS7-2022  Testsuite code coverage reporting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
 
         <!-- Non-default plugin versions and configuration -->
         <version.javacc.plugin>2.5</version.javacc.plugin>
+        <version.jacoco.plugin>0.5.5.201112152213</version.jacoco.plugin> <!-- Needs to be set explicitely to match with org.jacoco:org.jacoco.ant - see testsuite. -->
 
         <!-- Surefire args -->
         <surefire.jpda.args/>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -221,7 +221,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
                     
                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -643,7 +643,8 @@
                                             <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar"/>
                                         </taskdef>
                                         -->
-                                        
+                                        <echo>Creating JaCoCo test coverage reports...</echo>
+                                        <mkdir dir="${basedir}/target/coverage-report"/>
                                         <report>
                                             <executiondata>
                                                 <fileset dir="${basedir}">
@@ -672,7 +673,9 @@
                                                     </fileset>
                                                 </sourcefiles>
                                             </structure>
-                                            <html destdir="${basedir}/target/coverage-report"/>
+                                            <html destdir ="${basedir}/target/coverage-report/html"/>
+                                            <xml  destfile="${basedir}/target/coverage-report/coverage-report.xml"/>
+                                            <csv  destfile="${basedir}/target/coverage-report/coverage-report.csv"/>
                                         </report>                                        
                                     </target>
                                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -107,7 +107,7 @@
         
         <!-- JaCoCo - Code coverage (-Dcoverage). -->
         <!--jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/tools/jacoco/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>-->
-        <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/target/jacoco-jars/agent/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>
+        <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/target/jacoco-jars/agent/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=*,excludes=org.jboss.as.test.*,append=true,output=file</jvm.args.jacoco>
         
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.ratio.fsio>100</timeout.ratio.fsio>
@@ -557,12 +557,12 @@
                                 <configuration>
                                     <append>true</append>
                                     <destFile>target/jacoco.exec</destFile>
-                                    <!--
                                     <includes>
-                                        <include>${jboss.home}/modules/**/*</include>
+                                        <include>*</include>
                                     </includes>
+                                    <!--
                                     <excludes>
-                                        <exclude>${basedir}/target/classes/**/*</exclude>
+                                        <exclude>org.jboss.as.test.*</exclude>
                                     </excludes>
                                     -->
                                     <output>file</output>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -548,7 +548,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.5.5.201112152213</version>
+                        <version>${version.jacoco.plugin}</version>
                         <executions>
                             <execution><id>ts.jacoco-prepare</id>
                                 <phase>process-test-classes</phase>
@@ -568,8 +568,9 @@
                                     <propertyName>jvm.args.jacoco</propertyName>
                                 </configuration>
                             </execution>
+                            <!-- Doesn't work currently - waiting for JaCoCo to fix this. -->
                             <execution><id>ts.jacoco.report</id>
-                                <phase>post-integration-test</phase>
+                                <phase>none</phase> <!-- post-integration-test -->
                                 <goals><goal>report</goal></goals>
                                 <configuration>
                                     <dataFile>target/jacoco.exec</dataFile>
@@ -578,11 +579,35 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- DEBUG -->
+                    <!-- Copy JaCoCo jars to have them for the Ant plugin. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution><id>ts.jacoco.dep</id>
+                                <inherited>false</inherited>
+                                <goals><goal>copy</goal></goals>
+                                <phase>process-test-resources</phase>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.jacoco</groupId>
+                                            <artifactId>org.jacoco.ant</artifactId>
+                                            <version>${version.jacoco.plugin}</version>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <outputDirectory>${basedir}/target/jacoco-jars</outputDirectory>
+                                    <stripVersion>true</stripVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Ant plugin. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
+                            <!-- DEBUG -->
                             <execution>
                                 <id>ts.jacoco.debug</id>
                                 <phase>post-integration-test</phase>
@@ -590,11 +615,61 @@
                                 <inherited>false</inherited>
                                 <configuration>
                                     <target>
-                                        <echo>${jvm.args.jacoco}</echo>
+                                        <echo>Jacoco argline: ${jvm.args.jacoco}</echo>
+                                        <echo>Jacoco jar: ${basedir}/target/jacoco-jars/org.jacoco.ant.jar</echo>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <!-- Must be run using Ant due to https://sourceforge.net/tracker/?func=detail&aid=3474708&group_id=177969&atid=883354 -->
+                            <execution>
+                                <id>ts.jacoco.report-ant</id>
+                                <phase>post-integration-test</phase>
+                                <goals><goal>run</goal></goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <!--
+                                    <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
+                                        <classpath path=""/>
+                                    </taskdef>
+                                    -->
+                                    <target>
+                                        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="${maven.plugin.classpath}">
+                                            <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar">
+                                                <!--<path location="${basedir}/target/jacoco-jars/org.jacoco.ant.jar"/>-->
+                                            </classpath>
+                                        </taskdef>
+                                        
+                                        <jacoco:report>
+                                            <executiondata>
+                                                <file file="${basedir}/target/jacoco.exec"/>
+                                            </executiondata>
+                                            <structure name="AS 7 project">
+                                                <classfiles>
+                                                    <fileset dir="${jboss.dist}">
+                                                        <include name="**/*.class"/>
+                                                        <include name="**/*.jar"/>
+                                                    </fileset>
+                                                </classfiles>
+                                                <sourcefiles encoding="UTF-8">
+                                                    <fileset dir="${jbossas.project.dir}">
+                                                        <include name="**/*.java"/>
+                                                        <exclude name="testsuite/**/*.java"/>
+                                                    </fileset>
+                                                </sourcefiles>
+                                            </structure>
+                                            <html destdir="report"/>
+                                        </jacoco:report>                                        
                                     </target>
                                 </configuration>
                             </execution>
                         </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.ant</artifactId>
+                                <version>${version.jacoco.plugin}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -79,6 +79,12 @@
         <!-- This value is overridden in modules with the correct relative pathname. -->
         <jboss.dist>${project.basedir}/../build/target/jboss-as-${jboss.as.release.version}</jboss.dist>
         <jboss.home>${jboss.dist}</jboss.home>
+        
+        <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
+        <jbossas.ts.dir>${basedir}</jbossas.ts.dir>
+        <!-- This project's root dir. -->
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir> <!-- TODO: Remove from submodules (is inherited). -->
+        
 
         <!-- Used to provide an absolute location for the XSLT scripts. -->
         <!-- This value is overridden in modules with the correct relative pathname. -->
@@ -100,7 +106,7 @@
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
         
         <!-- JaCoCo - Code coverage (-Dcoverage). -->
-        <jvm.args.jacoco></jvm.args.jacoco>
+        <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/tools/jacoco/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>
         
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.ratio.fsio>100</timeout.ratio.fsio>
@@ -550,12 +556,14 @@
                                 <configuration>
                                     <append>true</append>
                                     <destFile>target/jacoco.exec</destFile>
+                                    <!--
                                     <includes>
-                                        <include>org.jboss.as.*</include>
+                                        <include>${jboss.home}/modules/**/*</include>
                                     </includes>
                                     <excludes>
-                                        <exclude>org.jboss.as.test*</exclude>
+                                        <exclude>${basedir}/target/classes/**/*</exclude>
                                     </excludes>
+                                    -->
                                     <output>file</output>
                                     <propertyName>jvm.args.jacoco</propertyName>
                                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -560,11 +560,9 @@
                                     <includes>
                                         <include>*</include>
                                     </includes>
-                                    <!--
                                     <excludes>
                                         <exclude>org.jboss.as.test.*</exclude>
                                     </excludes>
-                                    -->
                                     <output>file</output>
                                     <propertyName>jvm.args.jacoco</propertyName>
                                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -99,6 +99,9 @@
         <jvm.args.securityPolicy></jvm.args.securityPolicy>
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
         
+        <!-- JaCoCo - Code coverage (-Dcoverage). -->
+        <jvm.args.jacoco></jvm.args.jacoco>
+        
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.ratio.fsio>100</timeout.ratio.fsio>
         <timeout.ratio.netio>100</timeout.ratio.netio>
@@ -372,7 +375,7 @@
                     <testFailureIgnore>${surefire.test.failure.ignore}</testFailureIgnore>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <systemPropertyVariables>
-                        <jboss.options>${surefire.system.args}</jboss.options>
+                        <jboss.options>${surefire.system.args} ${jvm.args.jacoco}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.dist>${jboss.dist}</jboss.dist>
                         <jboss.home>${basedir}/target/jbossas</jboss.home>
@@ -528,6 +531,67 @@
                 <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
+        
+
+        <!-- JaCoCo test coverage. Will set ${jvm.args.jacoco} to be used in Arquillian config. -->
+        <profile>
+            <id>ts.jacoco.profile</id>
+            <activation><property><name>coverage</name></property></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.5.5.201112152213</version>
+                        <executions>
+                            <execution><id>ts.jacoco-prepare</id>
+                                <phase>process-test-classes</phase>
+                                <goals><goal>prepare-agent</goal></goals>
+                                <configuration>
+                                    <append>true</append>
+                                    <destFile>target/jacoco.exec</destFile>
+                                    <includes>
+                                        <include>org.jboss.as.*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>org.jboss.as.test*</exclude>
+                                    </excludes>
+                                    <output>file</output>
+                                    <propertyName>jvm.args.jacoco</propertyName>
+                                </configuration>
+                            </execution>
+                            <execution><id>ts.jacoco.report</id>
+                                <phase>post-integration-test</phase>
+                                <goals><goal>report</goal></goals>
+                                <configuration>
+                                    <dataFile>target/jacoco.exec</dataFile>
+                                    <outputDirectory>target/coverageReport</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- DEBUG -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>ts.jacoco.debug</id>
+                                <phase>post-integration-test</phase>
+                                <goals><goal>run</goal></goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <target>
+                                        <echo>${jvm.args.jacoco}</echo>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
 
 
         <!-- IPv6. AS7-2228. -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -106,8 +106,7 @@
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
         
         <!-- JaCoCo - Code coverage (-Dcoverage). -->
-        <!--jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/tools/jacoco/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>-->
-        <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/target/jacoco-jars/agent/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=*,excludes=org.jboss.as.test.*,append=true,output=file</jvm.args.jacoco>
+        <jvm.args.jacoco></jvm.args.jacoco>
         
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.ratio.fsio>100</timeout.ratio.fsio>
@@ -544,6 +543,9 @@
         <profile>
             <id>ts.jacoco.profile</id>
             <activation><property><name>coverage</name></property></activation>
+            <properties>
+                <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/target/jacoco-jars/agent/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=*,excludes=org.jboss.as.test.*,append=true,output=file</jvm.args.jacoco>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -646,13 +646,23 @@
                                         
                                         <report>
                                             <executiondata>
-                                                <file file="${basedir}/target/jacoco.exec"/>
+                                                <fileset dir="${basedir}">
+                                                    <include name="**/target/jacoco.exec"/>
+                                                </fileset>
                                             </executiondata>
                                             <structure name="AS 7 project">
                                                 <classfiles>
-                                                    <fileset dir="${jboss.dist}">
-                                                        <include name="**/*.class"/>
+                                                    <fileset dir="${jboss.dist}/modules">
                                                         <include name="**/*.jar"/>
+                                                        <!-- We have 2.x in main. -->
+                                                        <exclude name="com/sun/jsf-impl/1.*/**/*"/>
+                                                        <!--  AS7-3383 - com/sun/codemodel vs. /1.0/com/sun/codemodel -->
+                                                        <exclude name="com/sun/xml/**/*"/>
+                                                        <exclude name="javax/faces/api/1.2/**/*"/>
+                                                        <!-- AS7-3390 -->
+                                                        <exclude name="org/apache/commons/beanutils/**/*"/>
+                                                        <!-- AS7-3389 -->
+                                                        <exclude name="org/python/jython/standalone/**/*"/>
                                                     </fileset>
                                                 </classfiles>
                                                 <sourcefiles encoding="UTF-8">
@@ -662,7 +672,7 @@
                                                     </fileset>
                                                 </sourcefiles>
                                             </structure>
-                                            <html destdir="report"/>
+                                            <html destdir="${basedir}/target/coverage-report"/>
                                         </report>                                        
                                     </target>
                                 </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -568,7 +568,7 @@
                                     <propertyName>jvm.args.jacoco</propertyName>
                                 </configuration>
                             </execution>
-                            <!-- Doesn't work currently - waiting for JaCoCo to fix this. -->
+                            <!-- Doesn't work currently - waiting for JaCoCo to fix this. Moved to the Ant plugin execution. -->
                             <execution><id>ts.jacoco.report</id>
                                 <phase>none</phase> <!-- post-integration-test -->
                                 <goals><goal>report</goal></goals>
@@ -623,23 +623,21 @@
                             <!-- Must be run using Ant due to https://sourceforge.net/tracker/?func=detail&aid=3474708&group_id=177969&atid=883354 -->
                             <execution>
                                 <id>ts.jacoco.report-ant</id>
-                                <phase>post-integration-test</phase>
+                                <phase>site</phase> <!-- post-integration-test -->
                                 <goals><goal>run</goal></goals>
                                 <inherited>false</inherited>
                                 <configuration>
-                                    <!--
-                                    <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
-                                        <classpath path=""/>
-                                    </taskdef>
-                                    -->
                                     <target>
-                                        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="${maven.plugin.classpath}">
-                                            <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar">
-                                                <!--<path location="${basedir}/target/jacoco-jars/org.jacoco.ant.jar"/>-->
-                                            </classpath>
+                                        <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                            <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar"/>
                                         </taskdef>
+                                        <!--
+                                        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="maven.plugin.classpath">
+                                            <classpath path="${basedir}/target/jacoco-jars/org.jacoco.ant.jar"/>
+                                        </taskdef>
+                                        -->
                                         
-                                        <jacoco:report>
+                                        <report>
                                             <executiondata>
                                                 <file file="${basedir}/target/jacoco.exec"/>
                                             </executiondata>
@@ -658,7 +656,7 @@
                                                 </sourcefiles>
                                             </structure>
                                             <html destdir="report"/>
-                                        </jacoco:report>                                        
+                                        </report>                                        
                                     </target>
                                 </configuration>
                             </execution>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -106,7 +106,8 @@
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
         
         <!-- JaCoCo - Code coverage (-Dcoverage). -->
-        <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/tools/jacoco/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>
+        <!--jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/tools/jacoco/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>-->
+        <jvm.args.jacoco>-javaagent:${jbossas.ts.dir}/target/jacoco-jars/agent/jacocoagent.jar=destfile=${basedir}/target/jacoco.exec,includes=${jboss.home}/modules/**/*,excludes=${basedir}/target/classes/**/*,append=true,output=file</jvm.args.jacoco>
         
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.ratio.fsio>100</timeout.ratio.fsio>
@@ -584,22 +585,28 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
-                            <execution><id>ts.jacoco.dep</id>
-                                <inherited>false</inherited>
-                                <goals><goal>copy</goal></goals>
-                                <phase>process-test-resources</phase>
+                            <!-- Copy the ant tasks jar. Needed for ts.jacoco.report-ant . -->
+                            <execution> <id>ts.jacoco.dep.ant</id> <goals><goal>copy</goal></goals> <phase>process-test-resources</phase> <inherited>false</inherited>
                                 <configuration>
                                     <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.jacoco</groupId>
-                                            <artifactId>org.jacoco.ant</artifactId>
-                                            <version>${version.jacoco.plugin}</version>
-                                        </artifactItem>
+                                        <artifactItem><groupId>org.jacoco</groupId><artifactId>org.jacoco.ant</artifactId><version>${version.jacoco.plugin}</version></artifactItem>
                                     </artifactItems>
-                                    <outputDirectory>${basedir}/target/jacoco-jars</outputDirectory>
                                     <stripVersion>true</stripVersion>
+                                    <outputDirectory>${basedir}/target/jacoco-jars</outputDirectory>
                                 </configuration>
                             </execution>
+                            <!-- Copy the agent jar. Needed for ${jvm.args.jacoco} to have this jar on known path.
+                                 If the ts.jacoco-prepare worked and really put the value into the property, this might go away. -->
+                            <execution> <id>ts.jacoco.dep.agent</id> <goals><goal>unpack</goal></goals> <phase>process-test-resources</phase> <inherited>false</inherited>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem><groupId>org.jacoco</groupId><artifactId>org.jacoco.agent</artifactId><version>${version.jacoco.plugin}</version></artifactItem>
+                                    </artifactItems>
+                                    <stripVersion>true</stripVersion>
+                                    <outputDirectory>${basedir}/target/jacoco-jars/agent</outputDirectory>
+                                </configuration>
+                            </execution>
+
                         </executions>
                     </plugin>
                     <!-- Ant plugin. -->

--- a/testsuite/tools/jacoco/help.txt
+++ b/testsuite/tools/jacoco/help.txt
@@ -1,0 +1,166 @@
+
+Name: JaCoCo :: Maven Plugin
+Description: The JaCoCo Maven Plugin provides the JaCoCo runtime agent to
+  your tests and allows basic report creation.
+Group Id: org.jacoco
+Artifact Id: jacoco-maven-plugin
+Version: 0.5.5.201112152213
+Goal Prefix: jacoco
+
+This plugin has 3 goals:
+
+jacoco:help
+  Description: Display help information on jacoco-maven-plugin.
+    Call
+      mvn jacoco:help -Ddetail=true -Dgoal=<goal-name>
+    to display parameter details.
+  Implementation: org.jacoco.maven.HelpMojo
+  Language: java
+
+  Available parameters:
+
+    detail (Default: false)
+      Expression: ${detail}
+      If true, display all settable properties for each goal.
+
+    goal
+      Expression: ${goal}
+      The name of the goal for which to show help. If unspecified, all goals
+      will be displayed.
+
+    indentSize (Default: 2)
+      Expression: ${indentSize}
+      The number of spaces per indentation level, should be positive.
+
+    lineLength (Default: 80)
+      Expression: ${lineLength}
+      The maximum length of a display line, should be positive.
+
+
+jacoco:prepare-agent
+  Description: Prepares a property pointing to the JaCoCo runtime agent that
+    can be passed as a VM argument to the application under test. Depending on
+    the project packaging type by default a property with the following name is
+    set:
+    - tycho.testArgLine for packaging type eclipse-test-plugin and
+    - argLine otherwise.
+    Resulting coverage information is collected during execution and by default
+    written to a file when the process terminates.
+  Implementation: org.jacoco.maven.AgentMojo
+  Language: java
+  Bound to phase: initialize
+
+  Available parameters:
+
+    address
+      Expression: ${jacoco.address}
+      IP address or hostname to bind to when the output method is tcpserver or
+      connect to when the output method is tcpclient. In tcpserver mode the
+      value '*' causes the agent to accept connections on any local address.
+
+    append
+      Expression: ${jacoco.append}
+      If set to true and the execution data file already exists, coverage data
+      is appended to the existing file. If set to false, an existing execution
+      data file will be replaced.
+
+    destFile (Default: ${project.build.directory}/jacoco.exec)
+      Expression: ${jacoco.destFile}
+      Path to the output file for execution data.
+
+    dumpOnExit
+      Expression: ${jacoco.dumpOnExit}
+      If set to true coverage data will be written on VM shutdown.
+
+    exclClassLoaders
+      Expression: ${jacoco.exclClassLoaders}
+      A list of class loader names, that should be excluded from execution
+      analysis. The list entries are separated by a colon (:) and may use
+      wildcard characters (* and ?). This option might be required in case of
+      special frameworks that conflict with JaCoCo code instrumentation, in
+      particular class loaders that do not have access to the Java runtime
+      classes.
+
+    excludes
+      Expression: ${jacoco.excludes}
+      A list of class files to exclude from instrumentation/analysis/reports.
+      May use wildcard characters (* and ?).
+
+    includes
+      Expression: ${jacoco.includes}
+      A list of class files to include in instrumentation/analysis/reports. May
+      use wildcard characters (* and ?). When not specified - everything will
+      be included.
+
+    output
+      Expression: ${jacoco.output}
+      Output method to use for writing coverage data. Valid options are:
+      - file: At VM termination execution data is written to the file specified
+        in the destfile.
+      - tcpserver: The agent listens for incoming connections on the TCP port
+        specified by the address and port. Execution data is written to this
+        TCP connection.
+      - tcpclient: At startup the agent connects to the TCP port specified by
+        the address and port. Execution data is written to this TCP connection.
+      - mbean: The agent registers an JMX MBean under the name
+        org.jacoco:type=Runtime.
+
+    port
+      Expression: ${jacoco.port}
+      Port to bind to when the output method is tcpserver or connect to when
+      the output method is tcpclient. In tcpserver mode the port must be
+      available, which means that if multiple JaCoCo agents should run on the
+      same machine, different ports have to be specified.
+
+    propertyName
+      Expression: ${jacoco.propertyName}
+      Allows to specify property which will contains settings for JaCoCo Agent.
+      If not specified, then 'argLine' would be used for 'jar' packaging and
+      'tycho.testArgLine' for 'eclipse-test-plugin'.
+
+    sessionId
+      Expression: ${jacoco.sessionId}
+      A session identifier that is written with the execution data. Without
+      this parameter a random identifier is created by the agent.
+
+    skip (Default: false)
+      Expression: ${jacoco.skip}
+      Flag used to suppress execution.
+
+jacoco:report
+  Description: Creates a code coverage report for a single project in
+    multiple formats (HTML, XML, and CSV).
+  Implementation: org.jacoco.maven.ReportMojo
+  Language: java
+
+  Available parameters:
+
+    dataFile (Default: ${project.build.directory}/jacoco.exec)
+      File with execution data.
+
+    excludes
+      Expression: ${jacoco.excludes}
+      A list of class files to exclude from instrumentation/analysis/reports.
+      May use wildcard characters (* and ?).
+
+    includes
+      Expression: ${jacoco.includes}
+      A list of class files to include in instrumentation/analysis/reports. May
+      use wildcard characters (* and ?). When not specified - everything will
+      be included.
+
+    outputDirectory (Default: ${project.reporting.outputDirectory}/jacoco)
+      Output directory for the reports.
+
+    outputEncoding (Default: UTF-8)
+      Expression: ${project.reporting.outputEncoding}
+      Encoding of the generated reports.
+
+    skip (Default: false)
+      Expression: ${jacoco.skip}
+      Flag used to suppress execution.
+
+    sourceEncoding (Default: UTF-8)
+      Expression: ${project.build.sourceEncoding}
+      Encoding of the source files.
+

--- a/testsuite/tools/jacoco/prepare.sh
+++ b/testsuite/tools/jacoco/prepare.sh
@@ -10,19 +10,10 @@ SCRIPT_DIR=`readlink -f $DIRNAME`
 AS_DIR=`ls -d -1 $SCRIPT_DIR/../../../build/target/jboss-as-*` 
 
 
+##  -javaagent:/home/ondra/.m2/repository/org/jacoco/org.jacoco.agent/0.5.5.201112152213/org.jacoco.agent-0.5.5.201112152213-runtime.jar=destfile=${basedir}/target/jacoco.exec,append=true,includes=org.jboss.as.*,excludes=org.jboss.as.test*,output=file
+
+mkdir -p target
 #wget http://ignum.dl.sourceforge.net/project/eclemma/07_JaCoCo/trunk/jacoco-0.5.6.201201122002.zip -O jacoco.zip
-wget http://heanet.dl.sourceforge.net/project/eclemma/07_JaCoCo/0.5.5/jacoco-0.5.5.201112152213.zip -O jacoco.zip
-unzip -q jacoco.zip -d tmp-jacoco 
-
-##  Emma instrumentation.
-if [ $SUCC == 0 ] ; then
-  for i in `find $AS_DIR/modules/org/jboss/ -name '*.jar'`; do
-    echo "============  $i"
-    java -cp emma.jar emma instr -outmode overwrite -merge yes -instrpath $i;
-  done
-fi
-
-mkdir -p $AS_DIR/modules/com/vladium/emma/main
-cp emma.jar $AS_DIR/modules/com/vladium/emma/main/
-cp $SCRIPT_DIR/module.xml $AS_DIR/modules/com/vladium/emma/main/
- 
+wget http://heanet.dl.sourceforge.net/project/eclemma/07_JaCoCo/0.5.5/jacoco-0.5.5.201112152213.zip -O target/jacoco.zip
+unzip -q target/jacoco.zip -d target/jacoco-dist 
+#cp target/jacoco-dist/jacocoagent.jar 

--- a/testsuite/tools/jacoco/prepare.sh
+++ b/testsuite/tools/jacoco/prepare.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+#set -x
+
+##  This is testsuite/tools/jacoco/prepare.sh
+
+PROGNAME=`basename $0`
+DIRNAME=`dirname $0`
+SCRIPT_DIR=`readlink -f $DIRNAME`
+
+AS_DIR=`ls -d -1 $SCRIPT_DIR/../../../build/target/jboss-as-*` 
+
+
+#wget http://ignum.dl.sourceforge.net/project/eclemma/07_JaCoCo/trunk/jacoco-0.5.6.201201122002.zip -O jacoco.zip
+wget http://heanet.dl.sourceforge.net/project/eclemma/07_JaCoCo/0.5.5/jacoco-0.5.5.201112152213.zip -O jacoco.zip
+unzip -q jacoco.zip -d tmp-jacoco 
+
+##  Emma instrumentation.
+if [ $SUCC == 0 ] ; then
+  for i in `find $AS_DIR/modules/org/jboss/ -name '*.jar'`; do
+    echo "============  $i"
+    java -cp emma.jar emma instr -outmode overwrite -merge yes -instrpath $i;
+  done
+fi
+
+mkdir -p $AS_DIR/modules/com/vladium/emma/main
+cp emma.jar $AS_DIR/modules/com/vladium/emma/main/
+cp $SCRIPT_DIR/module.xml $AS_DIR/modules/com/vladium/emma/main/
+ 


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-2022

Adds an option -Dcoverage which causes Arq to start AS with JVM agent which captures execution paths and saves code coverate into a file. In the site phase, it creates a HTML, XML and CSV report.

Documented at https://docs.jboss.org/author/display/AS71/AS+7+Integration+Testsuite+User+Guide .
