### PR TITLE
Deprecate getModulesDir()

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -38,11 +38,25 @@ public class HostControllerEnvironment extends ProcessEnvironment {
     public static final String HOME_DIR = "jboss.home.dir";
 
     /**
-     * Constant that holds the name of the environment property
-     * for specifying the directory from which JBoss will read modules.
+     * Constant that holds the name of the system property for specifying the directory returned from
+     * {@link #getModulesDir()}.
      *
-     * <p>Defaults to <tt><em>HOME_DIR</em>/modules</tt>/
+     * <p>
+     * Defaults to <tt><em>HOME_DIR</em>/modules</tt>/
+     * </p>
+     *
+     * <strong>This system property has no real meaning and should not be regarded as providing any sort of useful
+     * information.</strong> The "modules" directory is the default location from which JBoss Modules looks to find
+     * modules. However, this behavior is in no way controlled by this system property, nor is it guaranteed that
+     * modules will be loaded from only one directory, nor is it guaranteed that the "modules" directory will be one
+     * of the directories used. Finally, the structure and contents of any directories from which JBoss Modules loads
+     * resources is not something available from this class. Users wishing to interact with the modular classloading
+     * system should use the APIs provided by JBoss Modules
+     *
+     *
+     * @deprecated  has no useful meaning
      */
+    @Deprecated
     public static final String MODULES_DIR = "jboss.modules.dir";
 
     /**
@@ -455,6 +469,20 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         return homeDir;
     }
 
+    /**
+     * <strong>A filesystem location that has no real meaning and should not be regarded as providing any sort of useful
+     * information.</strong> The "modules" directory is the default location from which JBoss Modules looks to find
+     * modules. However, this behavior is in no way controlled by the value returned by this method, nor is it guaranteed that
+     * modules will be loaded from only one directory, nor is it guaranteed that the "modules" directory will be one
+     * of the directories used. Finally, the structure and contents of any directories from which JBoss Modules loads
+     * resources is not something available from this class. Users wishing to interact with the modular classloading
+     * system should use the APIs provided by JBoss Modules.
+     *
+     * @return a file
+     *
+     * @deprecated has no reliable meaning
+     */
+    @Deprecated
     public File getModulesDir() {
         return modulesDir;
     }

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -91,11 +91,25 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
     public static final String HOME_DIR = "jboss.home.dir";
 
     /**
-     * Constant that holds the name of the environment property for specifying the directory from which JBoss will read modules.
+     * Constant that holds the name of the system property for specifying the directory returned from
+     * {@link #getModulesDir()}.
      *
      * <p>
      * Defaults to <tt><em>HOME_DIR</em>/modules</tt>/
+     * </p>
+     *
+     * <strong>This system property has no real meaning and should not be regarded as providing any sort of useful
+     * information.</strong> The "modules" directory is the default location from which JBoss Modules looks to find
+     * modules. However, this behavior is in no way controlled by this system property, nor is it guaranteed that
+     * modules will be loaded from only one directory, nor is it guaranteed that the "modules" directory will be one
+     * of the directories used. Finally, the structure and contents of any directories from which JBoss Modules loads
+     * resources is not something available from this class. Users wishing to interact with the modular classloading
+     * system should use the APIs provided by JBoss Modules
+     *
+     *
+     * @deprecated  has no useful meaning
      */
+    @Deprecated
     public static final String MODULES_DIR = "jboss.modules.dir";
 
     /**
@@ -287,6 +301,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         if (homeDir == null)
             throw ServerMessages.MESSAGES.missingHomeDirConfiguration(HOME_DIR);
 
+        @SuppressWarnings("deprecation")
         File tmp = getFileFromProperty(MODULES_DIR, props);
         if (tmp == null) {
             tmp = new File(homeDir, "modules");
@@ -386,6 +401,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         }
     }
 
+    @SuppressWarnings("deprecation")
     void install() {
         SecurityActions.setSystemProperty(QUALIFIED_HOST_NAME, qualifiedHostName);
         SecurityActions.setSystemProperty(HOST_NAME, hostName);
@@ -553,6 +569,20 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         return homeDir;
     }
 
+    /**
+     * <strong>A filesystem location that has no real meaning and should not be regarded as providing any sort of useful
+     * information.</strong> The "modules" directory is the default location from which JBoss Modules looks to find
+     * modules. However, this behavior is in no way controlled by the value returned by this method, nor is it guaranteed that
+     * modules will be loaded from only one directory, nor is it guaranteed that the "modules" directory will be one
+     * of the directories used. Finally, the structure and contents of any directories from which JBoss Modules loads
+     * resources is not something available from this class. Users wishing to interact with the modular classloading
+     * system should use the APIs provided by JBoss Modules.
+     *
+     * @return a file
+     *
+     * @deprecated has no reliable meaning
+     */
+    @Deprecated
     public File getModulesDir() {
         return modulesDir;
     }


### PR DESCRIPTION
ServerEnvironment and HostControllerEnvironment getModulesDir() provide non-reliable information, since there is no contract that JBoss Modules reads modules from there, or only from there. Nor is there any contract provided by the method as to how the contents of the directory are structured even if the directory is the only location used by JBoss Modules.

JBoss Modules APIs should be used for interacting with modules.

Therefore these methods are deprecated.
