### PR TITLE
Log VM args and sys props as INFO, not DEBUG.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -101,8 +101,8 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
             for (String property : new TreeSet<String>(properties.stringPropertyNames())) {
                 b.append("\n\t").append(property).append(" = ").append(properties.getProperty(property, "<undefined>"));
             }
-            CONFIG_LOGGER.debug(b);
-            CONFIG_LOGGER.debugf("VM Arguments: %s", getVMArguments());
+            CONFIG_LOGGER.info(b);
+            CONFIG_LOGGER.infof("VM Arguments: %s", getVMArguments());
             if (CONFIG_LOGGER.isTraceEnabled()) {
                 b.setLength(0);
                 final Map<String,String> env = System.getenv();


### PR DESCRIPTION
```
04:29:20,509 DEBUG [org.jboss.as.config] Configured system properties:
...
04:29:20,523 DEBUG [org.jboss.as.config] VM Arguments: -Xmx512m ...
```

I'd make these two INFO, not debug.
They are crucial information which every developer, integrator and admin needs.
No reason to hide them at DEBUG level.
