### PR TITLE
Remove the version from the jboss-client jar file name

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -105,7 +105,7 @@
     </target>
 
     <target name="copy-client">
-        <copy file="${org.jboss.as:jboss-as-client-all:jar}" tofile="${output.dir}/bin/client/jboss-client-${project.version}.jar"/>
+        <copy file="${org.jboss.as:jboss-as-client-all:jar}" tofile="${output.dir}/bin/client/jboss-client.jar"/>
     </target>
 
     <target name="minimalistic" depends="base, copy-standalone-minimalistic"/>


### PR DESCRIPTION
This commit removes the version from the jboss-client jar file name to make it convenient for external scripts to rely on a fixed jar name, across different AS7 versions (JBOSS_HOME/bin/client/jboss-client.jar).
