### PR TITLE
As7 409

### DIFF
--- a/dist/assembly-src.xml
+++ b/dist/assembly-src.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:maven:assembly:1.1.0-SNAPSHOT">
+    <id>src</id>
+    <formats>
+       <format>zip</format>
+       <format>tar.gz</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>..</directory>
+            <outputDirectory>jboss-as-${project.version}-src</outputDirectory>
+            <includes>
+                <include>**/*.xml</include>
+                <include>**/src/**</include>
+                <include>**/*.txt</include>
+                <include>**/*.sh</include>
+                <include>**/*.bat</include>
+                <include>**/*.md</include>
+                <include>tools/**</include>
+            </includes>
+            <excludes>
+                <!-- Ignore build output -->
+                <exclude>**/target/**</exclude>
+
+                <!-- Ignore git repo -->
+                <exclude>**/.git</exclude>
+
+                <!-- Ignore IDE configuration and other hidden files-->
+                <exclude>**/.project</exclude>
+                <exclude>**/.classpath</exclude>
+                <exclude>**/.settings</exclude>
+                <exclude>**/.metadata</exclude>
+                <exclude>**/.iml</exclude>
+                <exclude>**/.ipr</exclude>
+                <exclude>**/.iws</exclude>
+                <exclude>**/.idea</exclude>
+                <exclude>nbactions.xml</exclude>
+                <exclude>nb-configuration.xml</exclude>
+                <exclude>catalog.xml</exclude>
+
+            </excludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -80,6 +80,22 @@
                                     <workDirectory>target/assembly/work</workDirectory>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>assemble-src</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>assembly-src.xml</descriptor>
+                                    </descriptors>
+                                    <finalName>jboss-as-${project.version}</finalName>
+                                    <appendAssemblyId>true</appendAssemblyId>
+                                    <outputDirectory>target/</outputDirectory>
+                                    <workDirectory>target/assembly-src/work</workDirectory>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -78,6 +78,7 @@
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <outputDirectory>target/</outputDirectory>
                                     <workDirectory>target/assembly/work</workDirectory>
+                                    <tarLongFileMode>gnu</tarLongFileMode>
                                 </configuration>
                             </execution>
                             <execution>
@@ -94,6 +95,7 @@
                                     <appendAssemblyId>true</appendAssemblyId>
                                     <outputDirectory>target/</outputDirectory>
                                     <workDirectory>target/assembly-src/work</workDirectory>
+                                    <tarLongFileMode>gnu</tarLongFileMode>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Add Maven assembly configuration for building a dist source zip.
Fix long filename warnings when building release zips.
