### PR TITLE
cli updates

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -135,6 +135,12 @@ public interface CommandContext {
     void connectController(String host, int port);
 
     /**
+     * Connects the controller client using the default host and the port.
+     * It simply calls connectController(null, -1).
+     */
+    void connectController();
+
+    /**
      * Closes the previously established connection with the controller client.
      * If the connection hasn't been established, the method silently returns.
      */

--- a/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
@@ -78,8 +78,12 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
         }
 
         try {
-            ModelNode result = client.execute(request);
-            ctx.printLine(result.toString());
+            final ModelNode result = client.execute(request);
+            if(Util.isSuccess(result)) {
+                ctx.printLine(result.toString());
+            } else {
+                ctx.error(result.toString());
+            }
         } catch(NoSuchElementException e) {
             ctx.error("ModelNode request is incomplete: " + e.getMessage());
         } catch (CancellationException e) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -220,7 +220,7 @@ public class CliLauncher {
     private static void processCommands(String[] commands, CommandContext cmdCtx) {
         int i = 0;
         try {
-            while (i < commands.length && !cmdCtx.isTerminated()) {
+            while (cmdCtx.getExitCode() == 0 && i < commands.length && !cmdCtx.isTerminated()) {
                 cmdCtx.handle(commands[i]);
                 ++i;
             }
@@ -241,7 +241,7 @@ public class CliLauncher {
         try {
             reader = new BufferedReader(new FileReader(file));
             String line = reader.readLine();
-            while (!cmdCtx.isTerminated() && line != null) {
+            while (cmdCtx.getExitCode() == 0 && !cmdCtx.isTerminated() && line != null) {
                 cmdCtx.handle(line.trim());
                 line = reader.readLine();
             }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -218,11 +218,14 @@ public class CliLauncher {
     }
 
     private static void processCommands(String[] commands, CommandContext cmdCtx) {
+        int i = 0;
         try {
-            for (int i = 0; i < commands.length && !cmdCtx.isTerminated(); ++i) {
-                cmdCtx.handleSafe(commands[i]);
+            while (i < commands.length && !cmdCtx.isTerminated()) {
+                cmdCtx.handle(commands[i]);
+                ++i;
             }
         } catch(Throwable t) {
+            cmdCtx.error("Failed to process command '" + commands[i] + "': " + t.getLocalizedMessage());
             t.printStackTrace();
         } finally {
             if (!cmdCtx.isTerminated()) {
@@ -239,7 +242,7 @@ public class CliLauncher {
             reader = new BufferedReader(new FileReader(file));
             String line = reader.readLine();
             while (!cmdCtx.isTerminated() && line != null) {
-                cmdCtx.handleSafe(line.trim());
+                cmdCtx.handle(line.trim());
                 line = reader.readLine();
             }
         } catch (Throwable e) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -605,6 +605,11 @@ class CommandContextImpl implements CommandContext {
     }
 
     @Override
+    public void connectController() {
+        connectController(null, -1);
+    }
+
+    @Override
     public void connectController(String host, int port) {
         if (host == null) {
             host = defaultControllerHost;
@@ -944,7 +949,7 @@ class CommandContextImpl implements CommandContext {
             if(!handler.isBatchMode(this)) {
                 throw new OperationFormatException("The command is not allowed in a batch.");
             }
-        } else if (handler instanceof OperationCommand) {
+        } else if (!(handler instanceof OperationCommand)) {
             throw new OperationFormatException("The command does not translate to an operation request.");
         }
 

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -328,4 +328,9 @@ public class MockCommandContext implements CommandContext {
         // TODO Auto-generated method stub
         return null;
     }
+
+    @Override
+    public void connectController() {
+        connectController(null, -1);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/CommandsArgumentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/CommandsArgumentTestCase.java
@@ -1,0 +1,140 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class CommandsArgumentTestCase {
+
+    private static final String PROP_NAME = "cli-arg-test";
+    private static final String SET_PROP_COMMAND = "/system-property=" + PROP_NAME + ":add(value=set)";
+    private static final String GET_PROP_COMMAND = "/system-property=" + PROP_NAME + ":read-resource";
+    private static final String REMOVE_PROP_COMMAND = "/system-property=" + PROP_NAME + ":remove";
+
+    /**
+     * Tests that the exit code is 0 value after a successful operation
+     * @throws Exception
+     */
+    @Test
+    public void testSuccess() throws Exception {
+        int exitCode = execute(SET_PROP_COMMAND, true);
+        if(exitCode == 0) {
+            execute(REMOVE_PROP_COMMAND, true);
+        }
+        assertEquals(0, exitCode);
+    }
+
+    /**
+     * Tests that the exit code is not 0 after a failed operation.
+     * @throws Exception
+     */
+    @Test
+    public void testFailure() throws Exception {
+        assertFailure(GET_PROP_COMMAND);
+    }
+
+    /**
+     * Tests that commands following a failed command aren't executed.
+     * @throws Exception
+     */
+    @Test
+    public void testValidCommandAfterInvalidCommand() throws Exception {
+        int exitCode = execute('\"' + GET_PROP_COMMAND + ',' + SET_PROP_COMMAND + '\"', false);
+        if(exitCode == 0) {
+            execute(REMOVE_PROP_COMMAND, true);
+        } else {
+            assertFailure(GET_PROP_COMMAND);
+        }
+        assertTrue(exitCode != 0);
+    }
+
+    /**
+     * Tests that commands preceding a failed command are't affected by the failure.
+     * @throws Exception
+     */
+    @Test
+    public void testValidCommandBeforeInvalidCommand() throws Exception {
+        int exitCode = execute(SET_PROP_COMMAND + ",bad-wrong-illegal", false);
+        assertSuccess(GET_PROP_COMMAND);
+        execute(REMOVE_PROP_COMMAND, true);
+        assertTrue(exitCode != 0);
+    }
+
+    protected void assertSuccess(String cmd) throws Exception {
+        assertEquals(0, execute(cmd, true));
+    }
+
+    protected void assertFailure(String cmd) throws Exception {
+        assertTrue(execute(cmd, false) != 0);
+    }
+
+    protected int execute(String cmd, boolean logFailure) throws IOException, InterruptedException {
+        final String jbossDist = System.getProperty("jboss.dist");
+        if(jbossDist == null) {
+            fail("jboss.dist system property is not set");
+        }
+        final String modulePath = System.getProperty("module.path");
+        if(modulePath == null) {
+            fail("module.path system property is not set");
+        }
+
+        final ProcessBuilder builder = new ProcessBuilder();
+        builder.command("java" , "-jar" , jbossDist + File.separatorChar + "jboss-modules.jar", "-mp", modulePath, "org.jboss.as.cli", "-c", cmd);
+        final Process cliProc = builder.start();
+        int exitCode = cliProc.waitFor();
+        if (logFailure && exitCode != 0) {
+            System.out.println("Failed to execute '" + cmd + "'");
+            int bytesTotal = cliProc.getInputStream().available();
+            if (bytesTotal > 0) {
+                final byte[] bytes = new byte[bytesTotal];
+                cliProc.getInputStream().read(bytes);
+                System.out.println("Command's output: '"+ new String(bytes) + "'");
+            }
+
+            bytesTotal = cliProc.getErrorStream().available();
+            if (bytesTotal > 0) {
+                final byte[] bytes = new byte[bytesTotal];
+                cliProc.getErrorStream().read(bytes);
+                System.out.println("Command's error log: '" + new String(bytes) + "'");
+            } else {
+                System.out.println("No output data for the command.");
+            }
+        }
+        return exitCode;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,6 +52,13 @@ public class FileArgumentTestCase {
     private static final File TMP_FILE;
     static {
         TMP_FILE = new File(new File(System.getProperty("java.io.tmpdir")), FILE_NAME);
+    }
+
+    @AfterClass
+    public void cleanUp() {
+        if(TMP_FILE.exists()) {
+            TMP_FILE.delete();
+        }
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
@@ -55,7 +55,7 @@ public class FileArgumentTestCase {
     }
 
     @AfterClass
-    public void cleanUp() {
+    public static void cleanUp() {
         if(TMP_FILE.exists()) {
             TMP_FILE.delete();
         }


### PR DESCRIPTION
This includes fixes and tests for --commands and --file jboss-cli.[sh|bat] arguments.

AS7-3849 Operation with outcome 'failure' don't set the exit code to indicate failure
AS7-3814 CommandContext.buildRequest(line) throws OperationFormatException

Thanks,
Alexey
