### PR TITLE
Allow the appclient to specify an ejb-client.properties on launch

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientDependencyProcessor.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientDependencyProcessor.java
@@ -50,6 +50,7 @@ import org.jboss.modules.ModuleLoader;
 public class ApplicationClientDependencyProcessor implements DeploymentUnitProcessor {
 
     public static ModuleIdentifier CORBA_ID = ModuleIdentifier.create("org.omg.api");
+    public static ModuleIdentifier XNIO = ModuleIdentifier.create("org.jboss.xnio");
 
 
     public ApplicationClientDependencyProcessor() {
@@ -64,6 +65,7 @@ public class ApplicationClientDependencyProcessor implements DeploymentUnitProce
         final ModuleLoader loader = deploymentUnit.getAttachment(Attachments.SERVICE_MODULE_LOADER);
 
         moduleSpecification.addSystemDependency(new ModuleDependency(loader, CORBA_ID, false, true, true, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(loader, XNIO, false, true, true, false));
 
         final Set<ModuleIdentifier> moduleIdentifiers = new HashSet<ModuleIdentifier>();
         final DeploymentUnit top = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();

--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientStartProcessor.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientStartProcessor.java
@@ -21,8 +21,13 @@
  */
 package org.jboss.as.appclient.deployment;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.List;
+import java.util.Properties;
 
 import javax.security.auth.callback.CallbackHandler;
 
@@ -43,6 +48,8 @@ import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentClassIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
 import org.jboss.metadata.appclient.spec.ApplicationClientMetaData;
 import org.jboss.modules.Module;
 
@@ -57,10 +64,12 @@ public class ApplicationClientStartProcessor implements DeploymentUnitProcessor 
 
     private final String[] parameters;
     private final String hostUrl;
+    private final String connectionPropertiesUrl;
 
-    public ApplicationClientStartProcessor(final String hostUrl, final String[] parameters) {
+    public ApplicationClientStartProcessor(final String hostUrl, final String connectionPropertiesUrl, final String[] parameters) {
         this.hostUrl = hostUrl;
         this.parameters = parameters;
+        this.connectionPropertiesUrl = connectionPropertiesUrl;
     }
 
     @Override
@@ -71,6 +80,20 @@ public class ApplicationClientStartProcessor implements DeploymentUnitProcessor 
         final DeploymentReflectionIndex deploymentReflectionIndex = deploymentUnit.getAttachment(Attachments.REFLECTION_INDEX);
         final DeploymentClassIndex classIndex = deploymentUnit.getAttachment(Attachments.CLASS_INDEX);
 
+        //setup the callback handler
+        final CallbackHandler callbackHandler;
+        if (appClientData != null && appClientData.getCallbackHandler() != null && !appClientData.getCallbackHandler().isEmpty()) {
+            try {
+                final Class<?> callbackClass = classIndex.classIndex(appClientData.getCallbackHandler()).getModuleClass();
+                callbackHandler = new RealmCallbackWrapper((CallbackHandler) callbackClass.newInstance());
+            } catch (ClassNotFoundException e) {
+                throw AppClientMessages.MESSAGES.couldNotLoadCallbackClass(appClientData.getCallbackHandler());
+            } catch (Exception e) {
+                throw AppClientMessages.MESSAGES.couldNotCreateCallbackHandler(appClientData.getCallbackHandler());
+            }
+        } else {
+            callbackHandler = new DefaultApplicationClientCallbackHandler();
+        }
 
         final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
         Boolean activate = deploymentUnit.getAttachment(AppClientAttachments.START_APP_CLIENT);
@@ -88,25 +111,64 @@ public class ApplicationClientStartProcessor implements DeploymentUnitProcessor 
         if (method == null) {
             throw MESSAGES.cannotStartAppClient(deploymentUnit.getName(), mainClass);
         }
+        final ApplicationClientStartService startService;
 
-        //setup the callback handler
-        final CallbackHandler callbackHandler;
-        if (appClientData != null && appClientData.getCallbackHandler() != null && !appClientData.getCallbackHandler().isEmpty()) {
-            try {
-                final Class<?> callbackClass = classIndex.classIndex(appClientData.getCallbackHandler()).getModuleClass();
-                callbackHandler = new RealmCallbackWrapper((CallbackHandler) callbackClass.newInstance());
-            } catch (ClassNotFoundException e) {
-                throw AppClientMessages.MESSAGES.couldNotLoadCallbackClass(appClientData.getCallbackHandler());
-            } catch (Exception e) {
-                throw AppClientMessages.MESSAGES.couldNotCreateCallbackHandler(appClientData.getCallbackHandler());
-            }
-        } else {
-            callbackHandler = new DefaultApplicationClientCallbackHandler();
-        }
 
         final List<SetupAction> setupActions = deploymentUnit.getAttachmentList(org.jboss.as.ee.component.Attachments.OTHER_EE_SETUP_ACTIONS);
 
-        final ApplicationClientStartService startService = new ApplicationClientStartService(method, parameters, hostUrl, moduleDescription.getNamespaceContextSelector(), module.getClassLoader(), callbackHandler, setupActions);
+        if (connectionPropertiesUrl != null) {
+            EJBClientConfiguration configuration;
+            try {
+                final File file = new File(connectionPropertiesUrl);
+                final URL url;
+                if (file.exists()) {
+                    url = file.toURI().toURL();
+                } else {
+                    url = new URL(connectionPropertiesUrl);
+                }
+                Properties properties = new Properties();
+                InputStream stream = null;
+                try {
+                    stream = url.openStream();
+                    properties.load(stream);
+                } finally {
+                    if (stream != null) {
+                        try {
+                            stream.close();
+                        } catch (IOException e) {
+                            //ignore
+                        }
+                    }
+                }
+                final ClassLoader oldTccl = SecurityActions.getContextClassLoader();
+                try {
+                    SecurityActions.setContextClassLoader(module.getClassLoader());
+                    configuration = new PropertiesBasedEJBClientConfiguration(properties);
+
+                    //if there is no username or callback handler specified in the ejb-client properties file
+                    //we override the default
+                    if (!properties.contains("username") && !properties.contains("callback.handler.class")) {
+                        //no security config so we wrap the configuration
+                        configuration = new ForwardingEjbClientConfiguration(configuration) {
+                            @Override
+                            public CallbackHandler getCallbackHandler() {
+                                return callbackHandler;
+                            }
+                        };
+                    }
+
+                    startService = new ApplicationClientStartService(method, parameters, moduleDescription.getNamespaceContextSelector(), module.getClassLoader(), setupActions, configuration);
+                } finally {
+                    SecurityActions.setContextClassLoader(oldTccl);
+                }
+            } catch (Exception e) {
+                throw AppClientMessages.MESSAGES.exceptionLoadingEjbClientPropertiesURL(connectionPropertiesUrl, e);
+            }
+        } else {
+
+            startService = new ApplicationClientStartService(method, parameters, moduleDescription.getNamespaceContextSelector(), module.getClassLoader(), setupActions, hostUrl, callbackHandler);
+        }
+
         phaseContext.getServiceTarget()
                 .addService(deploymentUnit.getServiceName().append(ApplicationClientStartService.SERVICE_NAME), startService)
                 .addDependency(ApplicationClientDeploymentService.SERVICE_NAME, ApplicationClientDeploymentService.class, startService.getApplicationClientDeploymentServiceInjectedValue())

--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ForwardingEjbClientConfiguration.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ForwardingEjbClientConfiguration.java
@@ -1,0 +1,55 @@
+package org.jboss.as.appclient.deployment;
+
+import java.util.Iterator;
+
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.xnio.OptionMap;
+
+/**
+ * @author Stuart Douglas
+ */
+public abstract class ForwardingEjbClientConfiguration implements EJBClientConfiguration {
+
+    private final EJBClientConfiguration delegate;
+
+    protected ForwardingEjbClientConfiguration(final EJBClientConfiguration delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getEndpointName() {
+        return delegate.getEndpointName();
+    }
+
+    @Override
+    public OptionMap getEndpointCreationOptions() {
+        return delegate.getEndpointCreationOptions();
+    }
+
+    @Override
+    public OptionMap getRemoteConnectionProviderCreationOptions() {
+        return delegate.getRemoteConnectionProviderCreationOptions();
+    }
+
+    @Override
+    public CallbackHandler getCallbackHandler() {
+        return delegate.getCallbackHandler() ;
+    }
+
+    @Override
+    public Iterator<RemotingConnectionConfiguration> getConnectionConfigurations() {
+        return delegate.getConnectionConfigurations();
+    }
+
+    @Override
+    public Iterator<ClusterConfiguration> getClusterConfigurations() {
+        return delegate.getClusterConfigurations();
+    }
+
+    @Override
+    public ClusterConfiguration getClusterConfiguration(final String clusterName) {
+        return delegate.getClusterConfiguration(clusterName);
+    }
+}

--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/SecurityActions.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/SecurityActions.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.appclient.deployment;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+final class SecurityActions {
+
+    private SecurityActions() {
+        // forbidden inheritance
+    }
+
+    /**
+     * Gets context classloader.
+     *
+     * @return the current context classloader
+     */
+    static ClassLoader getContextClassLoader() {
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                public ClassLoader run() {
+                    return Thread.currentThread().getContextClassLoader();
+                }
+            });
+        }
+    }
+
+    /**
+     * Sets context classloader.
+     *
+     * @param classLoader
+     *            the classloader
+     */
+    static void setContextClassLoader(final ClassLoader classLoader) {
+        if (System.getSecurityManager() == null) {
+            Thread.currentThread().setContextClassLoader(classLoader);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                public Object run() {
+                    Thread.currentThread().setContextClassLoader(classLoader);
+                    return null;
+                }
+            });
+        }
+    }
+
+}

--- a/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientMessages.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientMessages.java
@@ -71,6 +71,15 @@ public interface AppClientMessages {
     String argHost();
 
     /**
+     * Instructions for the {@link org.jboss.as.appclient.subsystem.CommandLineArgument#CONNECTION_PROPERTIES} command line
+     * arguments.
+     *
+     * @return the instructions.
+     */
+    @Message(id = Message.NONE, value = "Load ejb-client.properties file from the given url")
+    String connectionProperties();
+
+    /**
      * Instructions for the {@link org.jboss.as.appclient.subsystem.CommandLineArgument#PROPERTIES} command line
      * arguments.
      *
@@ -301,5 +310,15 @@ public interface AppClientMessages {
      */
     @Message(id = 13239, value = "Could find application client %s")
     RuntimeException cannotFindAppClientFile(File deploymentName);
+
+    @Message(id = 13240, value = "Cannot specify both a host to connect to and an ejb-client.properties file. ")
+    RuntimeException cannotSpecifyBothHostAndPropertiesFile();
+
+    /**
+     * The ejb-client.properties could not be loaded
+     */
+    @Message(id = 13241, value = "Unable to load ejb-client.properties URL: %s ")
+    DeploymentUnitProcessingException exceptionLoadingEjbClientPropertiesURL(final String file, @Cause Throwable cause);
+
 }
 

--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/AppClientServerConfiguration.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/AppClientServerConfiguration.java
@@ -43,18 +43,18 @@ class AppClientServerConfiguration {
     private AppClientServerConfiguration() {
     }
 
-    public static List<ModelNode> serverConfiguration(final String filePath, final String deploymentName, final String hostUrl, final List<String> parameters, List<ModelNode> xmlNodes) {
+    public static List<ModelNode> serverConfiguration(final String filePath, final String deploymentName, final String hostUrl, final String propertiesFileUrl, final List<String> parameters, List<ModelNode> xmlNodes) {
         List<ModelNode> ret = new ArrayList<ModelNode>();
 
         for (final ModelNode node : xmlNodes) {
             ret.add(node);
         }
-        appclient(ret, filePath, deploymentName, hostUrl, parameters);
+        appclient(ret, filePath, deploymentName, hostUrl, propertiesFileUrl, parameters);
 
         return ret;
     }
 
-    private static void appclient(List<ModelNode> nodes, final String filePath, final String deploymentName, final String hostUrl, final List<String> parameters) {
+    private static void appclient(List<ModelNode> nodes, final String filePath, final String deploymentName, final String hostUrl, final String propertiesFileUrl, final List<String> parameters) {
         loadExtension(nodes, "org.jboss.as.appclient");
         ModelNode add = new ModelNode();
         add.get(OP_ADDR).set(new ModelNode().setEmptyList()).add(SUBSYSTEM, APPCLIENT);
@@ -70,7 +70,12 @@ class AppClientServerConfiguration {
                 add.get(Constants.PARAMETERS).add(param);
             }
         }
-        add.get(Constants.HOST_URL).set(hostUrl);
+        if(hostUrl != null) {
+            add.get(Constants.HOST_URL).set(hostUrl);
+        }
+        if(propertiesFileUrl != null) {
+            add.get(Constants.CONNECTION_PROPERTIES_URL).set(propertiesFileUrl);
+        }
         nodes.add(add);
     }
 

--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/ApplicationClientConfigurationPersister.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/ApplicationClientConfigurationPersister.java
@@ -65,12 +65,18 @@ public class ApplicationClientConfigurationPersister extends XmlConfigurationPer
      */
     private final String hostUrl;
 
-    public ApplicationClientConfigurationPersister(final String filePath, final String deploymentName, final String hostUrl, final List<String> parameters, final File configFile, final QName element, final XMLElementReader<List<ModelNode>> xmlParser) {
+    /**
+     * This URL of an ejb-client.properties file
+     */
+    private final String propertiesFileURL;
+
+    public ApplicationClientConfigurationPersister(final String filePath, final String deploymentName, final String hostUrl, final String propertiesFileUrl, final List<String> parameters, final File configFile, final QName element, final XMLElementReader<List<ModelNode>> xmlParser) {
         super(configFile, element, xmlParser, null);
         this.filePath = filePath;
         this.deploymentName = deploymentName;
         this.hostUrl = hostUrl;
         this.parameters = parameters;
+        this.propertiesFileURL = propertiesFileUrl;
     }
 
 
@@ -97,7 +103,7 @@ public class ApplicationClientConfigurationPersister extends XmlConfigurationPer
     @Override
     public List<ModelNode> load() throws ConfigurationPersistenceException {
         List<ModelNode> nodes = super.load();
-        return AppClientServerConfiguration.serverConfiguration(filePath, deploymentName, hostUrl, parameters, nodes);
+        return AppClientServerConfiguration.serverConfiguration(filePath, deploymentName, hostUrl, propertiesFileURL, parameters, nodes);
     }
 
     @Override

--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/CommandLineArgument.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/CommandLineArgument.java
@@ -22,9 +22,9 @@
 
 package org.jboss.as.appclient.subsystem;
 
-import org.jboss.as.process.CommandLineConstants;
-
 import java.io.PrintStream;
+
+import org.jboss.as.process.CommandLineConstants;
 
 import static org.jboss.as.appclient.logging.AppClientMessages.MESSAGES;
 
@@ -60,6 +60,12 @@ enum CommandLineArgument {
         @Override
         public String instructions() {
             return MESSAGES.argProperties();
+        }
+    },
+    CONNECTION_PROPERTIES(CommandLineConstants.CONNECTION_PROPERTIES, "=<url>") {
+        @Override
+        public String instructions() {
+            return MESSAGES.connectionProperties();
         }
     },
 

--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/Constants.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/Constants.java
@@ -29,6 +29,7 @@ class Constants {
     public static final String SUBSYSTEM_NAME = "appclient";
 
     public static final String HOST_URL ="host-url";
+    public static final String CONNECTION_PROPERTIES_URL ="connection-properties-url";
 
     public static final String FILE = "file";
     public static final String DEPLOYMENT = "deployment";

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -98,15 +98,17 @@ public class CommandLineConstants {
 
     public static final String DEFAULT_MULTICAST_ADDRESS = "-u";
 
-    /** Additional class path items, used only by app client*/
-    public static final String APPCLIENT_CONFIG = "--appclient-config";
-    public static final String SHORT_HOST = "-H";
-    public static final String HOST = "--host";
-
     public static final String ADMIN_ONLY = "--admin-only";
 
     public static final String MASTER_ADDRESS = "--master-address";
     public static final String MASTER_PORT = "--master-port";
+
+    /** Additional class path items, used only by app client*/
+    public static final String APPCLIENT_CONFIG = "--appclient-config";
+    public static final String SHORT_HOST = "-H";
+    public static final String HOST = "--host";
+    public static final String CONNECTION_PROPERTIES = "--ejb-client-properties";
+
 
     private CommandLineConstants() {
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/util/AppClientWrapper.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/util/AppClientWrapper.java
@@ -55,6 +55,7 @@ public class AppClientWrapper implements Runnable {
     private Thread shutdownThread;
     private final Archive<?> archive;
     private final String clientArchiveName;
+    private final String appClientArgs;
     private File archiveOnDisk;
     private final String args;
 
@@ -68,10 +69,11 @@ public class AppClientWrapper implements Runnable {
      * @param args
      * @throws Exception
      */
-    public AppClientWrapper(final Archive<?> archive, final String clientArchiveName, final String args) throws Exception {
+    public AppClientWrapper(final Archive<?> archive,final String appClientArgs, final String clientArchiveName, final String args) throws Exception {
         this.archive = archive;
         this.clientArchiveName = clientArchiveName;
         this.args = args;
+        this.appClientArgs = appClientArgs;
         init();
     }
 
@@ -168,13 +170,13 @@ public class AppClientWrapper implements Runnable {
         }
         final ZipExporter exporter = archive.as(ZipExporter.class);
         exporter.exportTo(archiveOnDisk);
-        final String appClientArg;
+        final String archiveArg;
         if(clientArchiveName == null) {
-            appClientArg = archiveOnDisk.getAbsolutePath();
+            archiveArg = archiveOnDisk.getAbsolutePath();
         } else {
-            appClientArg = archiveOnDisk.getAbsolutePath() + "#" + clientArchiveName;
+            archiveArg = archiveOnDisk.getAbsolutePath() + "#" + clientArchiveName;
         }
-        
+
         // TODO: Move to a self-test.
         System.out.println("*** System properties: ***");
         Properties props = System.getProperties();
@@ -184,8 +186,8 @@ public class AppClientWrapper implements Runnable {
             String name = (String) en.nextElement();
             System.out.println( "\t" + name + " = " + System.getProperty(name) );
         }
-        
-        
+
+
         // TODO: Move to a shared testsuite lib.
         String asDist = System.getProperty("jboss.dist");
         if( asDist == null ) throw new Exception("'jboss.dist' property is not set.");
@@ -203,8 +205,8 @@ public class AppClientWrapper implements Runnable {
                 " -mp "+ asDist + "/modules" +
                 " org.jboss.as.appclient" +
                 " -Djboss.server.base.dir="+ asInst + "/appclient" +
-                " -Djboss.home.dir="+ asInst + 
-                " " +appClientArg + " " + args;
+                " -Djboss.home.dir="+ asInst +
+                " " + this.appClientArgs + " " + archiveArg + " " + args;
         return appClientCommand;
     }
 


### PR DESCRIPTION
This allows it to use clustering, and also to specify all connection settings
