### PR TITLE
JBQA-5902 - EJB client reconnection tests for AS7-3215

### DIFF
--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-testsuite-integration-agg</artifactId>
+        <version>7.1.0.Final-SNAPSHOT</version>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- ************************* Manual-mode Integration Tests ************************** -->
+    <!-- ********************************************************************************** -->
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-testsuite-integration-manualmode</artifactId>
+    <version>7.1.0.Final-SNAPSHOT</version>
+
+    <name>JBoss AS Test Suite: Integration - Manual Mode Tests</name>
+    
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+    </properties>
+
+    <!--  TODO move this to parent? -->
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>src/test/java</directory>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </testResource>
+        </testResources>
+    </build>
+
+
+    <profiles>
+
+        <!-- ********************************************************************************** -->
+        <!-- ****     Manual-mode tests                                               ********* -->
+        <!-- ********************************************************************************** -->
+        <profile>
+            <id>manualmode.integration.tests.profile</id>
+            <activation>
+                <property>
+                    <name>!noManualmode</name>
+                </property>
+            </activation>
+
+            <properties>
+            </properties>
+
+            <!--
+                Server configuration executions.
+                Naming convention for executions (which we read in the log): for server config X, call it X.server
+            -->
+            <build>
+                <plugins>
+
+                    <!-- Build the target/jbossts server configuration. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>build-manualmode.server</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- Build the UDP server configs in target. -->
+                                        <ant antfile="${basedir}/../src/test/scripts/manualmode-build.xml">
+                                            <target name="build-manualmode"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Surefire. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution><id>default-test</id><goals><goal>test</goal></goals><phase>none</phase></execution>
+
+                            <!-- Manual-mode tests -->
+                            <execution>
+                                <id>manualmode.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <includes>
+                                        <include>org/jboss/as/test/manualmode/**/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+        
+    </profiles>
+</project>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true" mode="manual">
+        <configuration>
+            <property name="jbossHome">${basedir}/target/jbossas-manualmode</property>
+            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-manualmode</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="allowConnectingToRunningServer">true</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/EJBClientReconnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/EJBClientReconnectionTestCase.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+
+import org.jboss.arquillian.container.test.api.*;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientTransactionContext;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * Simple ejb client reconnection test case.
+ * See AS7-3215.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EJBClientReconnectionTestCase {
+    private static final Logger log = Logger.getLogger(EJBClientReconnectionTestCase.class);
+
+    private static final String DEPLOYMENT = "ejbclientreconnection";
+    private static final String CONTAINER = "jboss";
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+
+    @Deployment(name = DEPLOYMENT, managed = false, testable = false)
+    @TargetsContainer(CONTAINER)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(JavaArchive.class, DEPLOYMENT + ".jar")
+                .addClasses(SimpleCrashBean.class, SimpleCrashBeanRemote.class);
+    }
+
+    @Before
+    public void before() throws Exception {
+        controller.start(CONTAINER);
+        log.info("===appserver started===");
+        deployer.deploy(DEPLOYMENT);
+        log.info("===deployment deployed===");
+    }
+
+    @After
+    public void after() throws Exception {
+        try {
+            deployer.undeploy(DEPLOYMENT);
+            log.info("===deployment undeployed===");
+        } finally {
+            controller.stop(CONTAINER);
+            log.info("===appserver stopped===");
+        }
+    }
+
+    @Test
+    public void testReconnection() throws Throwable {
+        SimpleCrashBeanRemote bean = lookup(SimpleCrashBeanRemote.class, SimpleCrashBean.class, DEPLOYMENT);
+        assertNotNull(bean);
+        String echo = bean.echo("Hello!");
+        assertEquals("Hello!", echo);
+
+        controller.stop(CONTAINER);
+        log.info("===appserver stopped===");
+        controller.start(CONTAINER);
+        log.info("===appserver started again===");
+
+        SimpleCrashBeanRemote bean2 = lookup(SimpleCrashBeanRemote.class, SimpleCrashBean.class, DEPLOYMENT);
+        assertNotNull(bean2);
+        echo = bean2.echo("Bye!");
+        assertEquals("Bye!", echo);
+    }
+
+    @Test
+    public void testReconnectionWithClientAPI() throws Throwable {
+        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+
+        final StatelessEJBLocator<SimpleCrashBeanRemote> locator = new StatelessEJBLocator(SimpleCrashBeanRemote.class, "", DEPLOYMENT, SimpleCrashBean.class.getSimpleName(), "");
+        final SimpleCrashBeanRemote proxy = EJBClient.createProxy(locator);
+
+        assertNotNull(proxy);
+        String echo = proxy.echo("Hello!");
+        assertEquals("Hello!", echo);
+
+        controller.stop(CONTAINER);
+        log.info("===appserver stopped===");
+        controller.start(CONTAINER);
+        log.info("===appserver started again===");
+
+
+        final StatelessEJBLocator<SimpleCrashBeanRemote> locator2 = new StatelessEJBLocator(SimpleCrashBeanRemote.class, "", DEPLOYMENT, SimpleCrashBean.class.getSimpleName(), "");
+        final SimpleCrashBeanRemote proxy2 = EJBClient.createProxy(locator2);
+
+        assertNotNull(proxy2);
+        echo = proxy2.echo("Bye!");
+        assertEquals("Bye!", echo);
+    }
+
+    private <T> T lookup(final Class<T> remoteClass, final Class<?> beanClass, final String archiveName) throws NamingException {
+        String myContext = Util.createRemoteEjbJndiContext(
+                "",
+                archiveName,
+                "",
+                beanClass.getSimpleName(),
+                remoteClass.getName(),
+                false);
+
+        Context ctx = Util.createNamingContext();
+        return remoteClass.cast(ctx.lookup(myContext));
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/SimpleCrashBean.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/SimpleCrashBean.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+
+import javax.ejb.Stateless;
+
+/**
+ * Simple SLSB test bean.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@Stateless
+public class SimpleCrashBean implements SimpleCrashBeanRemote {
+
+    public String echo(String message) {
+        return message;
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/SimpleCrashBeanRemote.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/SimpleCrashBeanRemote.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface SimpleCrashBeanRemote {
+    String echo(String message);
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/Util.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejbclientreconnectiontest/Util.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+/**
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+public class Util {
+
+    /**
+     * Creates JNDI context string based on given parameters.
+     * See details at https://docs.jboss.org/author/display/AS71/EJB+invocations+from+a+remote+client+using+JNDI
+     *
+     * @param appName       - typically the ear name without the .ear
+     *                      - could be empty string when deploying just jar with EJBs
+     * @param moduleName    - jar file name without trailing .jar
+     * @param distinctName  - AS7 allows each deployment to have an (optional) distinct name
+     *                      - could be empty string when not specified
+     * @param beanName      - The EJB name which by default is the simple class name of the bean implementation class
+     * @param viewClassName - the remote view is fully qualified class name of @Remote EJB interface
+     * @param isStateful    - if the bean is stateful set to true
+     * @return - JNDI context string to use in your client JNDI lookup
+     */
+    public static String createRemoteEjbJndiContext(
+            String appName,
+            String moduleName,
+            String distinctName,
+            String beanName,
+            String viewClassName,
+            boolean isStateful) {
+
+        return "ejb:" + appName + "/" + moduleName + "/" + distinctName + "/" + beanName + "!" + viewClassName
+                + (isStateful ? "?stateful" : "");
+    }
+
+    /**
+     * Helper to create InitialContext with necessary properties.
+     *
+     * @return new InitialContext.
+     * @throws javax.naming.NamingException
+     */
+    public static Context createNamingContext() throws NamingException {
+
+        final Properties jndiProps = new Properties();
+        jndiProps.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+
+        return new InitialContext(jndiProps);
+
+    }
+
+    public static <T> T lookup(final String name, final Class<T> cls) throws NamingException {
+        InitialContext ctx = new InitialContext();
+        try {
+            return cls.cast(ctx.lookup(name));
+        } finally {
+            ctx.close();
+        }
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/resources/jboss-ejb-client.properties
+++ b/testsuite/integration/manualmode/src/test/resources/jboss-ejb-client.properties
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=localhost
+remote.connection.default.port=4447
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+
+

--- a/testsuite/integration/manualmode/src/test/resources/logging.properties
+++ b/testsuite/integration/manualmode/src/test/resources/logging.properties
@@ -1,0 +1,55 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=sun.rmi,org.jboss.shrinkwrap
+logger.org.jboss.shrinkwrap.level=INFO
+logger.sun.rmi.level=WARNING
+
+# Root logger level
+logger.level=DEBUG
+
+# Root logger handlers
+logger.handlers=FILE, CONSOLE
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=INFO
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.level=DEBUG
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
+
+
+logger.sun.rmi

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -57,6 +57,7 @@
                 <module>iiop</module>
                 <module>xts</module>
                 <module>multinode</module>
+                <module>manualmode</module>
             </modules>
         </profile>
         <!-- Define ts.integration uber-group. -->
@@ -70,6 +71,7 @@
                 <module>iiop</module>
                 <module>xts</module>
                 <module>multinode</module>
+                <module>manualmode</module>
             </modules>
         </profile>
 
@@ -124,6 +126,15 @@
             <activation><property><name>ts.multinode</name></property></activation>
             <modules>
                 <module>multinode</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.manualmode -->
+        <profile>
+            <id>ts.integ.group.manualmode</id>
+            <activation><property><name>ts.manualmode</name></property></activation>
+            <modules>
+                <module>manualmode</module>
             </modules>
         </profile>
 

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project>
+
+    <!-- import shared ant targets -->
+    <import file="common-targets.xml" as="common"/>
+
+    <target name="build-manualmode" description="Builds server configuration for manualmode tests">
+        <build-server-config name="manualmode"/>
+
+        <antcall target="changeDefaultDatabase">
+           <param name="server-config" value="manualmode"/>
+           <propertyset refid="ds.properties"/>
+        </antcall>
+
+        <change-ip-addresses name="manualmode" node="${node0}"/>
+    </target>
+
+</project>


### PR DESCRIPTION
A simple test for ejb client reconnection functionality, see AS7-3215 and JBQA-5902.
This test needs a manual mode of Arquillian container, hence it introduces a new maven module 'manualmode' under the testsuite/integration module. The new maven module can be used by everyone for other tests that need to manually control the server.
