### PR TITLE
[JBWS-3419] restoring managed endpoint registry

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/service/EndpointRegistryService.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/service/EndpointRegistryService.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2010, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -36,11 +36,9 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.jboss.ws.common.management.DefaultEndpointRegistry;
 import org.jboss.ws.common.management.ManagedEndpointRegistry;
-import org.jboss.wsf.spi.SPIProvider;
-import org.jboss.wsf.spi.SPIProviderResolver;
 import org.jboss.wsf.spi.management.EndpointRegistry;
-import org.jboss.wsf.spi.management.EndpointRegistryFactory;
 
 /**
  * The service for the endpoint registry
@@ -65,11 +63,12 @@ public final class EndpointRegistryService implements Service<EndpointRegistry> 
 
     @Override
     public void start(final StartContext context) throws StartException {
-        final SPIProvider spiProvider = SPIProviderResolver.getInstance().getProvider();
-        registry = spiProvider.getSPI(EndpointRegistryFactory.class).getEndpointRegistry();
-        if (injectedMBeanServer.getValue() != null && registry instanceof ManagedEndpointRegistry) {
-            final ManagedEndpointRegistry managedEndpointRegistry = (ManagedEndpointRegistry)registry;
+        if (injectedMBeanServer.getValue() != null) {
+            final ManagedEndpointRegistry managedEndpointRegistry = new ManagedEndpointRegistry();
             managedEndpointRegistry.setMbeanServer(injectedMBeanServer.getValue());
+            registry = managedEndpointRegistry;
+        } else {
+            registry = new DefaultEndpointRegistry();
         }
     }
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/EndpointRegistryFactory.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/EndpointRegistryFactory.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.webservices.util;
+
+import org.jboss.ws.common.management.DefaultEndpointRegistry;
+import org.jboss.wsf.spi.management.EndpointRegistry;
+
+/**
+ * JBoss AS 7 WS Endpoint registry factory
+ *
+ * @author alessio.soldano@jboss.com
+ * @since 25-Jan-2012
+ *
+ */
+public final class EndpointRegistryFactory extends org.jboss.wsf.spi.management.EndpointRegistryFactory {
+
+    private static final EndpointRegistry fallbackRegistry = new DefaultEndpointRegistry();;
+
+    public EndpointRegistryFactory() {
+        super();
+    }
+
+    /**
+     * Retrieves endpoint registry through the corresponding Service
+     *
+     * @return endpoint registry
+     */
+    public EndpointRegistry getEndpointRegistry() {
+        try {
+            EndpointRegistry registry = (EndpointRegistry) WSServices.getContainerRegistry()
+                    .getService(WSServices.REGISTRY_SERVICE).getService().getValue();
+            if (registry == null) {
+                registry = fallbackRegistry;
+            }
+            return registry;
+        } catch (Exception e) {
+            return fallbackRegistry;
+        }
+    }
+
+}

--- a/webservices/server-integration/src/main/resources/META-INF/services/org.jboss.wsf.spi.management.EndpointRegistryFactory
+++ b/webservices/server-integration/src/main/resources/META-INF/services/org.jboss.wsf.spi.management.EndpointRegistryFactory
@@ -1,0 +1,1 @@
+org.jboss.as.webservices.util.EndpointRegistryFactory


### PR DESCRIPTION
This pull request is equivalent to https://github.com/jbossas/jboss-as/pull/1220, which was previously closed by Brian due to a misunderstanding - sorry for not having been enough clear in comments.
https://github.com/jbossas/jboss-as/pull/1199 (also closed by Brian) has actually been pushed to the master and was fine wrt fixing AS7-3216 & AS7-3413.
When dealing with JBWS-3419, though, I had to rework the EndpointRegistryService and basically revert one of the commits Richard did in pull 1199 to have things work properly. I considered both Richard's (AS7-3413) and my (JBWS-3419) usecases and rebased over Richard's changes since they were already upstream on master. So anything is just fine, please pull this.
