### PR TITLE
AS7-3401 Ship jboss-app_7_0.xsd in the distribution

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-app_7_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-app_7_0.xsd
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:javaee="http://java.sun.com/xml/ns/javaee"
+           xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+           targetNamespace="http://www.jboss.com/xml/ns/javaee"
+           version="7.0"
+           elementFormDefault="qualified">
+
+    <xs:annotation>
+        <xs:documentation>
+            <![CDATA[
+
+	This is the XML Schema for the JBoss AS7 EAR application deployment descriptor.
+	The deployment descriptor must be named "jboss-app.xml" and placed in the
+	.ear/META-INF folder. All the descriptors must indicate
+	the JBoss schema by using the Java EE namespace:
+
+	http://www.jboss.com/xml/ns/javaee
+
+	and by indicating the version of the schema by
+	using the version attribute as shown below:
+
+	    <jboss-app xmlns="http://www.jboss.com/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             version="7.0">
+	       ...
+            </jboss-app>
+
+    The instance documents may indicate the published version of
+	the schema using the xsi:schemaLocation attribute for the
+	Java EE namespace with the following location:
+
+	http://www.jboss.org/j2ee/schema/jboss-app_7_0.xsd
+
+	]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <!-- Import the Java EE6 xsd -->
+    <xs:import namespace="http://java.sun.com/xml/ns/javaee"
+               schemaLocation="application_6.xsd"/>
+
+    <!-- Include the common JBoss EE elements -->
+    <xs:include schemaLocation="jboss-common_6_0.xsd"/>
+
+
+    <xs:element name="jboss-app" type="jboss-appType"/>
+
+    <xs:complexType name="jboss-appType">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for JBoss specific configurations in a .ear
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="javaee:applicationType">
+                <xs:sequence>
+                    <xs:element name="distinct-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The distinct-name for this application.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="security-domain" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The security domain application for this application.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="unauthenticated-principal" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The principal that will be used for unauthenticated requests in this application
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+
+                    <xs:element name="library-directory" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+                    <xs:element name="security-role" minOccurs="0" maxOccurs="unbounded"
+                                type="jboss:security-roleType"/>
+
+                    <xs:element name="module" minOccurs="0" maxOccurs="unbounded" type="moduleType"/>
+
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="moduleType">
+        <xs:sequence>
+            <xs:element name="service" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="har" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="web" type="javaee:webType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
Relates to https://issues.jboss.org/browse/AS7-3401. The commit here adds the jboss-app_7_0.xsd in the AS7 source (temporarily till we have a new release for jboss-metadata project, post AS 7.1.0.Final release), to make it available in the distribution.
