### PR TITLE
AS7-3458 remove native security realm fails

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementWriteAttributeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementWriteAttributeHandler.java
@@ -96,12 +96,12 @@ public class NativeManagementWriteAttributeHandler extends AbstractWriteAttribut
     private void installNativeManagementService(final OperationContext context, final ModelNode subModel, final ServiceVerificationHandler verificationHandler) throws OperationFailedException {
 
         // Remove the old connector
-        final ModelNode portNode = NativeManagementResourceDefinition.NATIVE_PORT.resolveModelAttribute(context, subModel);
-        int port = portNode.isDefined() ? portNode.asInt() : 0;
+        final ModelNode socketBinding = NativeManagementResourceDefinition.SOCKET_BINDING.resolveModelAttribute(context, subModel);
+        if(socketBinding == null || !socketBinding.isDefined()) {
+            final ModelNode portNode = NativeManagementResourceDefinition.NATIVE_PORT.resolveModelAttribute(context, subModel);
+        }
         ManagementRemotingServices.removeConnectorServices(context, ManagementRemotingServices.MANAGEMENT_CONNECTOR);
-
         NativeManagementAddHandler.installNativeManagementConnector(context, subModel, ManagementRemotingServices.MANAGEMENT_ENDPOINT, context.getServiceTarget(), verificationHandler, null);
-
     }
 
 


### PR DESCRIPTION
The port has been deprecated in favour of the socket-binding but still was validated.
This change checks whether the socket-binding is set and if not then checks the port.

Thanks,
Alexey
