### PR TITLE
AS7-2998 Lock the EJB client context selector on the server side

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
@@ -22,7 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors;
 
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
-import org.jboss.as.ejb3.remote.TCCLBasedEJBClientContextSelector;
+import org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -33,7 +33,7 @@ import org.jboss.msc.service.ServiceController;
 
 /**
  * A deployment processor which associates the {@link EJBClientContext}, belonging to a deployment unit,
- * with the deployment unit's classloader, so that the {@link TCCLBasedEJBClientContextSelector} can then
+ * with the deployment unit's classloader, so that the {@link org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService} can then
  * be used to return an appropriate {@link EJBClientContext} based on the classloader.
  *
  * @author Stuart Douglas
@@ -50,9 +50,9 @@ public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
             return;
         }
         final EJBClientContext ejbClientContext = deploymentUnit.getAttachment(EjbDeploymentAttachmentKeys.EJB_CLIENT_CONTEXT);
-        final ServiceController<TCCLBasedEJBClientContextSelector> tcclEJBClientContextSelectorServiceController = (ServiceController<TCCLBasedEJBClientContextSelector>) phaseContext.getServiceRegistry().getService(TCCLBasedEJBClientContextSelector.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME);
+        final ServiceController<TCCLEJBClientContextSelectorService> tcclEJBClientContextSelectorServiceController = (ServiceController<TCCLEJBClientContextSelectorService>) phaseContext.getServiceRegistry().getService(TCCLEJBClientContextSelectorService.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME);
         if (tcclEJBClientContextSelectorServiceController != null) {
-            final TCCLBasedEJBClientContextSelector tcclBasedEJBClientContextSelector = tcclEJBClientContextSelectorServiceController.getValue();
+            final TCCLEJBClientContextSelectorService tcclBasedEJBClientContextSelector = tcclEJBClientContextSelectorServiceController.getValue();
             // associate the EJB client context with the deployment classloader
             tcclBasedEJBClientContextSelector.registerEJBClientContext(ejbClientContext, module.getClassLoader());
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
@@ -21,11 +21,6 @@
  */
 package org.jboss.as.ejb3.remote;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBReceiver;
@@ -37,6 +32,11 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Service that manages an EJBClientContext
@@ -55,19 +55,36 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
      */
     public static final ServiceName DEFAULT_SERVICE_NAME = BASE_SERVICE_NAME.append("default");
 
+    // setup the EJB client context selector in a static block so that the service restart
+    // doesn't run into trouble while resetting a selector, since the ability to switch the
+    // selector will be locked https://issues.jboss.org/browse/AS7-2998
+    static {
+        // setup the selector
+        AccessController.doPrivileged(new SetSelectorAction(TCCLEJBClientContextSelector.INSTANCE));
+    }
+
     /**
      * The recievers to add to the context
      */
     private final List<InjectedValue<EJBReceiver>> ejbReceivers = new ArrayList<InjectedValue<EJBReceiver>>();
 
-    private final InjectedValue<TCCLBasedEJBClientContextSelector> tcclEJBClientContextSelector = new InjectedValue<TCCLBasedEJBClientContextSelector>();
+    private final InjectedValue<TCCLEJBClientContextSelectorService> tcclEJBClientContextSelector = new InjectedValue<TCCLEJBClientContextSelectorService>();
 
     /**
      * The client context
      */
     private volatile EJBClientContext context;
 
-    private ContextSelector<EJBClientContext> previousSelector;
+    private final boolean lockSelectorOnStart;
+
+    /**
+     * @param lockEJBClientContextSelectorOnStart
+     *         True if the EJB client context selector should be locked on start of this
+     *         service. False otherwise.
+     */
+    public DefaultEjbClientContextService(final boolean lockEJBClientContextSelectorOnStart) {
+        this.lockSelectorOnStart = lockEJBClientContextSelectorOnStart;
+    }
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
@@ -76,20 +93,24 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
             clientContext.registerEJBReceiver(receiver.getValue());
         }
         this.context = clientContext;
-        // setup the client context selector
-        // TODO: We set this up here, for now. But we need to rethink about how we are going to
-        // handle manual overrides of EJB client context selector by user code on the server side.
-        // Setting this up via interceptor isn't a good idea too since that will end up overriding
-        // the selector which the user code might have set intentionally. So let this be here for now
-        previousSelector = AccessController.doPrivileged(new SetSelectorAction(this.tcclEJBClientContextSelector.getValue()));
+        if (this.lockSelectorOnStart) {
+            // lock the EJB client context selector
+            AccessController.doPrivileged(new LockSelectorAction());
+        }
+
+        // the EJBClientContext selector is set to TCCLEJBClientContextSelector and is *locked* once
+        // (in a static block of this service) so that restarting this service will not cause failures related
+        // to resetting the selector. The TCCLEJBClientContextSelector is backed by a TCCLEJBClientContextSelectorService
+        // which is what we set here during the service start, so that the selector has the correct service to return the
+        // EJBClientContext. @see https://issues.jboss.org/browse/AS7-2998 for details
+        TCCLEJBClientContextSelector.INSTANCE.setTCCLEJBClientContextService(this.tcclEJBClientContextSelector.getValue());
+
     }
 
     @Override
     public synchronized void stop(final StopContext context) {
         this.context = null;
-        if (this.previousSelector != null) {
-            AccessController.doPrivileged(new SetSelectorAction(previousSelector));
-        }
+        TCCLEJBClientContextSelector.INSTANCE.setTCCLEJBClientContextService(null);
     }
 
     @Override
@@ -107,7 +128,7 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
         ejbReceivers.add(value);
     }
 
-    public Injector<TCCLBasedEJBClientContextSelector> getTCCLBasedEJBClientContextSelectorInjector() {
+    public Injector<TCCLEJBClientContextSelectorService> getTCCLBasedEJBClientContextSelectorInjector() {
         return this.tcclEJBClientContextSelector;
     }
 
@@ -124,4 +145,13 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
             return EJBClientContext.setSelector(selector);
         }
     }
+
+    private static final class LockSelectorAction implements PrivilegedAction<Void> {
+        @Override
+        public Void run() {
+            EJBClientContext.lockSelector();
+            return null;
+        }
+    }
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/TCCLEJBClientContextSelector.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/TCCLEJBClientContextSelector.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
+
+/**
+ * A {@link TCCLEJBClientContextSelector} is backed by {@link TCCLEJBClientContextSelectorService}
+ * which returns an appropriate {@link EJBClientContext} based on the current {@link Thread#getContextClassLoader() context classloader}
+ *
+ * @author Jaikiran Pai
+ */
+class TCCLEJBClientContextSelector implements ContextSelector<EJBClientContext> {
+
+    static final TCCLEJBClientContextSelector INSTANCE = new TCCLEJBClientContextSelector();
+
+    private volatile TCCLEJBClientContextSelectorService tcclEJBClientContextService;
+
+    void setTCCLEJBClientContextService(final TCCLEJBClientContextSelectorService clientContextService) {
+        this.tcclEJBClientContextService = clientContextService;
+    }
+
+    @Override
+    public EJBClientContext getCurrent() {
+        if (this.tcclEJBClientContextService == null) {
+            return null;
+        }
+        return this.tcclEJBClientContextService.getCurrent();
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/TCCLEJBClientContextSelectorService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/TCCLEJBClientContextSelectorService.java
@@ -38,7 +38,7 @@ import org.jboss.msc.service.StopContext;
  *
  * @author Jaikiran Pai
  */
-public class TCCLBasedEJBClientContextSelector implements Service<TCCLBasedEJBClientContextSelector>,
+public class TCCLEJBClientContextSelectorService implements Service<TCCLEJBClientContextSelectorService>,
         ContextSelector<EJBClientContext> {
 
     public static final ServiceName TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("remote").append("tccl-based-ejb-client-context-selector");
@@ -73,7 +73,7 @@ public class TCCLBasedEJBClientContextSelector implements Service<TCCLBasedEJBCl
     }
 
     @Override
-    public TCCLBasedEJBClientContextSelector getValue() throws IllegalStateException, IllegalArgumentException {
+    public TCCLEJBClientContextSelectorService getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
     }
 

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemAdd.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemAdd.java
@@ -42,7 +42,7 @@ import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
 import org.jboss.as.ejb3.remote.RemoteViewManagedReferenceFactory;
-import org.jboss.as.ejb3.remote.TCCLBasedEJBClientContextSelector;
+import org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService;
 import org.jboss.as.jmx.MBeanServerService;
 import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
@@ -91,7 +91,7 @@ class JSR77ManagementSubsystemAdd extends AbstractAddStepHandler {
                     .addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, managementEjbService.mbeanServerValue)
                     //TODO I think these are needed here since we don't go through EjbClientContextSetupProcessor
                     .addDependency(DefaultEjbClientContextService.DEFAULT_SERVICE_NAME, EJBClientContext.class, managementEjbService.ejbClientContextValue)
-                    .addDependency(TCCLBasedEJBClientContextSelector.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME, TCCLBasedEJBClientContextSelector.class, managementEjbService.ejbClientContextSelectorValue)
+                    .addDependency(TCCLEJBClientContextSelectorService.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME, TCCLEJBClientContextSelectorService.class, managementEjbService.ejbClientContextSelectorValue)
                     .setInitialMode(Mode.ACTIVE)
                     .install();
 

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/RegisterManagementEJBService.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/RegisterManagementEJBService.java
@@ -39,7 +39,7 @@ import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.EjbDeploymentInformation;
 import org.jboss.as.ejb3.deployment.ModuleDeployment;
-import org.jboss.as.ejb3.remote.TCCLBasedEJBClientContextSelector;
+import org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService;
 import org.jboss.as.jsr77.ejb.ManagementEjbDeploymentInformation;
 import org.jboss.as.jsr77.ejb.ManagementHomeEjbComponentView;
 import org.jboss.as.jsr77.ejb.ManagementRemoteEjbComponentView;
@@ -61,7 +61,7 @@ public class RegisterManagementEJBService implements Service<Void>{
     static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append(ServiceName.of(JSR77ManagementExtension.SUBSYSTEM_NAME, "ejb"));
 
     final InjectedValue<DeploymentRepository> deploymentRepositoryValue = new InjectedValue<DeploymentRepository>();
-    final InjectedValue<TCCLBasedEJBClientContextSelector> ejbClientContextSelectorValue = new InjectedValue<TCCLBasedEJBClientContextSelector>();
+    final InjectedValue<TCCLEJBClientContextSelectorService> ejbClientContextSelectorValue = new InjectedValue<TCCLEJBClientContextSelectorService>();
     final InjectedValue<EJBClientContext> ejbClientContextValue = new InjectedValue<EJBClientContext>();
     final InjectedValue<MBeanServer> mbeanServerValue = new InjectedValue<MBeanServer>();
     private volatile DeploymentModuleIdentifier moduleIdentifier;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/selector/EJBClientContextLockedSelectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/selector/EJBClientContextLockedSelectorTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.client.selector;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+/**
+ * Tests that server side application code cannot change
+ * {@link org.jboss.ejb.client.EJBClientContext#setSelector(org.jboss.ejb.client.ContextSelector) EJB client context selector}
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class EJBClientContextLockedSelectorTestCase {
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb-client-context-locked-selector-test.jar");
+        jar.addPackage(EJBClientContextSelectorChangingBean.class.getPackage());
+        return jar;
+    }
+
+    /**
+     * Tests that user application code cannot set EJB client context selector on the server side
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testChangingLockedEJBClientContextSelector() throws Exception {
+        final Context ctx = new InitialContext();
+        final EJBClientContextSelectorChangingBean bean = (EJBClientContextSelectorChangingBean) ctx.lookup("java:module/" + EJBClientContextSelectorChangingBean.class.getSimpleName() + "!" + EJBClientContextSelectorChangingBean.class.getName());
+        bean.changeLockedSelector();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/selector/EJBClientContextSelectorChangingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/selector/EJBClientContextSelectorChangingBean.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.client.selector;
+
+import org.jboss.ejb.client.ConstantContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.logging.Logger;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@LocalBean
+public class EJBClientContextSelectorChangingBean {
+
+    private static final Logger logger = Logger.getLogger(EJBClientContextSelectorChangingBean.class);
+
+    public void changeLockedSelector() {
+        final EJBClientContext dummyContext = EJBClientContext.create();
+        // try setting a selector
+        this.callSetSelector(dummyContext);
+        // now try the other API
+        this.callSetConstantContext(dummyContext);
+
+    }
+
+    private void callSetSelector(final EJBClientContext clientContext) {
+        try {
+            EJBClientContext.setSelector(new ConstantContextSelector<EJBClientContext>(clientContext));
+        } catch (SecurityException se) {
+            // expected
+            logger.info("Got the expected " + se + " while trying to call EJBClientContext.setSelector() on the server, from an EJB");
+            return;
+        }
+        throw new RuntimeException("EJBClientContext.setSelector() was expected to fail on server side");
+    }
+
+    private void callSetConstantContext(final EJBClientContext clientContext) {
+        try {
+            EJBClientContext.setConstantContext(clientContext);
+        } catch (SecurityException se) {
+            // expected
+            logger.info("Got the expected " + se + " while try to call EJBClientContext.setConstantContext() on the server, from an EJB");
+            return;
+        }
+        throw new RuntimeException("EJBClientContext.setConstantContext() was expected to fail on server side");
+    }
+
+}


### PR DESCRIPTION
The commit in this branch locks the EJB client context selector on the server side to prevent any user application(s) from trying to change it (and effectively affect other applications on the server). This completes the https://issues.jboss.org/browse/AS7-2998 task.
