### PR TITLE
Do not use "unsupported" designation for community

### DIFF
--- a/build/src/main/resources/modules/com/h2database/h2/main/module.xml
+++ b/build/src/main/resources/modules/com/h2database/h2/main/module.xml
@@ -23,9 +23,6 @@
   -->
 
 <module xmlns="urn:jboss:module:1.1" name="com.h2database.h2">
-    <properties>
-        <property name="jboss.api" value="unsupported"/>
-    </properties>
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/org/jdom/main/module.xml
+++ b/build/src/main/resources/modules/org/jdom/main/module.xml
@@ -22,10 +22,6 @@
 
 <module xmlns="urn:jboss:module:1.1" name="org.jdom">
 
-    <properties>
-        <property name="jboss.api" value="unsupported"/>
-    </properties>
-
     <dependencies>
         <module name="org.jaxen"/>
         <module name="javax.api"/>

--- a/build/src/main/resources/modules/org/joda/time/main/module.xml
+++ b/build/src/main/resources/modules/org/joda/time/main/module.xml
@@ -23,9 +23,6 @@
   -->
 
 <module xmlns="urn:jboss:module:1.1" name="org.joda.time">
-    <properties>
-        <property name="jboss.api" value="unsupported"/>
-    </properties>
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/org/osgi/core/main/module.xml
+++ b/build/src/main/resources/modules/org/osgi/core/main/module.xml
@@ -23,9 +23,6 @@
   -->
 
 <module xmlns="urn:jboss:module:1.1" name="org.osgi.core">
-    <properties>
-        <property name="jboss.api" value="unsupported"/>
-    </properties>
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/org/scannotation/scannotation/main/module.xml
+++ b/build/src/main/resources/modules/org/scannotation/scannotation/main/module.xml
@@ -24,7 +24,7 @@
 
 <module xmlns="urn:jboss:module:1.1" name="org.scannotation.scannotation">
     <properties>
-        <property name="jboss.api" value="unsupported"/>
+        <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>

--- a/build/src/main/resources/modules/org/w3c/css/sac/main/module.xml
+++ b/build/src/main/resources/modules/org/w3c/css/sac/main/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.1" name="org.w3c.css.sac">
 
     <properties>
-        <property name="jboss.api" value="unsupported"/>
+        <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>

--- a/build/src/main/resources/modules/org/yaml/snakeyaml/main/module.xml
+++ b/build/src/main/resources/modules/org/yaml/snakeyaml/main/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.1" name="org.yaml.snakeyaml">
 
     <properties>
-        <property name="jboss.api" value="unsupported"/>
+        <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>


### PR DESCRIPTION
These categorizations will be reserved for EAP.
