### PR TITLE
Upgrade EJB client to 1.0.0.Final

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
@@ -122,6 +122,11 @@ public class MessageDrivenComponent extends EJBComponent implements PooledCompon
             public void release(Object obj) {
                 // do nothing
             }
+
+            @Override
+            public ClassLoader getClassLoader() {
+                return ejbComponentCreateService.getComponentClass().getClassLoader();
+            }
         };
         this.endpointFactory = new JBossMessageEndpointFactory(getComponentClass().getClassLoader(), service);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/inflow/MessageEndpointInvocationHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/inflow/MessageEndpointInvocationHandler.java
@@ -150,7 +150,7 @@ public class MessageEndpointInvocationHandler extends AbstractInvocationHandler 
     }
 
     protected final ClassLoader getApplicationClassLoader() {
-        return service.getMessageListenerInterface().getClassLoader();
+        return this.service.getClassLoader();
     }
 
     protected final TransactionManager getTransactionManager() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/inflow/MessageEndpointService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/inflow/MessageEndpointService.java
@@ -38,4 +38,13 @@ public interface MessageEndpointService<T> {
     T obtain(long timeout, TimeUnit milliseconds);
 
     void release(T obj);
+
+    /**
+     * Returns the classloader that's applicable for the endpoint application.
+     * This classloader will be used to set the thread context classloader during the beforeDelivery()/afterDelivery()
+     * callbacks as mandated by the JCA 1.6 spec
+     *
+     * @return
+     */
+    ClassLoader getClassLoader();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
@@ -48,6 +48,7 @@ import org.jboss.ejb.client.EJBReceiverInvocationContext;
 import org.jboss.ejb.client.EntityEJBLocator;
 import org.jboss.ejb.client.SessionID;
 import org.jboss.ejb.client.StatefulEJBLocator;
+import org.jboss.ejb.client.TransactionID;
 import org.jboss.invocation.InterceptorContext;
 import org.jboss.marshalling.cloner.ClassLoaderClassCloner;
 import org.jboss.marshalling.cloner.ClonerConfiguration;
@@ -61,6 +62,8 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -232,6 +235,36 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
         } catch (IllegalArgumentException iae) {
             return false;
         }
+    }
+
+    @Override
+    protected int sendPrepare(EJBReceiverContext context, TransactionID transactionID) throws XAException {
+        // send a XA_OK since a local receiver doesn't have to do anything more
+        return XAResource.XA_OK;
+    }
+
+    @Override
+    protected void sendCommit(EJBReceiverContext context, TransactionID transactionID, boolean onePhase) throws XAException {
+        // no-op, since a local ejb receiver doesn't have to do anything more.
+        return;
+    }
+
+    @Override
+    protected void sendRollback(EJBReceiverContext context, TransactionID transactionID) throws XAException {
+        // no-op, since a local ejb receiver doesn't have to do anything more.
+        return;
+    }
+
+    @Override
+    protected void sendForget(EJBReceiverContext context, TransactionID transactionID) throws XAException {
+        // no-op, since a local ejb receiver doesn't have to do anything more.
+        return;
+    }
+
+    @Override
+    protected void beforeCompletion(EJBReceiverContext context, TransactionID transactionID) {
+        // no-op, since a local ejb receiver doesn't have to do anything more.
+        return;
     }
 
     private EjbDeploymentInformation findBean(final String appName, final String moduleName, final String distinctName, final String beanName) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
@@ -35,6 +35,7 @@ import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
 import org.jboss.as.txn.service.TransactionManagerService;
+import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.as.txn.service.UserTransactionService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
@@ -44,6 +45,7 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 
 import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -132,6 +134,8 @@ public class EJB3RemoteServiceAdd extends AbstractBoottimeAddStepHandler {
                 .addDependency(EJBRemoteTransactionsRepository.SERVICE_NAME, EJBRemoteTransactionsRepository.class, ejbRemoteConnectorService.getEJBRemoteTransactionsRepositoryInjector())
                 .addDependency(ClusteredBackingCacheEntryStoreSourceService.CLIENT_MAPPING_REGISTRY_COLLECTOR_SERVICE_NAME, RegistryCollector.class, ejbRemoteConnectorService.getClusterRegistryCollectorInjector())
                 .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, ejbRemoteConnectorService.getServerEnvironmentInjector())
+                .addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, ejbRemoteConnectorService.getTransactionManagerInjector())
+                .addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class, ejbRemoteConnectorService.getTxSyncRegistryInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE);
         if (verificationHandler != null) {
             ejbRemoteConnectorServiceBuilder.addListener(verificationHandler);

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <version.org.jboss.classfilewriter>1.0.0.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.common-core>2.2.17.GA</version.org.jboss.common-core>
         <version.org.jboss.com.sun.httpserver>1.0.0.Beta3</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb-client>1.0.0.Beta12</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.0.CR1-SNAPSHOT</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.0.0-beta-3</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.iiop-client>1.0.0.Beta2</version.org.jboss.iiop-client>
         <version.org.jboss.interceptor>2.0.0.Alpha3</version.org.jboss.interceptor>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <version.org.jboss.classfilewriter>1.0.0.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.common-core>2.2.17.GA</version.org.jboss.common-core>
         <version.org.jboss.com.sun.httpserver>1.0.0.Beta3</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb-client>1.0.0.CR1-SNAPSHOT</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.0.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.0.0-beta-3</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.iiop-client>1.0.0.Beta2</version.org.jboss.iiop-client>
         <version.org.jboss.interceptor>2.0.0.Alpha3</version.org.jboss.interceptor>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
@@ -22,16 +22,9 @@
 
 package org.jboss.as.test.integration.ejb.client.descriptor;
 
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
-
-import javax.ejb.EJBException;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -44,9 +37,15 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.ejb.EJBException;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
 
 /**
  * Tests that deployments containing a jboss-ejb-client.xml are processed correctly for EJB client context

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
@@ -201,7 +201,7 @@ public class EJBClientDescriptorTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore // EJBCLIENT-18
+    @OperateOnDeployment("local-and-remote-receviers-config")
     public void testLocalAndRemoteReceiversClientConfig() throws Exception {
         deployer.deploy("local-and-remote-receviers-config");
         try {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -67,6 +67,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.util.Base64;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -281,6 +282,7 @@ public class GetCallerPrincipalTestCase extends SecurityTest {
     }
 
     @Test
+    @Ignore("https://issues.jboss.org/browse/EJBCLIENT-17")
     public void testStatefulLifecycle() throws Exception {
         deployer.deploy("sfsb");
         SecurityClient client = this.login();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -67,7 +67,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.util.Base64;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -282,7 +281,6 @@ public class GetCallerPrincipalTestCase extends SecurityTest {
     }
 
     @Test
-    @Ignore("https://issues.jboss.org/browse/EJBCLIENT-17")
     public void testStatefulLifecycle() throws Exception {
         deployer.deploy("sfsb");
         SecurityClient client = this.login();


### PR DESCRIPTION
The commits in this branch upgrade EJB client to 1.0.0.Final and also fix a few other issues including setting up the EJB client transaction context by default on the server side.
