### PR TITLE
Added 'full' supplement to EJB subsystem for standalone-xts.xml

### DIFF
--- a/build/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/build/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -8,7 +8,7 @@
       <subsystem>configuration/subsystems/datasources.xml</subsystem>
       <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
       <subsystem>configuration/subsystems/ee.xml</subsystem>
-      <subsystem>configuration/subsystems/ejb3.xml</subsystem>
+      <subsystem supplement="full">configuration/subsystems/ejb3.xml</subsystem>
       <subsystem>configuration/subsystems/infinispan.xml</subsystem>
       <subsystem>configuration/subsystems/jacorb.xml</subsystem>
       <subsystem>configuration/subsystems/jaxr.xml</subsystem>


### PR DESCRIPTION
This is because standalone-xts.xml is based on standalone-full.xml with one additional subsytem. 
