### PR TITLE
DO NOT MERGE UNTIL CONSOLE IS UPGRADED

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
@@ -233,8 +233,6 @@ public class DomainFinalResultHandler implements OperationStepHandler {
                 groupNode.get(hostServer.serverName).set(serverNode);
             }
             context.getServerResults().get(groupName).set(groupNode);
-            // TODO AS7-3677
-            result.get(SERVER_GROUPS, groupName).set(groupNode);
         }
         if(!serverGroupSuccess) {
             // TODO see if we can extract more information from the server details


### PR DESCRIPTION
DON'T MERGE THIS UNTIL THE CONSOLE IS UPGRADED WITH THE AS7-3676 FIX INCLUDED.
Otherwise, the console will be broken for a managed domain.

It should be merged into 7.1.0.Final though.

What it does:

AS7-3677 Remove redundant 'server-groups' child of 'result' in multi-server domain ops
