### PR TITLE
AS7-436 enable JTS crash recovery in the JTS configuration

### DIFF
--- a/build/src/main/resources/modules/org/jboss/jts/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/jts/main/module.xml
@@ -41,5 +41,6 @@
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>
         <module name="org.hornetq"/>
+        <module name="org.jacorb"/>
     </dependencies>
 </module>

--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaRecoveryManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaRecoveryManagerService.java
@@ -47,6 +47,7 @@ import com.arjuna.ats.internal.jts.recovery.transactions.ServerTransactionRecove
 import com.arjuna.ats.internal.jts.recovery.transactions.TopLevelTransactionRecoveryModule;
 import com.arjuna.ats.internal.txoj.recovery.TORecoveryModule;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
+import com.arjuna.orbportability.internal.utils.PostInitLoader;
 
 import static org.jboss.as.txn.TransactionMessages.MESSAGES;
 
@@ -111,6 +112,8 @@ public class ArjunaRecoveryManagerService implements Service<RecoveryManagerServ
             this.recoveryManagerService = recoveryManagerService;
         } else {
             final ORB orb = orbInjector.getValue();
+            new PostInitLoader(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"), orb);
+
             recoveryExtensions.add(TopLevelTransactionRecoveryModule.class.getName());
             recoveryExtensions.add(ServerTransactionRecoveryModule.class.getName());
             recoveryExtensions.add(com.arjuna.ats.internal.jta.recovery.jts.XARecoveryModule.class.getName());

--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.txn.service;
 
+import static org.jboss.as.txn.TransactionMessages.MESSAGES;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,8 +49,7 @@ import com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrph
 import com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
-
-import static org.jboss.as.txn.TransactionMessages.MESSAGES;
+import com.arjuna.orbportability.internal.utils.PostInitLoader;
 
 /**
  * A service for the proprietary Arjuna {@link com.arjuna.ats.jbossatx.jta.TransactionManagerService}
@@ -126,6 +127,8 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
             value = service;
         } else {
             final ORB orb = orbInjector.getValue();
+            new PostInitLoader(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"), orb);
+
             // IIOP is enabled, so fire up JTS mode.
             jtaEnvironmentBean.setTransactionManagerClassName(com.arjuna.ats.jbossatx.jts.TransactionManagerDelegate.class.getName());
             jtaEnvironmentBean.setTransactionSynchronizationRegistryClassName(com.arjuna.ats.internal.jta.transaction.jts.TransactionSynchronizationRegistryImple.class.getName());


### PR DESCRIPTION
As the orb postinitloader isn't called by the integration code, the transaction service is not able to register a factorycontactitem, nor is it able to create a recovery coordinator.
