### PR TITLE
Add -DdebugClient to run Surefire with JPDA;  allow custom debugging port; rename debug Maven props not to be misleading.

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -66,7 +66,7 @@
                     <!-- parallel>none</parallel -->
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
-                        <jboss.options>${surefire.system.args}</jboss.options>
+                        <jboss.options>${jvm.args.as}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.home>${jboss.home}</jboss.home>
                         <module.path>${jboss.home}/modules</module.path>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -221,7 +221,7 @@
                     <!-- Forked process timeout -->
                     <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
-                    <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
+                    <argLine>${jvm.args.debug.surefire} ${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
 
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
@@ -239,7 +239,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${jvm.args.as} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/messaging/MessagingClientTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/messaging/MessagingClientTestCase.java
@@ -73,7 +73,7 @@ public class MessagingClientTestCase {
 
         // Check that the queue does not exists
         if (queueExists(queueName, sf)) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("Queue already exists: " + queueName);
         }
 
         // Create a new core queue using the standalone client
@@ -86,7 +86,7 @@ public class MessagingClientTestCase {
         applyUpdate(op, client);
         // Check if the queue exists
         if (!queueExists(queueName, sf)) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("Queue doesn't exist: " + queueName);
         }
 
         ClientSession session = null;

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -134,11 +134,18 @@
         <ds.jdbc.pass>test</ds.jdbc.pass>
         <ds.jdbc.driver.jar>${ds.db}-jdbc-driver.jar</ds.jdbc.driver.jar>
 
-        <!-- Common surefire properties. -->
-        <surefire.memory.args>-Xmx512m -XX:MaxPermSize=256m</surefire.memory.args>
-        <surefire.jpda.args></surefire.jpda.args>
-        <as.debug.port>8787</as.debug.port>
-        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
+        <!-- Debugging properties. -->
+        <debug.port.as>8787</debug.port.as>
+        <debug.port.surefire>5050</debug.port.surefire>
+        <debug.port.cli>5051</debug.port.cli>
+        <jvm.args.debug.as></jvm.args.debug.as>
+        <jvm.args.debug.surefire></jvm.args.debug.surefire>
+        
+        <!-- Common Surefire properties. -->
+
+        <jvm.args.mem.as>-Xmx512m -XX:MaxPermSize=256m</jvm.args.mem.as> <!-- Only used here; defined to allow overriding. -->
+        <!-- Goes to Surefire's config <systemArgs>. -->
+        <jvm.args.as>${jvm.args.mem.as} ${jvm.args.debug.as} -Djboss.dist=${jboss.dist}</jvm.args.as>
         <surefire.forked.process.timeout>900</surefire.forked.process.timeout>
 
         <!-- Arquillian dependency versions -->
@@ -393,7 +400,7 @@
                     <failIfNoTests>false</failIfNoTests>
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
-                        <jboss.options>${surefire.system.args}</jboss.options>
+                        <jboss.options>${jvm.args.as}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.dist>${jboss.dist}</jboss.dist>
                         <jboss.home>${basedir}/target/jbossas</jboss.home>
@@ -591,14 +598,21 @@
             <id>jpda.profile</id>
             <activation><property><name>jpda</name></property></activation>
             <properties>
-                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=${as.debug.port},server=y,suspend=y</surefire.jpda.args>
+                <jvm.args.debug.as  >-Xrunjdwp:transport=dt_socket,address=${debug.port.as},server=y,suspend=y</jvm.args.debug.as>
             </properties>
         </profile>
         <profile>
             <id>debug.profile</id>
             <activation><property><name>debug</name></property></activation>
             <properties>
-                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=${as.debug.port},server=y,suspend=y</surefire.jpda.args>
+                <jvm.args.debug.as  >-Xrunjdwp:transport=dt_socket,address=${debug.port.as},server=y,suspend=y</jvm.args.debug.as>
+            </properties>
+        </profile>
+        <profile>
+            <id>debugClient.profile</id>
+            <activation><property><name>debugClient</name></property></activation>
+            <properties>
+                <jvm.args.debug.surefire>-Xrunjdwp:transport=dt_socket,address=${debug.port.surefire},server=y,suspend=y</jvm.args.debug.surefire>
             </properties>
         </profile>
 


### PR DESCRIPTION
Currently, the debugging was limited to AS instances.
This branch allows launching also Surefire with JPDA args.

Also, the props names were misleading - e.g. surefire.jpda.args actually had nothing to do with surefire, it was passed to <jboss.options> .

This shouldn't break anyone's debugging use cases since -Djpda still makes AS run in debugging mode, and -Dsurefire.jpda.args seems to be only used internally.

See details and examples in section "Running with a debugger" at 
https://docs.jboss.org/author/display/AS71/AS+7+Integration+Testsuite+User+Guide
