### PR TITLE
Testsuite cleanup and simplification. WAS: PR 1281.

### DIFF
--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -36,9 +36,14 @@
     <name>JBoss Application Server Test Suite: Compatibility Tests</name>
     <properties>
 
-        <!-- used to provide an absolute location for the distribution under test -->
-        <!-- this value is overridden in modules with the correct relative pathname -->
-        <jboss.dist>${project.basedir}/../../build/target/jboss-as-${jboss.as.release.version}</jboss.dist>
+        <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
+        <jbossas.ts.dir>${basedir}/../..</jbossas.ts.dir>
+        
+        <!-- ${jbossas.project.dir} defined in /testsuite . -->
+
+        <!-- Used to provide an absolute location for the distribution under test. -->
+        <!-- This value is overridden in modules with the correct relative pathname. -->
+        <jboss.dist>${jbossas.project.dir}/build/target/jboss-as-${jboss.as.release.version}</jboss.dist>
         <jboss.home>${jboss.dist}</jboss.home>
 
         <!-- Used to provide an absolute location for the XSLT scripts. -->

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -32,14 +32,15 @@
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 
-    <artifactId>jboss-as-testsuite-integration-compat</artifactId>
+    <artifactId>jboss-as-testsuite-compat</artifactId>
     <name>JBoss Application Server Test Suite: Compatibility Tests</name>
     <properties>
 
         <!-- This project's testsuite dir. To be changed for every submodule (until we figure out how to do it automatically). -->
-        <jbossas.ts.dir>${basedir}/../..</jbossas.ts.dir>
+        <jbossas.ts.dir>${basedir}/..</jbossas.ts.dir>
         
-        <!-- ${jbossas.project.dir} defined in /testsuite . -->
+        <!-- ${jbossas.project.dir} defined in /testsuite. But for separated runs runs, let's duplicate it here. -->
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
 
         <!-- Used to provide an absolute location for the distribution under test. -->
         <!-- This value is overridden in modules with the correct relative pathname. -->

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -102,17 +102,14 @@
                 <inherited>false</inherited>
                 <executions>
                     <execution>
-                        <id>build-jars</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
+                        <id>ts.compat.copy-jars</id> <goals><goal>run</goal></goals>
                         <phase>test-compile</phase>
                         <configuration>
                             <target>
                                 <property name="tests.resources.dir" value="${basedir}/src/test/resources"/>
-                                <property name="tests.output.dir" value="${project.build.directory}"/>
+                                <property name="tests.output.dir"    value="${project.build.directory}"/>
                                 <ant antfile="src/test/scripts/build-jars.xml">
-                                    <target name="build-jars"/>
+                                    <target name="copy-jars"/>
                                 </ant>
                             </target>
                         </configuration>

--- a/testsuite/compat/src/test/resources/arquillian.xml
+++ b/testsuite/compat/src/test/resources/arquillian.xml
@@ -5,6 +5,8 @@
 	<container qualifier="jboss" default="true">
 		<configuration>
 			<property name="jbossHome">target/jbossas</property>
+			<property name="managementAddress">${node0:127.0.0.1}</property>
+			<property name="managementPort">${as.managementPort:9999}</property>
 		</configuration>
 	</container>
 </arquillian>

--- a/testsuite/compat/src/test/scripts/build-jars.xml
+++ b/testsuite/compat/src/test/scripts/build-jars.xml
@@ -23,15 +23,17 @@
   -->
 
 <project>
-    <target name="build-jars" description="Build the deployments.">
-    <copy file="${org.hibernate:hibernate-core:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-core.jar"/>
-    <copy file="${org.hibernate:hibernate-envers:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-envers.jar"/>
+    <target name="copy-jars" description="Copy jars to be tested.">
+    <copy file="${org.hibernate:hibernate-core:jar}"                tofile="${tests.output.dir}/test-libs/hibernate3-core.jar"/>
+    <copy file="${org.hibernate:hibernate-envers:jar}"              tofile="${tests.output.dir}/test-libs/hibernate3-envers.jar"/>
     <copy file="${org.hibernate:hibernate-commons-annotations:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-commons-annotations.jar"/>
-    <copy file="${org.hibernate:hibernate-entitymanager:jar}" tofile="${tests.output.dir}/test-libs/hibernate3-entitymanager.jar"/>
-    <copy file="${dom4j:dom4j:jar}" tofile="${tests.output.dir}/test-libs/dom4j.jar"/>
-    <!--copy file="${org.slf4j:slf4j-simple:jar}" tofile="${tests.output.dir}/test-libs/slf4j.jar"/>
-    <copy file="${org.slf4j:slf4j-api:jar}"     tofile="${tests.output.dir}/test-libs/slf4j-api.jar"/-->
-    <copy file="${commons-collections:commons-collections:jar}" tofile="${tests.output.dir}/test-libs/commons-collections.jar"/>
-    <copy file="${antlr:antlr:jar}" tofile="${tests.output.dir}/test-libs/antlr.jar"/>
+    <copy file="${org.hibernate:hibernate-entitymanager:jar}"       tofile="${tests.output.dir}/test-libs/hibernate3-entitymanager.jar"/>
+    <copy file="${dom4j:dom4j:jar}"                                 tofile="${tests.output.dir}/test-libs/dom4j.jar"/>
+    <!--
+    <copy file="${org.slf4j:slf4j-simple:jar}"                      tofile="${tests.output.dir}/test-libs/slf4j.jar"/>
+    <copy file="${org.slf4j:slf4j-api:jar}"                         tofile="${tests.output.dir}/test-libs/slf4j-api.jar"/>
+    -->
+    <copy file="${commons-collections:commons-collections:jar}"     tofile="${tests.output.dir}/test-libs/commons-collections.jar"/>
+    <copy file="${antlr:antlr:jar}"                                 tofile="${tests.output.dir}/test-libs/antlr.jar"/>
     </target>
 </project>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -64,7 +64,7 @@
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
                     <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <jboss.options>${surefire.system.args}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -100,6 +100,8 @@
                                         <property name="tests.resources.dir" value="${basedir}/../src/test/resources"/>
                                         <property name="tests.output.dir"    value="${project.build.directory}"/>
                                         <ant antfile="${basedir}/../src/test/scripts/basic-integration-build.xml">
+                                            <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="node1" value="${node1}"/>
                                             <target name="build-basic-integration"/>  <!-- TODO: Unify names, then call "recursively". -->
                                         </ant>
                                     </target>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <artifactId>jboss-as-ts-integ</artifactId>
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 
@@ -14,7 +14,7 @@
     <!-- ******************************** Basic Integration ******************************* -->
     <!-- ********************************************************************************** -->
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-basic</artifactId>
+    <artifactId>jboss-as-ts-integ-basic</artifactId>
     <version>7.1.1.Final-SNAPSHOT</version>
 
     <name>JBoss Application Server Test Suite: Integration - Basic</name>
@@ -98,7 +98,10 @@
                                 <configuration>
                                     <target>
                                         <property name="tests.resources.dir" value="${basedir}/../src/test/resources"/>
-                                        <property name="tests.output.dir" value="${project.build.directory}"/>
+                                        <property name="tests.output.dir"    value="${project.build.directory}"/>
+                                        <ant antfile="${basedir}/../src/test/scripts/basic-integration-build.xml">
+                                            <target name="build-basic-integration"/>  <!-- TODO: Unify names, then call "recursively". -->
+                                        </ant>
                                     </target>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -210,7 +210,7 @@
                                 <goals><goal>test</goal></goals>
                                 <configuration>
                                     <skipTests>${ts.skipTests}</skipTests>
-                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                                     <enableAssertions>true</enableAssertions>
                                     <includes>
                                         <include>org/jboss/as/test/integration/**/*SecondTestCase.java</include>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -10,6 +10,8 @@
 			<!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
 			     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
 			<property name="allowConnectingToRunningServer">true</property>
+			<property name="managementAddress">${node0:127.0.0.1}</property>
+			<property name="managementPort">${as.managementPort:9999}</property>
 		</configuration>
 	</container>
 </arquillian>

--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -71,8 +71,12 @@
                                 <goals><goal>run</goal></goals>
                                 <configuration>
                                     <target>
+                                        <echo>In Maven: node0: ${node0}</echo>
+                                        <echo>In Maven: node1: ${node1}</echo>
                                         <!-- Build the UDP server configs in target/ . -->
                                         <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
+                                            <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="node1" value="${node1}"/>
                                             <target name="build-clustering-udp"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <artifactId>jboss-as-ts-integ</artifactId>
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 
@@ -14,7 +14,7 @@
     <!-- *********************************** Clustering *********************************** -->
     <!-- ********************************************************************************** -->
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-clust</artifactId>
+    <artifactId>jboss-as-ts-integ-clust</artifactId>
     <version>7.1.1.Final-SNAPSHOT</version>
 
     <name>JBoss Application Server Test Suite: Integration - Clustering</name>

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -11,6 +11,8 @@
             <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-0</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-0</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="managementAddress">${node0}</property>
+            <property name="managementPort">${as.managementPort:9999}</property>
         </configuration>
     </container>
 
@@ -22,6 +24,8 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-0 -Djboss.node.name=node-udp-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9999}</property>
             </configuration>
         </container>
 
@@ -30,6 +34,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-1 -Djboss.node.name=node-udp-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
             </configuration>
         </container>
@@ -45,6 +50,8 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-0 -Djboss.node.name=node-udp-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9999}</property>
             </configuration>
         </container>
 
@@ -53,6 +60,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-udp-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-1 -Djboss.node.name=node-udp-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
             </configuration>
         </container>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <artifactId>jboss-as-ts-integ</artifactId>
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 
@@ -14,7 +14,7 @@
     <!-- *********************************** IIOP       *********************************** -->
     <!-- ********************************************************************************** -->
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-iiop</artifactId>
+    <artifactId>jboss-as-ts-integ-iiop</artifactId>
     <version>7.1.1.Final-SNAPSHOT</version>
 
     <name>JBoss Application Server Test Suite: Integration - IIOP</name>
@@ -49,8 +49,10 @@
                     <name>!ts.noIIOP</name>
                 </property>
             </activation>
+            
             <properties>
             </properties>
+            
             <!--
                 Server configuration executions.
             -->
@@ -63,12 +65,10 @@
                             <execution>
                                 <id>build-clustering.server</id>
                                 <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
+                                <goals><goal>run</goal></goals>
                                 <configuration>
                                     <target>
-                                        <!-- build the UDP server configs in target-->
+                                        <!-- Configure IIOP server and client. -->
                                         <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/iiop-build.xml">
                                             <target name="build-iiop"/>
                                         </ant>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -70,6 +70,8 @@
                                     <target>
                                         <!-- Configure IIOP server and client. -->
                                         <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/iiop-build.xml">
+                                            <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="node1" value="${node1}"/>
                                             <target name="build-iiop"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
@@ -10,6 +10,8 @@
                 <property name="jbossHome">${basedir}/target/jbossas-iiop-client</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-iiop-client</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9999}</property>
             </configuration>
         </container>
 
@@ -19,6 +21,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-iiop-server</property>
                 <property name="javaVmArguments">${server.jvm.args}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
             </configuration>
         </container>

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -14,7 +14,7 @@
     <!-- ************************* Multi-node Integration Tests *************************** -->
     <!-- ********************************************************************************** -->
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-multinode</artifactId>
+    <artifactId>jboss-as-ts-integ-multinode</artifactId>
     <version>7.1.1.Final-SNAPSHOT</version>
 
     <name>JBoss AS Test Suite: Integration - Multinode Tests</name>

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -78,7 +78,7 @@
                                 <configuration>
                                     <target>
                                         <!-- Build the UDP server configs in target. -->
-                                        <ant antfile="${basedir}/../src/test/scripts/multinode-build.xml">
+                                        <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/multinode-build.xml">
                                             <target name="build-multinode"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <artifactId>jboss-as-ts-integ</artifactId>
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -11,6 +11,8 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
                                                                                         <!-- jboss.node.name is defined in the test, not related to AS instance name! -->
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9999}</property>
             </configuration>
         </container>
 
@@ -20,6 +22,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
             </configuration>
         </container>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -7,8 +7,9 @@
         <!-- The server than invokes the exposed EJB's via remote outbound connection -->
         <container qualifier="multinode-client" default="true">
             <configuration>
-                <property name="jbossHome">${basedir}/target/multinode-client</property>
+                <property name="jbossHome">${basedir}/target/jbossas-multinode-client</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
+                                                                                        <!-- jboss.node.name is defined in the test, not related to AS instance name! -->
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             </configuration>
         </container>
@@ -16,7 +17,7 @@
         <!-- The server that exposes EJB's -->
         <container qualifier="multinode-server" default="false">
             <configuration>
-                <property name="jbossHome">${basedir}/target/multinode-server</property>
+                <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementPort">10099</property>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -7,7 +7,7 @@
         <!-- The server than invokes the exposed EJB's via remote outbound connection -->
         <container qualifier="multinode-client" default="true">
             <configuration>
-                <property name="jbossHome">${basedir}/target/jbossas-multinode-client</property>
+                <property name="jbossHome">${basedir}/target/multinode-client</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             </configuration>
@@ -16,7 +16,7 @@
         <!-- The server that exposes EJB's -->
         <container qualifier="multinode-server" default="false">
             <configuration>
-                <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
+                <property name="jbossHome">${basedir}/target/multinode-server</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementPort">10099</property>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -196,7 +196,7 @@
                 <configuration>
                     <skipTests>${ts.skipTests}</skipTests>
                     <!-- Prevent test and server output appearing in console. -->
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <enableAssertions>true</enableAssertions>
                     <!--<basedir>${jbossas.ts.integ.dir}</basedir>  <!- - "The base directory of the project being tested." Sets ${basedir}. -->
                     <workingDirectory>${basedir}/target/workdir</workingDirectory> <!-- Work in submodule's own dir. -->

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -164,33 +164,12 @@
             </plugin>
             
             
-            <!-- Copy JBoss AS to target/jbossas. -->
+            <!-- Resources plugin. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions combine.children="append">
-                    <!-- First, make a copy for this module. -->
-                    <execution>
-                        <inherited>false</inherited>
-                        <id>ts.copy-jbossas.integ</id>
-                        <phase>generate-test-resources</phase>
-                        <goals><goal>copy-resources</goal></goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>${jboss.home}</directory>
-                                    <!-- Modules and bundles not copied as they are read-only (see Surefire props). -->
-                                    <excludes>
-                                        <exclude>modules/</exclude>
-                                        <exclude>bundles/</exclude>
-                                    </excludes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <!-- Users and roles config. -->
+                    <!-- Copy users and roles config from shared resources. -->
                     <execution>
                         <id>ts.config-as.copy-mgmt-users</id>
                         <phase>generate-test-resources</phase>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -172,7 +172,7 @@
                     <!-- First, make a copy for this module. -->
                     <execution>
                         <inherited>false</inherited>
-                        <id>ts.copy-jbossas</id>
+                        <id>ts.copy-jbossas.integ</id>
                         <phase>generate-test-resources</phase>
                         <goals><goal>copy-resources</goal></goals>
                         <configuration>
@@ -186,22 +186,6 @@
                                         <exclude>modules/</exclude>
                                         <exclude>bundles/</exclude>
                                     </excludes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                    <!-- Copy this copy into submodules. -->
-                    <execution>
-                        <inherited>true</inherited>
-                        <id>ts.copy-jbossas.groups</id>
-                        <phase>generate-test-resources</phase>
-                        <goals><goal>copy-resources</goal></goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>${basedir}/../target/jbossas</directory>
                                 </resource>
                             </resources>
                         </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -190,7 +190,7 @@
                             </resources>
                         </configuration>
                     </execution>
-                    <!-- Management users config. -->
+                    <!-- Users and roles config. -->
                     <execution>
                         <id>ts.config-as.copy-mgmt-users</id>
                         <phase>generate-test-resources</phase>
@@ -201,7 +201,10 @@
                             <resources>
                                 <resource>
                                     <directory>../shared/src/main/resources</directory>
-                                    <includes><include>mgmt-users.properties</include></includes>
+                                    <includes>
+                                        <include>application-*.properties</include>
+                                        <include>messaging-*.properties</include>
+                                    </includes>
                                 </resource>
                             </resources>
                         </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+    <artifactId>jboss-as-ts-integ</artifactId>
     <packaging>pom</packaging>
     <version>7.1.1.Final-SNAPSHOT</version>
 
@@ -186,6 +186,22 @@
                                         <exclude>modules/</exclude>
                                         <exclude>bundles/</exclude>
                                     </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <!-- Management users config. -->
+                    <execution>
+                        <id>ts.config-as.copy-mgmt-users</id>
+                        <phase>generate-test-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/jbossas/standalone/configuration</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>../shared/src/main/resources</directory>
+                                    <includes><include>mgmt-users.properties</include></includes>
                                 </resource>
                             </resources>
                         </configuration>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -201,10 +201,7 @@
                             <resources>
                                 <resource>
                                     <directory>../shared/src/main/resources</directory>
-                                    <includes>
-                                        <include>application-*.properties</include>
-                                        <include>messaging-*.properties</include>
-                                    </includes>
+                                    <includes><include>*.properties</include></includes>
                                 </resource>
                             </resources>
                         </configuration>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -77,6 +77,8 @@
                                 <configuration>
                                     <target>
                                         <ant antfile="${basedir}/../src/test/scripts/smoke-build.xml">
+                                            <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="node1" value="${node1}"/>
                                             <target name="build-smoke"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -46,6 +46,7 @@
                 <executions>
                     <execution>
                         <id>copy-users</id>
+                        <id>ts.config-as.copy-users</id>
                         <phase>generate-test-resources</phase>
                         <goals><goal>copy-resources</goal></goals>
                         <configuration>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <artifactId>jboss-as-ts-integ</artifactId>
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 
@@ -14,7 +14,7 @@
     <!-- ******************************** Smoke Integration ******************************* -->
     <!-- ********************************************************************************** -->
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-smoke</artifactId>
+    <artifactId>jboss-as-ts-integ-smoke</artifactId>
     <version>7.1.1.Final-SNAPSHOT</version>
 
     <name>JBoss Application Server Test Suite: Integration - Smoke</name>
@@ -39,33 +39,6 @@
             </testResource>
         </testResources>
 
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-users</id>
-                        <id>ts.config-as.copy-users</id>
-                        <phase>generate-test-resources</phase>
-                        <goals><goal>copy-resources</goal></goals>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/jbossas-smoke/standalone/configuration</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>../../shared/src/main/resources</directory>
-                                    <includes>
-                                        <include>*-users.properties</include>
-                                        <include>*-roles.properties</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
     </build>
 
 
@@ -105,7 +78,6 @@
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <!-- Build the UDP server configs in target. -->
                                         <ant antfile="${basedir}/../src/test/scripts/smoke-build.xml">
                                             <target name="build-smoke"/>
                                         </ant>
@@ -140,7 +112,7 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
-                                        <jboss.inst>${basedir}/target/jbossas-smoke</jboss.inst>
+                                        <jboss.inst>${basedir}/target/jbossas</jboss.inst>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -161,7 +133,7 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
-                                        <jboss.inst>${basedir}/target/jbossas-smoke</jboss.inst>
+                                        <jboss.inst>${basedir}/target/jbossas</jboss.inst>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -73,9 +73,7 @@
                             <execution>
                                 <id>build-smoke.server</id>
                                 <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
+                                <goals><goal>run</goal></goals>
                                 <configuration>
                                     <target>
                                         <ant antfile="${basedir}/../src/test/scripts/smoke-build.xml">

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -4,8 +4,8 @@
 
 	<container qualifier="jboss" default="true">
 		<configuration>
-			<property name="jbossHome">${basedir}/target/jbossas-smoke</property>
-			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-smoke</property>
+			<property name="jbossHome">${basedir}/target/jbossas</property>
+			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
 			<property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
 			<property name="allowConnectingToRunningServer">true</property>
 		</configuration>

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -8,6 +8,8 @@
 			<property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
 			<property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
 			<property name="allowConnectingToRunningServer">true</property>
+			<property name="managementAddress">${node0:127.0.0.1}</property>
+			<property name="managementPort">${as.managementPort:9999}</property>
 		</configuration>
 	</container>
 </arquillian>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/datasource/DataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/datasource/DataSourceOperationsUnitTestCase.java
@@ -475,6 +475,7 @@ public class DataSourceOperationsUnitTestCase extends DsMgmtTestBase{
     }
 
     @Test
+    @Ignore("AS7-3534")
     public void testReadInstalledDrivers() throws Exception {
 
         final ModelNode address = new ModelNode();

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/datasource/DataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/embedded/mgmt/datasource/DataSourceOperationsUnitTestCase.java
@@ -475,7 +475,6 @@ public class DataSourceOperationsUnitTestCase extends DsMgmtTestBase{
     }
 
     @Test
-    @Ignore("AS7-3534")
     public void testReadInstalledDrivers() throws Exception {
 
         final ModelNode address = new ModelNode();

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/surefire/servermodule/HttpDeploymentUploadUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/surefire/servermodule/HttpDeploymentUploadUnitTestCase.java
@@ -49,6 +49,7 @@ import static junit.framework.Assert.assertNotNull;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import org.junit.Ignore;
 
 /**
  * Test the HTTP API upload functionality to ensure that a deployment is successfully
@@ -58,6 +59,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
  */
 @RunAsClient
 @RunWith(Arquillian.class)
+@Ignore("AS7-3704")
 public class HttpDeploymentUploadUnitTestCase {
 
     private static final String BOUNDARY_PARAM = "NeAG1QNIHHOyB5joAS7Rox!!";

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/surefire/servermodule/HttpDeploymentUploadUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/surefire/servermodule/HttpDeploymentUploadUnitTestCase.java
@@ -59,7 +59,6 @@ import org.junit.Ignore;
  */
 @RunAsClient
 @RunWith(Arquillian.class)
-@Ignore("AS7-3704")
 public class HttpDeploymentUploadUnitTestCase {
 
     private static final String BOUNDARY_PARAM = "NeAG1QNIHHOyB5joAS7Rox!!";

--- a/testsuite/integration/src/test/scripts/basic-integration-build.xml
+++ b/testsuite/integration/src/test/scripts/basic-integration-build.xml
@@ -28,19 +28,9 @@
     <import file="common-targets.xml" as="common"/>
 
     <target name="build-basic-integration" description="Builds server configuration for basic-integration tests">
-        <build-server-config name="jbossas"/>
-
-        <antcall target="changeDefaultDatabase">
-            <param name="server-config" value="jbossas"/>
-            <propertyset refid="ds.properties"/>
-        </antcall>
-
-        <change-ip-addresses name="jbossas" node="${node0}"/>
-
         <condition property="basic-jts-tests">
             <equals arg1="${jboss.test.jts}" arg2="true"/>
         </condition>
-
     </target>
 
     <target name="build-basic-integration-jts" depends="build-basic-integration" if="basic-jts-tests">

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -7,22 +7,17 @@
     <target name="build-clustering-udp" description="Builds server configurations for UDP tests">
 
         <echo message="Building config clustering-udp-0"/>
-
-        <build-server-config name="clustering-udp-0"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="clustering-udp-0"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
+        <copy todir="target/jbossas-clustering-udp-0">
+            <fileset dir="target/jbossas">
+        </copy>
         <change-ip-multicast-addresses name="clustering-udp-0" node="${node0}" mcastaddr="${udpGroup}"/>
         <add-port-offset name="clustering-udp-0" />
 
-        <echo message="Building config clustering-udp-1"/>
 
-        <build-server-config name="clustering-udp-1"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="clustering-udp-1"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
+        <echo message="Building config clustering-udp-1"/>
+        <copy todir="target/jbossas-clustering-udp-1">
+            <fileset dir="target/jbossas">
+        </copy>
         <change-ip-multicast-addresses name="clustering-udp-1" node="${node1}" mcastaddr="${udpGroup}"/>
         <add-port-offset name="clustering-udp-1" offset="100" nativePort="9999" httpPort="9990"/>
 

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -7,16 +7,20 @@
     <target name="build-clustering-udp" description="Builds server configurations for UDP tests">
 
         <echo message="Building config clustering-udp-0"/>
-        <copy todir="target/jbossas-clustering-udp-0">
-            <fileset dir="target/jbossas"/>
+                                        <echo>clustering-udp-0 node0: ${node0}</echo>
+                                        <echo>clustering-udp-0 node1: ${node1}</echo>
+        <copy todir="target/jbossas-clustering-udp-0" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
         </copy>
         <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-0" node="${node0}" mcastaddr="${udpGroup}"/>
         <ts.config-as.add-port-offset name="jbossas-clustering-udp-0" />
 
 
         <echo message="Building config clustering-udp-1"/>
-        <copy todir="target/jbossas-clustering-udp-1">
-            <fileset dir="target/jbossas"/>
+                                        <echo>clustering-udp-1 node0: ${node0}</echo>
+                                        <echo>clustering-udp-1 node1: ${node1}</echo>
+        <copy todir="target/jbossas-clustering-udp-1" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
         </copy>
         <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-1" node="${node1}" mcastaddr="${udpGroup}"/>
         <ts.config-as.add-port-offset name="jbossas-clustering-udp-1" offset="100" nativePort="9999" httpPort="9990"/>

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -8,18 +8,18 @@
 
         <echo message="Building config clustering-udp-0"/>
         <copy todir="target/jbossas-clustering-udp-0">
-            <fileset dir="target/jbossas">
+            <fileset dir="target/jbossas"/>
         </copy>
-        <change-ip-multicast-addresses name="clustering-udp-0" node="${node0}" mcastaddr="${udpGroup}"/>
-        <add-port-offset name="clustering-udp-0" />
+        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-0" node="${node0}" mcastaddr="${udpGroup}"/>
+        <ts.config-as.add-port-offset name="jbossas-clustering-udp-0" />
 
 
         <echo message="Building config clustering-udp-1"/>
         <copy todir="target/jbossas-clustering-udp-1">
-            <fileset dir="target/jbossas">
+            <fileset dir="target/jbossas"/>
         </copy>
-        <change-ip-multicast-addresses name="clustering-udp-1" node="${node1}" mcastaddr="${udpGroup}"/>
-        <add-port-offset name="clustering-udp-1" offset="100" nativePort="9999" httpPort="9990"/>
+        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-1" node="${node1}" mcastaddr="${udpGroup}"/>
+        <ts.config-as.add-port-offset name="jbossas-clustering-udp-1" offset="100" nativePort="9999" httpPort="9990"/>
 
     </target>
 

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -47,7 +47,7 @@
         <echo message="ds.jdbc.user = ${ds.jdbc.user}"/>
         <echo message="ds.jdbc.pass = ${ds.jdbc.pass}"/>
 
-        <property name="server.dir" value="${project.build.directory}/jbossas-${server-config}"/> <!-- Ant will copy actual instances from this "template" (when imlpemented). -->
+        <property name="server.dir" value="${project.build.directory}/${server-config}"/> <!-- Ant will copy actual instances from this "template" (when implemented). -->
         <property name="config.dir" value="${server.dir}/standalone/configuration"/>
 
         <!-- Copy jar into standalone/deployments. This installs the driver under a new driver name. -->
@@ -109,7 +109,7 @@
                 </fileset>
             </copy>
 
-            <copy todir="@{output.dir}/jbossas-@{name}/standalone/configuration" overwrite="true">
+            <copy todir="@{output.dir}/@{name}/standalone/configuration" overwrite="true">
                 <fileset dir="${jbossas.ts.integ.dir}/../shared/src/main/resources">
                     <include name="@{copyPattern}"/>
                 </fileset>
@@ -338,7 +338,7 @@
         Add a new Remote Outbound Connection.
         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
     -->
-    <macrodef name="add-remote-outbound-connection" description="Add Remote Outbound Connection">
+    <macrodef name="ts.config-as.add-remote-outbound-connection" description="Add Remote Outbound Connection">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
@@ -353,11 +353,11 @@
             <echo message="Adding a new remote outbound connection @{connectionName} for config @{name}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/addRemoteOutboundConnection.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
@@ -370,8 +370,8 @@
             </xslt>
 
             <!-- Move processed files back. -->
-            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
@@ -381,7 +381,7 @@
         </sequential>
     </macrodef>
     
-    <macrodef name="add-identity-realm" description="Add Server Identity Security Realm">
+    <macrodef name="ts.config-as.add-identity-realm" description="Add Server Identity Security Realm">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
@@ -393,11 +393,11 @@
             <echo message="Adding a new server identity realm @{realmName} with secret @{secret}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/addIdentityRealm.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
@@ -407,8 +407,8 @@
             </xslt>
 
             <!-- Move processed files back. -->
-            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -169,7 +169,7 @@
 
             <echo message="Changing IP addresses for config @{name}"/>
 
-            <var name="cur-as.config.dir" value="@{output.dir}/@{name}/@{config.dir.name}"/>
+            <property name="cur-as.config.dir" value="@{output.dir}/@{name}/@{config.dir.name}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
             <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
@@ -215,7 +215,7 @@
         <sequential>
             <echo message="Changing IP addresses for config @{name}"/>
 
-            <var name="cur-as.config.dir" value="@{output.dir}/@{name}/@{config.dir.name}"/>
+            <property name="cur-as.config.dir" value="@{output.dir}/@{name}/@{config.dir.name}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
             <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -32,6 +32,7 @@
 
     <!--
           Change AS database configuration.
+          TODO: Moved to maven.
     -->
     <condition property="changeDB">
         <not><equals arg1="${ds.db}" arg2=""/></not>
@@ -83,6 +84,8 @@
         Build server configutation:
            * Copy from distribution directory (TODO: Copy from ${basedir}target/jbossas to pick up changes by Maven!
            * Overwrite some config files, replace tokens.
+           
+        TODO: Not necessary - done in maven.
      -->
     <macrodef name="build-server-config" description="Builds a server configuration">
 
@@ -99,7 +102,7 @@
 
             <!-- copy the base distribution -->
             <!-- we exclude modules and bundles as they are read-only and we locate the via sys props-->
-            <copy todir="@{output.dir}/jbossas-@{name}">
+            <copy todir="@{output.dir}/@{name}">
                 <fileset dir="@{jboss.dist}">
                     <exclude name="**/modules/**"/>
                     <exclude name="**/bundles/**"/>
@@ -113,7 +116,7 @@
             </copy>
 
             <!-- overwrite with configs from test-configs and apply property filtering -->
-            <copy todir="@{output.dir}/jbossas-@{name}" overwrite="true" failonerror="false">
+            <copy todir="@{output.dir}/@{name}" overwrite="true" failonerror="false">
                 <fileset dir="@{test.configs.dir}/@{name}"/>
                 <filterset begintoken="${" endtoken="}">
                     <filter token="node0" value="${node0}"/>
@@ -126,11 +129,36 @@
     </macrodef>
 
 
+    <!--
+        Overwrite some config files, replace tokens.
+    -->
+    <macrodef name="ts.config-as.files" description="Changes server configuration.">
+
+        <attribute name="test.configs.dir" default="${jbossas.ts.integ.dir}/src/test/resources/test-configs"/>
+        <element name="filter-elements" optional="yes" description="Additional filter tokens to replace."/>
+
+        <sequential>
+            <echo message="Configuring AS instance &quot;@{name}&quot; at @{output.dir}"/>
+
+            <!-- Overwrite with configs from test-configs and apply property filtering. -->
+            <copy todir="@{output.dir}/@{name}" overwrite="true" failonerror="false">
+                <fileset dir="@{test.configs.dir}/@{name}"/>
+                <filterset begintoken="${" endtoken="}">
+                    <filter token="node0" value="${node0}"/>
+                    <filter token="node1" value="${node1}"/>
+                    <filter token="udpGroup" value="${udpGroup}"/>
+                    <filter-elements/>
+                </filterset>
+            </copy>
+        </sequential>
+    </macrodef>
+
 
     <!--
         Change IP adresses config.
+        TODO: Moved to maven.
      -->
-    <macrodef name="change-ip-addresses" description="Changes the IP addresses of a single node configuration">
+    <macrodef name="ts.config-as.ip" description="Changes the IP addresses of a single node configuration.">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
@@ -141,12 +169,14 @@
 
             <echo message="Changing IP addresses for config @{name}"/>
 
+            <var name="cur-as.config.dir" value="@{output.dir}/@{name}/@{config.dir.name}"/>
+
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
                     <include name="**/standalone-ha.xml"/>
@@ -156,8 +186,8 @@
             </xslt>
 
             <!-- Move processed files back. -->
-            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                    <include name="**/standalone-full.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-ha.xml.mod"/>
@@ -170,9 +200,11 @@
 
     <!--
         Change IP adresses, including multicast.
+        It's the same as above, only adds the udpMcastAddress param.
+        
         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
     -->
-    <macrodef name="change-ip-multicast-addresses" description="Changes the IP *and* multicast addresses of a node configuration">
+    <macrodef name="ts.config-as.ip-with-multicast" description="Changes the IP *and* multicast addresses of a node configuration">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
@@ -183,14 +215,16 @@
         <sequential>
             <echo message="Changing IP addresses for config @{name}"/>
 
+            <var name="cur-as.config.dir" value="@{output.dir}/@{name}/@{config.dir.name}"/>
+
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/changeIPAddresses.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <!-- Can't get this to work. -->
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
-                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone-full.xml"/>
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
@@ -201,8 +235,8 @@
             </xslt>
 
             <!-- Move processed files back. -->
-            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
@@ -218,7 +252,7 @@
         Configure port offset.
         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
     -->
-    <macrodef name="add-port-offset" description="Add a port offeset a node configuration">
+    <macrodef name="ts.config-as.add-port-offset" description="Add a port offeset a node configuration">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
@@ -231,13 +265,13 @@
             <echo message="Adding port offset for config @{name}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/addPortOffset.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <!-- can't get this to work -->
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
-                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
@@ -248,8 +282,8 @@
             </xslt>
 
             <!-- Move processed files back. -->
-            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
@@ -265,7 +299,7 @@
         Enable JTS.
         This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
     -->
-    <macrodef name="add-jts" description="Enable JTS">
+    <macrodef name="ts.config-as.add-jts" description="Enable JTS">
 
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
@@ -275,11 +309,11 @@
             <echo message="Enabling JTS for config @{name}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/enableJTS.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
-                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
@@ -287,8 +321,8 @@
             </xslt>
 
             <!-- Move processed files back. -->
-            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -393,7 +393,7 @@
             <echo message="Adding a new server identity realm @{realmName} with secret @{secret}"/>
 
             <!-- Process *.xml to *.xml.mod. -->
-            <xslt destdir="@{output.dir}/@{name}/@{config.dir.name}"
+            <xslt destdir="@{output.dir}/@{name}-tmp/@{config.dir.name}"
                   style="${jbossas.ts.integ.dir}/src/test/xslt/addIdentityRealm.xsl"
                   extension=".xml.mod"
                   useImplicitFileset="false">
@@ -408,7 +408,7 @@
 
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
-               <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/@{name}-tmp/@{config.dir.name}">
                    <include name="**/standalone-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>

--- a/testsuite/integration/src/test/scripts/iiop-build.xml
+++ b/testsuite/integration/src/test/scripts/iiop-build.xml
@@ -6,20 +6,19 @@
 
     <target name="build-iiop" description="Builds server configurations for IIOP tests">
 
-        <echo message="Building config iiop-client"/>
+        <echo message="Building config jbossas-iiop-client"/>
         <copy todir="target/jbossas-iiop-client">
             <fileset dir="target/jbossas"/>
         </copy>
-        <add-jts name="iiop-client"/>
+        <ts.config-as.add-jts name="jbossas-iiop-client"/>
 
 
-        <echo message="Building config iiop-server"/>
-        <build-server-config name="iiop-server"/>
-        <copy todir="target/iiop-server">
+        <echo message="Building config jbossas-iiop-server"/>
+        <copy todir="target/jbossas-iiop-server">
             <fileset dir="target/jbossas"/>
         </copy>
-        <add-jts name="iiop-server"/>
-        <add-port-offset name="iiop-server" offset="100" nativePort="9999" httpPort="9990"/>
+        <ts.config-as.add-jts name="jbossas-iiop-server"/>
+        <ts.config-as.add-port-offset name="jbossas-iiop-server" offset="100" nativePort="9999" httpPort="9990"/>
 
     </target>
 

--- a/testsuite/integration/src/test/scripts/iiop-build.xml
+++ b/testsuite/integration/src/test/scripts/iiop-build.xml
@@ -7,23 +7,19 @@
     <target name="build-iiop" description="Builds server configurations for IIOP tests">
 
         <echo message="Building config iiop-client"/>
-
-        <build-server-config name="iiop-client"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="iiop-client"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
+        <copy todir="target/jbossas-iiop-client">
+            <fileset dir="target/jbossas">
+        </copy>
         <add-jts name="iiop-client"/>
 
-        <echo message="Building config iiop-server"/>
 
+        <echo message="Building config iiop-server"/>
         <build-server-config name="iiop-server"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="iiop-server"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
-        <add-port-offset name="iiop-server" offset="100" nativePort="9999" httpPort="9990"/>
+        <copy todir="target/iiop-server">
+            <fileset dir="target/jbossas">
+        </copy>
         <add-jts name="iiop-server"/>
+        <add-port-offset name="iiop-server" offset="100" nativePort="9999" httpPort="9990"/>
 
     </target>
 

--- a/testsuite/integration/src/test/scripts/iiop-build.xml
+++ b/testsuite/integration/src/test/scripts/iiop-build.xml
@@ -8,7 +8,7 @@
 
         <echo message="Building config iiop-client"/>
         <copy todir="target/jbossas-iiop-client">
-            <fileset dir="target/jbossas">
+            <fileset dir="target/jbossas"/>
         </copy>
         <add-jts name="iiop-client"/>
 
@@ -16,7 +16,7 @@
         <echo message="Building config iiop-server"/>
         <build-server-config name="iiop-server"/>
         <copy todir="target/iiop-server">
-            <fileset dir="target/jbossas">
+            <fileset dir="target/jbossas"/>
         </copy>
         <add-jts name="iiop-server"/>
         <add-port-offset name="iiop-server" offset="100" nativePort="9999" httpPort="9990"/>

--- a/testsuite/integration/src/test/scripts/multinode-build.xml
+++ b/testsuite/integration/src/test/scripts/multinode-build.xml
@@ -29,14 +29,20 @@
 
     <target name="build-multinode" description="Builds server configurations for Multi-node tests">
 
-        <echo message="Copying and configuring instance multinode-client"/>
-        <build-server-config name="multinode-client"/>
-        <ts.config-as.add-remote-outbound-connection name="multinode-client" node="${node0}" remotePort="4547" securityRealm="PasswordRealm" userName="user1"/>
-        <ts.config-as.add-identity-realm name="multinode-client" realmName="PasswordRealm" secret="cGFzc3dvcmQx"/>
+        <echo message="Copying and configuring instance jbossas-multinode-client"/>
+        <build-server-config name="jbossas-multinode-client"/>
+        <ts.config-as.add-remote-outbound-connection name="jbossas-multinode-client" node="${node0}" remotePort="4547" securityRealm="PasswordRealm" userName="user1"/>
+        <ts.config-as.add-identity-realm name="jbossas-multinode-client" realmName="PasswordRealm" secret="cGFzc3dvcmQx"/>
 
-        <echo message="Copying and configuring instance multinode-server"/>
-        <build-server-config name="multinode-server"/>
-        <ts.config-as.add-port-offset name="multinode-server" offset="100" nativePort="9999" httpPort="9990"/>
+        <echo message="Copying and configuring instance jbossas-multinode-server"/>
+        <build-server-config name="jbossas-multinode-server"/>
+        <ts.config-as.add-port-offset name="jbossas-multinode-server" offset="100" nativePort="9999" httpPort="9990"/>
+        <!-- Security - users and roles definitions. -->
+        <copy todir="target/jbossas-multinode-server/standalone/configuration" overwrite="true">
+            <fileset dir="${jbossas.ts.integ.dir}/../shared/src/main/resources">
+                <include name="application-*.properties"/>
+            </fileset>
+        </copy>
     </target>
 
 </project>

--- a/testsuite/integration/src/test/scripts/multinode-build.xml
+++ b/testsuite/integration/src/test/scripts/multinode-build.xml
@@ -29,27 +29,14 @@
 
     <target name="build-multinode" description="Builds server configurations for Multi-node tests">
 
-        <echo message="Building config multinode-client"/>
-
+        <echo message="Copying and configuring instance multinode-client"/>
         <build-server-config name="multinode-client"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="multinode-client"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
-        <change-ip-addresses name="multinode-client" node="${node0}"/>
-        <add-remote-outbound-connection name="multinode-client" node="${node0}" remotePort="4547" securityRealm="PasswordRealm" userName="user1"/>
-        <add-identity-realm name="multinode-client" realmName="PasswordRealm" secret="cGFzc3dvcmQx"/>
+        <ts.config-as.add-remote-outbound-connection name="multinode-client" node="${node0}" remotePort="4547" securityRealm="PasswordRealm" userName="user1"/>
+        <ts.config-as.add-identity-realm name="multinode-client" realmName="PasswordRealm" secret="cGFzc3dvcmQx"/>
 
-        <echo message="Building config multinode-server"/>
-
-        <build-server-config name="multinode-server" copyPattern="*-users.properties"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="multinode-server"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
-        <change-ip-addresses name="multinode-server" node="${node0}"/>
-        <add-port-offset name="multinode-server" offset="100" nativePort="9999" httpPort="9990"/>
-
+        <echo message="Copying and configuring instance multinode-server"/>
+        <build-server-config name="multinode-server"/>
+        <ts.config-as.add-port-offset name="multinode-server" offset="100" nativePort="9999" httpPort="9990"/>
     </target>
 
 </project>

--- a/testsuite/integration/src/test/scripts/smoke-build.xml
+++ b/testsuite/integration/src/test/scripts/smoke-build.xml
@@ -28,14 +28,7 @@
     <import file="common-targets.xml" as="common"/>
 
     <target name="build-smoke" description="Builds server configuration for smoke tests">
-        <build-server-config name="smoke"/>
 
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="smoke"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
-
-        <change-ip-addresses name="smoke" node="${node0}"/>
     </target>
 
 </project>

--- a/testsuite/integration/src/test/scripts/xts-build.xml
+++ b/testsuite/integration/src/test/scripts/xts-build.xml
@@ -6,13 +6,8 @@
 
     <target name="build-xts" description="Builds server configuration for XTS tests">
 
-        <echo message="Building config xts"/>
-
-        <build-server-config name="xts"/>
-        <antcall target="changeDefaultDatabase">
-           <param name="server-config" value="xts"/>
-           <propertyset refid="ds.properties"/>
-        </antcall>
+        <echo message="Copying and configuring AS instance for XTS..."/>
+        <build-server-config name="jbossas-xts"/>
 
     </target>
 

--- a/testsuite/integration/src/test/xslt/addJmsDestinations.xsl
+++ b/testsuite/integration/src/test/xslt/addJmsDestinations.xsl
@@ -1,0 +1,43 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:d="urn:jboss:domain:1.1"
+                xmlns:jms="urn:jboss:domain:messaging:1.1"
+    >
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:param name="queueName"/>
+    <xsl:param name="topicName"/>
+
+    <xsl:variable name="newDest">
+                   <jms:jms-queue>
+                       <xsl:attribute name="name"><xsl:value-of select="$queueName"/></xsl:attribute>
+                       <jms:entry name="queue/test"/>
+                       <jms:entry name="java:jboss/exported/jms/queue/test"/>
+                   </jms:jms-queue>
+                   <jms:jms-topic>      
+                       <xsl:attribute name="name"><xsl:value-of select="$topicName"/></xsl:attribute>
+                       <jms:entry name="topic/test"/>
+                       <jms:entry name="java:jboss/exported/jms/topic/test"/>
+                   </jms:jms-topic>      
+    </xsl:variable>
+
+    <!-- Append the queue and topic defined above. -->
+    <xsl:template match="//jms:hornetq-server/jms:jms-destinations">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+            <xsl:copy-of select="$newDest"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- Prevent duplicates. -->
+    <xsl:template match="//jms:hornetq-server/jms:jms-destinations/jms:jms-queue[@name=$queueName]"/>
+    <xsl:template match="//jms:hornetq-server/jms:jms-destinations/jms:jms-topic[@name=$topicName]"/>
+
+    <!-- Copy everything else. -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+     
+</xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/changeDatabase.xsl
+++ b/testsuite/integration/src/test/xslt/changeDatabase.xsl
@@ -54,7 +54,7 @@
       -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:ds="urn:jboss:domain:datasources:1.0" version="1.0">
+                xmlns:ds="urn:jboss:domain:datasources:1.0">
     <xsl:output method="xml" indent="yes"/>
 
     <xsl:param name="ds.jdbc.driver.jar" select="'fred'"/>
@@ -63,24 +63,24 @@
     <xsl:param name="ds.jdbc.pass" select="'test'"/>
 
     <xsl:variable name="newDatasourceDefinition">
-        <ds:datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="MSQL" enabled="true" jta="true"
+            <ds:datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExamplePool" enabled="true" jta="true"
                        use-java-context="true">
-            <ds:connection-url><xsl:value-of select="$ds.jdbc.url"/></ds:connection-url>
-            <ds:driver><xsl:value-of select="$ds.jdbc.driver.jar"/></ds:driver>
-            <ds:security>
-                <ds:user-name><xsl:value-of select="$ds.jdbc.user"/></ds:user-name>
-                <ds:password><xsl:value-of select="$ds.jdbc.pass"/></ds:password>
-            </ds:security>
-        </ds:datasource>
+                <ds:connection-url><xsl:value-of select="$ds.jdbc.url"/></ds:connection-url>
+                <ds:driver><xsl:value-of select="$ds.jdbc.driver.jar"/></ds:driver>
+                <ds:security>
+                    <ds:user-name><xsl:value-of select="$ds.jdbc.user"/></ds:user-name>
+                    <ds:password><xsl:value-of select="$ds.jdbc.pass"/></ds:password>
+                </ds:security>
+            </ds:datasource>
     </xsl:variable>
 
-    <!-- replace the old definition with the new -->
+    <!-- Replace the old datasource with the new. -->
     <xsl:template match="//ds:subsystem/ds:datasources/ds:datasource[@jndi-name='java:jboss/datasources/ExampleDS']">
         <!-- http://docs.jboss.org/ironjacamar/userguide/1.0/en-US/html/deployment.html#deployingds_descriptor -->
         <xsl:copy-of select="$newDatasourceDefinition"/>
     </xsl:template>
 
-    <!-- get rid of the default driver defs -->
+    <!-- Get rid of the default driver defs. -->
     <xsl:template match="//ds:subsystem/ds:datasources/ds:drivers"/>
 
     <!-- Copy everything else. -->

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -3,6 +3,7 @@
 		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 		xmlns="urn:jboss:domain:1.1"
 		xmlns:d="urn:jboss:domain:1.1"
+        xmlns:ws11="urn:jboss:domain:webservices:1.1"
                 >
 
     <!--
@@ -30,7 +31,7 @@
       </server>
     -->
 
-    <!-- IP addresses. -->
+    <!-- IP addresses  select="..." is default value. -->
     <xsl:param name="managementIPAddress" select="'127.0.0.1'"/>
     <xsl:param name="publicIPAddress"     select="'127.0.0.1'"/>
 
@@ -97,6 +98,13 @@
             <xsl:apply-templates select="node()|@*"/>
         </xsl:copy>
     </xsl:template>
+    
+    <!-- Change WSDL host. -->
+    <xsl:template match="//ws11:wsdl-host">
+        <xsl:copy>${jboss.bind.address:<xsl:value-of select="$publicIPAddress"/>}</xsl:copy>
+    </xsl:template>
+    
+    
 
     <!-- Copy everything else. -->
     <xsl:template match="node()|@*">

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -1,8 +1,11 @@
+
 <xsl:stylesheet version="2.0"
 		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:d="urn:jboss:domain:1.0">
+		xmlns="urn:jboss:domain:1.1"
+		xmlns:d="urn:jboss:domain:1.1"
+                >
 
-  <!--
+    <!--
       An XSLT style sheet which will change IP unicast and multicast addresses for standalone.xml and standalone-ha.xml.
       This is done by changing:
       <server>
@@ -25,80 +28,81 @@
         </socket-binding-group>
 	...
       </server>
-  -->
+    -->
 
-  <!-- IP addresses -->
-  <xsl:param name="managementIPAddress" select="'127.0.0.1'"/>
-  <xsl:param name="publicIPAddress" select="'127.0.0.1'"/>
+    <!-- IP addresses. -->
+    <xsl:param name="managementIPAddress" select="'127.0.0.1'"/>
+    <xsl:param name="publicIPAddress"     select="'127.0.0.1'"/>
 
-  <!-- mcast addresses -->
-  <xsl:param name="udpMcastAddress" select="'230.0.0.4'"/>
-  <xsl:param name="diagnosticsMcastAddress" select="'224.0.75.75'"/>
-  <xsl:param name="mpingMcastAddress" select="'230.0.0.4'"/>
-  <xsl:param name="modclusterMcastAddress" select="'224.0.1.105'"/>
+    <!-- Multi-cast addresses. -->
+    <xsl:param name="udpMcastAddress"         select="'230.0.0.4'"/>
+    <xsl:param name="diagnosticsMcastAddress" select="'224.0.75.75'"/>
+    <xsl:param name="mpingMcastAddress"       select="'230.0.0.4'"/>
+    <xsl:param name="modclusterMcastAddress"  select="'224.0.1.105'"/>
 
-  <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
-  <xsl:template match="node()|@*">
-    <xsl:copy>
-      <xsl:apply-templates select="node()|@*"/>
-    </xsl:copy>
-  </xsl:template>
 
-  <!-- change the management and public IP addresses -->
-  <xsl:template match="//d:interfaces/d:interface[@name='management']/d:inet-address">
-    <xsl:copy>
-      <xsl:attribute name="value">
-	<xsl:value-of select="$managementIPAddress"/>
-      </xsl:attribute>
-    </xsl:copy>
-  </xsl:template>
-
-    <xsl:template match="//d:interfaces/d:interface[@name='public']/d:inet-address">
-      <xsl:copy>
-        <xsl:attribute name="value">
-          <xsl:value-of select="$publicIPAddress"/>
-        </xsl:attribute>
-      </xsl:copy>
+    <!-- Change the management and public IP addresses. -->
+    <xsl:template match="//d:interfaces/d:interface[@name='management']/d:inet-address">
+        <xsl:copy>
+            <xsl:attribute name="value">
+                <xsl:value-of select="$managementIPAddress"/>
+            </xsl:attribute>
+        </xsl:copy>
     </xsl:template>
 
-  <!-- change udp multicast addresses -->
-  <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-udp']">
-    <xsl:copy>
-      <xsl:attribute name="multicast-address">
-	    <xsl:value-of select="$udpMcastAddress"/>
-      </xsl:attribute>
-      <xsl:apply-templates select="node()|@*"/>
-    </xsl:copy>
-  </xsl:template>
+    <xsl:template match="//d:interfaces/d:interface[@name='public']/d:inet-address">
+        <xsl:copy>
+            <xsl:attribute name="value">
+                <xsl:value-of select="$publicIPAddress"/>
+            </xsl:attribute>
+        </xsl:copy>
+    </xsl:template>
 
-  <!-- change diagnostics multicast addresses -->
-  <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-diagnostics']">
-    <xsl:copy>
-      <xsl:attribute name="multicast-address">
-        <xsl:value-of select="$diagnosticsMcastAddress"/>
-      </xsl:attribute>
-      <xsl:apply-templates select="node()|@*"/>
-    </xsl:copy>
-  </xsl:template>
+    <!-- Change UDP multicast addresses. -->
+    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-udp']">
+        <xsl:copy>
+            <xsl:attribute name="multicast-address">
+                <xsl:value-of select="$udpMcastAddress"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
 
-  <!-- change MPING multicast addresses -->
-  <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-mping']">
-    <xsl:copy>
-      <xsl:attribute name="multicast-address">
-        <xsl:value-of select="$mpingMcastAddress"/>
-      </xsl:attribute>
-      <xsl:apply-templates select="node()|@*"/>
-    </xsl:copy>
-  </xsl:template>
+    <!-- Change diagnostics multicast addresses. -->
+    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-diagnostics']">
+        <xsl:copy>
+            <xsl:attribute name="multicast-address">
+                <xsl:value-of select="$diagnosticsMcastAddress"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
 
-  <!-- change modcluster multicast addresses -->
-  <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='modcluster']">
-    <xsl:copy>
-      <xsl:attribute name="multicast-address">
-         <xsl:value-of select="$modclusterMcastAddress"/>
-      </xsl:attribute>
-      <xsl:apply-templates select="node()|@*"/>
-    </xsl:copy>
-  </xsl:template>
+    <!-- Change MPING multicast addresses. -->
+    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-mping']">
+        <xsl:copy>
+            <xsl:attribute name="multicast-address">
+                <xsl:value-of select="$mpingMcastAddress"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Change modcluster multicast addresses. -->
+    <xsl:template match="//socket-binding-group[@name='standard-sockets']/socket-binding[@name='modcluster']">
+        <xsl:copy>
+            <xsl:attribute name="multicast-address">
+                <xsl:value-of select="$modclusterMcastAddress"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Copy everything else. -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
 
 </xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -51,7 +51,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//d:interfaces/d:interface[@name='public']/d:inet-address">
+    <xsl:template match="//d:interfaces/d:interface[@name='public' or @name='unsecure']/d:inet-address">
         <xsl:copy>
             <xsl:attribute name="value">
                 <xsl:value-of select="$publicIPAddress"/>
@@ -90,7 +90,7 @@
     </xsl:template>
 
     <!-- Change modcluster multicast addresses. -->
-    <xsl:template match="//socket-binding-group[@name='standard-sockets']/socket-binding[@name='modcluster']">
+    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='modcluster']">
         <xsl:copy>
             <xsl:attribute name="multicast-address">
                 <xsl:value-of select="$modclusterMcastAddress"/>

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -44,11 +44,7 @@
 
         <profile>
             <id>xts.integration.tests.profile</id>
-            <activation>
-                <property>
-                    <name>!ts.noXTS</name>
-                </property>
-            </activation>
+            <activation><property><name>!ts.noXTS</name></property></activation>
             <properties>
             </properties>
             <!--
@@ -63,13 +59,13 @@
                             <execution>
                                 <id>build-xts.server</id>
                                 <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
+                                <goals><goal>run</goal></goals>
                                 <configuration>
                                     <target>
                                         <!-- build the UDP server configs in target-->
                                         <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/xts-build.xml">
+                                            <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="node1" value="${node1}"/>
                                             <target name="build-xts"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <artifactId>jboss-as-ts-integ</artifactId>
         <version>7.1.1.Final-SNAPSHOT</version>
     </parent>
 
@@ -14,7 +14,7 @@
     <!-- *********************************** XTS       ************************************ -->
     <!-- ********************************************************************************** -->
     <groupId>org.jboss.as</groupId>
-    <artifactId>jboss-as-testsuite-integration-xts</artifactId>
+    <artifactId>jboss-as-ts-integ-xts</artifactId>
     <version>7.1.1.Final-SNAPSHOT</version>
 
     <name>JBoss Application Server Test Suite: Integration - XTS</name>

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -102,6 +102,7 @@
 
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
+                                        <!-- TODO: Use a property. -->
                                         <jboss.server.config.file.name>../../docs/examples/configs/standalone-xts.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/testsuite/integration/xts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/xts/src/test/config/arq/arquillian.xml
@@ -8,6 +8,8 @@
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-xts</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-xts.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>
+            <property name="managementAddress">${node0:127.0.0.1}</property>
+            <property name="managementPort">${as.managementPort:9999}</property>
         </configuration>
     </container>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -274,8 +274,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions combine.children="append">
+                    <!-- Copy AS from ${jboss.home} to testsuite/target/jbossas -->
                     <execution>
-                        <id>build-jbossas.server</id>
+                        <id>ts.copy-jbossas.from-dist</id>
+                        <inherited>false</inherited>
                         <phase>generate-test-resources</phase>
                         <goals><goal>copy-resources</goal></goals>
                         <configuration>
@@ -288,6 +290,22 @@
                                         <exclude>modules/</exclude>
                                         <exclude>bundles/</exclude>
                                     </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <!-- Copy that AS  ../target/jbossas into current_submodule/target/jbossas . This is executed recursively in submodules. -->
+                    <execution>
+                        <id>ts.copy-jbossas.groups</id>
+                        <inherited>true</inherited>
+                        <phase>generate-test-resources</phase>
+                        <goals><goal>copy-resources</goal></goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../target/jbossas</directory>
                                 </resource>
                             </resources>
                         </configuration>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -648,10 +648,11 @@
                 Profile used to perform database related changes.
             -->
             <id>ds.profile</id>
-            <activation><activeByDefault>true</activeByDefault></activation>
             <!--
+            <activation><activeByDefault>true</activeByDefault></activation>
             <activation><property><name>ds</name></property></activation>
             -->
+            <activation><property><name>!dummyPropertyKJDWQ</name></property></activation>
             <dependencies>
                 <dependency>
                     <groupId>jdbcdrivers</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -550,24 +550,31 @@
             <activation><property><name>compat.module</name></property></activation>
             <modules><module>compat</module></modules>
         </profile>
+        <profile>
+            <id>compat_.module.profile</id>
+            <activation><property><name>ts.compat</name></property></activation>
+            <modules><module>compat</module></modules>
+        </profile>
 
         <profile>
             <id>domain.module.profile</id>
             <activation><property><name>domain.module</name></property></activation>
             <modules><module>domain</module></modules>
         </profile>
-
-        <!-- Included by default.
         <profile>
-            <id>integration.module.profile</id>
-            <activation><property><name>integration.module</name></property></activation>
-            <modules><module>integration</module></modules>
+            <id>domain_.module.profile</id>
+            <activation><property><name>ts.domain</name></property></activation>
+            <modules><module>domain</module></modules>
         </profile>
-        -->
 
         <profile>
             <id>stress.module.profile</id>
             <activation><property><name>stress.module</name></property></activation>
+            <modules><module>stress</module></modules>
+        </profile>
+        <profile>
+            <id>stress_.module.profile</id>
+            <activation><property><name>ts.stress</name></property></activation>
             <modules><module>stress</module></modules>
         </profile>
 
@@ -578,11 +585,7 @@
         -->
         <profile>
             <id>jpda.profile</id>
-            <activation>
-                <property>
-                    <name>jpda</name>
-                </property>
-            </activation>
+            <activation><property><name>jpda</name></property></activation>
             <properties>
                 <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
             </properties>
@@ -635,11 +638,7 @@
                 general profile used to help orchestrate database changes
             -->
             <id>ds.profile</id>
-            <activation>
-                <property>
-                    <name>ds</name>
-                </property>
-            </activation>
+            <activation><property><name>ds</name></property></activation>
             <dependencies>
                 <dependency>
                     <groupId>jdbcdrivers</groupId>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -512,6 +512,34 @@
         </profile>
 
         <profile>
+            <id>integ.module.profile</id>
+            <activation><property><name>integ.module</name></property></activation>
+            <modules>
+                <module>integration</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>integ-basic.module.profile</id>
+            <activation><property><name>ts.basic</name></property></activation>
+            <modules><module>integration</module></modules>
+        </profile>
+        <profile>
+            <id>integ-clust.module.profile</id>
+            <activation><property><name>ts.clust</name></property></activation>
+            <modules><module>integration</module></modules>
+        </profile>
+        <profile>
+            <id>integ-iiop.module.profile</id>
+            <activation><property><name>ts.iiop</name></property></activation>
+            <modules><module>integration</module></modules>
+        </profile>
+        <profile>
+            <id>integ-xts.module.profile</id>
+            <activation><property><name>ts.xts</name></property></activation>
+            <modules><module>integration</module></modules>
+        </profile>
+
+        <profile>
             <id>benchmark.module.profile</id>
             <activation><property><name>benchmark.module</name></property></activation>
             <modules><module>benchmark</module></modules>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -367,6 +367,7 @@
                         </configuration>
                     </execution>
                 </executions>
+                <!--
                 <dependencies>
                     <dependency>
                         <groupId>net.sf.saxon</groupId>
@@ -374,6 +375,7 @@
                         <version>${version.saxon}</version>
                     </dependency>
                 </dependencies>
+                -->
             </plugin>
 
             <!--
@@ -694,10 +696,11 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <!-- Replace ExampleDS datasource in server configurations (target/jbossas). -->
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>xml-maven-plugin</artifactId>
                         <executions combine.children="append">
+                            <!-- Replace ExampleDS datasource in server configurations (target/jbossas). -->
+                            <!-- Not needed, done in ts.config-as.ip-and-ds.
                             <execution>
                                 <id>ts.config-as.db.change-datasource</id>
                                 <phase>process-test-resources</phase>
@@ -722,14 +725,8 @@
                                     </transformationSets>
                                 </configuration>
                             </execution>
+                            -->
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>net.sf.saxon</groupId>
-                                <artifactId>saxon</artifactId>
-                                <version>${version.saxon}</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
 
                     <!--

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -308,6 +308,11 @@
                             <resources>
                                 <resource>
                                     <directory>${basedir}/../target/jbossas</directory>
+                                    <excludes>
+                                        <exclude>standalone/data</exclude>
+                                        <exclude>standalone/log</exclude>
+                                        <exclude>standalone/tmp</exclude>
+                                    </excludes>
                                 </resource>
                             </resources>
                         </configuration>
@@ -329,6 +334,7 @@
                         <inherited>false</inherited>
                         <configuration>
                             <transformationSets>
+                                <!-- IPs. -->
                                 <transformationSet>
                                     <dir>${basedir}/target/jbossas/standalone/configuration</dir>
                                     <outputDir>${basedir}/target/jbossas/standalone/configuration</outputDir>
@@ -337,14 +343,24 @@
                                         <include>standalone*.xml</include>
                                     </includes>
                                     <parameters>
-                                        <parameter>
-                                            <name>managementIPAddress</name>
-                                            <value>${node0}</value>
-                                        </parameter>
-                                        <parameter>
-                                            <name>publicIPAddress</name>
-                                            <value>${node0}</value>
-                                        </parameter>
+                                        <parameter><name>managementIPAddress</name><value>${node0}</value></parameter>
+                                        <parameter><name>publicIPAddress</name><value>${node0}</value></parameter>
+                                        <parameter><name>udpMcastAddress</name><value>${udpGroup}</value></parameter><!-- Only somewhere - TODO. -->
+                                    </parameters>
+                                </transformationSet>
+                                <!-- Datasource. -->
+                                <transformationSet>
+                                    <dir      >${basedir}/target/jbossas/standalone/configuration</dir>
+                                    <outputDir>${basedir}/target/jbossas/standalone/configuration</outputDir>
+                                    <stylesheet>${xslt.scripts.dir}/changeDatabase.xsl</stylesheet>
+                                    <includes>
+                                        <include>standalone*.xml</include>
+                                    </includes>
+                                    <parameters>
+                                        <parameter><name>ds.jdbc.driver.jar</name><value>${ds.jdbc.driver.jar}</value></parameter>
+                                        <parameter><name>ds.jdbc.url</name><value>${ds.jdbc.url}</value></parameter>
+                                        <parameter><name>ds.jdbc.user</name><value>${ds.jdbc.user}</value></parameter>
+                                        <parameter><name>ds.jdbc.pass</name><value>${ds.jdbc.pass}</value></parameter>
                                     </parameters>
                                 </transformationSet>
                             </transformationSets>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -328,7 +328,7 @@
                 <artifactId>xml-maven-plugin</artifactId>
                 <executions combine.children="append">
                     <execution>
-                        <id>ts.config-as.ip-addresses</id>
+                        <id>ts.config-as.ip-and-ds</id>
                         <phase>process-test-resources</phase>
                         <goals><goal>transform</goal></goals>
                         <inherited>false</inherited>
@@ -581,7 +581,7 @@
 
 
         <!--
-          Debugging profiles
+          Debugging profiles.
         -->
         <profile>
             <id>jpda.profile</id>
@@ -624,21 +624,34 @@
 
 
         <!--
-          Database profiles
-          - here we define profiles used to configure default databases
-          - changing the default database involves:
-            - including a dependency for the database driver
-            - changing the server configuration file
-            - deploying the driver via the server's deployments directory
-          - for example, to change the default database from H2 to MySQL 5.1, use -Dds=mysql51
+          Database config profiles.
+          Changing the default database involves:
+            * Adding a dependency for the database driver.
+            * Changing the server configuration file.
+            * Deploying the driver via the server's deployments directory.
+            
+          DEFAULT DATASOURCE implementation note:
+            There are two ways:
+            *  Leaving the default DS as distributed in AS, or
+            *  Having a default set of properties and executing DS config even without -Dds=... specified.
+            Currently it's the 2nd.
+            Changing to 1st would need moving DS transformation from ts.config-as.ip-and-ds to this profile.
+            
+          Usage:
+             mvn clean install -rf testsuite -Dds=mysql51
+             
+          See: https://community.jboss.org/wiki/DataSourceConfigurationInAS7
         -->
 
         <profile>
             <!--
-                general profile used to help orchestrate database changes
+                Profile used to perform database related changes.
             -->
             <id>ds.profile</id>
+            <activation><activeByDefault>true</activeByDefault></activation>
+            <!--
             <activation><property><name>ds</name></property></activation>
+            -->
             <dependencies>
                 <dependency>
                     <groupId>jdbcdrivers</groupId>
@@ -654,17 +667,15 @@
             </repositories>
             <build>
                 <plugins>
-                    <!-- copy the JDBC driver which needs to be installed -->
+                    <!-- Copy the JDBC driver to target/jdbcDrivers. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions combine.children="append">
                             <execution>
-                                <id>copy-jdbc-jars.database</id>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <!-- binds to process-sources -->
+                                <id>ts.config-as.db.copy-jdbc-jars</id>
+                                <goals><goal>copy</goal></goals>
+                                <phase>process-sources</phase>
                                 <inherited>true</inherited>
                                 <configuration>
                                     <artifactItems>
@@ -682,12 +693,12 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <!-- replace the default datasource in server configurations (target/jbossas) -->
+                        <!-- Replace ExampleDS datasource in server configurations (target/jbossas). -->
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>xml-maven-plugin</artifactId>
                         <executions combine.children="append">
                             <execution>
-                                <id>update-datasource.server</id>
+                                <id>ts.config-as.db.change-datasource</id>
                                 <phase>process-test-resources</phase>
                                 <goals><goal>transform</goal></goals>
                                 <inherited>false</inherited>
@@ -701,22 +712,10 @@
                                                 <include>standalone*.xml</include>
                                             </includes>
                                             <parameters>
-                                                <parameter>
-                                                    <name>ds.jdbc.driver.jar</name>
-                                                    <value>${ds.jdbc.driver.jar}</value>
-                                                </parameter>
-                                                <parameter>
-                                                    <name>ds.jdbc.url</name>
-                                                    <value>${ds.jdbc.url}</value>
-                                                </parameter>
-                                                <parameter>
-                                                    <name>ds.jdbc.user</name>
-                                                    <value>${ds.jdbc.user}</value>
-                                                </parameter>
-                                                <parameter>
-                                                    <name>ds.jdbc.pass</name>
-                                                    <value>${ds.jdbc.pass}</value>
-                                                </parameter>
+                                                <parameter><name>ds.jdbc.driver.jar</name><value>${ds.jdbc.driver.jar}</value></parameter>
+                                                <parameter><name>ds.jdbc.url</name><value>${ds.jdbc.url}</value></parameter>
+                                                <parameter><name>ds.jdbc.user</name><value>${ds.jdbc.user}</value></parameter>
+                                                <parameter><name>ds.jdbc.pass</name><value>${ds.jdbc.pass}</value></parameter>
                                             </parameters>
                                         </transformationSet>
                                     </transformationSets>
@@ -733,7 +732,7 @@
                     </plugin>
 
                     <!--
-                        Deploy the jdbc driver by copying to the deployments directory.
+                        Deploy the JDBC driver by copying to the deployments directory.
                     -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -763,18 +762,40 @@
             </build>
         </profile>
 
+        <!-- Database properties profiles. -->
+        
+        <!-- H2 - http://www.h2database.com/html/features.html#database_url -->
         <profile>
-            <!-- specific profile for database changes  -->
+            <id>h2.profile</id>
+            <activation><property><name>ds</name><value>h2</value></property></activation>
+            <properties>
+                <ds.db>h2</ds.db>
+                <ds.jdbc.driver>org.h2.Driver</ds.jdbc.driver>
+                <ds.jdbc.driver-xa>org.h2.jdbcx.JdbcDataSource</ds.jdbc.driver-xa>
+                <ds.jdbc.url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</ds.jdbc.url>
+                <ds.jdbc.driver.version>1.3.159</ds.jdbc.driver.version>
+            </properties>
+        </profile>
+        <profile>  <!-- We need "OR" but Maven's activation system doesn't support any evaluation :/ -->
+            <id>h2_.profile</id>
+            <activation><property><name>!ds</name></property></activation>
+            <properties>
+                <ds.db>h2</ds.db>
+                <ds.jdbc.driver>org.h2.Driver</ds.jdbc.driver>
+                <ds.jdbc.driver-xa>org.h2.jdbcx.JdbcDataSource</ds.jdbc.driver-xa>
+                <ds.jdbc.url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</ds.jdbc.url>
+                <ds.jdbc.driver.version>1.3.159</ds.jdbc.driver.version>
+            </properties>
+        </profile>
+        
+        <!-- MySQL 5.1 -->
+        <profile>
             <id>mysql51.profile</id>
-            <activation>
-                <property>
-                    <name>ds</name>
-                    <value>mysql51</value>
-                </property>
-            </activation>
+            <activation><property><name>ds</name><value>mysql51</value></property></activation>
             <properties>
                 <ds.db>mysql</ds.db>
                 <ds.jdbc.driver>com.mysql.jdbc.Driver</ds.jdbc.driver>
+                <ds.jdbc.driver-xa>com.mysql.jdbc.jdbc2.optional.MysqlXADataSource</ds.jdbc.driver-xa>
                 <ds.jdbc.url>jdbc:mysql://localhost:3306/test</ds.jdbc.url>
                 <ds.jdbc.driver.version>5.1.17</ds.jdbc.driver.version>
             </properties>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -264,6 +264,8 @@
                 <configuration>
                     <compilerArgument>-Djava.endorsed.dirs=${project.build.directory}/endorsed</compilerArgument>
                 </configuration>
+                <!-- Don't compile src/main/java - nothing to do. -->
+                <executions><execution><id>default-compile</id><phase>none</phase></execution></executions>
             </plugin>
 
             <!--
@@ -461,6 +463,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <executions><execution><id>check-style</id><phase>none</phase></execution></executions>
+            </plugin>
+            
+            <!-- Don't install - nothing to do. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions><execution><id>default-install</id><phase>none</phase></execution></executions>
             </plugin>
 
         </plugins>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -98,6 +98,9 @@
         <jvm.args.securityManager></jvm.args.securityManager>
         <jvm.args.securityPolicy></jvm.args.securityPolicy>
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy}</jvm.args.security>
+        
+        <!-- Logging config -->
+        <testLogToFile>true</testLogToFile>
 
         <!-- Timeout ratios. 100 will leave the timeout as it was coded. -->
         <timeout.ratio.fsio>100</timeout.ratio.fsio>
@@ -392,7 +395,7 @@
                     <failIfNoTests>false</failIfNoTests>
                     <!-- don't halt the all test executions if a test fails -->
                     <testFailureIgnore>${surefire.test.failure.ignore}</testFailureIgnore>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <jboss.options>${surefire.system.args}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -328,7 +328,7 @@
                 <artifactId>xml-maven-plugin</artifactId>
                 <executions combine.children="append">
                     <execution>
-                        <id>ts.config-as.ip-and-ds</id>
+                        <id>ts.config-as.ip</id>
                         <phase>process-test-resources</phase>
                         <goals><goal>transform</goal></goals>
                         <inherited>false</inherited>
@@ -349,6 +349,7 @@
                                     </parameters>
                                 </transformationSet>
                                 <!-- Datasource. -->
+                                <!-- Not needed, done in ds.profile .
                                 <transformationSet>
                                     <dir      >${basedir}/target/jbossas/standalone/configuration</dir>
                                     <outputDir>${basedir}/target/jbossas/standalone/configuration</outputDir>
@@ -363,6 +364,7 @@
                                         <parameter><name>ds.jdbc.pass</name><value>${ds.jdbc.pass}</value></parameter>
                                     </parameters>
                                 </transformationSet>
+                                -->
                             </transformationSets>
                         </configuration>
                     </execution>
@@ -650,11 +652,7 @@
                 Profile used to perform database related changes.
             -->
             <id>ds.profile</id>
-            <!--
-            <activation><activeByDefault>true</activeByDefault></activation>
             <activation><property><name>ds</name></property></activation>
-            -->
-            <activation><property><name>!dummyPropertyKJDWQ</name></property></activation>
             <dependencies>
                 <dependency>
                     <groupId>jdbcdrivers</groupId>
@@ -700,7 +698,6 @@
                         <artifactId>xml-maven-plugin</artifactId>
                         <executions combine.children="append">
                             <!-- Replace ExampleDS datasource in server configurations (target/jbossas). -->
-                            <!-- Not needed, done in ts.config-as.ip-and-ds.
                             <execution>
                                 <id>ts.config-as.db.change-datasource</id>
                                 <phase>process-test-resources</phase>
@@ -725,7 +722,6 @@
                                     </transformationSets>
                                 </configuration>
                             </execution>
-                            -->
                         </executions>
                     </plugin>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -321,7 +321,7 @@
                 <artifactId>xml-maven-plugin</artifactId>
                 <executions combine.children="append">
                     <execution>
-                        <id>update-ip-addresses-jbossas.server</id>
+                        <id>ts.config-as.ip-addresses</id>
                         <phase>process-test-resources</phase>
                         <goals><goal>transform</goal></goals>
                         <inherited>false</inherited>
@@ -440,6 +440,13 @@
                         <version>1.6.5</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+
+            <!-- Don't create jars - nothing to do. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions><execution><id>default-jar</id><phase>none</phase></execution></executions>
             </plugin>
 
             <!-- Don't create source jars - nothing to do. -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -352,6 +352,19 @@
                                         <parameter><name>udpMcastAddress</name><value>${udpGroup}</value></parameter><!-- Only somewhere - TODO. -->
                                     </parameters>
                                 </transformationSet>
+                                <!-- JMS destinations. -->
+                                <transformationSet>
+                                    <dir>${basedir}/target/jbossas/standalone/configuration</dir>
+                                    <outputDir>${basedir}/target/jbossas/standalone/configuration</outputDir>
+                                    <stylesheet>${xslt.scripts.dir}/addJmsDestinations.xsl</stylesheet>
+                                    <includes>
+                                        <include>standalone*.xml</include>
+                                    </includes>
+                                    <parameters>
+                                        <parameter><name>queueName</name><value>testQueue</value></parameter>
+                                        <parameter><name>topicName</name><value>testTopic</value></parameter>
+                                    </parameters>
+                                </transformationSet>
                                 <!-- Datasource. -->
                                 <!-- Not needed, done in ds.profile .
                                 <transformationSet>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -124,6 +124,7 @@
         <!-- Common surefire properties. -->
         <surefire.memory.args>-Xmx512m -XX:MaxPermSize=256m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
+        <as.debug.port>8787</as.debug.port>
         <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
         <surefire.forked.process.timeout>900</surefire.forked.process.timeout>
         <surefire.test.failure.ignore>false</surefire.test.failure.ignore>
@@ -591,7 +592,14 @@
             <id>jpda.profile</id>
             <activation><property><name>jpda</name></property></activation>
             <properties>
-                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
+                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=${as.debug.port},server=y,suspend=y</surefire.jpda.args>
+            </properties>
+        </profile>
+        <profile>
+            <id>debug.profile</id>
+            <activation><property><name>debug</name></property></activation>
+            <properties>
+                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=${as.debug.port},server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
 

--- a/testsuite/stress/pom.xml
+++ b/testsuite/stress/pom.xml
@@ -48,7 +48,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <skipTests>${skip.stress.tests}</skipTests>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Most of AS configuration related tasks, which were done in Ant scripts and copied for each module, are now performed only once, and the resulting AS instance is copied by sub-modules.
