### PR TITLE
AS7-3758 ParsedInterfaceCriteria.parseCriteria is not maintaining ExpressionValues

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteria.java
@@ -186,13 +186,13 @@ public final class ParsedInterfaceCriteria {
                 ModelNode value = property.getValue();
                 value = parsePossibleExpression(value);
                 checkStringType(value, element.getLocalName(), true);
-                return createInetAddressCriteria(property.getValue());
+                return createInetAddressCriteria(value);
             }
             case LOOPBACK_ADDRESS: {
                 ModelNode value = property.getValue();
                 value = parsePossibleExpression(value);
                 checkStringType(value, element.getLocalName(), true);
-                return new LoopbackAddressInterfaceCriteria(property.getValue());
+                return new LoopbackAddressInterfaceCriteria(value);
             }
             case NIC: {
                 checkStringType(property.getValue(), element.getLocalName());


### PR DESCRIPTION
This patch enables the use of expressions in the loopback-address, and inet-address types.
