### PR TITLE
AS7-3000 Add support for distinct-name in deployments for EJB invocations

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/structure/Attachments.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/Attachments.java
@@ -41,6 +41,11 @@ public final class Attachments {
 
     public static final AttachmentKey<EarMetaData> EAR_METADATA = AttachmentKey.create(EarMetaData.class);
 
+    /**
+     * The distinct-name that is configured for the EE deployment, in the deployment descriptor
+     */
+    public static final AttachmentKey<String> DISTINCT_NAME = AttachmentKey.create(String.class);
+
     public static final AttachmentKey<ModuleMetaData> MODULE_META_DATA = AttachmentKey.create(ModuleMetaData.class);
 
     public static final AttachmentKey<EJBClientDescriptorMetaData> EJB_CLIENT_METADATA = AttachmentKey.create(EJBClientDescriptorMetaData.class);

--- a/ee/src/main/java/org/jboss/as/ee/structure/EarMetaDataParsingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EarMetaDataParsingProcessor.java
@@ -65,6 +65,10 @@ public class EarMetaDataParsingProcessor implements DeploymentUnitProcessor {
         if (earMetaData == null && jbossMetaData == null) {
             return;
         }
+        // the jboss-app.xml has a distinct-name configured then attach it to the deployment unit
+        if (jbossMetaData != null && jbossMetaData.getDistinctName() != null) {
+            deploymentUnit.putAttachment(Attachments.DISTINCT_NAME, jbossMetaData.getDistinctName());
+        }
         JBossAppMetaData merged;
         if (earMetaData != null) {
             merged = new JBossAppMetaData(earMetaData.getEarVersion());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
@@ -138,6 +138,11 @@ public class EjbJarParsingDeploymentUnitProcessor implements DeploymentUnitProce
         // attach the EjbJarMetaData to the deployment unit
         deploymentUnit.putAttachment(EjbDeploymentAttachmentKeys.EJB_JAR_METADATA, ejbJarMetaData);
 
+        // if the jboss-ejb3.xml has a distinct-name configured then attach it to the deployment unit
+        if (jbossMetaData != null && jbossMetaData.getDistinctName() != null) {
+            deploymentUnit.putAttachment(org.jboss.as.ee.structure.Attachments.DISTINCT_NAME, jbossMetaData.getDistinctName());
+        }
+
         if (ejbJarMetaData.getModuleName() != null) {
             eeModuleDescription.setModuleName(ejbJarMetaData.getModuleName());
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/DistinctNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/DistinctNameTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.Hashtable;
+
+/**
+ * Tests that invocation on EJBs deployed in a deployment with distinct name works successfully
+ *
+ * @author Jaikiran Pai
+ */
+public abstract class DistinctNameTestCase {
+
+    private static Context context;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        context = new InitialContext(props);
+    }
+
+    /**
+     * Test that invocation on a stateless bean, deployed in a deployment with distinct-name, works fine
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRemoteSLSBInvocation() throws Exception {
+        final Echo bean = (Echo) context.lookup("ejb:" + getAppName() + "/" + getModuleName() + "/" + getDistinctName()
+                + "/" + StatelessEcho.class.getSimpleName() + "!" + Echo.class.getName());
+        Assert.assertNotNull("Lookup returned a null bean proxy", bean);
+        final String msg = "Hello world from a really remote client!!!";
+        final String echo = bean.echo(msg);
+        Assert.assertEquals("Unexpected echo returned from remote stateless bean", msg, echo);
+    }
+
+    /**
+     * Test that invocation on a stateful bean, deployed in a deployment with distinct-name, works fine
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRemoteSFSBInvocation() throws Exception {
+        final Echo bean = (Echo) context.lookup("ejb:" + getAppName() + "/" + getModuleName() + "/" + getDistinctName()
+                + "/" + StatefulEcho.class.getSimpleName() + "!" + Echo.class.getName() + "?stateful");
+        Assert.assertNotNull("Lookup returned a null bean proxy", bean);
+        final String msg = "Hello world from a really remote client!!!";
+        final String echo = bean.echo(msg);
+        Assert.assertEquals("Unexpected echo returned from remote stateful bean", msg, echo);
+
+    }
+
+    /**
+     * Test that invocation on a singleton bean, deployed in a deployment with distinct-name, works fine
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testRemoteSingletonInvocation() throws Exception {
+        final Echo bean = (Echo) context.lookup("ejb:" + getAppName() + "/" + getModuleName() + "/" + getDistinctName()
+                + "/" + SingletonEcho.class.getSimpleName() + "!" + Echo.class.getName());
+        Assert.assertNotNull("Lookup returned a null bean proxy", bean);
+        final String msg = "Hello world from a really remote client!!!";
+        final String echo = bean.echo(msg);
+        Assert.assertEquals("Unexpected echo returned from remote singleton bean", msg, echo);
+
+    }
+
+    protected abstract String getAppName();
+
+    protected abstract String getModuleName();
+
+    protected abstract String getDistinctName();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/EarDeploymentDistinctNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/EarDeploymentDistinctNameTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the distinct-name configured in the jboss-app.xml of a EAR deployment is taken into
+ * consideration during remote EJB invocations.
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EarDeploymentDistinctNameTestCase extends DistinctNameTestCase {
+
+    private static final String APP_NAME = "remote-ejb-distinct-name";
+    private static final String DISTINCT_NAME = "distinct-name-in-jboss-app-xml";
+    private static final String MODULE_NAME = "remote-ejb-distinct-name-ear-test-case";
+
+    @Deployment(testable = false)
+    public static EnterpriseArchive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(EarDeploymentDistinctNameTestCase.class.getPackage());
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(EarDeploymentDistinctNameTestCase.class.getPackage(), "jboss-app.xml", "jboss-app.xml");
+
+        return ear;
+    }
+
+    @Override
+    protected String getAppName() {
+        return APP_NAME;
+    }
+
+    @Override
+    protected String getModuleName() {
+        return MODULE_NAME;
+    }
+
+    @Override
+    protected String getDistinctName() {
+        return DISTINCT_NAME;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/Echo.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/Echo.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface Echo {
+    
+    String echo(String msg);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/JarDeploymentDistinctNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/JarDeploymentDistinctNameTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the distinct-name configured in the jboss-ejb3.xml of a EJB jar deployment is taken into
+ * consideration during remote EJB invocations.
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JarDeploymentDistinctNameTestCase extends DistinctNameTestCase {
+
+
+    private static final String APP_NAME = "";
+    private static final String DISTINCT_NAME = "distinct-name-in-jboss-ejb3-xml";
+    private static final String MODULE_NAME = "remote-ejb-distinct-name-jar-test-case";
+
+
+    @Deployment(testable = false)
+    public static JavaArchive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(JarDeploymentDistinctNameTestCase.class.getPackage());
+        jar.addAsManifestResource(JarDeploymentDistinctNameTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
+        return jar;
+    }
+
+
+    @Override
+    protected String getAppName() {
+        return APP_NAME;
+    }
+
+    @Override
+    protected String getModuleName() {
+        return MODULE_NAME;
+    }
+
+    @Override
+    protected String getDistinctName() {
+        return DISTINCT_NAME;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/SingletonEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/SingletonEcho.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+import javax.ejb.Remote;
+import javax.ejb.Singleton;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Singleton
+@Remote(Echo.class)
+public class SingletonEcho implements Echo {
+    @Override
+    public String echo(String msg) {
+        return msg;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/StatefulEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/StatefulEcho.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+@Remote(Echo.class)
+public class StatefulEcho implements Echo {
+    @Override
+    public String echo(String msg) {
+        return msg;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/StatelessEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/StatelessEcho.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.distinctname;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(Echo.class)
+public class StatelessEcho implements Echo {
+
+    @Override
+    public String echo(String msg) {
+        return msg;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/jboss-app.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/jboss-app.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-app xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/noschema/jboss-app_5_0.xsd"
+           version="5.0"
+           id="jboss-app-id">
+
+    <distinct-name>distinct-name-in-jboss-app-xml</distinct-name>
+</jboss-app>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/distinctname/jboss-ejb3.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+               xmlns="http://www.jboss.com/xml/ns/javaee"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd"
+               version="3.1"
+               impl-version="2.0">
+
+    <distinct-name>distinct-name-in-jboss-ejb3-xml</distinct-name>
+</jboss:ejb-jar>

--- a/web/src/main/java/org/jboss/as/web/deployment/JBossWebParsingDeploymentProcessor.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/JBossWebParsingDeploymentProcessor.java
@@ -39,6 +39,7 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.metadata.parser.jbossweb.JBossWebMetaDataParser;
 import org.jboss.metadata.parser.util.NoopXMLResolver;
+import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.vfs.VirtualFile;
 
 /**
@@ -65,7 +66,13 @@ public class JBossWebParsingDeploymentProcessor implements DeploymentUnitProcess
                 final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
                 inputFactory.setXMLResolver(NoopXMLResolver.create());
                 XMLStreamReader xmlReader = inputFactory.createXMLStreamReader(is);
-                warMetaData.setJbossWebMetaData(JBossWebMetaDataParser.parse(xmlReader));
+                final JBossWebMetaData jBossWebMetaData = JBossWebMetaDataParser.parse(xmlReader);
+                warMetaData.setJbossWebMetaData(jBossWebMetaData);
+                // if the jboss-web.xml has a distinct-name configured, then attach the value to this
+                // deployment unit
+                if (jBossWebMetaData.getDistinctName() != null) {
+                    deploymentUnit.putAttachment(org.jboss.as.ee.structure.Attachments.DISTINCT_NAME, jBossWebMetaData.getDistinctName());
+                }
             } catch (XMLStreamException e) {
                 throw new DeploymentUnitProcessingException(MESSAGES.failToParseXMLDescriptor(jbossWebXml, e.getLocation().getLineNumber(), e.getLocation().getColumnNumber()), e);
             } catch (IOException e) {


### PR DESCRIPTION
The commits in this branch adds support for using the distinct-name configured in the deployment descriptors, for EJB invocations. This takes care of https://issues.jboss.org/browse/AS7-3000
