### PR TITLE
cli: allow operation headers in standalone

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
@@ -60,15 +60,7 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
     private Boolean addressAvailable;
     private String requiredType;
 
-    protected ArgumentWithValue headers = new ArgumentWithValue(this, HeadersCompleter.INSTANCE, ArgumentValueConverter.HEADERS, "--headers") {
-        @Override
-        public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
-            if(!ctx.isDomainMode()) {
-                return false;
-            }
-            return super.canAppearNext(ctx);
-        }
-    };
+    protected ArgumentWithValue headers = new ArgumentWithValue(this, HeadersCompleter.INSTANCE, ArgumentValueConverter.HEADERS, "--headers");
 
     public BaseOperationCommand(CommandContext ctx, String command, boolean connectionRequired) {
         super(command, connectionRequired);
@@ -218,10 +210,6 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
 
     protected void addHeaders(CommandContext ctx, ModelNode request) throws CommandFormatException {
         if(!headers.isPresent(ctx.getParsedCommandLine())) {
-            return;
-        }
-        if(!ctx.isDomainMode()) {
-            ctx.error(headers.getFullName() + " is allowed only in the domain mode.");
             return;
         }
         final String headersValue = headers.getValue(ctx.getParsedCommandLine());

--- a/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
@@ -687,6 +687,14 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
         }
         buf.append("<command> ").append(name.getFullName()).append("=<value> (--<parameter>=<value>)*");
 
+        if(ctx.isDomainMode()) {
+            buf.append('\n');
+            for(int i = 0; i <= commandName.length(); ++i) {
+                buf.append(' ');
+            }
+            buf.append("[--headers={operation_header (;operation_header)*}]");
+        }
+
         buf.append("\n\nDESCRIPTION\n\n");
         buf.append("The command is used to manage resources of type " + this.nodeType + ".");
 
@@ -753,6 +761,12 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
         buf.append("\n\n<parameter>  - parameter name of the <command> provided by the resourse.");
         buf.append("\n               For a complete list of available parameter names of a specific <command>,");
         buf.append("\n               their types and descriptions, execute ").append(commandName).append(" <command> --help.");
+
+        if(ctx.isDomainMode()) {
+            buf.append("\n\n--headers    - accepted only in the domain mode. The value is a list of operation headers");
+            buf.append("\n               separated by a semicolon. For the list of supported headers, please,");
+            buf.append("\n               refer to the domain management documentation or use tab-completion.");
+        }
 
         ctx.printLine(buf.toString());
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
@@ -763,9 +763,8 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
         buf.append("\n               their types and descriptions, execute ").append(commandName).append(" <command> --help.");
 
         if(ctx.isDomainMode()) {
-            buf.append("\n\n--headers    - accepted only in the domain mode. The value is a list of operation headers");
-            buf.append("\n               separated by a semicolon. For the list of supported headers, please,");
-            buf.append("\n               refer to the domain management documentation or use tab-completion.");
+            buf.append("\n\n--headers    - a list of operation headers separated by a semicolon. For the list of supported");
+            buf.append("\n               headers, please, refer to the domain management documentation or use tab-completion.");
         }
 
         ctx.printLine(buf.toString());

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -1,6 +1,8 @@
 SYNOPSIS
 
-    deploy (file_path [--name=deployment_name] [--runtime_name=deployment_runtime_name] [--force | --disabled] | --name=deployment_name) [--server-groups=group_name (,group_name)* | --all-server-groups]
+    deploy (file_path [--name=deployment_name] [--runtime_name=deployment_runtime_name] [--force | --disabled] | --name=deployment_name)
+           [--server-groups=group_name (,group_name)* | --all-server-groups]
+           [--headers={operation_header (;operation_header)*}]
 
 DESCRIPTION
 
@@ -41,3 +43,7 @@ ARGUMENTS
                        print all of the existing deployments in the repository. The presence of the -l switch
                        will make the existing deployments printed one deployment per line, instead of
                        in columns (the default).
+
+ --headers           - accepted only in the domain mode. The value is a list of operation headers
+                       separated by a semicolon. For the list of supported headers, please,
+                       refer to the domain management documentation or use tab-completion.

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -44,6 +44,5 @@ ARGUMENTS
                        will make the existing deployments printed one deployment per line, instead of
                        in columns (the default).
 
- --headers           - accepted only in the domain mode. The value is a list of operation headers
-                       separated by a semicolon. For the list of supported headers, please,
-                       refer to the domain management documentation or use tab-completion.
+ --headers           - a list of operation headers separated by a semicolon. For the list of supported
+                       headers, please, refer to the domain management documentation or use tab-completion.

--- a/cli/src/main/resources/help/deployment-info.txt
+++ b/cli/src/main/resources/help/deployment-info.txt
@@ -1,6 +1,6 @@
 SYNOPSIS
 
-    deployment-info --name=deployment_name
+    deployment-info --name=deployment_name [--headers={operation_header (;operation_header)*}]
 
 DESCRIPTION
 
@@ -33,3 +33,6 @@ DESCRIPTION
 ARGUMENTS
 
  --name              - the name of the deployment.
+
+ --headers           - a list of operation headers separated by a semicolon. For the list of supported
+                       headers, please, refer to the domain management documentation or use tab-completion.

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -65,7 +65,7 @@ Tab-completion is supported for the commands, just press the tab key to start.
 
 Operation requests start with './' or '/' and follow the format:
 
-[node-type=node-name (, node-type=node-name)*] : operation-name ['('[name=value [, name=value]*]')']
+[node-type=node-name (, node-type=node-name)*] : operation-name ['('[name=value [, name=value]*]')'] [{header (;header)*}]
 
 e.g. /subsystem=web/connector=http:read-attribute(name=protocol)
 

--- a/cli/src/main/resources/help/read-attribute.txt
+++ b/cli/src/main/resources/help/read-attribute.txt
@@ -2,6 +2,7 @@ SYNOPSIS
 
     read-attribute --help |
                    [--node=node_path] <attribute_name> [--include-defaults=true|false] [--verbose]
+                   [--headers={operation_header (;operation_header)*}]
 
 DESCRIPTION
 
@@ -25,3 +26,6 @@ ARGUMENTS
  
  --verbose (-v)      - will print all the available meta information about the attribute
                        in addition to the attribute value.
+
+ --headers           - a list of operation headers separated by a semicolon. For the list of supported
+                       headers, please, refer to the domain management documentation or use tab-completion.

--- a/cli/src/main/resources/help/undeploy.txt
+++ b/cli/src/main/resources/help/undeploy.txt
@@ -1,6 +1,7 @@
 SYNOPSIS
 
     undeploy name [--server-groups=group_name (,group_name)* | --all-relevant-server-groups] [--keep-content]
+                  [--headers={operation_header (;operation_header)*}]
 
 DESCRIPTION
 
@@ -29,3 +30,7 @@ ARGUMENTS
  -l                     - in case the deployment name isn't specified, the presence of the -l switch
                           will make the existing deployments printed one deployment per line, instead of
                           in columns (the default).
+
+ --headers              - accepted only in the domain mode. The value is a list of operation headers
+                          separated by a semicolon. For the list of supported headers, please,
+                          refer to the domain management documentation or use tab-completion.

--- a/cli/src/main/resources/help/undeploy.txt
+++ b/cli/src/main/resources/help/undeploy.txt
@@ -31,6 +31,5 @@ ARGUMENTS
                           will make the existing deployments printed one deployment per line, instead of
                           in columns (the default).
 
- --headers              - accepted only in the domain mode. The value is a list of operation headers
-                          separated by a semicolon. For the list of supported headers, please,
-                          refer to the domain management documentation or use tab-completion.
+ --headers              - a list of operation headers separated by a semicolon. For the list of supported
+                          headers, please, refer to the domain management documentation or use tab-completion.


### PR DESCRIPTION
Originally, there was only rollout plan which made sense only for the domain. But now, I think, headers should be allowed in any mode.

Thanks,
Alexey
