### PR TITLE
AS7-3485 Occasional deadlocks in StatefulFailoverTestCase and SingletonServiceTestCase

### DIFF
--- a/clustering/registry/src/main/java/org/jboss/as/clustering/registry/RegistryService.java
+++ b/clustering/registry/src/main/java/org/jboss/as/clustering/registry/RegistryService.java
@@ -185,7 +185,7 @@ public class RegistryService<K, V> extends AsynchronousService<Registry<K, V>> i
                 // Remove entry of crashed member
                 for (Address member: oldMembers) {
                     if (!newMembers.contains(member)) {
-                        Map.Entry<K, V> old = cache.remove(member);
+                        Map.Entry<K, V> old = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).remove(member);
                         if (old != null) {
                             removed.add(old.getKey());
                         }

--- a/clustering/service/src/main/java/org/jboss/as/clustering/service/ServiceProviderRegistryService.java
+++ b/clustering/service/src/main/java/org/jboss/as/clustering/service/ServiceProviderRegistryService.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.infinispan.Cache;
+import org.infinispan.context.Flag;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
 import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
 import org.jboss.as.clustering.ClusterNode;
@@ -153,7 +154,7 @@ public class ServiceProviderRegistryService implements ServiceProviderRegistry, 
                 List<Map.Entry<String, Set<ClusterNode>>> entries = new ArrayList<Map.Entry<String, Set<ClusterNode>>>(cache.size());
                 // Remove dead nodes for each service
                 for (String key: cache.keySet()) {
-                    Map<ClusterNode, Void> map = cache.get(key);
+                    Map<ClusterNode, Void> map = cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL).get(key);
                     if (map != null) {
                         Set<ClusterNode> nodes = map.keySet();
                         if (nodes.removeAll(deadNodes)) {


### PR DESCRIPTION
Since view change events are triggered on every node in the cluster, cache operations invoked within these events should either be local-only, or only invoked from one node.
