### PR TITLE
AS7-2493 fix

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -457,7 +457,6 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
                 properties.setProperty(propertyName, propertyValue);
             }
         }
-        log.debugf("Initializing cache store for cache %s with properties: %s", name, properties);
         builder.withProperties(properties);
 
         if (storeKey.equals(ModelKeys.FILE_STORE)) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheAdd.java
@@ -50,10 +50,10 @@ public abstract class ClusteredCacheAdd extends CacheAdd {
      * @return initialised Configuration object
      */
     @Override
-    void processModelNode(ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
+    void processModelNode(String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
 
         // process cache attributes and elements
-        super.processModelNode(cache, builder, dependencies);
+        super.processModelNode(containerName, cache, builder, dependencies);
 
         // process clustered cache attributes and elements
         if (CacheMode.valueOf(cache.get(ModelKeys.CACHE_MODE).asString()).isSynchronous()) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
@@ -52,9 +52,9 @@ public class DistributedCacheAdd extends SharedStateCacheAdd {
      * @return
      */
     @Override
-    void processModelNode(ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
+    void processModelNode(String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
         // process the basic clustered configuration
-        super.processModelNode(cache, builder, dependencies);
+        super.processModelNode(containerName, cache, builder, dependencies);
 
         // process the additional distributed attributes and elements
         if (cache.hasDefined(ModelKeys.OWNERS)) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheAdd.java
@@ -38,9 +38,9 @@ public abstract class SharedStateCacheAdd extends ClusteredCacheAdd {
     }
 
     @Override
-    void processModelNode(ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
+    void processModelNode(String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
         // process the basic clustered configuration
-        super.processModelNode(cache, builder, dependencies);
+        super.processModelNode(containerName, cache, builder, dependencies);
 
         // state transfer is a child resource
         if (cache.hasDefined(ModelKeys.STATE_TRANSFER) && cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME).isDefined()) {

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/ChannelFactory.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/ChannelFactory.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.clustering.jgroups;
 
+import org.jboss.as.server.ServerEnvironment;
 import org.jgroups.Channel;
 
 /**
@@ -34,4 +35,6 @@ public interface ChannelFactory {
      * @throws Exception if there was a failure setting up the protocol stack
      */
     Channel createChannel(String id) throws Exception;
+
+    ServerEnvironment getServerEnvironment();
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
@@ -37,6 +37,7 @@ import javax.management.MBeanServer;
 import org.jboss.as.clustering.concurrent.ManagedExecutorService;
 import org.jboss.as.clustering.concurrent.ManagedScheduledExecutorService;
 import org.jboss.as.network.SocketBinding;
+import org.jboss.as.server.ServerEnvironment;
 import org.jgroups.Channel;
 import org.jgroups.ChannelListener;
 import org.jgroups.Global;
@@ -63,6 +64,11 @@ public class JChannelFactory implements ChannelFactory, ChannelListener, Protoco
     }
 
     @Override
+    public ServerEnvironment getServerEnvironment() {
+        return this.configuration.getEnvironment();
+    }
+
+    @Override
     public Channel createChannel(String id) throws Exception {
         JChannel channel = new MuxChannel(this);
 
@@ -77,7 +83,7 @@ public class JChannelFactory implements ChannelFactory, ChannelListener, Protoco
             this.init(transport);
         }
 
-        channel.setName(configuration.getEnvironment().getNodeName() + "/" + id);
+        channel.setName(this.configuration.getEnvironment().getNodeName() + "/" + id);
 
         TransportConfiguration transportConfiguration = this.configuration.getTransport();
         if(transportConfiguration.hasTopology()) {

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/JGroupsMessages.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/JGroupsMessages.java
@@ -59,4 +59,7 @@ public interface JGroupsMessages {
      */
     @Message(id = 10271, value = "Failed to locate %s")
     String notFound(String resource);
+
+    @Message(id = 10272, value = "A node named %s already exists in this cluster.  Perhaps there is already a server running on this host?  If so, restart this server with a unique node name, via -Djboss.node.name=<node-name>")
+    IllegalStateException duplicateNodeName(String name);
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
@@ -1,9 +1,11 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import org.jboss.as.clustering.jgroups.ChannelFactory;
+import org.jboss.as.clustering.jgroups.JGroupsMessages;
 import org.jboss.as.clustering.msc.AsynchronousService;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.Value;
+import org.jgroups.Address;
 import org.jgroups.Channel;
 import org.jgroups.protocols.pbcast.STATE;
 import org.jgroups.protocols.pbcast.STATE_SOCK;
@@ -34,11 +36,22 @@ public class ChannelService extends AsynchronousService<Channel> {
 
     @Override
     protected void start() throws Exception {
-        this.channel = this.factory.getValue().createChannel(this.id);
+        ChannelFactory factory = this.factory.getValue();
+        this.channel = factory.createChannel(this.id);
         if (this.channel.getProtocolStack().findProtocol(STATE_TRANSFER.class, STATE.class, STATE_SOCK.class) != null) {
             this.channel.connect(this.id, null, STATE_TRANSFER_TIMEOUT);
         } else {
             this.channel.connect(this.id);
+        }
+        // Validate view
+        String localName = this.channel.getName();
+        Address localAddress = this.channel.getAddress();
+        for (Address address: this.channel.getView()) {
+            String name = this.channel.getName(address);
+            if (name.equals(localName) && !address.equals(localAddress)) {
+                this.channel.close();
+                throw JGroupsMessages.MESSAGES.duplicateNodeName(factory.getServerEnvironment().getNodeName());
+            }
         }
     }
 

--- a/web/src/main/java/org/jboss/as/web/session/DistributableSessionManager.java
+++ b/web/src/main/java/org/jboss/as/web/session/DistributableSessionManager.java
@@ -174,6 +174,8 @@ public class DistributableSessionManager<O extends OutgoingDistributableSessionD
 
     @Override
     public synchronized void start() throws LifecycleException {
+        if (this.started) return;
+
         // Identify ourself more clearly
         this.log = Logger.getLogger(getClass().getName() + "." + getContainer().getName().replaceAll("/", ""));
 


### PR DESCRIPTION
- Add view validation to ChannelService.start()
- Use cache container name as default file store path - not cache name.
- Short-circuit DistributableCacheManager.start() if manager is already started to prevent clustering valves from getting installed multiple times.
