### PR TITLE
Ship JBoss EJB xsds in the AS distribution

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -51,6 +51,15 @@
         <!-- These files contain digested passwords, which should not be visible to external users -->
         <chmod perm="600" file="${output.dir}/domain/configuration/mgmt-users.properties"/>
         <chmod perm="600" file="${output.dir}/standalone/configuration/mgmt-users.properties"/>
+
+        <!-- Copy the JBoss AS7 EJB specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <unzip src="${org.jboss.as:jboss-as-ejb3:jar}" dest="${output.dir}/docs/schema/">
+            <patternset>
+                <include name="*.xsd"/>
+            </patternset>
+            <mapper type="flatten"/>
+        </unzip>
+
     </target>
 
     <target name="copy-standalone" description="Copy all standard configurations">
@@ -83,6 +92,16 @@
     <target name="create-ext-content">
         <mkdir dir="${output.dir}/modules/org/jboss/integration/ext-content/main/bundled"/>
         <copy file="${org.jboss.seam.integration:jboss-seam-int-jbossas:jar}" tofile="${output.dir}/modules/org/jboss/integration/ext-content/main/bundled/jboss-seam-int.jar"/>
+
+        <!-- Copy the EJB specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <unzip src="${org.jboss.metadata:jboss-metadata-ejb:jar}" dest="${output.dir}/docs/schema/">
+            <patternset>
+                <include name="schema/ejb-jar*.xsd"/>
+                <include name="schema/jboss-ejb3*.xsd"/>
+                <include name="dtd/ejb-jar*.dtd"/>
+            </patternset>
+            <mapper type="flatten"/>
+        </unzip>
     </target>
 
     <target name="minimalistic" depends="base, copy-standalone-minimalistic"/>


### PR DESCRIPTION
This pull request is a continuation of the closed one here https://github.com/jbossas/jboss-as/pull/1255 (which I don't have permission to re-open).

The commits in this branch update the build.xml to include the JBoss EJB specific xsds in the JBOSS_HOME/docs/schema folder. This also contains a update to a testcase to exclude the JBoss EJB specific xsds which trigger the https://issues.apache.org/jira/browse/XERCESJ-1130 issue (discussion available on https://github.com/jbossas/jboss-as/pull/1255 pull request).

The commits in this branch take care of https://issues.jboss.org/browse/AS7-3438 task.
