### PR TITLE
JBQA-5190 - Transaction context propagation tests over EJB Remoting

### DIFF
--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <version>7.1.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- ************************* Multi-node Integration Tests *************************** -->
+    <!-- ********************************************************************************** -->
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-multinode</artifactId>
+    <version>7.1.0.Final-SNAPSHOT</version>
+
+    <name>JBoss AS Test Suite: Integration - Multinode Tests</name>
+    
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+    </properties>
+
+    <!--  TODO move this to parent? -->
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+    </build>
+
+
+    <profiles>
+
+        <!-- ********************************************************************************** -->
+        <!-- ****     Multi-node tests                                                ********* -->
+        <!-- ********************************************************************************** -->
+        <profile>
+            <id>multinode.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!noMultinode</name>
+                </property>
+            </activation>
+
+            <properties>
+            </properties>
+
+            <!--
+                Server configuration executions.
+                Naming convention for executions (which we read in the log): for server config X, call it X.server
+            -->
+            <build>
+                <plugins>
+
+                    <!-- Build the target/jbossts server configuration. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>build-multinode.server</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- Build the UDP server configs in target. -->
+                                        <ant antfile="${basedir}/../src/test/scripts/multinode-build.xml">
+                                            <target name="build-multinode"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Surefire. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution><id>default-test</id><goals><goal>test</goal></goals><phase>none</phase></execution>
+
+                            <!-- Multi-node tests -->
+                            <execution>
+                                <id>multinode.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <includes>
+                                        <include>org/jboss/as/test/multinode/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>multinode</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        
+    </profiles>
+</project>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
+
+    <group qualifier="multinode">
+
+        <!-- The server than invokes the exposed EJB's via remote outbound connection -->
+        <container qualifier="multinode-client" default="true">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-multinode-client</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            </configuration>
+        </container>
+
+        <!-- The server that exposes EJB's -->
+        <container qualifier="multinode-server" default="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="managementPort">10099</property>
+            </configuration>
+        </container>
+    </group>
+
+</arquillian>

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/ClientEjb.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/ClientEjb.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.multinode.transaction;
+
+import junit.framework.Assert;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.transaction.*;
+import java.rmi.RemoteException;
+import java.util.Hashtable;
+
+/**
+ * @author Stuart Douglas
+ * @author Ivo Studensky
+ */
+@Stateless
+@TransactionManagement(TransactionManagementType.BEAN)
+public class ClientEjb {
+
+    @Resource
+    private UserTransaction userTransaction;
+
+
+    private TransactionalRemote getRemote() throws NamingException {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new javax.naming.InitialContext(props);
+        final TransactionalRemote remote = (TransactionalRemote) context.lookup("ejb:/" + TransactionInvocationTestCase.SERVER_DEPLOYMENT + "/" + "" + "/" + "TransactionalStatelessBean" + "!" + TransactionalRemote.class.getName());
+        return remote;
+    }
+
+    private TransactionalStatefulRemote getStatefulRemote() throws NamingException {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new javax.naming.InitialContext(props);
+        final TransactionalStatefulRemote statefulRemote = (TransactionalStatefulRemote) context.lookup("ejb:/" + TransactionInvocationTestCase.SERVER_DEPLOYMENT + "/" + "" + "/" + "TransactionalStatefulBean" + "!" + TransactionalStatefulRemote.class.getName() + "?stateful");
+        return statefulRemote;
+    }
+
+    public void basicTransactionPropagationTest() throws RemoteException, SystemException, NotSupportedException, NamingException {
+        final TransactionalRemote remote = getRemote();
+        Assert.assertEquals("No transaction expected!", Status.STATUS_NO_TRANSACTION, remote.transactionStatus());
+        userTransaction.begin();
+        try {
+            Assert.assertEquals("Active transaction expected!", Status.STATUS_ACTIVE, remote.transactionStatus());
+        } finally {
+            userTransaction.rollback();
+        }
+
+    }
+
+    public void testSameTransactionEachCall() throws RemoteException, SystemException, NotSupportedException, NamingException {
+        final TransactionalStatefulRemote statefulRemote = getStatefulRemote();
+        userTransaction.begin();
+        try {
+            statefulRemote.sameTransaction(true);
+            statefulRemote.sameTransaction(false);
+        } finally {
+            userTransaction.rollback();
+        }
+    }
+
+    public void testSynchronization(final boolean succeeded) throws RemoteException, SystemException, NotSupportedException, RollbackException, HeuristicRollbackException, HeuristicMixedException, NamingException {
+        final TransactionalStatefulRemote statefulRemote = getStatefulRemote();
+        userTransaction.begin();
+        try {
+            statefulRemote.sameTransaction(true);
+            statefulRemote.sameTransaction(false);
+        } finally {
+            if (succeeded) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+        Assert.assertEquals("The beforeCompletion method invalid invocation!", succeeded, statefulRemote.isBeforeCompletion());
+        Assert.assertEquals("The result of the transaction does not match the input of afterCompletion!", (Boolean) succeeded, statefulRemote.getCommitSuceeded());
+    }
+
+    public void testRollbackOnly() throws RemoteException, SystemException, NotSupportedException, NamingException {
+        final TransactionalStatefulRemote statefulRemote = getStatefulRemote();
+        userTransaction.begin();
+        try {
+            Assert.assertEquals("Active transaction expected!", Status.STATUS_ACTIVE, statefulRemote.transactionStatus());
+            statefulRemote.rollbackOnly();
+            Assert.assertEquals("Rollback-only marked transaction expected!", Status.STATUS_MARKED_ROLLBACK, statefulRemote.transactionStatus());
+        } finally {
+            userTransaction.rollback();
+        }
+        Assert.assertFalse("The beforeCompletion method invoked even in case of rollback-only transaction!", statefulRemote.isBeforeCompletion());
+        Assert.assertFalse("The result of the transaction does not match the input of afterCompletion!", statefulRemote.getCommitSuceeded());
+    }
+
+    public void testRollbackOnlyBeforeCompletion() throws RemoteException, SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, NamingException {
+        final TransactionalStatefulRemote statefulRemote = getStatefulRemote();
+        userTransaction.begin();
+        try {
+            Assert.assertEquals("Active transaction expected!", Status.STATUS_ACTIVE, statefulRemote.transactionStatus());
+            statefulRemote.setRollbackOnlyBeforeCompletion(true);
+            userTransaction.commit();
+        } catch (RollbackException expected) {
+        } finally {
+            if (userTransaction.getStatus() == Status.STATUS_ACTIVE) {
+                userTransaction.rollback();
+            }
+        }
+        Assert.assertFalse("The result of the transaction does not match the input of afterCompletion!", statefulRemote.getCommitSuceeded());
+        Assert.assertEquals("No transaction expected!", Status.STATUS_NO_TRANSACTION, statefulRemote.transactionStatus());
+    }
+
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.transaction;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.*;
+import java.io.IOException;
+
+/**
+ * A simple EJB Remoting transaction context propagation in JTS style from one AS7 server to another.
+ *
+ * @author Stuart Douglas
+ * @author Ivo Studensky
+ */
+@RunWith(Arquillian.class)
+public class TransactionInvocationTestCase {
+
+    public static final String SERVER_DEPLOYMENT = "server";
+    public static final String CLIENT_DEPLOYMENT = "client";
+
+    @Deployment(name = "server", testable = false)
+    @TargetsContainer("multinode-server")
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, SERVER_DEPLOYMENT + ".jar");
+        jar.addClasses(TransactionalStatelessBean.class, TransactionalRemote.class,
+                TransactionalStatefulRemote.class, TransactionalStatefulBean.class);
+        return jar;
+    }
+
+    @Deployment(name = "client", testable = true)
+    @TargetsContainer("multinode-client")
+    public static Archive<?> clientDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, CLIENT_DEPLOYMENT + ".jar");
+        jar.addClasses(ClientEjb.class, TransactionalRemote.class, TransactionInvocationTestCase.class,
+                TransactionalStatefulRemote.class);
+        jar.addAsManifestResource("META-INF/jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        return jar;
+    }
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testRemoteInvocation() throws IOException, NamingException, NotSupportedException, SystemException {
+        final ClientEjb ejb = getClient();
+        ejb.basicTransactionPropagationTest();
+
+    }
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testRollbackOnly() throws IOException, NamingException, NotSupportedException, SystemException {
+        final ClientEjb ejb = getClient();
+        ejb.testRollbackOnly();
+    }
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testRollbackOnlyBeforeCompletion() throws IOException, NamingException, NotSupportedException, SystemException, HeuristicMixedException, HeuristicRollbackException {
+        final ClientEjb ejb = getClient();
+        ejb.testRollbackOnlyBeforeCompletion();
+    }
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testSameTransactionEachCall() throws IOException, NamingException, NotSupportedException, SystemException {
+        final ClientEjb ejb = getClient();
+        ejb.testSameTransactionEachCall();
+    }
+
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testSynchronizationSuceeded() throws IOException, NamingException, NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
+        final ClientEjb ejb = getClient();
+        ejb.testSynchronization(true);
+    }
+
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testSynchronizationFailed() throws IOException, NamingException, NotSupportedException, SystemException, RollbackException, HeuristicMixedException, HeuristicRollbackException {
+        final ClientEjb ejb = getClient();
+        ejb.testSynchronization(false);
+    }
+
+    private ClientEjb getClient() throws NamingException {
+        final InitialContext context = new InitialContext();
+        return (ClientEjb) context.lookup("java:module/" + ClientEjb.class.getSimpleName());
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalRemote.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalRemote.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.multinode.transaction;
+
+import java.rmi.RemoteException;
+
+/**
+ * @author Stuart Douglas
+ */
+public interface TransactionalRemote {
+
+    int transactionStatus() throws RemoteException;
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatefulBean.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatefulBean.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.multinode.transaction;
+
+import javax.annotation.Resource;
+import javax.ejb.*;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+import java.rmi.RemoteException;
+
+/**
+ * @author Stuart Douglas
+ * @author Ivo Studensky
+ */
+@Remote(TransactionalStatefulRemote.class)
+@Stateful
+public class TransactionalStatefulBean implements SessionSynchronization, TransactionalStatefulRemote {
+
+    private Boolean commitSuceeded;
+    private boolean beforeCompletion = false;
+    private Object transactionKey = null;
+    private boolean rollbackOnlyBeforeCompletion = false;
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @Resource
+    private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
+
+
+    @TransactionAttribute(TransactionAttributeType.SUPPORTS)
+    public int transactionStatus() {
+        try {
+            return userTransaction.getStatus();
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void resetStatus() {
+        commitSuceeded = null;
+        beforeCompletion = false;
+        transactionKey = null;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.SUPPORTS)
+    public void setRollbackOnlyBeforeCompletion(boolean rollbackOnlyBeforeCompletion) throws RemoteException {
+        this.rollbackOnlyBeforeCompletion = rollbackOnlyBeforeCompletion;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.MANDATORY)
+    public void sameTransaction(boolean first) throws RemoteException {
+        if (first) {
+            transactionKey = transactionSynchronizationRegistry.getTransactionKey();
+        } else {
+            if (!transactionKey.equals(transactionSynchronizationRegistry.getTransactionKey())) {
+                throw new RemoteException("Transaction on second call was not the same as on first call");
+            }
+        }
+    }
+
+    @TransactionAttribute(TransactionAttributeType.MANDATORY)
+    public void rollbackOnly() throws RemoteException {
+        try {
+            userTransaction.setRollbackOnly();
+        } catch (SystemException e) {
+            throw new RemoteException("SystemException during setRollbackOnly", e);
+        }
+    }
+
+    public void ejbCreate() {
+
+    }
+
+    public void afterBegin() throws EJBException, RemoteException {
+
+    }
+
+    public void beforeCompletion() throws EJBException, RemoteException {
+        beforeCompletion = true;
+
+        if (rollbackOnlyBeforeCompletion) {
+            try {
+                userTransaction.setRollbackOnly();
+            } catch (SystemException e) {
+                throw new RemoteException("SystemException during setRollbackOnly", e);
+            }
+        }
+    }
+
+    public void afterCompletion(final boolean committed) throws EJBException, RemoteException {
+        commitSuceeded = committed;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public Boolean getCommitSuceeded() {
+        return commitSuceeded;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public boolean isBeforeCompletion() {
+        return beforeCompletion;
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatefulRemote.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatefulRemote.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.multinode.transaction;
+
+import java.rmi.RemoteException;
+
+/**
+ * @author Stuart Douglas
+ */
+public interface TransactionalStatefulRemote {
+
+    int transactionStatus() throws RemoteException;
+
+    public Boolean getCommitSuceeded() throws RemoteException;
+
+    public boolean isBeforeCompletion() throws RemoteException;
+
+    public void resetStatus() throws RemoteException;
+
+    public void sameTransaction(boolean first) throws RemoteException;
+
+    void rollbackOnly() throws RemoteException;
+
+    public void setRollbackOnlyBeforeCompletion(boolean rollbackOnlyInBeforeCompletion) throws RemoteException;
+
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatelessBean.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatelessBean.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.multinode.transaction;
+
+import javax.annotation.Resource;
+import javax.ejb.*;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author Stuart Douglas
+ * @author Ivo Studensky
+ */
+@Remote(TransactionalRemote.class)
+@Stateless
+public class TransactionalStatelessBean implements TransactionalRemote {
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @TransactionAttribute(TransactionAttributeType.SUPPORTS)
+    public int transactionStatus() {
+        try {
+            return userTransaction.getStatus();
+        } catch (SystemException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/testsuite/integration/multinode/src/test/resources/META-INF/jboss-ejb-client.xml
+++ b/testsuite/integration/multinode/src/test/resources/META-INF/jboss-ejb-client.xml
@@ -1,0 +1,7 @@
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
+    <client-context>
+        <ejb-receivers>
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>

--- a/testsuite/integration/multinode/src/test/resources/logging.properties
+++ b/testsuite/integration/multinode/src/test/resources/logging.properties
@@ -1,0 +1,55 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=sun.rmi,org.jboss.shrinkwrap
+logger.org.jboss.shrinkwrap.level=INFO
+logger.sun.rmi.level=WARNING
+
+# Root logger level
+logger.level=DEBUG
+
+# Root logger handlers
+logger.handlers=FILE, CONSOLE
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=INFO
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.level=DEBUG
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
+
+
+logger.sun.rmi

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -56,6 +56,7 @@
                 <module>clust</module>
                 <module>iiop</module>
                 <module>xts</module>
+                <module>multinode</module>
             </modules>
         </profile>
         <!-- Define ts.integration uber-group. -->
@@ -68,6 +69,7 @@
                 <module>clust</module>
                 <module>iiop</module>
                 <module>xts</module>
+                <module>multinode</module>
             </modules>
         </profile>
 
@@ -113,6 +115,15 @@
             <activation><property><name>ts.xts</name></property></activation>
             <modules>
                 <module>xts</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.multinode -->
+        <profile>
+            <id>ts.integ.group.multinode</id>
+            <activation><property><name>ts.multinode</name></property></activation>
+            <modules>
+                <module>multinode</module>
             </modules>
         </profile>
 

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -291,4 +291,49 @@
         </sequential>
     </macrodef>
 
+
+
+    <!--
+        Add a new Remote Outbound Connection.
+        This macro makes use of saxon via  ${net.sf.saxon:saxon:jar}.
+    -->
+    <macrodef name="add-remote-outbound-connection" description="Add Remote Outbound Connection">
+
+        <attribute name="name" default="jbossas"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+        <attribute name="connectionName" default="remote-ejb-connection"/>
+        <attribute name="node" default="${node0}"/>
+        <attribute name="remotePort" default="4447"/>
+
+        <sequential>
+            <echo message="Adding a new remote outbound connection @{connectionName} for config @{name}"/>
+
+            <!-- Process *.xml to *.xml.mod. -->
+            <xslt destdir="@{output.dir}/jbossas-@{name}/@{config.dir.name}"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/addRemoteOutboundConnection.xsl"
+                  extension=".xml.mod"
+                  useImplicitFileset="false">
+                <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone.xml"/>
+                    <include name="**/standalone-full.xml"/>
+                </fileset>
+                <param name="connectionName" expression="@{connectionName}"/>
+                <param name="node" expression="@{node}"/>
+                <param name="remotePort" expression="@{remotePort}"/>
+            </xslt>
+
+            <!-- Move processed files back. -->
+            <move todir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+               <fileset dir="@{output.dir}/jbossas-@{name}/@{config.dir.name}">
+                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone.xml.mod"/>
+                   <include name="**/standalone-full.xml.mod"/>
+               </fileset>
+               <mapper type="glob" from="*.mod" to="*"/>
+             </move>
+        </sequential>
+    </macrodef>
+
 </project>

--- a/testsuite/integration/src/test/scripts/multinode-build.xml
+++ b/testsuite/integration/src/test/scripts/multinode-build.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project>
+
+    <!-- import shared ant targets -->
+    <import file="common-targets.xml" as="common"/>
+
+    <target name="build-multinode" description="Builds server configurations for Multi-node tests">
+
+        <echo message="Building config multinode-client"/>
+
+        <build-server-config name="multinode-client"/>
+        <antcall target="changeDefaultDatabase">
+           <param name="server-config" value="multinode-client"/>
+           <propertyset refid="ds.properties"/>
+        </antcall>
+        <change-ip-addresses name="multinode-client" node="${node0}"/>
+        <add-remote-outbound-connection name="multinode-client" node="${node0}" remotePort="4547"/>
+
+        <echo message="Building config multinode-server"/>
+
+        <build-server-config name="multinode-server"/>
+        <antcall target="changeDefaultDatabase">
+           <param name="server-config" value="multinode-server"/>
+           <propertyset refid="ds.properties"/>
+        </antcall>
+        <change-ip-addresses name="multinode-server" node="${node0}"/>
+        <add-port-offset name="multinode-server" offset="100" nativePort="9999" httpPort="9990"/>
+
+    </target>
+
+</project>

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -19,10 +19,10 @@
         <r:remote-outbound-connection>
             <xsl:attribute name="name"><xsl:value-of select="$connectionName"/></xsl:attribute>
             <xsl:attribute name="outbound-socket-binding-ref">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
-            <r:connection-creation-options>
-                <r:option name="SASL_POLICY_NOANONYMOUS" value="false"/>
-                <r:option name="SSL_ENABLED" value="false"/>
-            </r:connection-creation-options>
+            <r:properties>
+                <r:property name="SASL_POLICY_NOANONYMOUS" value="false"/>
+                <r:property name="SSL_ENABLED" value="false"/>
+            </r:properties>
         </r:remote-outbound-connection>
     </xsl:variable>
 

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -1,0 +1,83 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:d="urn:jboss:domain:1.1"
+                xmlns:r="urn:jboss:domain:remoting:1.1">
+    <xsl:output method="xml" indent="yes"/>
+
+    <!--
+        An XSLT style sheet which will enable EJB Remote calling to another server,
+        by adding an outbound-socket-binding and remote-outbound-connection.
+    -->
+
+    <!-- remote outbound connection parameters -->
+    <xsl:param name="connectionName" select="'remote-ejb-connection'"/>
+    <xsl:param name="node" select="'localhost'"/>
+    <xsl:param name="remotePort" select="'4447'"/>
+
+
+    <xsl:variable name="newRemoteOutboundConnection">
+        <r:remote-outbound-connection>
+            <xsl:attribute name="name"><xsl:value-of select="$connectionName"/></xsl:attribute>
+            <xsl:attribute name="outbound-socket-binding-ref">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
+            <r:connection-creation-options>
+                <r:option name="SASL_POLICY_NOANONYMOUS" value="false"/>
+                <r:option name="SSL_ENABLED" value="false"/>
+            </r:connection-creation-options>
+        </r:remote-outbound-connection>
+    </xsl:variable>
+
+    <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="//r:subsystem">
+        <xsl:choose>
+            <xsl:when test="not(//r:subsystem/r:outbound-connections)">
+                <xsl:copy>
+                    <xsl:apply-templates select="node()|@*"/>
+                    <r:outbound-connections>
+                        <xsl:copy-of select="$newRemoteOutboundConnection"/>
+                    </r:outbound-connections>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy>
+                    <xsl:apply-templates select="node()|@*"/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="//r:subsystem/r:outbound-connections">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+            <xsl:copy-of select="$newRemoteOutboundConnection"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']">
+        <xsl:copy>
+            <xsl:attribute name="name">
+                <xsl:value-of select="'standard-sockets'"/>
+            </xsl:attribute>
+            <xsl:attribute name="default-interface">
+                <xsl:value-of select="@default-interface"/>
+            </xsl:attribute>
+            <xsl:attribute name="port-offset">
+                <xsl:value-of select="@port-offset"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="node()"/>
+            <d:outbound-socket-binding>
+                <xsl:attribute name="name">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
+                <d:remote-destination>
+                    <xsl:attribute name="host"><xsl:value-of select="$node"/></xsl:attribute>
+                    <xsl:attribute name="port"><xsl:value-of select="$remotePort"/></xsl:attribute>
+                </d:remote-destination>
+            </d:outbound-socket-binding>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
These tests cover transaction context propagation between two servers over EJB Remoting protocol, introducing a new maven sub-module under testsuite/integration module which is called multinode and can serve for all other server to server testing over ejb remoting.
For more info see JBQA-5190 jira.
