### PR TITLE
Parse result of plan and create DeploymentActionResults.

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/BasicDomainUpdateResult.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/BasicDomainUpdateResult.java
@@ -52,19 +52,19 @@ public class BasicDomainUpdateResult implements Serializable {
         this.domainFailure = null;
     }
 
-    public BasicDomainUpdateResult(final UpdateFailedException domainFailure) {
+    public BasicDomainUpdateResult(final UpdateFailedException domainFailure, final boolean rolledBack) {
         this.domainFailure = domainFailure;
         this.cancelled = false;
-        this.rolledBack = false;
+        this.rolledBack = rolledBack;
     }
 
-    public BasicDomainUpdateResult(final Map<String, UpdateFailedException> hostFailures) {
+    public BasicDomainUpdateResult(final Map<String, UpdateFailedException> hostFailures, final boolean rolledBack) {
         this.domainFailure = null;
         if (hostFailures != null) {
             this.hostFailures.putAll(hostFailures);
         }
         this.cancelled = false;
-        this.rolledBack = false;
+        this.rolledBack = rolledBack;
     }
 
     public BasicDomainUpdateResult() {

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DomainDeploymentPlanResultFuture.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DomainDeploymentPlanResultFuture.java
@@ -1,15 +1,22 @@
 package org.jboss.as.controller.client.helpers.domain.impl;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.jboss.as.controller.client.ControllerClientMessages;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.domain.DeploymentAction;
 import org.jboss.as.controller.client.helpers.domain.DeploymentActionResult;
 import org.jboss.as.controller.client.helpers.domain.DeploymentPlanResult;
+import org.jboss.as.controller.client.helpers.domain.ServerIdentity;
+import org.jboss.as.controller.client.helpers.domain.UpdateFailedException;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -19,14 +26,22 @@ import org.jboss.dmr.ModelNode;
  */
 class DomainDeploymentPlanResultFuture implements Future<DeploymentPlanResult> {
 
+    private static final String DOMAIN_FAILURE_DESCRIPTION = "domain-failure-description";
+
+    private static final String HOST_FAILURE_DESCRIPTION = "host-failure-description";
+
+    private static final String ROLLED_BACK = "rolled-back";
+
     private final Future<ModelNode> nodeFuture;
     private final DeploymentPlanImpl plan;
-    private final Map<UUID, String> actionsById;
+    private final Map<UUID, List<String>> actionsById;
+    private final Set<ServerIdentity> servers;
 
-    DomainDeploymentPlanResultFuture(final DeploymentPlanImpl plan, final Future<ModelNode> nodeFuture, final Map<UUID, String> actionsById) {
+    DomainDeploymentPlanResultFuture(final DeploymentPlanImpl plan, final Future<ModelNode> nodeFuture, final Set<ServerIdentity> servers, final Map<UUID, List<String>> actionsById) {
         this.plan = plan;
         this.nodeFuture = nodeFuture;
         this.actionsById = actionsById;
+        this.servers = servers;
     }
 
     @Override
@@ -52,7 +67,7 @@ class DomainDeploymentPlanResultFuture implements Future<DeploymentPlanResult> {
 
     @Override
     public DeploymentPlanResult get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
-            TimeoutException {
+                                                                        TimeoutException {
         ModelNode node = nodeFuture.get(timeout, unit);
         return getResultFromNode(node);
     }
@@ -62,54 +77,85 @@ class DomainDeploymentPlanResultFuture implements Future<DeploymentPlanResult> {
         String outcome = planResultNode.get("outcome").asString();
         if ("cancelled".equals(outcome)) {
             createCancelledResults(actionResults);
-        }
-        else if ("success".equals(outcome)) {
+        } else if ("success".equals(outcome)) {
             createSuccessResults(actionResults, planResultNode);
-        }
-        else {
+        } else {
             createFailureResults(actionResults, planResultNode);
         }
         return new DeploymentPlanResultImpl(plan, actionResults);
     }
 
     private void createFailureResults(Map<UUID, DeploymentActionResult> actionResults, ModelNode planResultNode) {
-        // TODO Auto-generated method stub
-
+        boolean isDomainFailure = false;
+        boolean isHostFailure = false;
+        // Determine the failure type
+        if (planResultNode.hasDefined(ClientConstants.FAILURE_DESCRIPTION)) {
+            final ModelNode failureDescription = planResultNode.get(ClientConstants.FAILURE_DESCRIPTION);
+            isDomainFailure = failureDescription.hasDefined(DOMAIN_FAILURE_DESCRIPTION);
+            isHostFailure = failureDescription.hasDefined(HOST_FAILURE_DESCRIPTION);
+        }
+        final ModelNode result = planResultNode.get(ClientConstants.RESULT);
+        for (DeploymentAction deploymentAction : plan.getDeploymentActions()) {
+            // Get the steps used for this deployment action
+            final List<String> steps = actionsById.get(deploymentAction.getId());
+            for (String step : steps) {
+                if (result.hasDefined(step)) {
+                    // Get the result for this step
+                    final ModelNode stepResult = result.get(step);
+                    final boolean isRolledBack = (stepResult.hasDefined(ROLLED_BACK) && stepResult.get(ROLLED_BACK).asBoolean());
+                    final UpdateFailedException updateFailedException;
+                    // Create the failure description
+                    if (stepResult.hasDefined(ClientConstants.FAILURE_DESCRIPTION)) {
+                        updateFailedException = new UpdateFailedException(stepResult.get(ClientConstants.FAILURE_DESCRIPTION).asString());
+                    } else if (planResultNode.hasDefined(ClientConstants.FAILURE_DESCRIPTION)) {
+                        updateFailedException = new UpdateFailedException(planResultNode.get(ClientConstants.FAILURE_DESCRIPTION).asString());
+                    } else {
+                        updateFailedException = new UpdateFailedException(ControllerClientMessages.MESSAGES.noFailureDetails());
+                    }
+                    final BasicDomainUpdateResult domainUpdateResult;
+                    if (isDomainFailure) {
+                        domainUpdateResult = new BasicDomainUpdateResult(updateFailedException, isRolledBack);
+                    } else if (isHostFailure) {
+                        final Map<String, UpdateFailedException> hostExceptions = new HashMap<String, UpdateFailedException>();
+                        for (ServerIdentity serverId : servers) {
+                            hostExceptions.put(serverId.getHostName(), updateFailedException);
+                        }
+                        domainUpdateResult = new BasicDomainUpdateResult(hostExceptions, isRolledBack);
+                    } else {
+                        domainUpdateResult = new BasicDomainUpdateResult();
+                    }
+                    // Create the deployment action result
+                    final DeploymentActionResultImpl deploymentActionResult = new DeploymentActionResultImpl(deploymentAction, domainUpdateResult);
+                    final UpdateResultHandlerResponse resultHandlerResponse = UpdateResultHandlerResponse.createFailureResponse(updateFailedException);
+                    // Update the action result with updates for each server
+                    for (ServerIdentity serverId : servers) {
+                        final ServerUpdateResultImpl serverUpdateResult = new ServerUpdateResultImpl(deploymentAction.getId(), serverId, resultHandlerResponse);
+                        deploymentActionResult.storeServerUpdateResult(serverId, serverUpdateResult);
+                    }
+                    actionResults.put(deploymentAction.getId(), deploymentActionResult);
+                }
+            }
+        }
     }
 
     private void createSuccessResults(Map<UUID, DeploymentActionResult> actionResults, ModelNode planResultNode) {
-        // TODO Auto-generated method stub
-
+        createDefaultResults(actionResults, new BasicDomainUpdateResult(), UpdateResultHandlerResponse.createSuccessResponse(planResultNode));
     }
 
     private void createCancelledResults(Map<UUID, DeploymentActionResult> actionResults) {
-        // TODO Auto-generated method stub
-
+        createDefaultResults(actionResults, new BasicDomainUpdateResult(true), UpdateResultHandlerResponse.createCancellationResponse());
     }
 
-//    private DeploymentActionResult getActionResult(DeploymentAction action, ModelNode actionResultNode) {
-//        DeploymentActionResultImpl actionResult = null;
-//        String outcome = actionResultNode.get("outcome").asString();
-//        if ("cancelled".equals(outcome)) {
-//            actionResult = new DeploymentActionResultImpl(action, new BasicDomainUpdateResult(true));
-//        } else if ("failed".equals(outcome)) {
-//            throw new UnsupportedOperationException("implement me");
-////            Exception e = actionResultNode.hasDefined("failure-description") ? new Exception(actionResultNode.get("failure-description").toString()) : null;
-////            if (actionResultNode.hasDefined("rolled-back") && actionResultNode.get("rolled-back").asBoolean()) {
-////                if (e == null) {
-////                    actionResult = new SimpleServerDeploymentActionResult(actionId, Result.ROLLED_BACK);
-////                } else {
-////                    actionResult = new SimpleServerDeploymentActionResult(actionId, Result.ROLLED_BACK, e);
-////                }
-////            } else {
-////                actionResult = new SimpleServerDeploymentActionResult(actionId, e);
-////            }
-//        } else {
-//            throw new UnsupportedOperationException("implement me");
-////            actionResult = new SimpleServerDeploymentActionResult(actionId, Result.EXECUTED);
-//        }
-//        // FIXME deal with shutdown possibilities
-//        return actionResult;
-//    }
-
+    private void createDefaultResults(final Map<UUID, DeploymentActionResult> actionResults, final BasicDomainUpdateResult domainUpdateResult, final UpdateResultHandlerResponse resultHandlerResponse) {
+        for (DeploymentAction deploymentAction : plan.getDeploymentActions()) {
+            // Create the deployment action result
+            final DeploymentActionResultImpl deploymentActionResult = new DeploymentActionResultImpl(deploymentAction, domainUpdateResult);
+            // Update the action result with updates for each server
+            for (ServerIdentity serverId : servers) {
+                final ServerUpdateResultImpl serverUpdateResult = new ServerUpdateResultImpl(deploymentAction.getId(), serverId, resultHandlerResponse);
+                deploymentActionResult.storeServerUpdateResult(serverId, serverUpdateResult);
+            }
+            actionResults.put(deploymentAction.getId(), deploymentActionResult);
+        }
+    }
 }


### PR DESCRIPTION
This needs a review from someone with more knowledge than me for deploying to domains.

As far as I can tell these helpers are not used in anywhere except the legacy demos and the test suite. This pull request only adds the results of a domain deployments success, cancellation or failure.
