### PR TITLE
Fix for AS7-3830

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
@@ -101,14 +101,14 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
         // to resetting the selector. The TCCLEJBClientContextSelector is backed by a TCCLEJBClientContextSelectorService
         // which is what we set here during the service start, so that the selector has the correct service to return the
         // EJBClientContext. @see https://issues.jboss.org/browse/AS7-2998 for details
-        TCCLEJBClientContextSelector.INSTANCE.setTCCLEJBClientContextService(this.tcclEJBClientContextSelector.getValue());
+        TCCLEJBClientContextSelector.INSTANCE.setup(this.tcclEJBClientContextSelector.getValue(), this.context);
 
     }
 
     @Override
     public synchronized void stop(final StopContext context) {
         this.context = null;
-        TCCLEJBClientContextSelector.INSTANCE.setTCCLEJBClientContextService(null);
+        TCCLEJBClientContextSelector.INSTANCE.destroy();
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
@@ -199,7 +199,7 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
         }
         final StatefulSessionComponent statefulComponent = (StatefulSessionComponent) component;
         final SessionID sessionID = statefulComponent.createSession();
-        return new StatefulEJBLocator<T>(viewType, appName, moduleName, beanName, distinctName, sessionID, statefulComponent.getCache().getStrictAffinity());
+        return new StatefulEJBLocator<T>(viewType, appName, moduleName, beanName, distinctName, sessionID, statefulComponent.getCache().getStrictAffinity(), this.getNodeName());
     }
 
     private Object clone(final Class<?> target, final ObjectCloner cloner, final Object object, final boolean allowPassByReference) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/Singleton.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/Singleton.java
@@ -22,13 +22,13 @@
 
 package org.jboss.as.test.integration.naming.remote.ejb;
 
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
 
 /**
- * @author John Bailey, Ondrej Chaloupka
+ * @author John Bailey
  */
-@Singleton
-public class Bean implements Remote {
+@Stateless
+public class Singleton implements Remote {
     public String echo(String value) {
         return "Echo: " + value;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/StatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/StatefulBean.java
@@ -22,13 +22,13 @@
 
 package org.jboss.as.test.integration.naming.remote.ejb;
 
-import javax.ejb.Singleton;
+import javax.ejb.Stateful;
 
 /**
  * @author John Bailey, Ondrej Chaloupka
  */
-@Singleton
-public class Bean implements Remote {
+@Stateful
+public class StatefulBean implements Remote {
     public String echo(String value) {
         return "Echo: " + value;
     }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-3830 where a stateful EJB lookup using the newly remote-naming InitialContextFactory would result in no EJB client context being available to handle the stateful session creation. More details about the issue and the fix are available in the JIRA comments.
