### PR TITLE
AS7-2815 Make ModuleFlag allowed values conform to xsd

### DIFF
--- a/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
+++ b/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
@@ -74,8 +74,8 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
         "    <naming root-context=\"JBoss/Naming/root\" export-corbaloc=\"on\"/>" +
         "    <interop sun=\"on\" comet=\"off\" iona=\"off\" chunk-custom-rmi-valuetypes=\"on\" " +
         "        lax-boolean-encoding=\"off\" indirection-encoding-disable=\"off\" strict-check-on-tc-creation=\"off\"/>" +
-        "    <security support-ssl=\"off\" add-component-via-interceptor=\"on\" client-supports=\"mutualAuth\"" +
-        "        client-requires=\"none\" server-supports=\"mutualAuth\" server-requires=\"none\"/>" +
+        "    <security support-ssl=\"off\" add-component-via-interceptor=\"on\" client-supports=\"MutualAuth\"" +
+        "        client-requires=\"None\" server-supports=\"MutualAuth\" server-requires=\"None\"/>" +
         "    <properties>" +
         "        <property name=\"some_property\" value=\"some_value\"/>" +
         "    </properties>" +

--- a/security/src/main/java/org/jboss/as/security/LoginModulesAttributeDefinition.java
+++ b/security/src/main/java/org/jboss/as/security/LoginModulesAttributeDefinition.java
@@ -147,7 +147,7 @@ public class LoginModulesAttributeDefinition extends ListAttributeDefinition {
         flag.get(NILLABLE).set(false);
 
         for (ModuleFlag value : ModuleFlag.values())
-            flag.get(ALLOWED).add(value.name());
+            flag.get(ALLOWED).add(value.toString());
 
         final ModelNode moduleOptions = valueType.get(Constants.MODULE_OPTIONS);
         moduleOptions.get(DESCRIPTION);  // placeholder

--- a/security/src/main/java/org/jboss/as/security/ModuleFlag.java
+++ b/security/src/main/java/org/jboss/as/security/ModuleFlag.java
@@ -1,6 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.security;
 
 /**
-* @author Jason T. Greene
-*/
-enum ModuleFlag {REQUIRED, REQUISITE, SUFFICIENT, OPTIONAL}
+ * Enumeration of valid login module flags.
+ *
+ * @author Jason T. Greene
+ */
+enum ModuleFlag {
+    REQUIRED("required"),
+    REQUISITE("requisite"),
+    SUFFICIENT("sufficient"),
+    OPTIONAL("optional");
+
+    private final String name;
+
+    private ModuleFlag(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}


### PR DESCRIPTION
EnumValidator accepts allowExpression param but will fail if one is provided
AS7-2815 Dodgy approach to storing the "allowed" value in the model by cheating with the validator

The last bit is admittedly dodgy so I won't cry if someone rejects it. (See EnumValidator)
