### PR TITLE
AS7-3633: the security domain "other" should have a DisabledLoginModule

### DIFF
--- a/build/src/main/resources/standalone/configuration/standalone-full.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-full.xml
@@ -315,7 +315,7 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required"/>
+                        <login-module code="Disabled" flag="required"/>
                     </authentication>
                 </security-domain>
                 <security-domain name="jboss-web-policy" cache-type="default">

--- a/build/src/main/resources/standalone/configuration/standalone-ha.xml
+++ b/build/src/main/resources/standalone/configuration/standalone-ha.xml
@@ -382,7 +382,7 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required"/>
+                        <login-module code="Disabled" flag="required"/>
                     </authentication>
                 </security-domain>
                 <security-domain name="messaging" cache-type="default">

--- a/build/src/main/resources/standalone/configuration/standalone.xml
+++ b/build/src/main/resources/standalone/configuration/standalone.xml
@@ -227,7 +227,7 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required"/>
+                        <login-module code="Disabled" flag="required"/>
                     </authentication>
                 </security-domain>
                 <security-domain name="jboss-web-policy" cache-type="default">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/FullyRestrictedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/FullyRestrictedBean.java
@@ -34,7 +34,7 @@ import javax.ejb.Singleton;
 @Singleton
 @DenyAll
 @LocalBean
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class FullyRestrictedBean extends AnnotatedSLSB {
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/HelloBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/HelloBean.java
@@ -13,7 +13,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 @Stateless
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 @RemoteHome(HelloHome.class)
 public class HelloBean implements SessionBean {
     private SessionContext ctx;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
@@ -74,6 +74,8 @@ public class RunAsPrincipalTestCase extends SecurityTest {
                 .addClass(SecurityTest.class)
                 .addAsResource(CallerWithIdentity.class.getPackage(),"users.properties", "users.properties")
                 .addAsResource(CallerWithIdentity.class.getPackage(),"roles.properties", "roles.properties")
+                .addAsWebInfResource("ejb3/security/web.xml", "web.xml")
+                .addAsWebInfResource("ejb3/security/jboss-web.xml", "jboss-web.xml")
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"),"MANIFEST.MF");
         log.info(war.toString(true));
         return war;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/QueueTestMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/QueueTestMDB.java
@@ -48,7 +48,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/queue/mdbtest") })
 @RunAs("TestRole")
-@SecurityDomain(value = "other", unauthenticatedPrincipal = "user")
+@SecurityDomain(value = "ejb3-tests", unauthenticatedPrincipal = "user")
 @ResourceAdapter(value = "hornetq-ra.rar")
 public class QueueTestMDB implements MessageListener {
     @Resource(mappedName = "java:/ConnectionFactory")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/StatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/mdb/StatelessBean.java
@@ -32,7 +32,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
  */
 @Stateless
 @Remote(MyStateless.class)
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class StatelessBean implements MyStateless {
     // static so it's shared by all
     private static String state;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/Caller.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/Caller.java
@@ -34,7 +34,7 @@ import javax.ejb.Stateless;
 @Stateless
 @Remote(WhoAmI.class)
 @RunAs("Admin")
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class Caller implements WhoAmI {
     @EJB(beanName = "StatelessBBean")
     private WhoAmI beanB;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/CallerWithIdentity.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/CallerWithIdentity.java
@@ -36,7 +36,7 @@ import javax.ejb.Stateless;
 @Remote(WhoAmI.class)
 @RunAs("Admin")
 @RunAsPrincipal("jackinabox")
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class CallerWithIdentity implements WhoAmI {
     @EJB(beanName = "StatelessABean")
     private WhoAmI beanA;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/StatelessABean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/StatelessABean.java
@@ -34,7 +34,7 @@ import javax.ejb.Stateless;
 @Stateless
 @Local(WhoAmI.class)
 @RolesAllowed("Admin")
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class StatelessABean implements WhoAmI {
     @EJB(beanName = "StatelessBBean")
     private WhoAmI beanB;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/StatelessBBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/StatelessBBean.java
@@ -35,7 +35,7 @@ import javax.ejb.Stateless;
 @Stateless
 @Local(WhoAmI.class)
 @RolesAllowed("Admin")
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class StatelessBBean implements WhoAmI {
     @Resource
     private SessionContext ctx;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SecuredSingletonBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SecuredSingletonBean.java
@@ -34,7 +34,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
  * User: jpai
  */
 @Singleton
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 @Remote(SingletonSecurity.class)
 public class SecuredSingletonBean implements SingletonSecurity {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
@@ -30,10 +30,12 @@ import javax.naming.InitialContext;
 import junit.framework.Assert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.ejb.security.SecurityTest;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,15 +47,23 @@ import org.junit.runner.RunWith;
  * @author Jaikiran Pai, Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
-public class SingletonSecurityTestCase {
+public class SingletonSecurityTestCase extends SecurityTest {
     private static final Logger log = Logger.getLogger(SingletonSecurityTestCase.class.getName()); 
     
     @Deployment
     public static Archive<?> deploy() {
+    	try {
+            // create required security domains
+            createSecurityDomain();
+        } catch (Exception e) {
+            // ignore
+        }
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb3-singleton-security.jar");
         jar.addPackage(SingletonSecurityTestCase.class.getPackage());
+        jar.addClass(SecurityTest.class);
         jar.addAsResource(SingletonSecurityTestCase.class.getPackage(), "users.properties", "users.properties");
         jar.addAsResource(SingletonSecurityTestCase.class.getPackage(), "roles.properties", "roles.properties");
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"),"MANIFEST.MF");
         log.info(jar.toString(true));
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/ServletUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/ServletUnitTestCase.java
@@ -29,6 +29,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.ejb.security.SecurityTest;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -47,7 +48,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class ServletUnitTestCase {
+public class ServletUnitTestCase extends SecurityTest {
     private static final Logger log = Logger.getLogger(ServletUnitTestCase.class.getName());
 
     @Deployment(name = "ejb", order = 2)
@@ -60,6 +61,12 @@ public class ServletUnitTestCase {
 
     @Deployment(name = "client", order = 1)
     public static Archive<?> deployClient() {
+    	try {
+            // create required security domains
+            createSecurityDomain();
+        } catch (Exception e) {
+            // ignore
+        }
         JavaArchive jar = getClient("ejb3-servlet-client.jar");
         log.info(jar.toString(true));
         return jar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/Session30Bean.java
@@ -40,7 +40,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @Local(Session30BusinessLocal.class)
 @RemoteHome(Session30Home.class)
 @LocalHome(Session30LocalHome.class)
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class Session30Bean implements Session30 {
 
     @EJB

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/servlet/StatefulBean.java
@@ -34,7 +34,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @Stateful(name = "Stateful")
 @Remote(StatefulRemote.class)
 @Local(StatefulLocal.class)
-@SecurityDomain("other")
+@SecurityDomain("ejb3-tests")
 public class StatefulBean implements StatefulRemote, StatefulLocal {
     public String access(TestObject o) {
         return "Session30";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
@@ -142,46 +142,64 @@ public class FormAuthUnitTestCase {
 
         final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, getCallbackHandler());
 
-        final List<ModelNode> updates = new ArrayList<ModelNode>();
-        ModelNode op = new ModelNode();
+        try{
+        	final List<ModelNode> updates = new ArrayList<ModelNode>();
+        	ModelNode op = new ModelNode();
 
-        op.get(OP).set(ADD);
-        op.get(OP_ADDR).add(SUBSYSTEM, "security");
-        op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomain);
-        updates.add(op);
+        	op.get(OP).set(ADD);
+        	op.get(OP_ADDR).add(SUBSYSTEM, "security");
+        	op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomain);
+        	updates.add(op);
 
-        op = new ModelNode();
-        op.get(OP).set(ADD);
-        op.get(OP_ADDR).add(SUBSYSTEM, "security");
-        op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomain);
-        op.get(OP_ADDR).add(AUTHENTICATION, Constants.CLASSIC);
+        	op = new ModelNode();
+        	op.get(OP).set(ADD);
+        	op.get(OP_ADDR).add(SUBSYSTEM, "security");
+        	op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomain);
+        	op.get(OP_ADDR).add(AUTHENTICATION, Constants.CLASSIC);
 
-        ModelNode loginModule = op.get(Constants.LOGIN_MODULES).add();
-        loginModule.get(CODE).set("UsersRoles");
-        loginModule.get(FLAG).set("required");
-        op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        updates.add(op);
+        	ModelNode loginModule = op.get(Constants.LOGIN_MODULES).add();
+        	loginModule.get(CODE).set("UsersRoles");
+        	loginModule.get(FLAG).set("required");
+        	op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        	updates.add(op);
 
-        try {
-            applyUpdates(updates, client);
+        	try {
+        		applyUpdates(updates, client);
+        	}
+        	catch (Exception e) {
+        		log.error(e);
+        		throw e;
+        	}
+        } finally {
+        	try {
+        		client.close();
+        	} catch (Exception e) {
+        		// ignore
+        		log.debug("Ignoring exception while closing model controller client", e);
+        	}
         }
-        catch (Exception e) {
-            log.error(e);
-            throw e;
-        }
+
         log.debug("end of the domain creation");
     }
     public static void removeSecurityDomain() throws Exception {
         final ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9999, getCallbackHandler());
+        try{
+            ModelNode op = new ModelNode();
+            op.get(OP).set(REMOVE);
+            op.get(OP_ADDR).add(SUBSYSTEM, "security");
+            op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomain);
+            // Don't rollback when the AS detects the war needs the module
+            op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
 
-        ModelNode op = new ModelNode();
-        op.get(OP).set(REMOVE);
-        op.get(OP_ADDR).add(SUBSYSTEM, "security");
-        op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomain);
-        // Don't rollback when the AS detects the war needs the module
-        op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
-
-        applyUpdate(op, client, true);
+            applyUpdate(op, client, true);	
+        }finally {
+        	try {
+        		client.close();
+        	} catch (Exception e) {
+        		// ignore
+        		log.debug("Ignoring exception while closing model controller client", e);
+        	}
+        }
     }
 
     public static void applyUpdates(final List<ModelNode> updates, final ModelControllerClient client) throws Exception {


### PR DESCRIPTION
The original intent was to make "other" security domain have a failing login module.  This forces users to configure their security domains and not to fallback on "other" security domain. 

This pull request brings back to the "other" security domain to have DisabledLoginModule while fixing all the AS testsuite classes that were relying on "other" to use the ejb3-tests security domain.
