### PR TITLE
AS7-2907 All composite ops targeting an HC should use the two-stage resp...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2399,7 +2399,7 @@ public interface ControllerMessages {
      *
      * @return a {@link OperationFailedRuntimeException} for the error.
      */
-    @Message(id = 14840, value = "Operation '%s' targetted at resource '%s' was directly invoked by a user. " +
+    @Message(id = 14840, value = "Operation '%s' targeted at resource '%s' was directly invoked by a user. " +
             "User operations are not permitted to directly update the persistent configuration of a server in a managed domain.")
     OperationFailedRuntimeException modelUpdateNotAuthorized(String operation, PathAddress address);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainModelUtil.java
@@ -229,7 +229,8 @@ public class DomainModelUtil {
         root.registerReadOnlyAttribute(PROCESS_TYPE, isMaster ? ProcessTypeHandler.MASTER : ProcessTypeHandler.SLAVE, Storage.RUNTIME);
         root.registerReadOnlyAttribute(ServerDescriptionConstants.LAUNCH_TYPE, new LaunchTypeHandler(ServerEnvironment.LaunchType.DOMAIN), Storage.RUNTIME);
 
-        root.registerOperationHandler(ValidateAddressOperationHandler.OPERATION_NAME, ValidateAddressOperationHandler.INSTANCE, ValidateAddressOperationHandler.INSTANCE, false);
+        root.registerOperationHandler(ValidateAddressOperationHandler.OPERATION_NAME, ValidateAddressOperationHandler.INSTANCE,
+                ValidateAddressOperationHandler.INSTANCE, false, EnumSet.of(OperationEntry.Flag.READ_ONLY));
 
         root.registerOperationHandler(ResolveExpressionOnDomainHandler.OPERATION_NAME, ResolveExpressionOnDomainHandler.INSTANCE,
                 ResolveExpressionOnDomainHandler.INSTANCE, EnumSet.of(OperationEntry.Flag.READ_ONLY, OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS));

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
@@ -93,7 +93,7 @@ public class OperationCoordinatorStepHandler {
         OperationRouting routing = OperationRouting.determineRouting(operation, localHostControllerInfo, opRegistry);
 
         if (!localHostControllerInfo.isMasterDomainController()
-                && (routing.isRouteToMaster() || !routing.isLocalOnly(localHostControllerInfo.getLocalHostName()))) {
+                && !routing.isLocalOnly(localHostControllerInfo.getLocalHostName())) {
             // We cannot handle this ourselves
             routetoMasterDomainController(context, operation);
         }

--- a/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
+++ b/server/src/main/java/org/jboss/as/server/ServerControllerModelUtil.java
@@ -236,7 +236,8 @@ public class ServerControllerModelUtil {
         root.registerOperationHandler(NamespaceRemoveHandler.OPERATION_NAME, NamespaceRemoveHandler.INSTANCE, NamespaceRemoveHandler.INSTANCE, false);
         root.registerOperationHandler(SchemaLocationAddHandler.OPERATION_NAME, SchemaLocationAddHandler.INSTANCE, SchemaLocationAddHandler.INSTANCE, false);
         root.registerOperationHandler(SchemaLocationRemoveHandler.OPERATION_NAME, SchemaLocationRemoveHandler.INSTANCE, SchemaLocationRemoveHandler.INSTANCE, false);
-        root.registerOperationHandler(ValidateAddressOperationHandler.OPERATION_NAME, ValidateAddressOperationHandler.INSTANCE, ValidateAddressOperationHandler.INSTANCE, false);
+        root.registerOperationHandler(ValidateAddressOperationHandler.OPERATION_NAME, ValidateAddressOperationHandler.INSTANCE,
+                ValidateAddressOperationHandler.INSTANCE, false, EnumSet.of(OperationEntry.Flag.READ_ONLY));
 
         DeploymentUploadBytesHandler dubh = new DeploymentUploadBytesHandler(contentRepository);
         root.registerOperationHandler(DeploymentUploadBytesHandler.OPERATION_NAME, dubh, dubh, false);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementAccessTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementAccessTestCase.java
@@ -171,14 +171,14 @@ public class ManagementAccessTestCase {
 
         ModelNode response = masterClient.execute(request);
         System.out.println(response);
-        ModelNode returnVal = validateResponse(response);
+        ModelNode returnVal = validateResponse(response).get(DOMAIN_RESULTS);
         validateResponse(returnVal.get("step-1"));
         ModelNode profile = validateResponse(returnVal.get("step-2"));
         Assert.assertEquals("osgi", profile.asString());
 
         response = slaveClient.execute(request);
         System.out.println(response);
-        ModelNode slaveReturnVal = validateResponse(response);
+        ModelNode slaveReturnVal = validateResponse(response).get(DOMAIN_RESULTS);
         Assert.assertEquals(returnVal, slaveReturnVal);
     }
 
@@ -227,7 +227,7 @@ public class ManagementAccessTestCase {
 
         ModelNode response = masterClient.execute(masterRequest);
         System.out.println(response);
-        ModelNode returnVal = validateResponse(response);
+        ModelNode returnVal = validateResponse(response).get(DOMAIN_RESULTS);
         ModelNode name = validateResponse(returnVal.get("step-1"));
         Assert.assertEquals("master", name.asString());
         ModelNode inetAddress = validateResponse(returnVal.get("step-2"));
@@ -241,7 +241,7 @@ public class ManagementAccessTestCase {
 
         response = slaveClient.execute(slaveRequest);
         System.out.println(response);
-        ModelNode slaveReturnVal = validateResponse(response);
+        ModelNode slaveReturnVal = validateResponse(response).get(DOMAIN_RESULTS);
         name = validateResponse(slaveReturnVal.get("step-1"));
         Assert.assertEquals("slave", name.asString());
         inetAddress = validateResponse(slaveReturnVal.get("step-2"));
@@ -249,7 +249,7 @@ public class ManagementAccessTestCase {
 
         // Check we get the same thing via the master
         response = masterClient.execute(slaveRequest);
-        returnVal = validateResponse(response);
+        returnVal = validateResponse(response).get(DOMAIN_RESULTS);
         Assert.assertEquals(returnVal, slaveReturnVal);
 
         // Can't access the master via the slave


### PR DESCRIPTION
...onse format

Previously if all steps were read only of the HC model or some other conditions, the response format would look like a simple read of a single HC resource (i.e. no information about domain-wide results). Other times composites would include domain wide results because some steps modified other hosts or had to be applied to servers. This was inconsistent; clients couldn't readily predict the format of the response.

This patch makes the response format consistent.
