### PR TITLE
Minor Maven build cleanup

### DIFF
--- a/arquillian/container-managed/pom.xml
+++ b/arquillian/container-managed/pom.xml
@@ -81,6 +81,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.0_spec</artifactId>
             <scope>test</scope>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -679,6 +679,21 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jboss-common-core</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jboss-iiop-client</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jboss-vfs</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-appclient</artifactId>
                 </dependency>
@@ -766,6 +781,31 @@
 
                 <dependency>
                     <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-controller</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-controller-client</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-domain-http-interface</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-domain-management</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-deployment-repository</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-deployment-scanner</artifactId>
                 </dependency>
 
@@ -782,6 +822,11 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-ejb3</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-embedded</artifactId>
                 </dependency>
 
                 <dependency>
@@ -841,7 +886,7 @@
 
                 <dependency>
                     <groupId>org.jboss.as</groupId>
-                    <artifactId>jboss-as-pojo</artifactId>
+                    <artifactId>jboss-as-network</artifactId>
                 </dependency>
 
                 <dependency>
@@ -852,6 +897,31 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-osgi-service</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-platform-mbean</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-pojo</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-process-controller</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-protocol</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-remoting</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1114,13 +1184,48 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>org.jboss.osgi.metadata</groupId>
+                    <artifactId>jbosgi-metadata</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>org.jboss.osgi.repository</groupId>
                     <artifactId>jbosgi-repository</artifactId>
                 </dependency>
 
                 <dependency>
+                    <groupId>org.jboss.osgi.repository</groupId>
+                    <artifactId>jbosgi-repository-api</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.osgi.resolver</groupId>
+                    <artifactId>jbosgi-resolver-api</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.osgi.resolver</groupId>
+                    <artifactId>jbosgi-resolver-felix</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.osgi.resolver</groupId>
+                    <artifactId>jbosgi-resolver-metadata</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.osgi.resolver</groupId>
+                    <artifactId>jbosgi-resolver-spi</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>org.jboss.osgi.spi</groupId>
                     <artifactId>jbosgi-spi</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.remoting3</groupId>
+                    <artifactId>jboss-remoting</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1181,6 +1286,11 @@
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-yaml-provider</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.sasl</groupId>
+                    <artifactId>jboss-sasl</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1329,6 +1439,16 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>org.jboss.stdio</groupId>
+                    <artifactId>jboss-stdio</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.threads</groupId>
+                    <artifactId>jboss-threads</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>org.jboss.web</groupId>
                     <artifactId>jasper-jdt</artifactId>
                 </dependency>
@@ -1417,6 +1537,16 @@
                 <dependency>
                     <groupId>org.jboss.ws.native</groupId>
                     <artifactId>jbossws-native-services</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.xnio</groupId>
+                    <artifactId>xnio-api</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.xnio</groupId>
+                    <artifactId>xnio-nio</artifactId>
                 </dependency>
 
                 <dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -179,6 +179,11 @@ projects that depend on this project.-->
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_1.1_spec</artifactId>
         </dependency>

--- a/jpa/hibernate-infinispan/pom.xml
+++ b/jpa/hibernate-infinispan/pom.xml
@@ -40,6 +40,10 @@
     <dependencies>
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-infinispan</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,9 @@
         <version.org.jboss.osgi.framework>1.1.1</version.org.jboss.osgi.framework>
         <version.org.jboss.osgi.http>1.0.5</version.org.jboss.osgi.http>
         <version.org.jboss.osgi.logging>1.0.0</version.org.jboss.osgi.logging>
+        <version.org.jboss.osgi.metadata>2.0.0.CR1</version.org.jboss.osgi.metadata>
         <version.org.jboss.osgi.repository>1.0.3</version.org.jboss.osgi.repository>
+        <version.org.jboss.osgi.resolver>1.0.10</version.org.jboss.osgi.resolver>
         <version.org.jboss.osgi.spi>2.0.3</version.org.jboss.osgi.spi>
         <version.org.jboss.remote-naming>1.0.0.Beta4</version.org.jboss.remote-naming>
         <version.org.jboss.remoting3>3.2.0.CR9</version.org.jboss.remoting3>
@@ -395,6 +397,7 @@
                                             <exclude>commons-httpclient:commons-httpclient</exclude>
                                             <exclude>commons-logging:commons-logging</exclude>
                                             <exclude>concurrent:concurrent</exclude>
+                                            <exclude>jacorb:jacorb</exclude>
                                             <exclude>javassist:javassist</exclude>
                                             <exclude>javax.persistence:persistence-api</exclude>
                                             <exclude>javax.servlet:servlet-api</exclude>
@@ -446,6 +449,7 @@
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
                                             <exclude>oro:oro</exclude>
+                                            <exclude>stax:stax-api</exclude>
                                             <exclude>sun-jaxb:jaxb-api</exclude>
                                             <exclude>trove:trove</exclude>
                                             <exclude>woodstox:wstx-lgpl</exclude>
@@ -2900,6 +2904,12 @@
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
                 <version>${version.org.codehaus.jettison}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>stax</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -3963,6 +3973,10 @@
                         <artifactId>idl</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>jacorb</groupId>
+                        <artifactId>jacorb</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.jboss.integration</groupId>
                         <artifactId>jboss-corba-ots-spi</artifactId>
                     </exclusion>
@@ -4269,6 +4283,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.osgi.metadata</groupId>
+                <artifactId>jbosgi-metadata</artifactId>
+                <version>${version.org.jboss.osgi.metadata}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.osgi.repository</groupId>
                 <artifactId>jbosgi-repository</artifactId>
                 <version>${version.org.jboss.osgi.repository}</version>
@@ -4278,6 +4298,30 @@
                 <groupId>org.jboss.osgi.repository</groupId>
                 <artifactId>jbosgi-repository-api</artifactId>
                 <version>${version.org.jboss.osgi.repository}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.osgi.resolver</groupId>
+                <artifactId>jbosgi-resolver-api</artifactId>
+                <version>${version.org.jboss.osgi.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.osgi.resolver</groupId>
+                <artifactId>jbosgi-resolver-felix</artifactId>
+                <version>${version.org.jboss.osgi.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.osgi.resolver</groupId>
+                <artifactId>jbosgi-resolver-metadata</artifactId>
+                <version>${version.org.jboss.osgi.resolver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.osgi.resolver</groupId>
+                <artifactId>jbosgi-resolver-spi</artifactId>
+                <version>${version.org.jboss.osgi.resolver}</version>
             </dependency>
 
             <dependency>
@@ -4511,10 +4555,6 @@
                     <exclusion>
                         <groupId>org.jboss.seam</groupId>
                         <artifactId>jboss-seam</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss</groupId>
-                        <artifactId>jboss-vfs</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
- Flatten the dependency tree for the build module
- Excluding some bad artifacts from the dependency tree
- Add a couple of explicit compile time dependencies that were being used transitively.
