### PR TITLE
[AS7-3386] Minor base-cache-container start attribute parsing error

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -107,7 +107,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                     break;
                 }
                 case START: {
-                    container.get(ModelKeys.START).set(Boolean.parseBoolean(value));
+                    container.get(ModelKeys.START).set(value);
                     break;
                 }
                 case LISTENER_EXECUTOR: {


### PR DESCRIPTION
StartMode is being parsed as a boolean but is an enum.
