### PR TITLE
AS7-3475 / AS7-2409 / AS7-2824

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_1.xsd
@@ -80,9 +80,12 @@
             <xs:attribute name="name" type="xs:string" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                        The name to use for this host's host controller. Must be
-                        unique across the domain. If not set, defaults to the
-                        runtime value of InetAddress.getLocalHost().getHostName().
+                        The name to use for this host's host controller. Must be unique across the domain.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
@@ -116,8 +119,12 @@
             <xs:attribute name="name" type="xs:string" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                        The name to use for this server. If not set, defaults to
-                        the runtime value of InetAddress.getLocalHost().getHostName().
+                        The name to use for this server.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
@@ -179,7 +186,7 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:complexType name="ldapType"> 
+    <xs:complexType name="ldapType">
         <xs:annotation>
             <xs:documentation>
                 The LDAP connection definition.
@@ -341,14 +348,14 @@
                 </xs:annotation>
             </xs:element>
             <xs:choice minOccurs="0">
-                <xs:element name="jaas" type="jaasAuthenticationType" minOccurs="0" />            
+                <xs:element name="jaas" type="jaasAuthenticationType" minOccurs="0" />
                 <xs:element name="ldap" type="ldapAuthenticationType" minOccurs="0" />
                 <xs:element name="properties" type="propertiesAuthenticationType" minOccurs="0" />
                 <xs:element name="users" type="usersAuthenticationType" minOccurs="0" />
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
-    
+
     <xs:complexType name="jaasAuthenticationType">
         <xs:annotation>
             <xs:documentation>
@@ -361,7 +368,7 @@
                     The name identifying the jaas configuration of LoginModules.
                 </xs:documentation>
             </xs:annotation>
-        </xs:attribute>            
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="ldapAuthenticationType">
@@ -1158,7 +1165,7 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
-    
+
     <xs:complexType name="socket-binding-client-mappingType">
         <xs:annotation>
                 <xs:documentation>

--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -2365,4 +2366,9 @@ public interface ControllerMessages {
      */
     @Message(id = 14836, value = "Illegal '%s' value %s -- must be a valid port number")
     XMLStreamException invalidPort(String name, String value, @Param Location location);
+
+    @Message(id = 14837, value = "Cannot resolve the localhost address to create a UUID-based name for this process")
+    RuntimeException cannotResolveProcessUUID(@Cause UnknownHostException cause);
+
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
@@ -107,7 +107,7 @@ public abstract class ProcessEnvironment {
                                                                     boolean bootTime) throws OperationFailedException;
 
     /**
-     * Informs this {@code ProcessEnvironment} that the runtime value of the given system property has been updated,
+     * Notifies this {@code ProcessEnvironment} that the runtime value of the given system property has been updated,
      * allowing it to update any state that was originally set via the system property during primordial process boot.
      * This method should only be invoked after a call to {@link #isRuntimeSystemPropertyUpdateAllowed(String, String, boolean)}
      * has returned {@code true}.
@@ -115,7 +115,7 @@ public abstract class ProcessEnvironment {
      * @param propertyName  the name of the property. Cannot be {@code null}
      * @param propertyValue the value of the property. May be {@code null}
      */
-    protected abstract void updateSystemProperty(String propertyName, String propertyValue);
+    protected abstract void systemPropertyUpdated(String propertyName, String propertyValue);
 
     protected static String resolveGUID(final String unresolvedName) {
 
@@ -172,8 +172,6 @@ public abstract class ProcessEnvironment {
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-
-            new Exception().printStackTrace(System.out);
 
             final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
             if (model.hasDefined(NAME.getName())) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
@@ -1,0 +1,188 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.operations.common;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.UUID;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.interfaces.InetAddressUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Base class for objects that store environment information for a process.
+ *
+ * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ */
+public abstract class ProcessEnvironment {
+
+    /** The special process name value that triggers calculation of a UUID */
+    public static final String JBOSS_DOMAIN_UUID = "jboss.domain.uuid";
+
+    /** {@link AttributeDefinition} for the {@code name} attribute for a processes root resource */
+    public static final AttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.NAME, ModelType.STRING, true)
+            .setAllowExpression(true).build();
+
+    /**
+     * Gets an {@link OperationStepHandler} that can read the {@code name} attribute for a processes root resource
+     * @return the handler
+     */
+    public OperationStepHandler getProcessNameReadHandler() {
+        return new ProcessNameReadAttributeHandler();
+    }
+
+    /**
+     * Gets an {@link OperationStepHandler} that can write the {@code name} attribute for a processes root resource
+     * @return the handler
+     */
+    public OperationStepHandler getProcessNameWriteHandler() {
+        return new ProcessNameWriteAttributeHandler();
+    }
+
+    /**
+     * Gets the resolved name of this process; a value previously passed to {@link #setProcessName(String)} or
+     * a value derived from the environment.
+     *
+     * @return the process name. Cannot be {@code null}
+     */
+    protected abstract String getProcessName();
+
+    /**
+     * Sets the process name. This method can only be called by the handler returned by
+     * {@link #getProcessNameWriteHandler()}; its visibility is protected only because subclasses need to implement it.
+     *
+     * @param processName the process name. May be {@code null} in which case a default process name should be used.
+     */
+    protected abstract void setProcessName(String processName);
+
+    /**
+     * Gets whether updating the runtime system properties with the given property is allowed.
+     *
+     * @param propertyName  the name of the property. Cannot be {@code null}
+     * @param propertyValue the value of the property. May be {@code null}
+     * @param bootTime {@code true} if the process is currently booting
+     *
+     * @return {@code true} if the update can be applied to the runtime system properties; {@code} false if it
+     *         should just be stored in the persistent configuration and the process should be put into
+     *         {@link ControlledProcessState.State#RELOAD_REQUIRED reload-required state}.
+     *
+     * @throws OperationFailedException if a change to the given property is not allowed at all; e.g. changing
+     *                                  {@code jboss.server.base.dir} after primordial boot is not allowed; the
+     *                                  property can only be set from the command line
+     */
+    protected abstract boolean isRuntimeSystemPropertyUpdateAllowed(String propertyName,
+                                                                    String propertyValue,
+                                                                    boolean bootTime) throws OperationFailedException;
+
+    /**
+     * Informs this {@code ProcessEnvironment} that the runtime value of the given system property has been updated,
+     * allowing it to update any state that was originally set via the system property during primordial process boot.
+     * This method should only be invoked after a call to {@link #isRuntimeSystemPropertyUpdateAllowed(String, String, boolean)}
+     * has returned {@code true}.
+     *
+     * @param propertyName  the name of the property. Cannot be {@code null}
+     * @param propertyValue the value of the property. May be {@code null}
+     */
+    protected abstract void updateSystemProperty(String propertyName, String propertyValue);
+
+    protected static String resolveGUID(final String unresolvedName) {
+
+        String result;
+
+        if (JBOSS_DOMAIN_UUID.equals(unresolvedName)) {
+            try {
+                InetAddress localhost = InetAddressUtil.getLocalHost();
+                result = UUID.nameUUIDFromBytes(localhost.getAddress()).toString();
+            } catch (UnknownHostException e) {
+                throw ControllerMessages.MESSAGES.cannotResolveProcessUUID(e);
+            }
+        } else {
+            result = unresolvedName;
+        }
+
+        return result;
+    }
+
+    private class ProcessNameWriteAttributeHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+            final ModelNode model = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel();
+
+            final ModelNode newValue = operation.hasDefined(VALUE) ? operation.get(VALUE) : new ModelNode();
+            final ModelNode mockOp = new ModelNode();
+            mockOp.get(NAME.getName()).set(newValue);
+
+            NAME.validateAndSet(mockOp, model);
+
+            boolean booting = context.isBooting();
+            String resolved = null;
+            if (context.isBooting()) {
+                final ModelNode resolvedNode = NAME.resolveModelAttribute(context, model);
+                resolved = resolvedNode.isDefined() ? resolvedNode.asString() : null;
+                resolved = resolved == null ? null : resolveGUID(resolved);
+            } else {
+                context.reloadRequired();
+            }
+
+            if (context.completeStep() == OperationContext.ResultAction.KEEP) {
+                if (booting) {
+                    ProcessEnvironment.this.setProcessName(resolved);
+                }
+            } else if (!booting) {
+                context.revertReloadRequired();
+            }
+        }
+    }
+
+    private class ProcessNameReadAttributeHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+            new Exception().printStackTrace(System.out);
+
+            final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+            if (model.hasDefined(NAME.getName())) {
+                context.getResult().set(model.get(NAME.getName()));
+            } else {
+                context.getResult().set(ProcessEnvironment.this.getProcessName());
+            }
+
+            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/SystemPropertyAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/SystemPropertyAddHandler.java
@@ -18,37 +18,36 @@
  */
 package org.jboss.as.controller.operations.common;
 
-import java.util.List;
-import java.util.Locale;
-import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_TIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
+import java.util.Locale;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.common.CommonDescriptions;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.msc.service.ServiceController;
 
 /**
- * Base class for domain/host and server system property add handlers.
+ * Operation handler for adding domain/host and server system properties.
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-public class SystemPropertyAddHandler extends AbstractAddStepHandler implements DescriptionProvider {
+public class SystemPropertyAddHandler implements OperationStepHandler, DescriptionProvider {
 
     public static final String OPERATION_NAME = ADD;
 
-    public static final SystemPropertyAddHandler INSTANCE_WITH_BOOTTIME = new SystemPropertyAddHandler(true);
-    public static final SystemPropertyAddHandler INSTANCE_WITHOUT_BOOTTIME = new SystemPropertyAddHandler(false);
+    public static final SystemPropertyAddHandler INSTANCE_WITH_BOOTTIME = new SystemPropertyAddHandler(null, true);
+    public static final SystemPropertyAddHandler INSTANCE_WITHOUT_BOOTTIME = new SystemPropertyAddHandler(null, false);
 
     public static ModelNode getOperation(ModelNode address, String value) {
         return getOperation(address, value, null);
@@ -69,12 +68,18 @@ public class SystemPropertyAddHandler extends AbstractAddStepHandler implements 
 
 
     private final ParametersValidator validator = new ParametersValidator();
+    private final ProcessEnvironment processEnvironment;
     private final boolean useBoottime;
 
     /**
      * Create the SystemPropertyAddHandler
+     *
+     * @param processEnvironment the local process environment, or {@code null} if interaction with the process
+     *                           environment is not required
+     * @param useBoottime {@code true} if the system property resource should support the "boot-time" attribute
      */
-    private SystemPropertyAddHandler(boolean useBoottime) {
+    public SystemPropertyAddHandler(ProcessEnvironment processEnvironment, boolean useBoottime) {
+        this.processEnvironment = processEnvironment;
         this.useBoottime = useBoottime;
         validator.registerValidator(VALUE, new StringLengthValidator(0, true));
         if (useBoottime) {
@@ -82,25 +87,60 @@ public class SystemPropertyAddHandler extends AbstractAddStepHandler implements 
         }
     }
 
-    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
         validator.validate(operation);
 
-        final String value = operation.get(VALUE).isDefined() ? operation.get(VALUE).asString() : null;
+        final String name = PathAddress.pathAddress(operation.get(OP_ADDR)).getLastElement().getValue();
+        final String value = operation.hasDefined(VALUE) ? operation.get(VALUE).asString() : null;
+
+        final boolean applyToRuntime = processEnvironment != null && processEnvironment.isRuntimeSystemPropertyUpdateAllowed(name, value, context.isBooting());
+        final boolean reload = !applyToRuntime && context.getProcessType().isServer();
+
+        final ModelNode model = context.createResource(PathAddress.EMPTY_ADDRESS).getModel();
         if (value == null) {
             model.get(VALUE).set(new ModelNode());
         } else {
             model.get(VALUE).set(value);
         }
         if (useBoottime) {
-            boolean boottime = operation.get(BOOT_TIME).isDefined() ? operation.get(BOOT_TIME).asBoolean() : true;
+            boolean boottime = !operation.hasDefined(BOOT_TIME) || operation.get(BOOT_TIME).asBoolean();
             model.get(BOOT_TIME).set(boottime);
         }
-    }
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) {
-        final String name = PathAddress.pathAddress(operation.get(OP_ADDR)).getLastElement().getValue();
-        final String value = operation.get(VALUE).isDefined() ? operation.get(VALUE).asString() : null;
-        SecurityActions.setSystemProperty(name, value);
+        if (applyToRuntime) {
+            context.addStep(new OperationStepHandler() {
+                public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+
+                    SecurityActions.setSystemProperty(name, value);
+                    if (processEnvironment != null) {
+                        processEnvironment.systemPropertyUpdated(name, value);
+                    }
+
+                    context.completeStep(new OperationContext.RollbackHandler() {
+                        @Override
+                        public void handleRollback(OperationContext context, ModelNode operation) {
+                            SecurityActions.clearSystemProperty(name);
+                            if (processEnvironment != null) {
+                                processEnvironment.systemPropertyUpdated(name, null);
+                            }
+                        }
+                    });
+                }
+            }, OperationContext.Stage.RUNTIME);
+        } else if (reload) {
+            context.reloadRequired();
+        }
+
+        context.completeStep(new OperationContext.RollbackHandler() {
+            @Override
+            public void handleRollback(OperationContext context, ModelNode operation) {
+                if (reload) {
+                    context.revertReloadRequired();
+                }
+            }
+        });
     }
 
     protected boolean requiresRuntimeVerification() {

--- a/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/CommonXml.java
@@ -152,7 +152,7 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
     }
 
     protected String getDefaultName() {
-        return  InetAddressUtil.getLocalHostName();
+        return InetAddressUtil.getLocalHostName();
     }
 
     protected void parseNamespaces(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> nodes) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -44,8 +44,8 @@ import org.jboss.modules.Module;
  */
 public class ConfigurationPersisterFactory {
 
-    public static ExtensibleConfigurationPersister createHostXmlConfigurationPersister(final ConfigurationFile file, ExecutorService executorService) {
-        HostXml hostXml = new HostXml(Module.getBootModuleLoader(), executorService);
+    public static ExtensibleConfigurationPersister createHostXmlConfigurationPersister(final ConfigurationFile file, String defaultHostControllerName) {
+        HostXml hostXml = new HostXml(defaultHostControllerName);
         BackupXmlConfigurationPersister persister =  new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "host"), hostXml, hostXml);
         persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "host"), hostXml);
         return persister;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -152,7 +152,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
                                                             final BootstrapListener bootstrapListener) {
         final Map<String, ProxyController> hostProxies = new ConcurrentHashMap<String, ProxyController>();
         final Map<String, ProxyController> serverProxies = new ConcurrentHashMap<String, ProxyController>();
-        final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(processState);
+        final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(processState, environment);
         final AbstractVaultReader vaultReader = service(AbstractVaultReader.class);
         ROOT_LOGGER.debugf("Using VaultReader %s", vaultReader);
         final ContentRepository contentRepository = ContentRepository.Factory.create(environment.getDomainDeploymentDir());

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
@@ -64,7 +64,7 @@ public class HostControllerConfigurationPersister implements ExtensibleConfigura
         this.extensionRegistry = extensionRegistry;
         final File configDir = environment.getDomainConfigurationDir();
         final ConfigurationFile configurationFile = environment.getHostConfigurationFile();
-        this.hostPersister = ConfigurationPersisterFactory.createHostXmlConfigurationPersister(configurationFile, executorService);
+        this.hostPersister = ConfigurationPersisterFactory.createHostXmlConfigurationPersister(configurationFile, environment.getHostControllerName());
     }
 
     public void initializeDomainConfigurationPersister(boolean slave) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -545,14 +545,14 @@ public class HostControllerEnvironment extends ProcessEnvironment {
 
     @Override
     protected boolean isRuntimeSystemPropertyUpdateAllowed(String propertyName, String propertyValue, boolean bootTime) {
-        //TODO implement validateSystemPropertyUpdate
-        throw new UnsupportedOperationException();
+        // Currently any system-property in host.xml should not be applied to the HC runtime. This method
+        // should not be invoked.
+        throw HostControllerMessages.MESSAGES.hostControllerSystemPropertyUpdateNotSupported();
     }
 
     @Override
-    protected void updateSystemProperty(String propertyName, String propertyValue) {
-        //TODO implement updateSystemProperty
-        throw new UnsupportedOperationException();
+    protected void systemPropertyUpdated(String propertyName, String propertyValue) {
+        // no-op
     }
 
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
@@ -556,4 +556,7 @@ public interface HostControllerMessages {
      */
     @Message(id = 10988, value = "No socket-binding-group called: %s")
     OperationFailedException noSocketBindingGroupCalled(String groupName);
+
+    @Message(id = 10989, value = "HostControllerEnvironment does not support system property updates")
+    UnsupportedOperationException hostControllerSystemPropertyUpdateNotSupported();
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -149,43 +149,6 @@ import org.jboss.dmr.ModelType;
  */
 public class HostModelUtil {
 
-    public static void initCoreModel(final ModelNode root, HostControllerEnvironment environment) {
-
-        root.get(RELEASE_VERSION).set(Version.AS_VERSION);
-        root.get(RELEASE_CODENAME).set(Version.AS_RELEASE_CODENAME);
-        root.get(MANAGEMENT_MAJOR_VERSION).set(Version.MANAGEMENT_MAJOR_VERSION);
-        root.get(MANAGEMENT_MINOR_VERSION).set(Version.MANAGEMENT_MINOR_VERSION);
-
-        // Community uses UNDEF values
-        ModelNode nameNode = root.get(PRODUCT_NAME);
-        ModelNode versionNode = root.get(PRODUCT_VERSION);
-
-        if (environment != null) {
-            String productName = environment.getProductConfig().getProductName();
-            String productVersion = environment.getProductConfig().getProductVersion();
-
-            if (productName != null) {
-                nameNode.set(productName);
-            }
-            if (productVersion != null) {
-                versionNode.set(productVersion);
-            }
-        }
-
-        root.get(NAME);
-        root.get(NAMESPACES).setEmptyList();
-        root.get(SCHEMA_LOCATIONS).setEmptyList();
-        root.get(EXTENSION);
-        root.get(SYSTEM_PROPERTY);
-        root.get(PATH);
-        root.get(CORE_SERVICE);
-        root.get(SERVER_CONFIG);
-        root.get(DOMAIN_CONTROLLER);
-        root.get(INTERFACE);
-        root.get(JVM);
-        root.get(RUNNING_SERVER);
-    }
-
     public static void createHostRegistry(final ManagementResourceRegistration root, final HostControllerConfigurationPersister configurationPersister,
                                           final HostControllerEnvironment environment, final HostRunningModeControl runningModeControl,
                                           final HostFileRepository localFileRepository,
@@ -199,7 +162,7 @@ public class HostModelUtil {
                                           final ControlledProcessState processState) {
         // Add of the host itself
         ManagementResourceRegistration hostRegistration = root.registerSubModel(PathElement.pathElement(HOST), HostDescriptionProviders.HOST_ROOT_PROVIDER);
-        LocalHostAddHandler handler = LocalHostAddHandler.getInstance(hostControllerInfo);
+        LocalHostAddHandler handler = LocalHostAddHandler.getInstance(environment);
         hostRegistration.registerOperationHandler(LocalHostAddHandler.OPERATION_NAME, handler, handler, false, OperationEntry.EntryType.PRIVATE);
 
         // Global operations
@@ -229,7 +192,7 @@ public class HostModelUtil {
         hostRegistration.registerOperationHandler(SchemaLocationAddHandler.OPERATION_NAME, SchemaLocationAddHandler.INSTANCE, SchemaLocationAddHandler.INSTANCE, false);
         hostRegistration.registerOperationHandler(SchemaLocationRemoveHandler.OPERATION_NAME, SchemaLocationRemoveHandler.INSTANCE, SchemaLocationRemoveHandler.INSTANCE, false);
 
-        hostRegistration.registerReadWriteAttribute(NAME, null, new WriteAttributeHandlers.StringLengthValidatingHandler(1), Storage.CONFIGURATION);
+        hostRegistration.registerReadWriteAttribute(NAME, environment.getProcessNameReadHandler(), environment.getProcessNameWriteHandler(), Storage.CONFIGURATION);
         hostRegistration.registerReadOnlyAttribute(MASTER, IsMasterHandler.INSTANCE, Storage.RUNTIME);
         hostRegistration.registerReadOnlyAttribute(HOST_STATE, new ProcessStateAttributeHandler(processState), Storage.RUNTIME);
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ModelCombiner.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ModelCombiner.java
@@ -181,7 +181,6 @@ class ModelCombiner implements ManagedServerBootConfiguration {
         List<ModelNode> updates = new ArrayList<ModelNode>();
 
         addNamespaces(updates);
-        addServerName(updates);
         addProfileName(updates);
         addSchemaLocations(updates);
         addExtensions(updates);
@@ -289,10 +288,6 @@ class ModelCombiner implements ManagedServerBootConfiguration {
                 map.put(prop.getName(), NamespaceAddHandler.getAddNamespaceOperation(EMPTY, prop.getName(), prop.getValue().asString()));
             }
         }
-    }
-
-    private void addServerName(List<ModelNode> updates) {
-        updates.add(Util.getWriteAttributeOperation(EMPTY, NAME, serverName));
     }
 
     private void addProfileName(List<ModelNode> updates) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostAddHandler.java
@@ -21,25 +21,41 @@
  */
 package org.jboss.as.host.controller.operations;
 
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.PathElement;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_CONTROLLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MINOR_VERSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRODUCT_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRODUCT_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_CODENAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SCHEMA_LOCATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.host.controller.HostControllerMessages.MESSAGES;
 
 import java.util.Locale;
 
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
-
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.host.controller.HostControllerService;
-import org.jboss.as.host.controller.HostModelUtil;
+import org.jboss.as.host.controller.HostControllerEnvironment;
 import org.jboss.as.platform.mbean.PlatformMBeanConstants;
 import org.jboss.as.platform.mbean.RootPlatformMBeanResource;
+import org.jboss.as.version.Version;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -51,14 +67,14 @@ public class LocalHostAddHandler implements OperationStepHandler, DescriptionPro
 
     public static final String OPERATION_NAME = "add-host";
 
-    private final LocalHostControllerInfoImpl hostControllerInfo;
+    private final HostControllerEnvironment hostControllerEnvironment;
 
-    public static LocalHostAddHandler getInstance(final LocalHostControllerInfoImpl hostControllerInfo) {
-        return new LocalHostAddHandler(hostControllerInfo);
+    public static LocalHostAddHandler getInstance(final HostControllerEnvironment hostControllerEnvironment) {
+        return new LocalHostAddHandler(hostControllerEnvironment);
     }
 
-    private LocalHostAddHandler(final LocalHostControllerInfoImpl hostControllerInfo) {
-        this.hostControllerInfo = hostControllerInfo;
+    private LocalHostAddHandler(final HostControllerEnvironment hostControllerEnvironment) {
+        this.hostControllerEnvironment = hostControllerEnvironment;
     }
 
     @Override
@@ -78,10 +94,7 @@ public class LocalHostAddHandler implements OperationStepHandler, DescriptionPro
         final Resource rootResource = context.createResource(PathAddress.EMPTY_ADDRESS);
         final ModelNode model = rootResource.getModel();
 
-
-        // TODO Revisit this
-        HostControllerService service = (HostControllerService) context.getServiceRegistry(false).getRequiredService(HostControllerService.HC_SERVICE_NAME).getService();
-        HostModelUtil.initCoreModel(model, service.getEnvironment());
+        initCoreModel(model, hostControllerEnvironment);
 
         // Create the empty management security resources
         context.createResource(PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MANAGEMENT)));
@@ -90,11 +103,48 @@ public class LocalHostAddHandler implements OperationStepHandler, DescriptionPro
         // we want to use our own resource type. But it's ok as the createResource calls above have taken the lock
         rootResource.registerChild(PlatformMBeanConstants.ROOT_PATH, new RootPlatformMBeanResource());
 
-        final String localHostName = operation.require(NAME).asString();
-        model.get(NAME).set(localHostName);
+        // Add a step to store the HC name
+        ModelNode writeNameOp = Util.getWriteAttributeOperation(operation.get(OP_ADDR), NAME, operation.get(NAME));
+        context.addStep(writeNameOp, hostControllerEnvironment.getProcessNameWriteHandler(), OperationContext.Stage.IMMEDIATE);
 
-        hostControllerInfo.setLocalHostName(localHostName);
-
-        context.completeStep();
+        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
     }
+
+    private static void initCoreModel(final ModelNode root, HostControllerEnvironment environment) {
+
+        root.get(RELEASE_VERSION).set(Version.AS_VERSION);
+        root.get(RELEASE_CODENAME).set(Version.AS_RELEASE_CODENAME);
+        root.get(MANAGEMENT_MAJOR_VERSION).set(Version.MANAGEMENT_MAJOR_VERSION);
+        root.get(MANAGEMENT_MINOR_VERSION).set(Version.MANAGEMENT_MINOR_VERSION);
+
+        // Community uses UNDEF values
+        ModelNode nameNode = root.get(PRODUCT_NAME);
+        ModelNode versionNode = root.get(PRODUCT_VERSION);
+
+        if (environment != null) {
+            String productName = environment.getProductConfig().getProductName();
+            String productVersion = environment.getProductConfig().getProductVersion();
+
+            if (productName != null) {
+                nameNode.set(productName);
+            }
+            if (productVersion != null) {
+                versionNode.set(productVersion);
+            }
+        }
+
+        root.get(NAME);
+        root.get(NAMESPACES).setEmptyList();
+        root.get(SCHEMA_LOCATIONS).setEmptyList();
+        root.get(EXTENSION);
+        root.get(SYSTEM_PROPERTY);
+        root.get(PATH);
+        root.get(CORE_SERVICE);
+        root.get(SERVER_CONFIG);
+        root.get(DOMAIN_CONTROLLER);
+        root.get(INTERFACE);
+        root.get(JVM);
+        root.get(RUNNING_SERVER);
+    }
+
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
@@ -24,6 +24,7 @@ package org.jboss.as.host.controller.operations;
 
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.host.controller.HostControllerEnvironment;
 
 /**
  * Default implementation of {@link LocalHostControllerInfo}.
@@ -33,8 +34,9 @@ import org.jboss.as.domain.controller.LocalHostControllerInfo;
 public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
 
     private final ControlledProcessState processState;
+    private final HostControllerEnvironment hostEnvironment;
 
-    private String localHostName;
+    private final String localHostName;
     private boolean master;
     private String nativeManagementInterface;
     private int nativeManagementPort;
@@ -48,12 +50,21 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
     private String nativeManagementSecurityRealm;
     private String httpManagementSecurityRealm;
 
-    public LocalHostControllerInfoImpl(final ControlledProcessState processState) {
+    /** Constructor solely for test cases */
+    public LocalHostControllerInfoImpl(final ControlledProcessState processState, final String localHostName) {
         this.processState = processState;
+        this.hostEnvironment = null;
+        this.localHostName = localHostName;
+    }
+
+    public LocalHostControllerInfoImpl(final ControlledProcessState processState, final HostControllerEnvironment hostEnvironment) {
+        this.processState = processState;
+        this.hostEnvironment = hostEnvironment;
+        this.localHostName = null;
     }
 
     public String getLocalHostName() {
-        return localHostName;
+        return hostEnvironment == null ? localHostName : hostEnvironment.getHostControllerName();
     }
 
     @Override
@@ -114,10 +125,6 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
 
     void setMasterDomainController(boolean master) {
         this.master = master;
-    }
-
-    void setLocalHostName(String localHostName) {
-        this.localHostName = localHostName;
     }
 
     void setNativeManagementInterface(String nativeManagementInterface) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -26,8 +26,8 @@ import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONSOLE_ENABLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_CONTROLLER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
@@ -69,7 +69,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -86,7 +85,6 @@ import org.jboss.as.host.controller.resources.NativeManagementResourceDefinition
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
-import org.jboss.modules.ModuleLoader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
@@ -98,8 +96,10 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public class HostXml extends CommonXml implements ManagementXml.Delegate {
 
-    public HostXml(final ModuleLoader loader, ExecutorService executorService) {
-        super();
+    private final String defaultHostControllerName;
+
+    public HostXml(String defaultHostControllerName) {
+        this.defaultHostControllerName = defaultHostControllerName;
     }
 
     @Override
@@ -239,10 +239,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
             }
         }
 
-        if (hostName == null) {
-            hostName = getDefaultName();
-        }
-        // The follownig also updates the address parameter so this address can be used for future operations
+        // The following also updates the address parameter so this address can be used for future operations
         // in the context of this host.
         addLocalHost(address, list, hostName);
         // The namespace operations were created before the host name was known, the address can now be updated
@@ -337,10 +334,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
             }
         }
 
-        if (hostName == null) {
-            hostName = getDefaultName();
-        }
-        // The follownig also updates the address parameter so this address can be used for future operations
+        // The following also updates the address parameter so this address can be used for future operations
         // in the context of this host.
         addLocalHost(address, list, hostName);
         // The namespace operations were created before the host name was known, the address can now be updated
@@ -684,7 +678,9 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
         host.get(OP).set("add-host");
         host.get(OP_ADDR).set(address.clone());
 
-        host.get(NAME).set(hostName);
+        if (hostName != null) {
+            host.get(NAME).set(hostName);
+        }
 
         operationList.add(host);
     }

--- a/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
+++ b/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
@@ -59,7 +59,6 @@ import java.util.EnumSet;
 
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningModeControl;
@@ -284,8 +283,10 @@ public class ServerControllerModelUtil {
         }
         // System Properties
         ManagementResourceRegistration sysProps = root.registerSubModel(PathElement.pathElement(SYSTEM_PROPERTY), ServerDescriptionProviders.SYSTEM_PROPERTIES_PROVIDER);
-        sysProps.registerOperationHandler(SystemPropertyAddHandler.OPERATION_NAME, SystemPropertyAddHandler.INSTANCE_WITHOUT_BOOTTIME, SystemPropertyAddHandler.INSTANCE_WITHOUT_BOOTTIME, false);
-        sysProps.registerOperationHandler(SystemPropertyRemoveHandler.OPERATION_NAME, SystemPropertyRemoveHandler.INSTANCE, SystemPropertyRemoveHandler.INSTANCE, false);
+        SystemPropertyAddHandler spah = new SystemPropertyAddHandler(serverEnvironment, false);
+        sysProps.registerOperationHandler(SystemPropertyAddHandler.OPERATION_NAME, spah, spah, false);
+        SystemPropertyRemoveHandler sprh = new SystemPropertyRemoveHandler(serverEnvironment);
+        sysProps.registerOperationHandler(SystemPropertyRemoveHandler.OPERATION_NAME, sprh, sprh, false);
         sysProps.registerReadWriteAttribute(VALUE, null, SystemPropertyValueWriteAttributeHandler.INSTANCE, AttributeAccess.Storage.CONFIGURATION);
 
         //vault

--- a/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
+++ b/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
@@ -59,6 +59,7 @@ import java.util.EnumSet;
 
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningModeControl;
@@ -195,10 +196,14 @@ public class ServerControllerModelUtil {
 
         boolean isDomain = serverEnvironment == null || serverEnvironment.getLaunchType() == LaunchType.DOMAIN;
 
-        // Build up the core model registry
-        root.registerReadWriteAttribute(NAME, null, new StringLengthValidatingHandler(1), AttributeAccess.Storage.CONFIGURATION);
-        if (serverEnvironment != null && serverEnvironment.getLaunchType() == ServerEnvironment.LaunchType.DOMAIN) {
-            root.registerReadWriteAttribute(PROFILE_NAME, null, new StringLengthValidatingHandler(1), AttributeAccess.Storage.CONFIGURATION);
+        // Root resource attributes
+        if (serverEnvironment != null) { // TODO eliminate test cases that result in serverEnviroment == null
+            if (isDomain) {
+                root.registerReadOnlyAttribute(NAME, serverEnvironment.getProcessNameReadHandler(), AttributeAccess.Storage.CONFIGURATION);
+                root.registerReadWriteAttribute(PROFILE_NAME, null, new StringLengthValidatingHandler(1), AttributeAccess.Storage.CONFIGURATION);
+            } else {
+                root.registerReadWriteAttribute(NAME, serverEnvironment.getProcessNameReadHandler(), serverEnvironment.getProcessNameWriteHandler(), AttributeAccess.Storage.CONFIGURATION);
+            }
         }
 
         // Global operations

--- a/server/src/main/java/org/jboss/as/server/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/ServerLogger.java
@@ -315,4 +315,8 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 15897, value = "Could not find Extension-List entry %s referenced from %s")
     void cannotFindExtensionListEntry(ExtensionListEntry entry, ResourceRoot resourceRoot);
+
+    @LogMessage(level = WARN)
+    @Message(id = 15898, value = "A server name configuration was provided both via system propert %s ('%s') and via the xml configuration ('%s'). The xml configuration valid will be used.")
+    void duplicateServerNameConfiguration(String systemProperty, String rawServerProp, String processName);
 }

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -341,6 +341,14 @@ public interface ServerMessages {
                                                                              String socketBindingAttr,
                                                                              String secureSocketBindingAttr);
 
+    @Message(id = 15845, value = "System property %s cannot be set via the xml configuration file or from a management client; " +
+            "it's value must be known at initial process start so it can only set from the commmand line")
+    OperationFailedException systemPropertyNotManageable(String propertyName);
+
+
+    @Message(id = 15846, value = "System property %s cannot be set after the server name has been set via the xml " +
+            "configuration file or from a management client")
+    OperationFailedException systemPropertyCannotOverrideServerName(String propertyName);
 
     /*
      * WARNING!!! id 15849 is the last id in the available block for this class. Once the block
@@ -348,5 +356,4 @@ public interface ServerMessages {
      * class from the overall id pool used by this module and update the class javadoc above
      * and this message accordingly.
      */
-
 }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -276,6 +276,7 @@ public final class ServerService extends AbstractControllerService {
         super.stop(context);
 
         configuration.getExtensionRegistry().clear();
+        configuration.getServerEnvironment().resetProvidedProperties();
 
         if (queuelessExecutor != null) {
             context.asynchronous();

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -190,9 +190,6 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
             }
         }
 
-        if (serverName == null) {
-            serverName = getDefaultName();
-        }
         setServerName(address, list, serverName);
 
         // elements - sequence
@@ -298,9 +295,6 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
             }
         }
 
-        if (serverName == null) {
-            serverName = getDefaultName();
-        }
         setServerName(address, list, serverName);
 
         // elements - sequence
@@ -912,7 +906,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
     }
 
     private void setServerName(final ModelNode address, final List<ModelNode> operationList, final String value) {
-        if (value.length() > 0) {
+        if (value != null && value.length() > 0) {
             final ModelNode update = Util.getWriteAttributeOperation(address, NAME, value);
             operationList.add(update);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/parse/ParseAndMarshalModelsTestCase.java
@@ -147,7 +147,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.vfs.VirtualFile;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -507,7 +506,7 @@ public class ParseAndMarshalModelsTestCase {
 
     private ModelNode loadHostModel(final File file) throws Exception {
         final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "host");
-        final HostXml parser = new HostXml(Module.getBootModuleLoader(), null);
+        final HostXml parser = new HostXml("host-controller");
         final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
         for (Namespace namespace : Namespace.values()) {
             if (namespace != Namespace.CURRENT) {
@@ -530,7 +529,7 @@ public class ParseAndMarshalModelsTestCase {
                 host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), Resource.Factory.create());
                 host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
 
-                final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(new ControlledProcessState(false));
+                final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(new ControlledProcessState(false), "master");
 
                 // Add of the host itself
                 ManagementResourceRegistration hostRegistration = root.registerSubModel(PathElement.pathElement(HOST), HostDescriptionProviders.HOST_ROOT_PROVIDER);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/parse/ParseAndMarshalModelsTestCase.java
@@ -372,7 +372,7 @@ public class ParseAndMarshalModelsTestCase {
 
     private ModelNode loadHostModel(final File file) throws Exception {
         final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "host");
-        final HostXml parser = new HostXml(Module.getBootModuleLoader(), null);
+        final HostXml parser = new HostXml("host-controller");
         final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
         for (Namespace namespace : Namespace.values()) {
             if (namespace != Namespace.CURRENT) {
@@ -395,7 +395,7 @@ public class ParseAndMarshalModelsTestCase {
                 host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), Resource.Factory.create());
                 host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
 
-                final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(new ControlledProcessState(false));
+                final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(new ControlledProcessState(false), "master");
 
                 // Add of the host itself
                 ManagementResourceRegistration hostRegistration = root.registerSubModel(PathElement.pathElement(HOST), HostDescriptionProviders.HOST_ROOT_PROVIDER);


### PR DESCRIPTION
AS7-3475 Properly integrate HostControllerEnvironment/ServerEnvironment with changes made via the management API

AS7-2409 - ability to generate a UUID as the host or server name for large, particularly cloud, deployment cases

AS7-2824 -- expose the files in the actual module.path instead of just the $JBOSS_HOME/modules dir
