### PR TITLE
AS7-3662 Make default config file configurable

### DIFF
--- a/build/src/main/resources/bin/domain.conf
+++ b/build/src/main/resources/bin/domain.conf
@@ -44,6 +44,7 @@ fi
 if [ "x$JAVA_OPTS" = "x" ]; then
    JAVA_OPTS="-Xms64m -Xmx512m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Dorg.jboss.resolver.warning=true -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
    JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
+   JAVA_OPTS="$JAVA_OPTS -Djboss.domain.default.config=domain.xml -Djboss.host.default.config=host.xml"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi

--- a/build/src/main/resources/bin/domain.conf.bat
+++ b/build/src/main/resources/bin/domain.conf.bat
@@ -55,6 +55,9 @@ rem # Make Byteman classes visible in all module loaders
 rem # This is necessary to inject Byteman rules into AS7 deployments
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=org.jboss.byteman"
 
+rem # Set the default configuration files to use if -c, --domain-config or --host-config are not used
+set "JAVA_OPTS=%JAVA_OPTS% -Djboss.domain.default.config=domain.xml -Djboss.host.default.config=host.xml"
+
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"
 

--- a/build/src/main/resources/bin/standalone.conf
+++ b/build/src/main/resources/bin/standalone.conf
@@ -49,6 +49,7 @@ fi
 if [ "x$JAVA_OPTS" = "x" ]; then
    JAVA_OPTS="-Xms64m -Xmx512m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true -Dorg.jboss.resolver.warning=true -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000"
    JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
+   JAVA_OPTS="$JAVA_OPTS -Djboss.server.default.config=standalone.xml"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
 fi
@@ -56,7 +57,7 @@ fi
 # Sample JPDA settings for remote socket debugging
 #JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
 
-# Sample JPDA settings for shared memory debugging 
+# Sample JPDA settings for shared memory debugging
 #JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_shmem,server=y,suspend=n,address=jboss"
 
 # Uncomment to not use JBoss Modules lockless mode

--- a/build/src/main/resources/bin/standalone.conf.bat
+++ b/build/src/main/resources/bin/standalone.conf.bat
@@ -7,9 +7,9 @@ rem ############################################################################
 rem # $Id: run.conf.bat 88820 2009-05-13 15:25:44Z dimitris@jboss.org $
 
 rem #
-rem # This batch file is executed by run.bat to initialize the environment 
+rem # This batch file is executed by run.bat to initialize the environment
 rem # variables that run.bat uses. It is recommended to use this file to
-rem # configure these variables, rather than modifying run.bat itself. 
+rem # configure these variables, rather than modifying run.bat itself.
 rem #
 
 rem Uncomment the following line to disable manipulation of JAVA_OPTS (JVM parameters)
@@ -58,10 +58,13 @@ rem # Make Byteman classes visible in all module loaders
 rem # This is necessary to inject Byteman rules into AS7 deployments
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=org.jboss.byteman"
 
+rem # Set the default configuration file to use if -c or --server-config are not used
+set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.default.config=standalone.xml"
+
 rem # Sample JPDA settings for remote socket debugging
 rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
 
-rem # Sample JPDA settings for shared memory debugging 
+rem # Sample JPDA settings for shared memory debugging
 rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 rem # Use JBoss Modules lockless mode

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -165,6 +165,22 @@ public class HostControllerEnvironment extends ProcessEnvironment {
      */
     public static final String JBOSS_DOMAIN_MASTER_PORT = "jboss.domain.master.port";
 
+    /**
+     * The system property used to store the name of the default domain configuration file. If not set,
+     * the default domain configuration file is "domain.xml". The default domain configuration file is only
+     * relevant if the user does not use the {@code -c} or {@code --domain-config} command line switches
+     * to explicitly set the domain configuration file.
+     */
+    public static final String JBOSS_DOMAIN_DEFAULT_CONFIG = "jboss.domain.default.config";
+
+    /**
+     * The system property used to store the name of the default host configuration file. If not set,
+     * the default domain configuration file is "host.xml". The default domain configuration file is only
+     * relevant if the user does not use the {@code --host-config} command line switch
+     * to explicitly set the host configuration file.
+     */
+    public static final String JBOSS_HOST_DEFAULT_CONFIG = "jboss.host.default.config";
+
     private final Map<String, String> hostSystemProperties;
     private final InetAddress processControllerAddress;
     private final Integer processControllerPort;
@@ -296,8 +312,10 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         this.domainConfigurationDir = tmp;
         SecurityActions.setSystemProperty(DOMAIN_CONFIG_DIR, this.domainConfigurationDir.getAbsolutePath());
 
-        hostConfigurationFile = new ConfigurationFile(domainConfigurationDir, "host.xml", hostConfig);
-        domainConfigurationFile = new ConfigurationFile(domainConfigurationDir, "domain.xml", domainConfig);
+        String defaultHostConfig = SecurityActions.getSystemProperty(JBOSS_HOST_DEFAULT_CONFIG, "host.xml");
+        hostConfigurationFile = new ConfigurationFile(domainConfigurationDir, defaultHostConfig, hostConfig);
+        String defaultDomainConfig = SecurityActions.getSystemProperty(JBOSS_DOMAIN_DEFAULT_CONFIG, "domain.xml");
+        domainConfigurationFile = new ConfigurationFile(domainConfigurationDir, defaultDomainConfig, domainConfig);
 
         tmp = getFileFromProperty(DOMAIN_DATA_DIR);
         if (tmp == null) {

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -240,12 +240,23 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
      */
     public static final String JBOSS_DEFAULT_MULTICAST_ADDRESS = "jboss.default.multicast.address";
 
+    /**
+     * The system property used to store the name of the default server configuration file. If not set,
+     * the default domain configuration file is "standalone.xml". The default domain configuration file is only
+     * relevant if the user does not use the {@code -c} or {@code --server-config} command line switches
+     * to explicitly set the server configuration file.
+     */
+    public static final String JBOSS_SERVER_DEFAULT_CONFIG = "jboss.server.default.config";
+
     protected static final String DOMAIN_BASE_DIR = "jboss.domain.base.dir";
     protected static final String DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
 
+    /** Properties that cannot be set via {@link #systemPropertyUpdated(String, String)} */
     private static final Set<String> ILLEGAL_PROPERTIES = new HashSet<String>(Arrays.asList(DOMAIN_BASE_DIR,
             DOMAIN_CONFIG_DIR, JAVA_EXT_DIRS, HOME_DIR, "modules.path", SERVER_BASE_DIR, SERVER_CONFIG_DIR,
-            SERVER_DATA_DIR, SERVER_DEPLOY_DIR, SERVER_LOG_DIR, BOOTSTRAP_MAX_THREADS, CONTROLLER_TEMP_DIR));
+            SERVER_DATA_DIR, SERVER_DEPLOY_DIR, SERVER_LOG_DIR, BOOTSTRAP_MAX_THREADS, CONTROLLER_TEMP_DIR,
+            JBOSS_SERVER_DEFAULT_CONFIG));
+    /** Properties that can only be set via {@link #systemPropertyUpdated(String, String)} during server boot. */
     private static final Set<String> BOOT_PROPERTIES = new HashSet<String>(Arrays.asList(BUNDLES_DIR, SERVER_TEMP_DIR,
             NODE_NAME, SERVER_NAME, HOST_NAME, QUALIFIED_HOST_NAME));
 
@@ -338,7 +349,8 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         }
         serverConfigurationDir = tmp;
 
-        serverConfigurationFile = standalone ? new ConfigurationFile(serverConfigurationDir, "standalone.xml", serverConfig) : null;
+        String defaultServerConfig = SecurityActions.getSystemProperty(JBOSS_SERVER_DEFAULT_CONFIG, "standalone.xml");
+        serverConfigurationFile = standalone ? new ConfigurationFile(serverConfigurationDir, defaultServerConfig, serverConfig) : null;
 
         tmp = getFileFromProperty(SERVER_DATA_DIR, props);
         if (tmp == null) {


### PR DESCRIPTION
The default config versions used if -c, --server-config, --domain-config, --host-config are not provided are currently hardcoded. Instead make them configurable via a system property (set in domain.conf and standalone.conf), with the hardcoded defaults a fallback if the system properties are not set.

Benefit of this is a user who always wants, for example, to use standalone-ha.xml doesn't have to repeatedly type ./standalone.sh -c standalone-ha.xml. They can just edit standalone.conf and thereafter simply use ./standalone.sh
