### PR TITLE
Change JGroups subsystem model names PROTOCOL and PROPERTY to reflect their LIST nature

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsDescriptions.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsDescriptions.java
@@ -84,10 +84,10 @@ public class JGroupsDescriptions {
         ModelNode description = createProtocolStackOperationDescription(ModelDescriptionConstants.ADD, resources);
         description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.TRANSPORT, ModelDescriptionConstants.TYPE).set(ModelType.OBJECT);
         description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.TRANSPORT, ModelDescriptionConstants.DESCRIPTION).set(resources.getString("jgroups.stack.transport"));
-        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOL, ModelDescriptionConstants.TYPE).set(ModelType.LIST);
-        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOL, ModelDescriptionConstants.VALUE_TYPE).set(ModelType.OBJECT);
-        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOL, ModelDescriptionConstants.DESCRIPTION).set(resources.getString("jgroups.stack.protocol"));
-        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOL, ModelDescriptionConstants.REQUIRED).set(false);
+        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOLS, ModelDescriptionConstants.TYPE).set(ModelType.LIST);
+        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOLS, ModelDescriptionConstants.VALUE_TYPE).set(ModelType.OBJECT);
+        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOLS, ModelDescriptionConstants.DESCRIPTION).set(resources.getString("jgroups.stack.protocol"));
+        description.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelKeys.PROTOCOLS, ModelDescriptionConstants.REQUIRED).set(false);
         return description;
     }
 

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader_1_0.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader_1_0.java
@@ -134,7 +134,7 @@ public class JGroupsSubsystemXMLReader_1_0 implements XMLElementReader<List<Mode
             Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case PROTOCOL: {
-                    this.parseProtocol(reader, stack.get(ModelKeys.PROTOCOL).add(), Protocol.class);
+                    this.parseProtocol(reader, stack.get(ModelKeys.PROTOCOLS).add(), Protocol.class);
                     break;
                 }
                 default: {
@@ -221,7 +221,7 @@ public class JGroupsSubsystemXMLReader_1_0 implements XMLElementReader<List<Mode
                 throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.NAME));
             }
             String value = reader.getElementText();
-            protocol.get(ModelKeys.PROPERTY).add(property, value);
+            protocol.get(ModelKeys.PROPERTIES).add(property, value);
         }
     }
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader_1_1.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader_1_1.java
@@ -134,7 +134,7 @@ public class JGroupsSubsystemXMLReader_1_1 implements XMLElementReader<List<Mode
             Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case PROTOCOL: {
-                    this.parseProtocol(reader, stack.get(ModelKeys.PROTOCOL).add(), Protocol.class);
+                    this.parseProtocol(reader, stack.get(ModelKeys.PROTOCOLS).add(), Protocol.class);
                     break;
                 }
                 default: {
@@ -233,7 +233,7 @@ public class JGroupsSubsystemXMLReader_1_1 implements XMLElementReader<List<Mode
                 throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.NAME));
             }
             String value = reader.getElementText();
-            protocol.get(ModelKeys.PROPERTY).add(property, value);
+            protocol.get(ModelKeys.PROPERTIES).add(property, value);
         }
     }
 

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
@@ -51,8 +51,8 @@ public class JGroupsSubsystemXMLWriter implements XMLElementWriter<SubsystemMars
                 writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
                 ModelNode stack = property.getValue();
                 this.writeProtocol(writer, stack.get(ModelKeys.TRANSPORT), Element.TRANSPORT);
-                if (stack.hasDefined(ModelKeys.PROTOCOL)) {
-                    for (ModelNode protocol: stack.get(ModelKeys.PROTOCOL).asList()) {
+                if (stack.hasDefined(ModelKeys.PROTOCOLS)) {
+                    for (ModelNode protocol: stack.get(ModelKeys.PROTOCOLS).asList()) {
                         this.writeProtocol(writer, protocol, Element.PROTOCOL);
                     }
                 }
@@ -75,8 +75,8 @@ public class JGroupsSubsystemXMLWriter implements XMLElementWriter<SubsystemMars
         this.writeOptional(writer, Attribute.MACHINE, protocol, ModelKeys.MACHINE);
         this.writeOptional(writer, Attribute.RACK, protocol, ModelKeys.RACK);
         this.writeOptional(writer, Attribute.SITE, protocol, ModelKeys.SITE);
-        if (protocol.has(ModelKeys.PROPERTY)) {
-            for (Property property: protocol.get(ModelKeys.PROPERTY).asPropertyList()) {
+        if (protocol.has(ModelKeys.PROPERTIES)) {
+            for (Property property: protocol.get(ModelKeys.PROPERTIES).asPropertyList()) {
                 writer.writeStartElement(Element.PROPERTY.getLocalName());
                 writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
                 writer.writeCharacters(property.getValue().asString());

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ModelKeys.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ModelKeys.java
@@ -33,7 +33,9 @@ class ModelKeys {
     static final String NAME = "name";
     static final String OOB_EXECUTOR = "oob-executor";
     static final String PROPERTY = "property";
+    static final String PROPERTIES = "properties";
     static final String PROTOCOL = "protocol";
+    static final String PROTOCOLS = "protocols";
     static final String RACK = "rack";
     static final String SHARED = "shared";
     static final String SITE = "site";

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
@@ -76,9 +76,9 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
 
     private static void populate(ModelNode source, ModelNode target) {
         target.get(ModelKeys.TRANSPORT).set(source.require(ModelKeys.TRANSPORT));
-        if (source.hasDefined(ModelKeys.PROTOCOL)) {
-            ModelNode protocols = target.get(ModelKeys.PROTOCOL);
-            for (ModelNode protocol : source.get(ModelKeys.PROTOCOL).asList()) {
+        if (source.hasDefined(ModelKeys.PROTOCOLS)) {
+            ModelNode protocols = target.get(ModelKeys.PROTOCOLS);
+            for (ModelNode protocol : source.get(ModelKeys.PROTOCOLS).asList()) {
                 protocols.add(protocol);
             }
         }
@@ -130,7 +130,7 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
         if (transport.hasDefined(ModelKeys.THREAD_FACTORY)) {
             builder.addDependency(ThreadsServices.threadFactoryName(transport.get(ModelKeys.THREAD_FACTORY).asString()), ThreadFactory.class, transportConfig.getThreadFactoryInjector());
         }
-        for (ModelNode protocol : operation.get(ModelKeys.PROTOCOL).asList()) {
+        for (ModelNode protocol : operation.get(ModelKeys.PROTOCOLS).asList()) {
             Protocol protocolConfig = new Protocol(protocol.require(ModelKeys.TYPE).asString());
             build(builder, protocol, protocolConfig);
             stackConfig.getProtocols().add(protocolConfig);
@@ -143,8 +143,8 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
     private void build(ServiceBuilder<ChannelFactory> builder, ModelNode protocol, Protocol protocolConfig) {
         this.addSocketBindingDependency(builder, protocol, ModelKeys.SOCKET_BINDING, protocolConfig.getSocketBindingInjector());
         Map<String, String> properties = protocolConfig.getProperties();
-        if (protocol.hasDefined(ModelKeys.PROPERTY)) {
-            for (Property property : protocol.get(ModelKeys.PROPERTY).asPropertyList()) {
+        if (protocol.hasDefined(ModelKeys.PROPERTIES)) {
+            for (Property property : protocol.get(ModelKeys.PROPERTIES).asPropertyList()) {
                 properties.put(property.getName(), property.getValue().asString());
             }
         }


### PR DESCRIPTION
This makes the usage of consistent with Infinispan and also frees up the names PROTOCOL and PROPERTY to reflect individual instances a the LIST.
