### PR TITLE
Enhancing RunAs testcase on basis of JBPAPP-7897

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodBye.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodBye.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import java.rmi.RemoteException;
+import javax.ejb.EJBObject;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface GoodBye extends EJBObject {
+    public String sayGoodBye(String userID) throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeBean.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Simple bean which returns goodbye greeting.
+ * 
+ * @author Ondrej Chaloupka
+ */
+public class GoodByeBean implements SessionBean {
+    private static final long serialVersionUID = 1L;
+    private SessionContext sessionContext;
+    private static final Logger log = Logger.getLogger(GoodByeBean.class);
+
+    public void setSessionContext(SessionContext sessionContext) {
+        this.sessionContext = sessionContext;
+    }
+
+    public String sayGoodBye(String userID) {
+        String greeting = "GoodBye " + userID;
+        log.info("Inside GoodByeBean.sayGoodBye(). Greeting: " + greeting);
+        return greeting;
+    }
+
+    // Methods typically ignored.
+    public void ejbCreate() {
+    }
+
+    public void ejbRemove() {
+    }
+
+    public void ejbActivate() {
+    }
+
+    public void ejbPassivate() {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeHome.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import java.rmi.RemoteException;
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface GoodByeHome extends EJBHome {
+    public GoodBye create() throws RemoteException, CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeLocal.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.ejb.EJBLocalObject;
+import javax.ejb.EJBException;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface GoodByeLocal extends EJBLocalObject {
+    public String sayGoodBye(String userID) throws EJBException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeLocalHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/GoodByeLocalHome.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.ejb.EJBLocalHome;
+import javax.ejb.CreateException;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface GoodByeLocalHome extends EJBLocalHome {
+    public GoodByeLocal create() throws CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/Hello.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/Hello.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface Hello {
+    public String sayHello() throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HelloBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HelloBean.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+// Security related imports
+import javax.annotation.security.RolesAllowed;
+import javax.jms.*;
+import javax.naming.*;
+import org.jboss.logging.Logger;
+
+/**
+ * Bean passes message to HelloMDB bean and checks the reply queue. The HellpMDB bean calls this one for getting hello greeting
+ * for JBossAdmin role.
+ * 
+ * @author Ondrej Chaloupka
+ */
+@Stateless(name = "Hello")
+@RolesAllowed({})
+@Remote(Hello.class)
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class HelloBean implements Hello {
+    private static final Logger log = Logger.getLogger(HelloBean.class);
+
+    @Resource
+    private SessionContext context;
+
+    @RolesAllowed("JBossAdmin")
+    public String sayHello() throws Exception {
+        log.debug("session context: " + context);
+        log.debug("caller name: " + context.getCallerPrincipal().getName());
+
+        if (context.isCallerInRole("JBossAdmin")) {
+            throw new IllegalArgumentException("User is in role!!");
+        }
+
+        log.info("HelloBean - sending message");
+        String msg = this.sendMessage();
+
+        String name = getName();
+        return "Hello " + name + "! " + msg;
+    }
+
+    private String getName() {
+        return "Fred";
+    }
+
+    public String sendMessage() throws Exception {
+        String destinationName = "java:jboss/exported/queue/TestQueue";
+        Context ic = null;
+        ConnectionFactory cf = null;
+        Connection connection = null;
+
+        try {
+            ic = getInitialContext();
+            cf = (ConnectionFactory) ic.lookup("java:/ConnectionFactory");
+            Queue queue = (Queue) ic.lookup(destinationName);
+            connection = cf.createConnection("guest", "guest");
+            connection.start(); // we need to start connection for consumer
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageProducer sender = session.createProducer(queue);
+            TextMessage message = session.createTextMessage("hello goodbye");
+            TemporaryQueue replyQueue = session.createTemporaryQueue();
+            message.setJMSReplyTo(replyQueue);
+            sender.send(message);
+
+            MessageConsumer consumer = session.createConsumer(replyQueue);
+            TextMessage replyMsg = (TextMessage) consumer.receive(5000);
+            log.info("Message received:" + replyMsg);
+            return replyMsg.getText();
+        } finally {
+            if (ic != null) {
+                try {
+                    ic.close();
+                } catch (Exception ignore) {
+                }
+            }
+            closeConnection(connection);
+        }
+
+    }
+
+    public static InitialContext getInitialContext() throws NamingException {
+        return new InitialContext();
+    }
+
+    private void closeConnection(Connection conn) {
+        try {
+            if (conn != null) {
+                conn.close();
+            }
+        } catch (JMSException jmse) {
+            log.info("connection close failed: " + jmse);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HelloMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HelloMDB.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.ejb.EJB;
+import javax.ejb.MessageDriven;
+import javax.ejb.ActivationConfigProperty;
+
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueSender;
+import javax.jms.QueueSession;
+import javax.jms.TextMessage;
+import javax.annotation.security.RunAs;
+import javax.annotation.Resource;
+import org.jboss.ejb3.annotation.ResourceAdapter;
+import org.jboss.logging.Logger;
+
+/**
+ * MDB with RunAs annotation. Takes data from in queue and replies to reply queue.
+ * 
+ * @author Ondrej Chaloupka
+ */
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/exported/queue/TestQueue"),
+        @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge"),
+        @ActivationConfigProperty(propertyName = "maxSession", propertyValue = "1") })
+@RunAs("INTERNAL_ROLE")
+@ResourceAdapter(value = "hornetq-ra.rar")
+public class HelloMDB implements MessageListener {
+    private static final Logger log = Logger.getLogger(HowdyBean.class);
+
+    @EJB
+    Howdy howdy;
+
+    @Resource(mappedName = "java:/ConnectionFactory")
+    private QueueConnectionFactory qFactory;
+
+    @Resource(lookup = "java:global/runasmdbejb-ejb2/GoodBye!org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.GoodByeLocalHome")
+    GoodByeLocalHome goodByeHome;
+    GoodByeLocal goodBye;
+
+    public void onMessage(Message message) {
+        try {
+            log.debug("[HelloMDB] calling goodByeHome.create()");
+            goodBye = goodByeHome.create();
+            log.debug("[HelloMDB] returned from goodByeHome.create()");
+            String replyMsg = this.callEJB() + goodBye.sayGoodBye("user1");
+            log.info("[HelloMDB] calling sayHowdy: " + replyMsg);
+
+            sendReply(replyMsg, (Queue) message.getJMSReplyTo(), message.getJMSMessageID());
+        } catch (Exception e) {
+            log.error("EXCEPTION: ", e);
+        }
+    }
+
+    private final String callEJB() {
+        return howdy.sayHowdy();
+    }
+
+    private void sendReply(String msg, Queue destination, String messageID) throws JMSException {
+        QueueConnection conn = qFactory.createQueueConnection("guest", "guest");
+        try {
+            QueueSession session = conn.createQueueSession(false, QueueSession.AUTO_ACKNOWLEDGE);
+            conn.start();
+            QueueSender sender = session.createSender(destination);
+            TextMessage message = session.createTextMessage(msg);
+            message.setJMSCorrelationID(messageID);
+            sender.send(message, DeliveryMode.NON_PERSISTENT, 4, 500);
+        } finally {
+            conn.close();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/Hola.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/Hola.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface Hola {
+    public String sayHola();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HolaBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HolaBean.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+// Security related imports
+import javax.annotation.security.RolesAllowed;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Returns hola greeting for INTERNAL_ROLE.
+ * 
+ * @author Ondrej Chaloupka
+ */
+@Stateless(name = "Hola")
+@RolesAllowed({})
+@Remote(Hola.class)
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class HolaBean implements Hola {
+    private static final Logger log = Logger.getLogger(HowdyBean.class);
+    
+    @Resource
+    private SessionContext context;
+
+    @RolesAllowed("INTERNAL_ROLE")
+    public String sayHola() {
+        log.info("HolaBean.sayHola(). Caller name: " + context.getCallerPrincipal().getName());
+
+        if (context.isCallerInRole("JBossAdmin")) {
+            log.info("User is in role!!");
+        }
+
+        String name = getName();
+        return "Hola " + name + "!";
+    }
+
+    private String getName() {
+        return "Fred";
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/Howdy.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/Howdy.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public interface Howdy {
+    public String sayHowdy();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HowdyBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/HowdyBean.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import javax.annotation.Resource;
+import javax.ejb.Local;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+// Security related imports
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.EJB;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Returns howdy greeting for INTERNAL_ROLE.
+ * 
+ * @author Ondrej Chaloupka
+ */
+@Stateless(name = "Howdy")
+@RolesAllowed("INTERNAL_ROLE")
+@Local(Howdy.class)
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class HowdyBean implements Howdy {
+    private static final Logger log = Logger.getLogger(HowdyBean.class);
+    
+    @Resource
+    private SessionContext context;
+
+    @EJB
+    Hola hola;
+    
+    public String sayHowdy() {
+        log.info("HowdyBean.sayHowdy(). Caller name: " + context.getCallerPrincipal().getName());
+        log.info("[Howdy] calling sayHola: " + hola.sayHola());
+
+        String name = getName();
+
+        return "Howdy " + name + "! ";
+    }
+
+    private String getName() {
+        return "Fred";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsTestCaseEJBMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsTestCaseEJBMDB.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.runas.ejb2mdb;
+
+import java.net.URL;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
+import javax.jms.TextMessage;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.JMSAdminOperations;
+import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case based on reproducer for JBPAPP-7897 - RunAs role not propogated past first ejb3 method.
+ * 
+ * @author Derek Horton, Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RunAsTestCaseEJBMDB {
+    private static final Logger log = Logger.getLogger(RunAsTestCaseEJBMDB.class.getName());
+
+    private static Integer REMOTE_PORT = 4447;
+    
+    private static String QUEUE_NAME = "queue/TestQueue";
+    private static JMSAdminOperations jmsAdminOps;
+    
+    @ArquillianResource
+    @OperateOnDeployment("ejb2")
+    URL baseUrl;
+    
+    @AfterClass
+    public static void tearDown() throws Exception {
+        jmsAdminOps.removeJmsQueue(QUEUE_NAME);
+        jmsAdminOps.close();
+    }
+    
+    @Deployment(testable = false, managed = true, name = "ejb2", order = 1)
+    public static Archive<?> runAsEJB2() {
+        try {
+            // create JMS queue
+            jmsAdminOps = new JMSAdminOperations();
+            jmsAdminOps.createJmsQueue(QUEUE_NAME, "java:jboss/exported/" + QUEUE_NAME);
+        } catch (Exception e) {
+            // ignore
+        }
+        
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "runasmdbejb-ejb2.jar")
+                .addClasses(
+                        GoodBye.class,
+                        GoodByeBean.class, 
+                        GoodByeHome.class, 
+                        GoodByeLocal.class, 
+                        GoodByeLocalHome.class);
+        jar.addAsManifestResource(RunAsTestCaseEJBMDB.class.getPackage(), "ejb-jar-ejb2.xml", "ejb-jar.xml");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    @Deployment(testable = false, managed = true, name = "ejb3", order = 1)
+    public static Archive<?> runAsEJB3() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "runasmdbejb-ejb3.jar")
+                .addClasses(
+                        HelloBean.class,
+                        Hello.class, 
+                        HolaBean.class, 
+                        Hola.class, 
+                        Howdy.class, 
+                        HowdyBean.class, 
+                        HelloMDB.class);
+        jar.addAsManifestResource(new StringAsset("Dependencies: deployment.runasmdbejb-ejb2.jar  \n"), "MANIFEST.MF");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    private InitialContext getInitialContext() throws NamingException {
+        final Properties jndiProperties = new Properties();
+        // getting remote jndi: AS7-1338
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
+        jndiProperties.put(Context.PROVIDER_URL, "remote://" + baseUrl.getHost() + ":" + REMOTE_PORT);
+        jndiProperties.put("jboss.naming.client.ejb.context", true);
+        jndiProperties.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
+        jndiProperties.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());
+        return new InitialContext(jndiProperties);
+    }
+    
+    @Test
+    public void testEjb() throws Exception {
+        InitialContext ctx = getInitialContext();
+        Hello helloBean = (Hello) ctx.lookup("runasmdbejb-ejb3/Hello!org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.Hello");
+        String hellomsg = helloBean.sayHello();
+        log.info(hellomsg);
+        Assert.assertEquals("Hello Fred! Howdy Fred! GoodBye user1", hellomsg);
+        ctx.close();
+    }
+    
+    @Test
+    public void testSendMessage() throws Exception {
+        InitialContext ctx = null;
+        ConnectionFactory cf = null;
+        Connection connection = null;
+        Session session = null;
+
+        try {           
+            ctx = getInitialContext();
+            cf = (ConnectionFactory) ctx.lookup("jms/RemoteConnectionFactory");
+            Queue queue = (Queue) ctx.lookup(QUEUE_NAME);
+            connection = cf.createConnection("guest", "guest");
+            connection.start(); //for consumer we need to start connection
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageProducer sender = session.createProducer(queue);
+            TemporaryQueue replyQueue = session.createTemporaryQueue();
+            TextMessage message = session.createTextMessage("hello goodbye");
+            message.setJMSReplyTo(replyQueue);
+            sender.send(message);
+            log.info("testSendMessage(): Message sent!");
+            
+            MessageConsumer consumer = session.createConsumer(replyQueue);
+            Message replyMsg = consumer.receive(5000);
+            Assert.assertNotNull(replyMsg);
+            Assert.assertTrue(replyMsg instanceof TextMessage);
+            String actual = ((TextMessage) replyMsg).getText();
+            Assert.assertEquals("Howdy Fred! GoodBye user1", actual);
+        } finally {
+            try {
+                ctx.close();
+            } catch (Exception ignore) {
+                // ok
+            }
+            if(session != null) {
+                session.close();
+            }
+            closeConnection(connection);
+        }
+
+    }
+
+    private void closeConnection(Connection conn) {
+        try {
+            if (conn != null) {
+                conn.close();
+            }
+        } catch (JMSException jmse) {
+            System.out.println("connection close failed: " + jmse);
+        }
+    }
+    
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/ejb-jar-ejb2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/ejb-jar-ejb2.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE ejb-jar PUBLIC
+    "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN"
+    "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+
+<ejb-jar>
+    <enterprise-beans>
+      <session>
+          <ejb-name>GoodBye</ejb-name>
+          <home>org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.GoodByeHome</home>
+          <remote>org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.GoodBye</remote>
+          <local-home>org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.GoodByeLocalHome</local-home>
+          <local>org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.GoodByeLocal</local>
+          <ejb-class>org.jboss.as.test.integration.ejb.security.runas.ejb2mdb.GoodByeBean</ejb-class>
+          <session-type>Stateless</session-type>
+          <transaction-type>Bean</transaction-type>
+      </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
Adding test for RunAs annotation. It's based on one-off patch reproducer for jira JBPAPP-7897 and it tests calling MDB and EJB2 beans.
