### PR TITLE
Fix @EJB injection when the target bean has a @WebService view

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbInjectionSource.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbInjectionSource.java
@@ -111,6 +111,11 @@ public class EjbInjectionSource extends InjectionSource {
                     final Set<EJBViewDescription> ejbsForViewName = new HashSet<EJBViewDescription>();
                     for (final ViewDescription view : views) {
                         if (view instanceof EJBViewDescription) {
+                            final MethodIntf viewType = ((EJBViewDescription) view).getMethodIntf();
+                            // @EJB injection *shouldn't* consider the @WebService endpoint view or MDBs
+                            if (viewType == MethodIntf.SERVICE_ENDPOINT || viewType == MethodIntf.MESSAGE_ENDPOINT) {
+                                continue;
+                            }
                             ejbsForViewName.add((EJBViewDescription) view);
                         }
                     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/multiple/view/InjectingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/multiple/view/InjectingBean.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.injection.multiple.view;
+
+import javax.ejb.EJB;
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@LocalBean
+@Stateless
+public class InjectingBean {
+
+    @EJB
+    private NoInterfaceAndWebServiceViewBean otherBean;
+
+    public boolean isBeanInjected() {
+        return this.otherBean != null;
+    }
+
+    public void invokeInjectedBean() {
+        this.otherBean.doNothing();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/multiple/view/NoInterfaceAndWebServiceViewBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/multiple/view/NoInterfaceAndWebServiceViewBean.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.injection.multiple.view;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+import javax.jws.WebService;
+
+/**
+ * @author Jaikiran Pai
+ */
+@LocalBean
+@Stateless
+@WebService
+public class NoInterfaceAndWebServiceViewBean {
+
+    public void doNothing() {
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/multiple/view/WSViewEJBInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/multiple/view/WSViewEJBInjectionTestCase.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.injection.multiple.view;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class WSViewEJBInjectionTestCase {
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "multiple-view-ejb-injection");
+        jar.addPackage(WSViewEJBInjectionTestCase.class.getPackage());
+        return jar;
+    }
+
+    @Test
+    public void testInjection() throws Exception {
+        final InjectingBean injectingBean = InitialContext.doLookup("java:module/" + InjectingBean.class.getSimpleName() + "!" + InjectingBean.class.getName());
+        Assert.assertTrue("@EJB injection did not happen in bean", injectingBean.isBeanInjected());
+        // try an invocation on the bean
+        injectingBean.invokeInjectedBean();
+    }
+}


### PR DESCRIPTION
The commit here fixes a @EJB injection issue which would result in the following exception if a target bean had a @WebService view exposed (along with other views):

```
    Caused by: org.jboss.as.server.deployment.DeploymentUnitProcessingException: More than 1 component found for type 'foo.bar.Bean' and bean name null for binding foo.bar.OtherBean/targetBean
        at org.jboss.as.ejb3.deployment.processors.EjbInjectionSource.getResourceValue(EjbInjectionSource.java:88)
        at org.jboss.as.ee.component.deployers.ModuleJndiBindingProcessor.addJndiBinding(ModuleJndiBindingProcessor.java:227)
        at org.jboss.as.ee.component.deployers.ModuleJndiBindingProcessor$1.handle(ModuleJndiBindingProcessor.java:194)
        at org.jboss.as.ee.component.ClassDescriptionTraversal.run(ClassDescriptionTraversal.java:54)
```

The issue has been reported here https://community.jboss.org/message/717861#717861. The fix makes sure that we only consider valid @EJB injection views.
