### PR TITLE
Add two convenience tools for tests.

### DIFF
--- a/testsuite/tools/runSummary.sh
+++ b/testsuite/tools/runSummary.sh
@@ -1,0 +1,15 @@
+##  Cat the file or stdin if no args,
+##  filter only interesting lines - plugin executions and modules separators,
+##  plus Test runs summaries,
+##  and remove the boring plugins like enforcer etc.
+ 
+cat $1 \
+ | egrep ' --- |Building| ---------|Tests run: | T E S T S' \
+ | grep -v 'Time elapsed' \
+ | sed 's|Tests run:|                Tests run:|' \
+ | grep -v maven-clean-plugin \
+ | grep -v maven-enforcer-plugin \
+ | grep -v buildnumber-maven-plugin \
+ | grep -v maven-help-plugin \
+ | grep -v properties-maven-plugin:.*:write-project-properties \
+;

--- a/testsuite/tools/showLogs.sh
+++ b/testsuite/tools/showLogs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+
+##  Determine this script's location ("Tools" home dir).
+scriptPath="$(cd "${0%/*}" 2>/dev/null; echo "$PWD"/"${0##*/}")"
+# For the case when called through a symlink
+scriptPath=`readlink -f "$scriptPath"`
+scriptDir=`dirname $scriptPath`
+
+#############
+
+EDITOR=${EDITOR:-less}
+
+LOGS=`find $scriptDir/.. -name *$1*.xml -or -name *$1*-output.txt`
+
+if [ "" == "$LOGS" ] ; then
+  echo "No logs found.";
+  exit 0;
+fi;
+
+$EDITOR $LOGS;
+
+


### PR DESCRIPTION
# new file:   testsuite/tools/runSummary.sh

Makes the maven output easier to read (filters only the key lines).
# new file:   testsuite/tools/showLogs.sh

Makes test logs easier to find (opens $EDITOR with matching logs).
