### PR TITLE
AS7-3296 - fix inconsistent handling of properties

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-remoting_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-remoting_1_1.xsd
@@ -300,7 +300,7 @@
 
     <xs:complexType name="base-outbound-connectionType">
         <xs:all>
-            <xs:element name="connection-creation-options" type="xnio-optionsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>

--- a/controller/src/main/java/org/jboss/as/controller/parsing/ParseUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/ParseUtils.java
@@ -296,7 +296,8 @@ public final class ParseUtils {
         String name = null;
         String value = null;
         for (int i = 0; i < cnt; i++) {
-            if (reader.getAttributeNamespace(i) != null) {
+            String uri = reader.getAttributeNamespace(i);
+            if (uri != null&&!"".equals(XMLConstants.NULL_NS_URI)) {
                 throw unexpectedAttribute(reader, i);
             }
             final String localName = reader.getAttributeLocalName(i);

--- a/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -109,7 +109,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
         assertEquals(1, connector.require(CommonAttributes.PROPERTY).require("org.xnio.Options.WORKER_ACCEPT_THREADS").require(CommonAttributes.VALUE).asInt());
     }
 
-    @Test @Ignore("AS7-2717")
+    @Test
     public void testSubsystemWithThreadAttributeChange() throws Exception {
         final int port = 12345;
         KernelServices services = installInController(new AdditionalInitialization(){
@@ -154,7 +154,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
 
-    @Test @Ignore("AS7-2717")
+    @Test
     public void testSubsystemWithConnectorPropertyChange() throws Exception {
         final int port = 12345;
         KernelServices services = installInController(new AdditionalInitialization(){
@@ -207,7 +207,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
         current.updateCurrentConnector(false);
     }
 
-    @Test @Ignore("AS7-2717")
+    @Test
     public void testSubsystemWithBadConnectorProperty() throws Exception {
         final int port = 12345;
         KernelServices services = installInController(new AdditionalInitialization(){

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
@@ -3,16 +3,16 @@
 
     <outbound-connections>
         <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket">
-        	<connection-creation-options>
-        	    <option name="SASL_POLICY_NOANONYMOUS" value="false"/>
-				<option name="SSL_ENABLED" value="false"/>
-        	</connection-creation-options>
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
         </remote-outbound-connection>
         <local-outbound-connection name="local-conn1" outbound-socket-binding-ref="other-outbound-socket">
-        	<connection-creation-options>
-        	    <option name="SASL_POLICY_NOANONYMOUS" value="false"/>
-				<option name="SSL_ENABLED" value="false"/>
-        	</connection-creation-options>
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
         </local-outbound-connection>
     </outbound-connections>
 </subsystem>

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
@@ -1,19 +1,19 @@
 <subsystem xmlns="urn:jboss:domain:remoting:1.1">
     <connector name="test-connector" socket-binding="test"/>
 
-    <outbound-connections>
-        <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket">
-            <properties>
-                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
-                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
-            </properties>
-        </remote-outbound-connection>
-        <local-outbound-connection name="local-conn1" outbound-socket-binding-ref="other-outbound-socket">
-            <properties>
-                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
-                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
-            </properties>
-        </local-outbound-connection>
-    </outbound-connections>
+        <outbound-connections>
+            <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket">
+                <properties>
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+                </properties>
+            </remote-outbound-connection>
+            <local-outbound-connection name="local-conn1" outbound-socket-binding-ref="other-outbound-socket">
+                <properties>
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+                </properties>
+            </local-outbound-connection>
+        </outbound-connections>
 </subsystem>
 

--- a/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionAddHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionAddHandler.java
@@ -23,54 +23,27 @@
 package org.jboss.as.remoting;
 
 
-import static org.xnio.Options.SSL_ENABLED;
-import static org.xnio.Options.SSL_STARTTLS;
-
-import java.util.List;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.xnio.Option;
 import org.xnio.OptionMap;
-import org.xnio.Options;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 /**
  * @author Jaikiran Pai
  */
 abstract class AbstractOutboundConnectionAddHandler extends AbstractAddStepHandler {
-
     @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
 
-        AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS.validateAndSet(operation, model);
     }
 
-    /**
-     * Parses the {@link CommonAttributes#CONNECTION_CREATION_OPTIONS} from the passed <code>model</code>
-     * and returns a {@link OptionMap} representing those options. If the <code>model</code> doesn't
-     * have any {@link CommonAttributes#CONNECTION_CREATION_OPTIONS} then this method returns {@link OptionMap#EMPTY}
-     *
-     * @param model The model which might contain the connection creation options
-     * @return
-     */
-    protected static OptionMap getConnectionCreationOptions(final ModelNode model) {
-        if (!model.hasDefined(CommonAttributes.CONNECTION_CREATION_OPTIONS)) {
-            return OptionMap.create(SSL_ENABLED, true, SSL_STARTTLS, true);
-        }
-        final OptionMap.Builder optionMapBuilder = OptionMap.builder();
-        final List<Property> connectionCreationProps = model.get(CommonAttributes.CONNECTION_CREATION_OPTIONS).asPropertyList();
-        for (final Property property : connectionCreationProps) {
-            final String xnioOptionName = property.getName();
-            final String value = property.getValue().asString();
 
-            final String fullyQualifiedOptionName = Options.class.getName() + "." + xnioOptionName;
-            // create the XNIO option for the option name
-            final Option connectionCreationOption = Option.fromString(fullyQualifiedOptionName, Options.class.getClassLoader());
-            // now parse and set the value
-            optionMapBuilder.parse(connectionCreationOption, value);
-        }
-        return optionMapBuilder.getMap();
+    protected static OptionMap getConnectionCreationOptions(final OperationContext context, final ModelNode operation) {
+        final PathAddress pathAddress = PathAddress.pathAddress(operation.require(OP_ADDR));
+        return ConnectorResource.getOptions(context, pathAddress);
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionResourceDefinition.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionResourceDefinition.java
@@ -52,10 +52,8 @@ abstract class AbstractOutboundConnectionResourceDefinition extends SimpleResour
     }
 
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerSubModel(PropertyResource.INSTANCE);
-    }
+
+    public abstract void registerChildren(ManagementResourceRegistration resourceRegistration);
 
     /**
      * Returns the write attribute handler for the <code>attribute</code>

--- a/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionResourceDefinition.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/AbstractOutboundConnectionResourceDefinition.java
@@ -46,18 +46,15 @@ import org.jboss.dmr.ModelType;
  */
 abstract class AbstractOutboundConnectionResourceDefinition extends SimpleResourceDefinition {
 
-    public static final MapAttributeDefinition CONNECTION_CREATION_OPTIONS =
-            new PropertiesAttributeDefinition(CommonAttributes.CONNECTION_CREATION_OPTIONS,
-                    Element.CONNECTION_CREATION_OPTIONS.getLocalName(), true, null, null);
-
     protected AbstractOutboundConnectionResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver,
                                                            final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
         super(pathElement, descriptionResolver, addHandler, removeHandler);
     }
 
+
     @Override
-    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(CONNECTION_CREATION_OPTIONS, null, this.getWriteAttributeHandler(CONNECTION_CREATION_OPTIONS));
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerSubModel(PropertyResource.INSTANCE);
     }
 
     /**
@@ -67,39 +64,4 @@ abstract class AbstractOutboundConnectionResourceDefinition extends SimpleResour
      */
     protected abstract OperationStepHandler getWriteAttributeHandler(final AttributeDefinition attribute);
 
-    /**
-     * This is just a stop-gap solution for {@link ModelType#PROPERTY} type attributes.
-     * This class needs to be moved to a better place and the marshallAsElement should be implemented.
-     * For now, we don't use the {@link #marshallAsElement(org.jboss.dmr.ModelNode, javax.xml.stream.XMLStreamWriter)}
-     */
-    private static class PropertiesAttributeDefinition extends MapAttributeDefinition {
-
-        PropertiesAttributeDefinition(final String name, final String xmlName, boolean allowNull,final String[] alternatives,
-                                      final String[] requires, final AttributeAccess.Flag... flags) {
-            super(name, xmlName, allowNull, 0, Integer.MAX_VALUE, new ModelTypeValidator(ModelType.STRING), alternatives, requires, flags);
-        }
-
-        @Override
-        protected void addValueTypeDescription(ModelNode node, ResourceBundle bundle) {
-            node.get(ModelDescriptionConstants.VALUE_TYPE).set(ModelType.STRING);
-        }
-
-        @Override
-        protected void addAttributeValueTypeDescription(ModelNode node, ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
-            node.get(ModelDescriptionConstants.VALUE_TYPE).set(ModelType.STRING);
-        }
-
-        @Override
-        protected void addOperationParameterValueTypeDescription(ModelNode node, String operationName, ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
-            node.get(ModelDescriptionConstants.VALUE_TYPE).set(ModelType.STRING);
-        }
-
-        // TODO: We don't currently support marshalling. This entire attribute definition needs to be
-        // moved at a better place and the subsystem writers/marshallers should start relying on these attribute
-        // definitions for marshalling. For now, let the subsystem writers/marshallers handle the marshalling
-        @Override
-        public void marshallAsElement(ModelNode resourceModel, XMLStreamWriter writer) throws XMLStreamException {
-            throw new RuntimeException("marshallAsElement isn't supported for " + this.getClass().getName());
-        }
-    }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/CommonAttributes.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/CommonAttributes.java
@@ -28,7 +28,7 @@ package org.jboss.as.remoting;
 interface CommonAttributes {
 
     String AUTHENTICATION_PROVIDER = "authentication-provider";
-    String CONNECTION_CREATION_OPTIONS = "connection-creation-options";
+    //String CONNECTION_CREATION_OPTIONS = "connection-creation-options";
     String CONNECTOR = "connector";
     String FORWARD_SECRECY = "forward-secrecy";
     String INCLUDE_MECHANISMS = "include-mechanisms";

--- a/remoting/src/main/java/org/jboss/as/remoting/CommonAttributes.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/CommonAttributes.java
@@ -28,7 +28,6 @@ package org.jboss.as.remoting;
 interface CommonAttributes {
 
     String AUTHENTICATION_PROVIDER = "authentication-provider";
-    //String CONNECTION_CREATION_OPTIONS = "connection-creation-options";
     String CONNECTOR = "connector";
     String FORWARD_SECRECY = "forward-secrecy";
     String INCLUDE_MECHANISMS = "include-mechanisms";

--- a/remoting/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
@@ -23,46 +23,22 @@
 package org.jboss.as.remoting;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.remoting.CommonAttributes.FORWARD_SECRECY;
-import static org.jboss.as.remoting.CommonAttributes.INCLUDE_MECHANISMS;
-import static org.jboss.as.remoting.CommonAttributes.NO_ACTIVE;
-import static org.jboss.as.remoting.CommonAttributes.NO_ANONYMOUS;
-import static org.jboss.as.remoting.CommonAttributes.NO_DICTIONARY;
-import static org.jboss.as.remoting.CommonAttributes.NO_PLAIN_TEXT;
-import static org.jboss.as.remoting.CommonAttributes.PASS_CREDENTIALS;
-import static org.jboss.as.remoting.CommonAttributes.POLICY;
-import static org.jboss.as.remoting.CommonAttributes.QOP;
-import static org.jboss.as.remoting.CommonAttributes.SASL;
 import static org.jboss.as.remoting.CommonAttributes.SECURITY_REALM;
-import static org.jboss.as.remoting.CommonAttributes.SERVER_AUTH;
-import static org.jboss.as.remoting.CommonAttributes.STRENGTH;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.controller.registry.Resource.ResourceEntry;
 import org.jboss.as.domain.management.security.SecurityRealmService;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.xnio.Option;
 import org.xnio.OptionMap;
-import org.xnio.Options;
-import org.xnio.Sequence;
-import org.xnio.sasl.SaslQop;
-import org.xnio.sasl.SaslStrength;
 
 /**
  * Add a connector to a remoting container.
@@ -99,24 +75,7 @@ public class ConnectorAdd extends AbstractAddStepHandler {
         final ServiceTarget target = context.getServiceTarget();
 
         final ServiceName socketBindingName = SocketBinding.JBOSS_BINDING_NAME.append(ConnectorResource.SOCKET_BINDING.resolveModelAttribute(context, model).asString());
-
-
-        final OptionMap optionMap;
-        Resource resource = findResource(context.getRootResource(), pathAddress);
-        Set<ResourceEntry> entries = resource.getChildren(CommonAttributes.PROPERTY);
-        if (entries.size() > 0) {
-            OptionMap.Builder builder = OptionMap.builder();
-            final ClassLoader loader = SecurityActions.getClassLoader(this.getClass());
-            for (ResourceEntry entry : entries) {
-                final Option option = Option.fromString(entry.getName(), loader);
-                builder.set(option, option.parseValue(entry.getModel().get(CommonAttributes.VALUE).asString(), loader));
-            }
-            optionMap = builder.getMap();
-        } else {
-            optionMap = OptionMap.EMPTY;
-        }
-
-
+        final OptionMap optionMap = ConnectorResource.getOptions(context, pathAddress);
         RemotingServices.installConnectorServicesForSocketBinding(target, RemotingServices.SUBSYSTEM_ENDPOINT, connectorName, socketBindingName, optionMap, verificationHandler, newControllers);
 
         //TODO AuthenticationHandler
@@ -140,15 +99,7 @@ public class ConnectorAdd extends AbstractAddStepHandler {
 //        }
     }
 
-    private Resource findResource(Resource rootResource, PathAddress address) {
-        Resource resource = rootResource;
-        for (ListIterator<PathElement> iterator = address.iterator() ; iterator.hasNext() ; ) {
-            resource = resource.getChild(iterator.next());
-        }
-        return resource;
-    }
-
-    static OptionMap createOptionMap(final ModelNode parameters) {
+   /* static OptionMap createOptionMap(final ModelNode parameters) {
         final OptionMap.Builder builder = OptionMap.builder();
 
         if (parameters.hasDefined(SASL)) {
@@ -186,4 +137,5 @@ public class ConnectorAdd extends AbstractAddStepHandler {
         }
         return set;
     }
+    */
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/ConnectorResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/ConnectorResource.java
@@ -23,13 +23,21 @@ package org.jboss.as.remoting;
 
 import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
 
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelType;
+import org.xnio.Option;
+import org.xnio.OptionMap;
+
+import java.util.ListIterator;
+import java.util.Set;
 
 /**
  *
@@ -47,6 +55,32 @@ public class ConnectorResource extends SimpleResourceDefinition {
                 RemotingExtension.getResourceDescriptionResolver(CONNECTOR),
                 ConnectorAdd.INSTANCE,
                 ConnectorRemove.INSTANCE);
+    }
+
+    protected static OptionMap getOptions(OperationContext context, PathAddress pathAddress) {
+        final OptionMap optionMap;
+        Resource resource = findResource(context.getRootResource(), pathAddress);
+        Set<Resource.ResourceEntry> entries = resource.getChildren(CommonAttributes.PROPERTY);
+        if (entries.size() > 0) {
+            OptionMap.Builder builder = OptionMap.builder();
+            final ClassLoader loader = SecurityActions.getClassLoader(ConnectorResource.class);
+            for (Resource.ResourceEntry entry : entries) {
+                final Option option = Option.fromString(entry.getName(), loader);
+                builder.set(option, option.parseValue(entry.getModel().get(CommonAttributes.VALUE).asString(), loader));
+            }
+            optionMap = builder.getMap();
+        } else {
+            optionMap = OptionMap.EMPTY;
+        }
+        return optionMap;
+    }
+
+    private static Resource findResource(Resource rootResource, PathAddress address) {
+        Resource resource = rootResource;
+        for (ListIterator<PathElement> iterator = address.iterator() ; iterator.hasNext() ; ) {
+            resource = resource.getChild(iterator.next());
+        }
+        return resource;
     }
 
     @Override

--- a/remoting/src/main/java/org/jboss/as/remoting/Element.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/Element.java
@@ -34,7 +34,6 @@ public enum Element {
 
     // Remoting 1.0 elements in alpha order
     AUTHENTICATION_PROVIDER("authentication-provider"),
-    //CONNECTION_CREATION_OPTIONS("connection-creation-options"),
     CONNECTOR("connector"),
     FORWARD_SECRECY("forward-secrecy"),
     INCLUDE_MECHANISMS("include-mechanisms"),

--- a/remoting/src/main/java/org/jboss/as/remoting/Element.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/Element.java
@@ -34,7 +34,7 @@ public enum Element {
 
     // Remoting 1.0 elements in alpha order
     AUTHENTICATION_PROVIDER("authentication-provider"),
-    CONNECTION_CREATION_OPTIONS("connection-creation-options"),
+    //CONNECTION_CREATION_OPTIONS("connection-creation-options"),
     CONNECTOR("connector"),
     FORWARD_SECRECY("forward-secrecy"),
     INCLUDE_MECHANISMS("include-mechanisms"),

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionRemoveHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionRemoveHandler.java
@@ -50,7 +50,6 @@ class GenericOutboundConnectionRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void recoverServices(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        final String name = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
-        GenericOutboundConnectionAdd.INSTANCE.installRuntimeService(context, name, model, null);
+        GenericOutboundConnectionAdd.INSTANCE.installRuntimeService(context, operation, null);
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionResourceDefinition.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionResourceDefinition.java
@@ -52,6 +52,11 @@ class GenericOutboundConnectionResourceDefinition extends AbstractOutboundConnec
     }
 
     @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerSubModel(new PropertyResource(CommonAttributes.OUTBOUND_CONNECTION));
+    }
+
+    @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
         resourceRegistration.registerReadWriteAttribute(URI, null, GenericOutboundConnectionWriteHandler.INSTANCE);

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionWriteHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionWriteHandler.java
@@ -40,7 +40,7 @@ class GenericOutboundConnectionWriteHandler extends AbstractWriteAttributeHandle
     static final GenericOutboundConnectionWriteHandler INSTANCE = new GenericOutboundConnectionWriteHandler();
 
     private GenericOutboundConnectionWriteHandler() {
-        super(AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS, GenericOutboundConnectionResourceDefinition.URI);
+        super(GenericOutboundConnectionResourceDefinition.URI);
     }
 
     @Override
@@ -67,16 +67,14 @@ class GenericOutboundConnectionWriteHandler extends AbstractWriteAttributeHandle
         ServiceController sc = registry.getService(serviceName);
         if (sc != null && sc.getState() == ServiceController.State.UP) {
             GenericOutboundConnectionService svc = GenericOutboundConnectionService.class.cast(sc.getValue());
-            if (AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS.getName().equals(attributeName)) {
-                svc.setConnectionCreationOptions(AbstractOutboundConnectionAddHandler.getConnectionCreationOptions(model));
-            } else if (GenericOutboundConnectionResourceDefinition.URI.getName().equals(attributeName)) {
+            if (GenericOutboundConnectionResourceDefinition.URI.getName().equals(attributeName)) {
                 svc.setDestination(GenericOutboundConnectionAdd.INSTANCE.getDestinationURI(context, model));
             }
         } else {
             // Service isn't up so we can bounce it
             context.removeService(serviceName); // safe even if the service doesn't exist
             // install the service with new values
-            GenericOutboundConnectionAdd.INSTANCE.installRuntimeService(context, connectionName, model, null);
+            GenericOutboundConnectionAdd.INSTANCE.installRuntimeService(context, operation, null);
         }
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
@@ -46,36 +46,6 @@ class LocalOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler {
 
     static final LocalOutboundConnectionAdd INSTANCE = new LocalOutboundConnectionAdd();
 
-    static ModelNode getAddOperation(final String connectionName, final String outboundSocketBindingRef, final Map<String, String> connectionCreationOptions) {
-        if (connectionName == null || connectionName.trim().isEmpty()) {
-            throw new IllegalArgumentException("Connection name cannot be null or empty");
-        }
-        if (outboundSocketBindingRef == null || outboundSocketBindingRef.trim().isEmpty()) {
-            throw new IllegalArgumentException("Outbound socket binding reference cannot be null or empty for connection named " + connectionName);
-        }
-        final ModelNode addOperation = new ModelNode();
-        addOperation.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-        // /subsystem=remoting/local-outbound-connection=<connection-name>
-        final PathAddress address = PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME),
-                PathElement.pathElement(CommonAttributes.LOCAL_OUTBOUND_CONNECTION, connectionName));
-        addOperation.get(ModelDescriptionConstants.OP_ADDR).set(address.toModelNode());
-
-        // set the other params
-        addOperation.get(CommonAttributes.OUTBOUND_SOCKET_BINDING_REF).set(outboundSocketBindingRef);
-        // optional connection creation options
-        if (connectionCreationOptions != null) {
-            for (final Map.Entry<String, String> entry : connectionCreationOptions.entrySet()) {
-                if (entry.getKey() == null) {
-                    // skip
-                    continue;
-                }
-                addOperation.get(CommonAttributes.CONNECTION_CREATION_OPTIONS).add(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return addOperation;
-    }
-
     private LocalOutboundConnectionAdd() {
 
     }
@@ -89,18 +59,16 @@ class LocalOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        final String name = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
-        final ServiceController serviceController = installRuntimeService(context, name, model, verificationHandler);
+        final ServiceController serviceController = installRuntimeService(context, operation, verificationHandler);
         newControllers.add(serviceController);
     }
 
-    ServiceController installRuntimeService(OperationContext context, String connectionName, ModelNode outboundConnection,
-                                            ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-
-        final String outboundSocketBindingRef = LocalOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, outboundConnection).asString();
+    ServiceController installRuntimeService(OperationContext context, ModelNode operation, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
+        final String connectionName = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
+        final String outboundSocketBindingRef = LocalOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, operation).asString();
         final ServiceName outboundSocketBindingDependency = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketBindingRef);
         // fetch the connection creation options from the model
-        final OptionMap connectionCreationOptions = getConnectionCreationOptions(outboundConnection);
+        final OptionMap connectionCreationOptions = getConnectionCreationOptions(context,operation);
         // create the service
         final LocalOutboundConnectionService outboundConnectionService = new LocalOutboundConnectionService(connectionName, connectionCreationOptions);
         final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionRemoveHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionRemoveHandler.java
@@ -50,7 +50,6 @@ class LocalOutboundConnectionRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void recoverServices(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        final String name = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
-        LocalOutboundConnectionAdd.INSTANCE.installRuntimeService(context, name, model, null);
+        LocalOutboundConnectionAdd.INSTANCE.installRuntimeService(context, operation, null);
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionResourceDefinition.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionResourceDefinition.java
@@ -52,6 +52,11 @@ class LocalOutboundConnectionResourceDefinition extends AbstractOutboundConnecti
     }
 
     @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerSubModel(new PropertyResource(CommonAttributes.LOCAL_OUTBOUND_CONNECTION));
+    }
+
+    @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
         resourceRegistration.registerReadWriteAttribute(OUTBOUND_SOCKET_BINDING_REF, null, LocalOutboundConnectionWriteHandler.INSTANCE);

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionWriteHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionWriteHandler.java
@@ -40,7 +40,7 @@ class LocalOutboundConnectionWriteHandler extends AbstractWriteAttributeHandler<
     static final LocalOutboundConnectionWriteHandler INSTANCE = new LocalOutboundConnectionWriteHandler();
 
     private LocalOutboundConnectionWriteHandler() {
-        super(AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS, LocalOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF);
+        super(LocalOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF);
     }
 
     @Override
@@ -68,18 +68,12 @@ class LocalOutboundConnectionWriteHandler extends AbstractWriteAttributeHandler<
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController sc = registry.getService(serviceName);
         if (sc != null && sc.getState() == ServiceController.State.UP) {
-            LocalOutboundConnectionService svc = LocalOutboundConnectionService.class.cast(sc.getValue());
-            if (AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS.getName().equals(attributeName)) {
-                svc.setConnectionCreationOptions(AbstractOutboundConnectionAddHandler.getConnectionCreationOptions(model));
-            } else {
-                // We can't change the socket binding ref on a running service
                 reloadRequired = true;
-            }
         } else {
             // Service isn't up so we can bounce it
             context.removeService(serviceName); // safe even if the service doesn't exist
             // install the service with new values
-            LocalOutboundConnectionAdd.INSTANCE.installRuntimeService(context, connectionName, model, null);
+            LocalOutboundConnectionAdd.INSTANCE.installRuntimeService(context, operation, null);
         }
         return reloadRequired;
     }

--- a/remoting/src/main/java/org/jboss/as/remoting/PropertyResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/PropertyResource.java
@@ -45,20 +45,21 @@ import org.jboss.msc.service.ServiceName;
  */
 public class PropertyResource extends SimpleResourceDefinition {
 
-    static final PropertyResource INSTANCE = new PropertyResource();
+    static final PropertyResource INSTANCE_CONNECTOR = new PropertyResource(CONNECTOR);
 
     static final SimpleAttributeDefinition VALUE = new NamedValueAttributeDefinition(CommonAttributes.VALUE, Attribute.VALUE, null, ModelType.STRING, true);
-
-    private PropertyResource() {
+    private final String parent;
+    protected PropertyResource(String parent) {
         super(PathElement.pathElement(PROPERTY),
                 RemotingExtension.getResourceDescriptionResolver(PROPERTY),
-                PropertyAdd.INSTANCE,
-                PropertyRemove.INSTANCE);
+                new PropertyAdd(parent),
+                new PropertyRemove(parent));
+        this.parent = parent;
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadWriteAttribute(VALUE, null, new PropertyWriteAttributeHandler());
+        resourceRegistration.registerReadWriteAttribute(VALUE, null, new PropertyWriteAttributeHandler(parent));
     }
 
     private static void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel,
@@ -77,9 +78,9 @@ public class PropertyResource extends SimpleResourceDefinition {
 
     private static class PropertyWriteAttributeHandler extends RestartParentWriteAttributeHandler {
 
-        public PropertyWriteAttributeHandler() {
+        public PropertyWriteAttributeHandler(String parent) {
             // FIXME PropertyWriteAttributeHandler constructor
-            super(CONNECTOR, VALUE);
+            super(parent, VALUE);
         }
 
         @Override
@@ -96,10 +97,8 @@ public class PropertyResource extends SimpleResourceDefinition {
 
     private static class PropertyAdd extends RestartParentResourceAddHandler {
 
-        static final PropertyAdd INSTANCE = new PropertyAdd();
-
-        private PropertyAdd() {
-            super(CONNECTOR);
+        private PropertyAdd(String parent) {
+            super(parent);
         }
 
         protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException{
@@ -119,11 +118,8 @@ public class PropertyResource extends SimpleResourceDefinition {
     }
 
     private static class PropertyRemove extends RestartParentResourceRemoveHandler {
-
-        static final PropertyRemove INSTANCE = new PropertyRemove();
-
-        private PropertyRemove() {
-            super(CONNECTOR);
+        private PropertyRemove(String parent) {
+            super(parent);
         }
 
         @Override

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionRemoveHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionRemoveHandler.java
@@ -50,7 +50,6 @@ class RemoteOutboundConnectionRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void recoverServices(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        final String name = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
-        RemoteOutboundConnectionAdd.INSTANCE.installRuntimeService(context, name, model, null);
+        RemoteOutboundConnectionAdd.INSTANCE.installRuntimeService(context,  model, null);
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionWriteHandler.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionWriteHandler.java
@@ -40,7 +40,7 @@ class RemoteOutboundConnectionWriteHandler extends AbstractWriteAttributeHandler
     static final RemoteOutboundConnectionWriteHandler INSTANCE = new RemoteOutboundConnectionWriteHandler();
 
     private RemoteOutboundConnectionWriteHandler() {
-        super(AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS, RemoteOutboundConnnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF);
+        super(RemoteOutboundConnnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF);
     }
 
     @Override
@@ -69,18 +69,12 @@ class RemoteOutboundConnectionWriteHandler extends AbstractWriteAttributeHandler
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController sc = registry.getService(serviceName);
         if (sc != null && sc.getState() == ServiceController.State.UP) {
-            RemoteOutboundConnectionService svc = RemoteOutboundConnectionService.class.cast(sc.getValue());
-            if (AbstractOutboundConnectionResourceDefinition.CONNECTION_CREATION_OPTIONS.getName().equals(attributeName)) {
-                svc.setConnectionCreationOptions(AbstractOutboundConnectionAddHandler.getConnectionCreationOptions(model));
-            } else {
-                // We can't change the socket binding ref on a running service
-                reloadRequired = true;
-            }
+            reloadRequired = true;
         } else {
             // Service isn't up so we can bounce it
             context.removeService(serviceName); // safe even if the service doesn't exist
             // install the service with new values
-            RemoteOutboundConnectionAdd.INSTANCE.installRuntimeService(context, connectionName, model, null);
+            RemoteOutboundConnectionAdd.INSTANCE.installRuntimeService(context, model, null);
         }
 
         return reloadRequired;

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnnectionResourceDefinition.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnnectionResourceDefinition.java
@@ -52,6 +52,11 @@ class RemoteOutboundConnnectionResourceDefinition extends AbstractOutboundConnec
     }
 
     @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerSubModel(new PropertyResource(CommonAttributes.REMOTE_OUTBOUND_CONNECTION));
+    }
+
+    @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
         resourceRegistration.registerReadWriteAttribute(OUTBOUND_SOCKET_BINDING_REF, null, RemoteOutboundConnectionWriteHandler.INSTANCE);

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -121,10 +121,10 @@ public class RemotingExtension implements Extension {
         subsystem.registerOperationHandler(DESCRIBE, GenericSubsystemDescribeHandler.INSTANCE, GenericSubsystemDescribeHandler.INSTANCE, false, OperationEntry.EntryType.PRIVATE);
 
         final ManagementResourceRegistration connector = subsystem.registerSubModel(ConnectorResource.INSTANCE);
-        connector.registerSubModel(PropertyResource.INSTANCE);
+        connector.registerSubModel(PropertyResource.INSTANCE_CONNECTOR);
         final ManagementResourceRegistration sasl = connector.registerSubModel(SaslResource.INSTANCE);
         sasl.registerSubModel(SaslPolicyResource.INSTANCE);
-        sasl.registerSubModel(PropertyResource.INSTANCE);
+        sasl.registerSubModel(PropertyResource.INSTANCE_CONNECTOR);
 
         // remote outbound connection
         subsystem.registerSubModel(RemoteOutboundConnnectionResourceDefinition.INSTANCE);

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
@@ -22,6 +22,26 @@
 
 package org.jboss.as.remoting;
 
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+import org.xnio.sasl.SaslQop;
+import org.xnio.sasl.SaslStrength;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import java.util.EnumSet;
+import java.util.List;
+
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -38,54 +58,7 @@ import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
-import static org.jboss.as.remoting.CommonAttributes.AUTHENTICATION_PROVIDER;
-import static org.jboss.as.remoting.CommonAttributes.CONNECTION_CREATION_OPTIONS;
-import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
-import static org.jboss.as.remoting.CommonAttributes.FORWARD_SECRECY;
-import static org.jboss.as.remoting.CommonAttributes.INCLUDE_MECHANISMS;
-import static org.jboss.as.remoting.CommonAttributes.LOCAL_OUTBOUND_CONNECTION;
-import static org.jboss.as.remoting.CommonAttributes.NO_ACTIVE;
-import static org.jboss.as.remoting.CommonAttributes.NO_ANONYMOUS;
-import static org.jboss.as.remoting.CommonAttributes.NO_DICTIONARY;
-import static org.jboss.as.remoting.CommonAttributes.NO_PLAIN_TEXT;
-import static org.jboss.as.remoting.CommonAttributes.OUTBOUND_CONNECTION;
-import static org.jboss.as.remoting.CommonAttributes.OUTBOUND_SOCKET_BINDING_REF;
-import static org.jboss.as.remoting.CommonAttributes.PASS_CREDENTIALS;
-import static org.jboss.as.remoting.CommonAttributes.POLICY;
-import static org.jboss.as.remoting.CommonAttributes.PROPERTY;
-import static org.jboss.as.remoting.CommonAttributes.QOP;
-import static org.jboss.as.remoting.CommonAttributes.REMOTE_OUTBOUND_CONNECTION;
-import static org.jboss.as.remoting.CommonAttributes.REUSE_SESSION;
-import static org.jboss.as.remoting.CommonAttributes.SASL;
-import static org.jboss.as.remoting.CommonAttributes.SASL_POLICY;
-import static org.jboss.as.remoting.CommonAttributes.SECURITY;
-import static org.jboss.as.remoting.CommonAttributes.SECURITY_REALM;
-import static org.jboss.as.remoting.CommonAttributes.SERVER_AUTH;
-import static org.jboss.as.remoting.CommonAttributes.SOCKET_BINDING;
-import static org.jboss.as.remoting.CommonAttributes.STRENGTH;
-import static org.jboss.as.remoting.CommonAttributes.URI;
-import static org.jboss.as.remoting.CommonAttributes.VALUE;
-
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
-import org.xnio.sasl.SaslQop;
-import org.xnio.sasl.SaslStrength;
+import static org.jboss.as.remoting.CommonAttributes.*;
 
 /**
  * Parser for remoting subsystem 1.1 version
@@ -422,7 +395,58 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         }
     }
 
-    private void parseRemoteOutboundConnection(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
+    private void parseRemoteOutboundConnection(final XMLExtendedStreamReader reader, final ModelNode parentAddress, final List<ModelNode> operations) throws XMLStreamException {
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.OUTBOUND_SOCKET_BINDING_REF);
+        final int count = reader.getAttributeCount();
+        String name = null;
+        String outboundSocketBindingRef = null;
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                case OUTBOUND_SOCKET_BINDING_REF: {
+                    outboundSocketBindingRef = value;
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        final PathAddress address = PathAddress.pathAddress(PathAddress.pathAddress(parentAddress), PathElement.pathElement(CommonAttributes.REMOTE_OUTBOUND_CONNECTION, name));
+
+        // create add operation add it to the list of operations
+        operations.add(getConnectionAddOperation(name, outboundSocketBindingRef, address));
+        // parse the nested elements
+        final EnumSet<Element> visited = EnumSet.noneOf(Element.class);
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            if (visited.contains(element)) {
+                throw ParseUtils.unexpectedElement(reader);
+            }
+            visited.add(element);
+            switch (element) {
+                case PROPERTIES: {
+                    parseProperties(reader, address.toModelNode(), operations);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+
+    }
+
+    private void parseLocalOutboundConnection(final XMLExtendedStreamReader reader, final ModelNode parentAddress, final List<ModelNode> operations) throws XMLStreamException {
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.OUTBOUND_SOCKET_BINDING_REF);
         final int count = reader.getAttributeCount();
         String name = null;
@@ -449,8 +473,11 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             throw missingRequired(reader, required);
         }
 
-        // parse the nested elements
-        Map<String, String> connectionCreationOptions = Collections.emptyMap();
+        final PathAddress address = PathAddress.pathAddress(PathAddress.pathAddress(parentAddress), PathElement.pathElement(CommonAttributes.LOCAL_OUTBOUND_CONNECTION, name));
+        // add it to the list of operations
+        operations.add(getConnectionAddOperation(name, outboundSocketBindingRef, address));
+        // create add operation parse the nested elements
+
         final EnumSet<Element> visited = EnumSet.noneOf(Element.class);
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
@@ -459,8 +486,8 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             }
             visited.add(element);
             switch (element) {
-                case CONNECTION_CREATION_OPTIONS: {
-                    connectionCreationOptions = this.parseXnioOptions(reader);
+                case PROPERTIES: {
+                    parseProperties(reader, address.toModelNode(), operations);
                     break;
                 }
                 default: {
@@ -468,67 +495,9 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
                 }
             }
         }
-
-        // create add operation
-        final ModelNode addOperation = RemoteOutboundConnectionAdd.getAddOperation(name, outboundSocketBindingRef, connectionCreationOptions);
-        // add it to the list of operations
-        operations.add(addOperation);
     }
 
-    private void parseLocalOutboundConnection(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
-        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.OUTBOUND_SOCKET_BINDING_REF);
-        final int count = reader.getAttributeCount();
-        String name = null;
-        String outboundSocketBindingRef = null;
-        for (int i = 0; i < count; i++) {
-            requireNoNamespaceAttribute(reader, i);
-            final String value = reader.getAttributeValue(i);
-            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
-            required.remove(attribute);
-            switch (attribute) {
-                case NAME: {
-                    name = value;
-                    break;
-                }
-                case OUTBOUND_SOCKET_BINDING_REF: {
-                    outboundSocketBindingRef = value;
-                    break;
-                }
-                default:
-                    throw unexpectedAttribute(reader, i);
-            }
-        }
-        if (!required.isEmpty()) {
-            throw missingRequired(reader, required);
-        }
-
-        // parse the nested elements
-        Map<String, String> connectionCreationOptions = Collections.emptyMap();
-        final EnumSet<Element> visited = EnumSet.noneOf(Element.class);
-        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
-            final Element element = Element.forName(reader.getLocalName());
-            if (visited.contains(element)) {
-                throw ParseUtils.unexpectedElement(reader);
-            }
-            visited.add(element);
-            switch (element) {
-                case CONNECTION_CREATION_OPTIONS: {
-                    connectionCreationOptions = this.parseXnioOptions(reader);
-                    break;
-                }
-                default: {
-                    throw unexpectedElement(reader);
-                }
-            }
-        }
-
-        // create add operation
-        final ModelNode addOperation = LocalOutboundConnectionAdd.getAddOperation(name, outboundSocketBindingRef, connectionCreationOptions);
-        // add it to the list of operations
-        operations.add(addOperation);
-    }
-
-    private void parseOutboundConnection(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
+    private void parseOutboundConnection(final XMLExtendedStreamReader reader, final ModelNode parentAddress, final List<ModelNode> operations) throws XMLStreamException {
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.URI);
         final int count = reader.getAttributeCount();
         String name = null;
@@ -555,8 +524,10 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             throw missingRequired(reader, required);
         }
 
+        final PathAddress address = PathAddress.pathAddress(PathAddress.pathAddress(parentAddress), PathElement.pathElement(CommonAttributes.OUTBOUND_CONNECTION, name));
+        // create add operation add it to the list of operations
+        operations.add(GenericOutboundConnectionAdd.getAddOperation(name, uri, address));
         // parse the nested elements
-        Map<String, String> connectionCreationOptions = Collections.emptyMap();
         final EnumSet<Element> visited = EnumSet.noneOf(Element.class);
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
@@ -565,8 +536,8 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             }
             visited.add(element);
             switch (element) {
-                case CONNECTION_CREATION_OPTIONS: {
-                    connectionCreationOptions = this.parseXnioOptions(reader);
+                case PROPERTIES: {
+                    parseProperties(reader, address.toModelNode(), operations);
                     break;
                 }
                 default: {
@@ -575,69 +546,30 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             }
         }
 
-        // create add operation
-        final ModelNode addOperation = GenericOutboundConnectionAdd.getAddOperation(name, uri, connectionCreationOptions);
-        // add it to the list of operations
-        operations.add(addOperation);
 
     }
 
-    private Map<String, String> parseXnioOptions(final XMLExtendedStreamReader reader) throws XMLStreamException {
-        final Map<String, String> xnioOptions = new HashMap();
-        // Handle nested elements
-        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
-            final Element element = Element.forName(reader.getLocalName());
-            switch (element) {
-                case OPTION: {
-                    final Map<String, String> xnioOption = this.parseXnioOption(reader);
-                    xnioOptions.putAll(xnioOption);
-                    break;
-                }
-                default: {
-                    throw unexpectedElement(reader);
-                }
-            }
+    static ModelNode getConnectionAddOperation(final String connectionName, final String outboundSocketBindingRef, PathAddress address) {
+        if (connectionName == null || connectionName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Connection name cannot be null or empty");
         }
-        return xnioOptions;
+        if (outboundSocketBindingRef == null || outboundSocketBindingRef.trim().isEmpty()) {
+            throw new IllegalArgumentException("Outbound socket binding reference cannot be null or empty for connection named " + connectionName);
+        }
+        final ModelNode addOperation = new ModelNode();
+        addOperation.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        // /subsystem=remoting/local-outbound-connection=<connection-name>
+        addOperation.get(ModelDescriptionConstants.OP_ADDR).set(address.toModelNode());
+
+        // set the other params
+        addOperation.get(CommonAttributes.OUTBOUND_SOCKET_BINDING_REF).set(outboundSocketBindingRef);
+        // optional connection creation options
+
+
+        return addOperation;
     }
 
-    private Map<String, String> parseXnioOption(final XMLExtendedStreamReader reader) throws XMLStreamException {
-        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.VALUE);
-        final int count = reader.getAttributeCount();
-        String optionName = null;
-        String optionValue = null;
-        for (int i = 0; i < count; i++) {
-            requireNoNamespaceAttribute(reader, i);
-            final String value = reader.getAttributeValue(i);
-            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
-            required.remove(attribute);
-            switch (attribute) {
-                case NAME: {
-                    if (value.trim().isEmpty()) {
-                        throw ParseUtils.invalidAttributeValue(reader, i);
-                    }
-                    optionName = value;
-                    break;
-                }
-                case VALUE: {
-                    optionValue = value;
-                    break;
-                }
-                default:
-                    throw unexpectedAttribute(reader, i);
-            }
-        }
-        if (!required.isEmpty()) {
-            throw missingRequired(reader, required);
-        }
-        // This element is just composed of attributes which we already processed, so no more content
-        // is expected
-        requireNoContent(reader);
-
-        return Collections.singletonMap(optionName, optionValue);
-    }
-
-    /**
+   /**
      * {@inheritDoc}
      */
     @Override
@@ -695,21 +627,22 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeEndElement();
 
     }
+
     private void writeWorkerThreadPoolIfAttributesSet(final XMLExtendedStreamWriter writer, final ModelNode node) throws XMLStreamException {
         if (node.hasDefined(CommonAttributes.WORKER_READ_THREADS) || node.hasDefined(CommonAttributes.WORKER_TASK_CORE_THREADS) || node.hasDefined(CommonAttributes.WORKER_TASK_KEEPALIVE) ||
                 node.hasDefined(CommonAttributes.WORKER_TASK_LIMIT) || node.hasDefined(CommonAttributes.WORKER_TASK_MAX_THREADS) || node.hasDefined(CommonAttributes.WORKER_WRITE_THREADS)) {
 
-                writer.writeStartElement(Element.WORKER_THREAD_POOL.getLocalName());
+            writer.writeStartElement(Element.WORKER_THREAD_POOL.getLocalName());
 
-                RemotingSubsystemRootResource.WORKER_READ_THREADS.marshallAsAttribute(node, false, writer);
-                RemotingSubsystemRootResource.WORKER_TASK_CORE_THREADS.marshallAsAttribute(node, false, writer);
-                RemotingSubsystemRootResource.WORKER_TASK_KEEPALIVE.marshallAsAttribute(node, false, writer);
-                RemotingSubsystemRootResource.WORKER_TASK_LIMIT.marshallAsAttribute(node, false, writer);
-                RemotingSubsystemRootResource.WORKER_TASK_MAX_THREADS.marshallAsAttribute(node, false, writer);
-                RemotingSubsystemRootResource.WORKER_WRITE_THREADS.marshallAsAttribute(node, false, writer);
+            RemotingSubsystemRootResource.WORKER_READ_THREADS.marshallAsAttribute(node, false, writer);
+            RemotingSubsystemRootResource.WORKER_TASK_CORE_THREADS.marshallAsAttribute(node, false, writer);
+            RemotingSubsystemRootResource.WORKER_TASK_KEEPALIVE.marshallAsAttribute(node, false, writer);
+            RemotingSubsystemRootResource.WORKER_TASK_LIMIT.marshallAsAttribute(node, false, writer);
+            RemotingSubsystemRootResource.WORKER_TASK_MAX_THREADS.marshallAsAttribute(node, false, writer);
+            RemotingSubsystemRootResource.WORKER_WRITE_THREADS.marshallAsAttribute(node, false, writer);
 
-                writer.writeEndElement();
-            }
+            writer.writeEndElement();
+        }
 
     }
 
@@ -784,8 +717,8 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeAttribute(Attribute.URI.getLocalName(), uri);
 
         // write the connection-creation-options if any
-        if (model.hasDefined(CommonAttributes.CONNECTION_CREATION_OPTIONS)) {
-            this.writeConnectionCreationOptions(writer, model);
+        if (model.hasDefined(PROPERTY)) {
+            writeProperties(writer, model.get(PROPERTY));
         }
 
         // </outbound-connection>
@@ -802,8 +735,8 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeAttribute(Attribute.OUTBOUND_SOCKET_BINDING_REF.getLocalName(), outboundSocketRef);
 
         // write the connection-creation-options if any
-        if (model.hasDefined(CommonAttributes.CONNECTION_CREATION_OPTIONS)) {
-            this.writeConnectionCreationOptions(writer, model);
+        if (model.hasDefined(PROPERTY)) {
+            writeProperties(writer, model.get(PROPERTY));
         }
 
         // </remote-outbound-connection>
@@ -820,31 +753,11 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
         writer.writeAttribute(Attribute.OUTBOUND_SOCKET_BINDING_REF.getLocalName(), outboundSocketRef);
 
         // write the connection-creation-options if any
-        if (model.hasDefined(CommonAttributes.CONNECTION_CREATION_OPTIONS)) {
-            this.writeConnectionCreationOptions(writer, model);
+        if (model.hasDefined(PROPERTY)) {
+            writeProperties(writer, model.get(PROPERTY));
         }
 
         // </local-outbound-connection>
-        writer.writeEndElement();
-    }
-
-    private void writeConnectionCreationOptions(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
-        // <connection-creation-options>
-        writer.writeStartElement(Element.CONNECTION_CREATION_OPTIONS.getLocalName());
-        final List<Property> connectionCreationOptions = model.get(CONNECTION_CREATION_OPTIONS).asPropertyList();
-        for (final Property connectionCreationOption : connectionCreationOptions) {
-            // <option>
-            writer.writeStartElement(Element.OPTION.getLocalName());
-            // write the name attribute
-            final String optionName = connectionCreationOption.getName();
-            writer.writeAttribute(Attribute.NAME.getLocalName(), optionName);
-            // write the value attribute
-            final String optionValue = connectionCreationOption.getValue().asString();
-            writer.writeAttribute(Attribute.VALUE.getLocalName(), optionValue);
-            // </option>
-            writer.writeEndElement();
-        }
-        // </connection-creation-options>
         writer.writeEndElement();
     }
 

--- a/remoting/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -24,7 +24,7 @@ outbound-connection.add=Adds a generic URI based remoting outbound connection.
 outbound-connection.remove=Removes a generic URI based remoting outbound connection.
 outbound-connection.name=Name of the outbound connection.
 outbound-connection.uri=The connection URI for the outbound connection.
-outbound-connection.connection-creation-options=The XNIO Options that will be used during the connection creation.
+outbound-connection.property=The XNIO Options that will be used during the connection creation.
 
 remoting.remote-outbound-connection=Remoting outbound connections for remote:// URI scheme.
 remote-outbound-connection=Remoting outbound connection with a implicit remote:// URI scheme.
@@ -32,7 +32,7 @@ remote-outbound-connection.add=Adds a remote:// URI scheme based outbound connec
 remote-outbound-connection.remove=Removes a remote:// URI scheme based outbound connection.
 remote-outbound-connection.name=Name of the remote:// URI scheme based outbound connection.
 remote-outbound-connection.outbound-socket-binding-ref=Name of the outbound-socket-binding which will be used to determine the destination address and port for the connection.
-remote-outbound-connection.connection-creation-options=The XNIO Options that will be used during the connection creation.
+remote-outbound-connection.property=The XNIO Options that will be used during the connection creation.
 
 remoting.local-outbound-connection=Remoting outbound connections for local:// URI scheme.
 local-outbound-connection=Remoting outbound connection with a implicit local:// URI scheme.
@@ -40,7 +40,7 @@ local-outbound-connection.add=Adds a local:// URI scheme based outbound connecti
 local-outbound-connection.remove=Removes a local:// URI scheme based outbound connection.
 local-outbound-connection.name=Name of the local:// URI scheme based outbound connection.
 local-outbound-connection.outbound-socket-binding-ref=Name of the outbound-socket-binding which will be used to determine the destination address and port for the connection.
-local-outbound-connection.connection-creation-options=The XNIO Options that will be used during the connection creation.
+local-outbound-connection.property=The XNIO Options that will be used during the connection creation.
 
 sasl=The "sasl" element contains the SASL authentication configuration for this connector.
 sasl.add=Adds the SASL authentication configuration for its connector

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
@@ -134,9 +134,9 @@ public class EJBClientDescriptorTestCase {
 
         if (!outboundConnectionCreated) {
             final Map<String, String> connectionCreationOptions = new HashMap<String, String>();
-            connectionCreationOptions.put("SSL_ENABLED", "false");
-            connectionCreationOptions.put("SASL_POLICY_NOANONYMOUS", "false");
-
+            connectionCreationOptions.put("org.xnio.Options.SSL_ENABLED", "false");
+            connectionCreationOptions.put("org.xnio.Options.SASL_POLICY_NOANONYMOUS", "false");
+            logger.info("Creatng remote outbound connection " + outboundConnectionName);
             EJBManagementUtil.createRemoteOutboundConnection("localhost", 9999, outboundConnectionName, outboundSocketName, connectionCreationOptions, Authentication.getCallbackHandler());
             outboundConnectionCreated = true;
             logger.info("Created remote outbound connection " + outboundConnectionName);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.integration.ejb.remote.common;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -34,6 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_REF;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -50,6 +52,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.ejb3.subsystem.EJB3Extension;
 import org.jboss.as.ejb3.subsystem.EJB3SubsystemModel;
 import org.jboss.as.remoting.RemotingExtension;
@@ -228,17 +231,29 @@ public class EJBManagementUtil {
 
             // set the other properties
             addRemoteOutboundConnection.get("outbound-socket-binding-ref").set(outboundSocketRef);
-            if (!connectionCreationOptions.isEmpty()) {
+          /*  if (!connectionCreationOptions.isEmpty()) {
                 final ModelNode connectionCreationOptionsModel = addRemoteOutboundConnection.get("connection-creation-options");
                 for (final Map.Entry<String, String> entry : connectionCreationOptions.entrySet()) {
                     final String optionName = entry.getKey();
                     final String optionValue = entry.getValue();
                     connectionCreationOptionsModel.get(optionName).set(optionValue);
                 }
-            }
+            }*/
+            final ModelNode op = Util.getEmptyOperation(COMPOSITE, new ModelNode());
+            final ModelNode steps = op.get(STEPS);
+            steps.add(addRemoteOutboundConnection);
 
             // execute the add operation
-            execute(modelControllerClient, addRemoteOutboundConnection);
+            if (!connectionCreationOptions.isEmpty()) {
+                for (Map.Entry<String, String> property : connectionCreationOptions.entrySet()) {
+                    ModelNode propertyOp = new ModelNode();
+                    propertyOp.get(OP).set(ADD);
+                    propertyOp.get(OP_ADDR).set(address.toModelNode()).add("property", property.getKey());
+                    propertyOp.get("value").set(property.getValue());
+                    steps.add(propertyOp);
+                }
+            }
+            execute(modelControllerClient, op);
 
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
@@ -251,6 +266,15 @@ public class EJBManagementUtil {
             }
         }
     }
+
+    private ModelNode getCompositeUpdate(final ModelNode... updates) {
+                final ModelNode op = Util.getEmptyOperation(COMPOSITE, new ModelNode());
+                final ModelNode steps = op.get(STEPS);
+                for (ModelNode update : updates) {
+                    steps.add(update);
+                }
+                return op;
+            }
 
     public static void removeRemoteOutboundConnection(final String managementServerHostName, final int managementPort,
                                                       final String connectionName, final CallbackHandler callbackHandler) {
@@ -383,6 +407,7 @@ public class EJBManagementUtil {
      * @throws IOException
      */
     private static ModelNode execute(final ModelControllerClient modelControllerClient, final ModelNode operation) throws IOException {
+        logger.info("operation: "+operation);
         final ModelNode result = modelControllerClient.execute(operation);
         if (result.hasDefined(ClientConstants.OUTCOME) && ClientConstants.SUCCESS.equals(result.get(ClientConstants.OUTCOME).asString())) {
             logger.info("Operation " + operation.toString() + " successful");


### PR DESCRIPTION
Code was changed so that now whole subsystem uses submodel for properties
According to same principal xml configuration has been unified 
this breaks old configuration but as this only shows up in version 1.1

There is also fix for AS7-2717 which enables some tests again
