### PR TITLE
Add config for Zanata translations

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -44,7 +44,18 @@
         </license>
     </licenses>
 
-    <build>    
+    <build>
+        <plugins>
+            <plugin>
+              <groupId>org.zanata</groupId>
+              <artifactId>zanata-maven-plugin</artifactId>
+              <version>1.4.5.1</version>
+              <configuration>
+                 <skip>true</skip>
+              </configuration>
+            </plugin>
+        </plugins>
+
         <extensions>
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>

--- a/jdr/jboss-as-sos/pom.xml
+++ b/jdr/jboss-as-sos/pom.xml
@@ -34,4 +34,17 @@
 
     <artifactId>jboss-as-sos</artifactId>
     <name>JBoss Application Server: sosreport scripts</name>
+
+    <build>
+        <plugins>
+            <!-- skip sosreport; it is translated upstream -->
+            <plugin>
+              <groupId>org.zanata</groupId>
+              <artifactId>zanata-maven-plugin</artifactId>
+              <configuration>
+                 <skip>true</skip>
+              </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
 
         <!-- Non-default plugin versions and configuration -->
         <version.javacc.plugin>2.5</version.javacc.plugin>
+        <version.org.zanata.plugin>1.4.5.1</version.org.zanata.plugin>
         <version.shade.plugin>1.5</version.shade.plugin>
 
         <!-- Surefire args -->
@@ -285,6 +286,22 @@
 
     <build>
         <plugins>
+           <!-- Zanata translations -->
+            <plugin>
+              <groupId>org.zanata</groupId>
+              <artifactId>zanata-maven-plugin</artifactId>
+              <version>${version.org.zanata.plugin}</version>
+              <configuration>
+                 <!-- Process sub-modules separately, sharing parent config -->
+                 <enableModules>true</enableModules>
+                 <projectConfig>${session.executionRootDirectory}/zanata.xml</projectConfig>
+                  <!-- Generated English i18n.properties are written here: -->
+                 <srcDir>target/classes</srcDir>
+                 <transDir>src/main/resources</transDir>
+                 <includes>**/*.i18n.properties,**/LocalDescriptions.properties</includes>
+              </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<config xmlns="http://zanata.org/namespace/config/">
+    <url>https://translate.jboss.org/</url>
+    <project>jboss-as</project>
+    <project-version>master</project-version>
+    <project-type>properties</project-type>
+
+    <locales mapping="java">
+       <locale>de</locale>
+       <locale>es</locale>
+       <locale>fr</locale>
+       <locale>ja</locale>
+       <locale>pt-BR</locale>
+       <locale map-from="zh-CN">zh-Hans</locale>
+    </locales>
+
+</config>


### PR DESCRIPTION
This will enable jboss-as .properties files to be sent to https://translate.jboss.org for translation using the command `mvn zanata:push`, and when available the translations can be retrieved with `mvn zanata:pull`.
