### PR TITLE
AS7-3522: Upgrade to JAXB RI 2.2.4 to fix http://java.net/jira/browse/JAX_WS-870

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <version.org.w3c.css.sac>1.3</version.org.w3c.css.sac>
         <version.org.yaml.snakeyaml>1.8</version.org.yaml.snakeyaml>
         <version.osgi>4.2.0</version.osgi>
-        <version.sun.jaxb>2.2</version.sun.jaxb>
+        <version.sun.jaxb>2.2.4</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.wsdl4j>1.6.2</version.wsdl4j>


### PR DESCRIPTION
Version 2.2 of the JAXB RI contains a bug (http://java.net/jira/browse/JAX_WS-870) that can cause loads of warnings and stacktraces during server startup.

Please upgrade to the current JAXB RI Version 2.2.4 to incorporate the fix for JAX_WS-870.
