### PR TITLE
Better removal of operation context service controllers

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
@@ -79,14 +79,14 @@ public class DataSourceDisable implements OperationStepHandler {
                     final ServiceName referenceServiceName = DataSourceReferenceFactoryService.SERVICE_NAME_BASE.append(dsName);
                     final ServiceController<?> referenceController = registry.getService(referenceServiceName);
                     if (referenceController != null ) {
-                        referenceController.setMode(ServiceController.Mode.REMOVE);
+                        context.removeService(referenceController);
                     }
 
                     final ServiceName binderServiceName = ContextNames.bindInfoFor(jndiName).getBinderServiceName();
 
                     final ServiceController<?> binderController = registry.getService(binderServiceName);
                     if (binderController != null ) {
-                        binderController.setMode(ServiceController.Mode.REMOVE);
+                        context.removeService(binderController);
                     }
 
                     final ServiceName dataSourceConfigServiceName = DataSourceConfigService.SERVICE_NAME_BASE.append(dsName);
@@ -131,14 +131,19 @@ public class DataSourceDisable implements OperationStepHandler {
 
 
                     if (xaDataSourceConfigController != null) {
-                        xaDataSourceConfigController.setMode(ServiceController.Mode.REMOVE);
+                        context.removeService(xaDataSourceConfigController);
                     }
 
                     if (dataSourceConfigController != null) {
-                        dataSourceConfigController.setMode(ServiceController.Mode.REMOVE);
+                        context.removeService(dataSourceConfigController);
                     }
 
-                    context.completeStep();
+                    context.completeStep(new OperationContext.RollbackHandler() {
+                        @Override
+                        public void handleRollback(OperationContext context, ModelNode operation) {
+                            //TODO Readd services
+                        }
+                    });
                 }
             }, OperationContext.Stage.RUNTIME);
         }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -381,10 +381,8 @@ abstract class AbstractOperationContext implements OperationContext {
                 }
 
             } catch (Throwable t) {
-                t.printStackTrace();
                 // Special handling for OperationClientException marker interface
                 if (! (t instanceof OperationClientException)) {
-                    t.printStackTrace();
                     throw t;
                 } else if (currentStage != Stage.DONE) {
                     // Handler threw OCE before calling completeStep(); that's equivalent to

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -381,8 +381,10 @@ abstract class AbstractOperationContext implements OperationContext {
                 }
 
             } catch (Throwable t) {
+                t.printStackTrace();
                 // Special handling for OperationClientException marker interface
                 if (! (t instanceof OperationClientException)) {
+                    t.printStackTrace();
                     throw t;
                 } else if (currentStage != Stage.DONE) {
                     // Handler threw OCE before calling completeStep(); that's equivalent to

--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2376,5 +2376,5 @@ public interface ControllerMessages {
      * @return a {@link XMLStreamException} for the error.
      */
     @Message(id = 14838, value = "Do not call ServiceController.setMode(REMOVE), use OperationContext.removeService() instead.")
-    String useOperationContextRemoveService();
+    IllegalStateException useOperationContextRemoveService();
 }

--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2370,5 +2370,11 @@ public interface ControllerMessages {
     @Message(id = 14837, value = "Cannot resolve the localhost address to create a UUID-based name for this process")
     RuntimeException cannotResolveProcessUUID(@Cause UnknownHostException cause);
 
-
+    /**
+     * Creates an exception indicating a user tried calling ServiceController.setMode(REMOVE) from an operation handler.
+     *
+     * @return a {@link XMLStreamException} for the error.
+     */
+    @Message(id = 14838, value = "Do not call ServiceController.setMode(REMOVE), use OperationContext.removeService() instead.")
+    String useOperationContextRemoveService();
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -298,7 +298,9 @@ public interface OperationContext {
 
     /**
      * Get the service registry.  If the step is not a runtime operation handler step, an exception will be thrown.  The
-     * returned registry must not be used to remove services.
+     * returned registry must not be used to remove services, if an attempt is made to call {@code ServiceController.setMode(REMOVE)}
+     * on a {@code ServiceController} returned from this registry an {@code IllegalStateException} will be thrown. To
+     * remove a service call {@link removeService(ServiceName name)}.
      *
      * @param modify {@code true} if the operation may be modifying a service, {@code false} otherwise
      * @return the service registry

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1024,8 +1024,7 @@ final class OperationContextImpl extends AbstractOperationContext {
 
         private void checkModeTransition(Mode mode) {
             if (mode == Mode.REMOVE) {
-                ControllerLogger.ROOT_LOGGER.warn(MESSAGES.useOperationContextRemoveService());
-                throw new IllegalArgumentException(MESSAGES.useOperationContextRemoveService());
+                throw MESSAGES.useOperationContextRemoveService();
             }
         }
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
@@ -45,7 +45,6 @@ import static org.jboss.as.webservices.dmr.Constants.WSDL_SECURE_PORT;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
@@ -84,7 +83,7 @@ public final class WSExtension implements Extension {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(WSSubsystemProviders.SUBSYSTEM);
         registration.registerOperationHandler(ADD, WSSubsystemAdd.INSTANCE, WSSubsystemProviders.SUBSYSTEM_ADD, false);
         registration.registerOperationHandler(DESCRIBE, WSSubsystemDescribe.INSTANCE, WSSubsystemProviders.SUBSYSTEM_DESCRIBE, false, PRIVATE);
-        registration.registerOperationHandler(REMOVE, ReloadRequiredRemoveStepHandler.INSTANCE, WSSubsystemProviders.SUBSYSTEM_REMOVE, false);
+        registration.registerOperationHandler(REMOVE, WSSubsystemRemove.INSTANCE, WSSubsystemProviders.SUBSYSTEM_REMOVE, false);
         registration.registerReadWriteAttribute(WSDL_HOST, null, new WSSubsystemAttributeChangeHandler(new StringLengthValidator(1, Integer.MAX_VALUE, true, true)), Storage.CONFIGURATION);
         registration.registerReadWriteAttribute(WSDL_PORT, null, new WSSubsystemAttributeChangeHandler(new IntRangeValidator(1, Integer.MAX_VALUE, true, true)), Storage.CONFIGURATION);
         registration.registerReadWriteAttribute(WSDL_SECURE_PORT, null, new WSSubsystemAttributeChangeHandler(new IntRangeValidator(1, Integer.MAX_VALUE, true, true)), Storage.CONFIGURATION);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemRemove.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemRemove.java
@@ -1,0 +1,54 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.webservices.dmr;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.webservices.util.WSServices;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class WSSubsystemRemove extends ReloadRequiredRemoveStepHandler {
+
+    static final WSSubsystemRemove INSTANCE = new WSSubsystemRemove();
+
+    private WSSubsystemRemove() {
+
+    }
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performRuntime(context, operation, model);
+        WSServices.clearContainerRegistry();
+    }
+
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+        WSServices.saveContainerRegistry(context.getServiceRegistry(false));
+        super.recoverServices(context, operation, model);
+
+    }
+}

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/WSServices.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/WSServices.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.webservices.util;
 
-import java.lang.ref.WeakReference;
-
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 
@@ -44,14 +42,18 @@ public final class WSServices {
     public static final ServiceName ENDPOINT_PUBLISH_SERVICE = WS_SERVICE.append("endpoint-publish");
     public static final ServiceName PORT_COMPONENT_LINK_SERVICE = WS_SERVICE.append("port-component-link");
 
-    private static WeakReference<ServiceRegistry> registry;
+    private static ServiceRegistry registry;
 
     public static void saveContainerRegistry(ServiceRegistry containerRegistry) {
-        registry = new WeakReference<ServiceRegistry>(containerRegistry);
+        registry = containerRegistry;
+    }
+
+    public static void clearContainerRegistry() {
+        registry = null;
     }
 
     public static ServiceRegistry getContainerRegistry() {
-        return registry.get();
+        return registry;
     }
 
     private WSServices() {


### PR DESCRIPTION
Throws an error if ServiceController.setMode(REMOVE) on service controllers obtained from the OperationContext's service registry.

Fixes to WS subsystem causing problems here, since it was using a WeakReference and the delegating service controllers are created on demand.
