### PR TITLE
AS7-3596 allow JPA default datasource to be set to null

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPADefaultDatasourceWriteHandler.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPADefaultDatasourceWriteHandler.java
@@ -23,7 +23,7 @@ public class JPADefaultDatasourceWriteHandler extends AbstractWriteAttributeHand
     static final JPADefaultDatasourceWriteHandler INSTANCE = new JPADefaultDatasourceWriteHandler();
 
     private JPADefaultDatasourceWriteHandler() {
-        super(new StringLengthValidator(0, Integer.MAX_VALUE, false, true), new StringLengthValidator(0, Integer.MAX_VALUE, false, false));
+        super(new StringLengthValidator(0, Integer.MAX_VALUE, true, true), new StringLengthValidator(0, Integer.MAX_VALUE, true, false));
     }
 
     @Override

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPADescriptions.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPADescriptions.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HEAD_COMMENT_ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_LENGTH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REPLY_PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
@@ -65,6 +66,7 @@ public class JPADescriptions {
         subsystem.get(ATTRIBUTES, CommonAttributes.DEFAULT_DATASOURCE, TYPE).set(ModelType.STRING);
         subsystem.get(ATTRIBUTES, CommonAttributes.DEFAULT_DATASOURCE, REQUIRED).set(true);
         subsystem.get(ATTRIBUTES, CommonAttributes.DEFAULT_DATASOURCE, MIN_LENGTH).set(0);
+        subsystem.get(ATTRIBUTES, CommonAttributes.DEFAULT_DATASOURCE, NILLABLE).set(true);
         subsystem.get(CHILDREN).setEmptyObject();
         return subsystem;
     }
@@ -81,7 +83,7 @@ public class JPADescriptions {
         op.get(REQUEST_PROPERTIES, CommonAttributes.DEFAULT_DATASOURCE, TYPE).set(ModelType.STRING);
         op.get(REQUEST_PROPERTIES, CommonAttributes.DEFAULT_DATASOURCE, REQUIRED).set(true);
         op.get(REQUEST_PROPERTIES, CommonAttributes.DEFAULT_DATASOURCE, MIN_LENGTH).set(0);
-
+        op.get(REQUEST_PROPERTIES, CommonAttributes.DEFAULT_DATASOURCE, NILLABLE).set(true);
         op.get(REPLY_PROPERTIES).setEmptyObject();
 
         return op;

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPAExtension.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPAExtension.java
@@ -94,7 +94,7 @@ public class JPAExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
-        SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0);
+        SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, 1, 1);
         final ManagementResourceRegistration nodeRegistration = registration.registerSubsystemModel(DESCRIPTION);
         PersistenceUnitRegistryImpl persistenceUnitRegistry = new PersistenceUnitRegistryImpl();
         JPASubSystemAdd subsystemAdd = new JPASubSystemAdd(persistenceUnitRegistry);

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
@@ -77,8 +77,8 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler implements Descript
     private final PersistenceUnitRegistryImpl persistenceUnitRegistry;
 
     public JPASubSystemAdd(final PersistenceUnitRegistryImpl persistenceUnitRegistry) {
-        modelValidator.registerValidator(CommonAttributes.DEFAULT_DATASOURCE, new StringLengthValidator(0, Integer.MAX_VALUE, false, true));
-        runtimeValidator.registerValidator(CommonAttributes.DEFAULT_DATASOURCE, new StringLengthValidator(0, Integer.MAX_VALUE, false, false));
+        modelValidator.registerValidator(CommonAttributes.DEFAULT_DATASOURCE, new StringLengthValidator(0, Integer.MAX_VALUE, true, true));
+        runtimeValidator.registerValidator(CommonAttributes.DEFAULT_DATASOURCE, new StringLengthValidator(0, Integer.MAX_VALUE, true, false));
         this.persistenceUnitRegistry = persistenceUnitRegistry;
     }
 


### PR DESCRIPTION
Brian, I changed both of the definitions passed in for AbstractWriteAttributeHandler.unresolvedValueValidator  + AbstractWriteAttributeHandler.resolvedValueValidator to allow null (for the JPA default datasource).  How wrong is that? 
