### PR TITLE
[AS7-1751] Decouple channel name from cache container name; allow expressions in certain attribtes

### DIFF
--- a/build/src/main/resources/configuration/retired-delete-once-stable/domain.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/domain.xml
@@ -136,7 +136,7 @@
                 </thread-pools>
                 <iiop enable-by-default="false" use-qualified-name="false"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="hibernate">
+            <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
                 <cache-container name="hibernate" default-cache="local-query">
                     <local-cache name="entity">
                         <transaction mode="NON_XA"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-hornetq-colocated.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-hornetq-colocated.xml
@@ -149,7 +149,7 @@
             </thread-pools>
             <iiop enable-by-default="false" use-qualified-name="false"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="hibernate">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
             <cache-container name="hibernate" default-cache="local-query">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-jts.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-jts.xml
@@ -151,7 +151,7 @@
                 </thread-pool>
             </thread-pools>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="hibernate">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
             <cache-container name="hibernate" default-cache="local-query">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-xts.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-xts.xml
@@ -157,7 +157,7 @@
             </thread-pools>
             <iiop enable-by-default="true" use-qualified-name="true"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="hibernate">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
             <cache-container name="hibernate" default-cache="local-query">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full-ha.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full-ha.xml
@@ -160,7 +160,7 @@
             </thread-pools>
             <iiop enable-by-default="false" use-qualified-name="false"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="cluster">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="cluster">
             <cache-container name="cluster" aliases="ha-partition" default-cache="default">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="default" mode="SYNC" batching="true">

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full.xml
@@ -156,7 +156,7 @@
             </thread-pools>
             <iiop enable-by-default="false" use-qualified-name="false"/>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="hibernate">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
             <cache-container name="hibernate" default-cache="local-query">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone-ha.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone-ha.xml
@@ -153,7 +153,7 @@
                 </thread-pool>
             </thread-pools>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="cluster">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="cluster">
             <cache-container name="cluster" aliases="ha-partition" default-cache="default">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="default" mode="SYNC" batching="true">

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone.xml
@@ -149,7 +149,7 @@
                 </thread-pool>
             </thread-pools>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="hibernate">
+        <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="hibernate">
             <cache-container name="hibernate" default-cache="local-query">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>

--- a/build/src/main/resources/configuration/subsystems/infinispan.xml
+++ b/build/src/main/resources/configuration/subsystems/infinispan.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.clustering.infinispan</extension-module>
-   <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="@@default-cache-container@@">
+   <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="@@default-cache-container@@">
        <?CACHE-CONTAINERS?>
    </subsystem>
    <supplement name="default">

--- a/build/src/main/resources/docs/schema/jboss-as-infinispan_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-infinispan_1_1.xsd
@@ -160,6 +160,11 @@
                 <xs:documentation>Defines the jgroups stack used by the transport.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="cluster" type="xs:string" >
+            <xs:annotation>
+                <xs:documentation>Defines the name for the underlying group communication cluster.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="executor" type="xs:string" >
             <xs:annotation>
                 <xs:documentation>Defines the executor used for asynchronous transport communication.</xs:documentation>

--- a/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
@@ -160,6 +160,11 @@
                 <xs:documentation>Defines the jgroups stack used by the transport.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="cluster" type="xs:string" >
+            <xs:annotation>
+                <xs:documentation>Defines the name for the underlying group communication cluster.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="executor" type="xs:string" >
             <xs:annotation>
                 <xs:documentation>Defines the executor used for asynchronous transport communication.</xs:documentation>

--- a/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
@@ -21,12 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<xs:schema targetNamespace="urn:jboss:domain:infinispan:1.1"
+<xs:schema targetNamespace="urn:jboss:domain:infinispan:1.2"
             xmlns:xs="http://www.w3.org/2001/XMLSchema"
-            xmlns:tns="urn:jboss:domain:infinispan:1.1"
+            xmlns:tns="urn:jboss:domain:infinispan:1.2"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
-            version="1.1">
+            version="1.2">
 
     <xs:element name="subsystem" type="tns:subsystem">
         <xs:annotation>

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
@@ -22,10 +22,9 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import javax.xml.XMLConstants;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.xml.XMLConstants;
 
 import org.jboss.as.controller.AttributeDefinition;
 
@@ -44,6 +43,7 @@ public enum Attribute {
     CACHE(ModelKeys.CACHE),
     CHUNK_SIZE(ModelKeys.CHUNK_SIZE),
     CLASS(ModelKeys.CLASS),
+    CLUSTER(ModelKeys.CLUSTER),
     CONCURRENCY_LEVEL(ModelKeys.CONCURRENCY_LEVEL),
     DATASOURCE(ModelKeys.DATASOURCE),
     DEFAULT_CACHE(ModelKeys.DEFAULT_CACHE),

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -76,7 +76,7 @@ public interface CommonAttributes {
     SimpleAttributeDefinition CLUSTER =
             new SimpleAttributeDefinitionBuilder(ModelKeys.CLUSTER, ModelType.STRING, true)
                     .setXmlName(Attribute.CLUSTER.getLocalName())
-                    .setAllowExpression(false)
+                    .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     SimpleAttributeDefinition CONCURRENCY_LEVEL =
@@ -96,13 +96,13 @@ public interface CommonAttributes {
     SimpleAttributeDefinition DEFAULT_CACHE =
             new SimpleAttributeDefinitionBuilder(ModelKeys.DEFAULT_CACHE, ModelType.STRING, true)
                     .setXmlName(Attribute.DEFAULT_CACHE.getLocalName())
-                    .setAllowExpression(false)
+                    .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     SimpleAttributeDefinition DEFAULT_CACHE_CONTAINER =
             new SimpleAttributeDefinitionBuilder(ModelKeys.DEFAULT_CACHE_CONTAINER, ModelType.STRING, false)
                     .setXmlName(Attribute.DEFAULT_CACHE_CONTAINER.getLocalName())
-                    .setAllowExpression(false)
+                    .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     // this was removed?

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -73,6 +73,12 @@ public interface CommonAttributes {
                     .setAllowExpression(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
+    SimpleAttributeDefinition CLUSTER =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.CLUSTER, ModelType.STRING, true)
+                    .setXmlName(Attribute.CLUSTER.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .build();
     SimpleAttributeDefinition CONCURRENCY_LEVEL =
             new SimpleAttributeDefinitionBuilder(ModelKeys.CONCURRENCY_LEVEL, ModelType.INT, true)
                     .setXmlName(Attribute.CONCURRENCY_LEVEL.getLocalName())
@@ -438,7 +444,7 @@ public interface CommonAttributes {
                     .build();
 
     AttributeDefinition[] CACHE_CONTAINER_ATTRIBUTES = {DEFAULT_CACHE, ALIASES, JNDI_NAME, START, LISTENER_EXECUTOR, EVICTION_EXECUTOR, REPLICATION_QUEUE_EXECUTOR};
-    AttributeDefinition[] TRANSPORT_ATTRIBUTES = {STACK, EXECUTOR, LOCK_TIMEOUT, SITE, RACK, MACHINE};
+    AttributeDefinition[] TRANSPORT_ATTRIBUTES = {STACK, CLUSTER, EXECUTOR, LOCK_TIMEOUT, SITE, RACK, MACHINE};
 
     AttributeDefinition[] CACHE_ATTRIBUTES = { START, BATCHING, INDEXING, JNDI_NAME};
     AttributeDefinition[] CLUSTERED_CACHE_ATTRIBUTES = {ClusteredCacheAdd.MODE, QUEUE_SIZE, QUEUE_FLUSH_INTERVAL, REMOTE_TIMEOUT};

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -361,8 +361,9 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(60000))
                     .build();
+    // if stack is null, use default stack
     SimpleAttributeDefinition STACK =
-            new SimpleAttributeDefinitionBuilder(ModelKeys.STACK, ModelType.STRING, false)
+            new SimpleAttributeDefinitionBuilder(ModelKeys.STACK, ModelType.STRING, true)
                     .setXmlName(Attribute.STACK.getLocalName())
                     .setAllowExpression(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
@@ -17,7 +19,7 @@ public class DistributedCacheAdd extends SharedStateCacheAdd {
     static final DistributedCacheAdd INSTANCE = new DistributedCacheAdd();
 
     // used to create subsystem description
-    static ModelNode createOperation(ModelNode address, ModelNode model) {
+    static ModelNode createOperation(ModelNode address, ModelNode model) throws OperationFailedException {
         ModelNode operation = Util.getEmptyOperation(ADD, address);
         INSTANCE.populateMode(model, operation);
         INSTANCE.populate(model, operation);
@@ -29,47 +31,41 @@ public class DistributedCacheAdd extends SharedStateCacheAdd {
     }
 
     @Override
-    void populate(ModelNode fromModel, ModelNode toModel) {
+    void populate(ModelNode fromModel, ModelNode toModel) throws OperationFailedException {
         super.populate(fromModel, toModel);
 
-        if (fromModel.hasDefined(ModelKeys.OWNERS)) {
-            toModel.get(ModelKeys.OWNERS).set(fromModel.get(ModelKeys.OWNERS));
-        }
-        if (fromModel.hasDefined(ModelKeys.VIRTUAL_NODES)) {
-            toModel.get(ModelKeys.VIRTUAL_NODES).set(fromModel.get(ModelKeys.VIRTUAL_NODES));
-        }
-        if (fromModel.hasDefined(ModelKeys.L1_LIFESPAN)) {
-            toModel.get(ModelKeys.L1_LIFESPAN).set(fromModel.get(ModelKeys.L1_LIFESPAN));
-        }
+        CommonAttributes.OWNERS.validateAndSet(fromModel, toModel);
+        CommonAttributes.VIRTUAL_NODES.validateAndSet(fromModel, toModel);
+        CommonAttributes.L1_LIFESPAN.validateAndSet(fromModel, toModel);
     }
 
     /**
      * Implementation of abstract method processModelNode suitable for distributed cache
      *
-     * @param cache
+     * @param context
+     * @param containerName
      * @param builder
      * @param dependencies
      * @return
      */
     @Override
-    void processModelNode(String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
+    void processModelNode(OperationContext context, String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies)
+            throws OperationFailedException {
+
         // process the basic clustered configuration
-        super.processModelNode(containerName, cache, builder, dependencies);
+        super.processModelNode(context, containerName, cache, builder, dependencies);
+
+        final int owners = CommonAttributes.OWNERS.resolveModelAttribute(context, cache).asInt();
+        final int virtualNodes = CommonAttributes.VIRTUAL_NODES.resolveModelAttribute(context, cache).asInt();
+        final long lifespan = CommonAttributes.L1_LIFESPAN.resolveModelAttribute(context, cache).asLong();
 
         // process the additional distributed attributes and elements
-        if (cache.hasDefined(ModelKeys.OWNERS)) {
-            builder.clustering().hash().numOwners(cache.get(ModelKeys.OWNERS).asInt());
-        }
-        if (cache.hasDefined(ModelKeys.VIRTUAL_NODES)) {
-            builder.clustering().hash().numVirtualNodes(cache.get(ModelKeys.VIRTUAL_NODES).asInt());
-        }
-        if (cache.hasDefined(ModelKeys.L1_LIFESPAN)) {
-            long lifespan = cache.get(ModelKeys.L1_LIFESPAN).asLong();
-            if (lifespan > 0) {
-                builder.clustering().l1().lifespan(lifespan);
-            } else {
-                builder.clustering().l1().disable();
-            }
+        builder.clustering().hash().numOwners(owners);
+        builder.clustering().hash().numVirtualNodes(virtualNodes);
+        if (lifespan > 0) {
+            builder.clustering().l1().lifespan(lifespan);
+        } else {
+            builder.clustering().l1().disable();
         }
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
@@ -47,7 +47,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case DEFAULT_CACHE_CONTAINER: {
-                    subsystem.get(ModelKeys.DEFAULT_CACHE_CONTAINER).set(value);
+                    CommonAttributes.DEFAULT_CACHE_CONTAINER.parseAndSetParameter(value, subsystem, reader);
                     break;
                 }
                 default: {
@@ -92,23 +92,23 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
                     break;
                 }
                 case DEFAULT_CACHE: {
-                    container.get(ModelKeys.DEFAULT_CACHE).set(value);
+                    CommonAttributes.DEFAULT_CACHE.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case JNDI_NAME: {
-                    container.get(ModelKeys.JNDI_NAME).set(value);
+                    CommonAttributes.JNDI_NAME.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case LISTENER_EXECUTOR: {
-                    container.get(ModelKeys.LISTENER_EXECUTOR).set(value);
+                    CommonAttributes.LISTENER_EXECUTOR.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case EVICTION_EXECUTOR: {
-                    container.get(ModelKeys.EVICTION_EXECUTOR).set(value);
+                    CommonAttributes.EVICTION_EXECUTOR.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case REPLICATION_QUEUE_EXECUTOR: {
-                    container.get(ModelKeys.REPLICATION_QUEUE_EXECUTOR).set(value);
+                    CommonAttributes.REPLICATION_QUEUE_EXECUTOR.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 default: {
@@ -176,27 +176,27 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case STACK: {
-                    transport.get(ModelKeys.STACK).set(value);
+                    CommonAttributes.STACK.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case EXECUTOR: {
-                    transport.get(ModelKeys.EXECUTOR).set(value);
+                    CommonAttributes.EXECUTOR.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case LOCK_TIMEOUT: {
-                    transport.get(ModelKeys.LOCK_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.LOCK_TIMEOUT.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case SITE: {
-                    transport.get(ModelKeys.SITE).set(value);
+                    CommonAttributes.SITE.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case RACK: {
-                    transport.get(ModelKeys.RACK).set(value);
+                    CommonAttributes.RACK.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case MACHINE: {
-                    transport.get(ModelKeys.MACHINE).set(value);
+                    CommonAttributes.MACHINE.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 default: {
@@ -224,20 +224,20 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             case START: {
                 try {
                     StartMode mode = StartMode.valueOf(value);
-                    cache.get(ModelKeys.START).set(mode.name());
+                    CommonAttributes.START.parseAndSetParameter(mode.name(), cache, reader);
                 } catch (IllegalArgumentException e) {
                     throw ParseUtils.invalidAttributeValue(reader, index);
                 }
                 break;
             }
             case BATCHING: {
-                cache.get(ModelKeys.BATCHING).set(Boolean.parseBoolean(value));
+                CommonAttributes.BATCHING.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case INDEXING: {
                 try {
                     Indexing indexing = Indexing.valueOf(value);
-                    cache.get(ModelKeys.INDEXING).set(indexing.name());
+                    CommonAttributes.INDEXING.parseAndSetParameter(indexing.name(), cache, reader);
                 } catch (IllegalArgumentException e) {
                     throw ParseUtils.invalidAttributeValue(reader, index);
                 }
@@ -252,19 +252,19 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
     private void parseClusteredCacheAttribute(XMLExtendedStreamReader reader, int index, Attribute attribute, String value, ModelNode cache) throws XMLStreamException {
         switch (attribute) {
             case MODE: {
-                cache.get(ModelKeys.MODE).set(value);
+                ClusteredCacheAdd.MODE.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case QUEUE_SIZE: {
-                cache.get(ModelKeys.QUEUE_SIZE).set(Integer.parseInt(value));
+                CommonAttributes.QUEUE_SIZE.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case QUEUE_FLUSH_INTERVAL: {
-                cache.get(ModelKeys.QUEUE_FLUSH_INTERVAL).set(Long.parseLong(value));
+                CommonAttributes.QUEUE_FLUSH_INTERVAL.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case REMOTE_TIMEOUT: {
-                cache.get(ModelKeys.REMOTE_TIMEOUT).set(Long.parseLong(value));
+                CommonAttributes.REMOTE_TIMEOUT.parseAndSetParameter(value, cache, reader);
                 break;
             }
             default: {
@@ -320,15 +320,15 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case OWNERS: {
-                    cache.get(ModelKeys.OWNERS).set(Integer.parseInt(value));
+                    CommonAttributes.OWNERS.parseAndSetParameter(value, cache, reader);
                     break;
                 }
                 case VIRTUAL_NODES: {
-                    cache.get(ModelKeys.VIRTUAL_NODES).set(Integer.parseInt(value));
+                    CommonAttributes.VIRTUAL_NODES.parseAndSetParameter(value, cache, reader);
                     break;
                 }
                 case L1_LIFESPAN: {
-                    cache.get(ModelKeys.L1_LIFESPAN).set(Long.parseLong(value));
+                    CommonAttributes.L1_LIFESPAN.parseAndSetParameter(value, cache, reader);
                     break;
                 }
                 default: {
@@ -514,11 +514,11 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case ENABLED: {
-                    rehashing.get(ModelKeys.ENABLED).set(Boolean.parseBoolean(value));
+                    CommonAttributes.ENABLED.parseAndSetParameter(value, rehashing, reader);
                     break;
                 }
                 case TIMEOUT: {
-                    rehashing.get(ModelKeys.TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.TIMEOUT.parseAndSetParameter(value, rehashing, reader);
                     break;
                 }
                 default: {
@@ -543,11 +543,11 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case ENABLED: {
-                    stateTransfer.get(ModelKeys.ENABLED).set(Boolean.parseBoolean(value));
+                    CommonAttributes.ENABLED.parseAndSetParameter(value, stateTransfer, reader);
                     break;
                 }
                 case TIMEOUT: {
-                    stateTransfer.get(ModelKeys.TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.TIMEOUT.parseAndSetParameter(value, stateTransfer, reader);
                     break;
                 }
                 case FLUSH_TIMEOUT: {
@@ -578,22 +578,22 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
                 case ISOLATION: {
                     try {
                         IsolationLevel level = IsolationLevel.valueOf(value);
-                        locking.get(ModelKeys.ISOLATION).set(level.name());
+                        CommonAttributes.ISOLATION.parseAndSetParameter(level.name(), locking, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
                     break;
                 }
                 case STRIPING: {
-                    locking.get(ModelKeys.STRIPING).set(Boolean.parseBoolean(value));
+                    CommonAttributes.STRIPING.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 case ACQUIRE_TIMEOUT: {
-                    locking.get(ModelKeys.ACQUIRE_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.ACQUIRE_TIMEOUT.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 case CONCURRENCY_LEVEL: {
-                    locking.get(ModelKeys.CONCURRENCY_LEVEL).set(Integer.parseInt(value));
+                    CommonAttributes.CONCURRENCY_LEVEL.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 default: {
@@ -618,12 +618,13 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case STOP_TIMEOUT: {
-                    transaction.get(ModelKeys.STOP_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.STOP_TIMEOUT.parseAndSetParameter(value, transaction, reader);
                     break;
                 }
                 case MODE: {
                     try {
-                        transaction.get(ModelKeys.MODE).set(TransactionMode.valueOf(value).name());
+                        TransactionMode txnMode = TransactionMode.valueOf(value);
+                        CommonAttributes.MODE.parseAndSetParameter(txnMode.name(), transaction, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
@@ -631,7 +632,8 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
                 }
                 case LOCKING: {
                     try {
-                        transaction.get(ModelKeys.LOCKING).set(LockingMode.valueOf(value).name());
+                        LockingMode lockingMode = LockingMode.valueOf(value);
+                        CommonAttributes.LOCKING.parseAndSetParameter(lockingMode.name(), transaction, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
@@ -664,14 +666,14 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
                 case STRATEGY: {
                     try {
                         EvictionStrategy strategy = EvictionStrategy.valueOf(value);
-                        eviction.get(ModelKeys.STRATEGY).set(strategy.name());
+                        CommonAttributes.STRATEGY.parseAndSetParameter(strategy.name(), eviction, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
                     break;
                 }
                 case MAX_ENTRIES: {
-                    eviction.get(ModelKeys.MAX_ENTRIES).set(Integer.parseInt(value));
+                    CommonAttributes.MAX_ENTRIES.parseAndSetParameter(value, eviction, reader);
                     break;
                 }
                 case INTERVAL: {
@@ -700,15 +702,15 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case MAX_IDLE: {
-                    expiration.get(ModelKeys.MAX_IDLE).set(Long.parseLong(value));
+                    CommonAttributes.MAX_IDLE.parseAndSetParameter(value, expiration, reader);
                     break;
                 }
                 case LIFESPAN: {
-                    expiration.get(ModelKeys.LIFESPAN).set(Long.parseLong(value));
+                    CommonAttributes.LIFESPAN.parseAndSetParameter(value, expiration, reader);
                     break;
                 }
                 case INTERVAL: {
-                    expiration.get(ModelKeys.INTERVAL).set(Long.parseLong(value));
+                    CommonAttributes.INTERVAL.parseAndSetParameter(value, expiration, reader);
                     break;
                 }
                 default: {
@@ -732,7 +734,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case CLASS: {
-                    store.get(ModelKeys.CLASS).set(value);
+                    CommonAttributes.CLASS.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -761,11 +763,11 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case RELATIVE_TO: {
-                    store.get(ModelKeys.RELATIVE_TO).set(value);
+                    CommonAttributes.RELATIVE_TO.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 case PATH: {
-                    store.get(ModelKeys.PATH).set(value);
+                    CommonAttributes.PATH.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -790,15 +792,15 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case CACHE: {
-                    store.get(ModelKeys.CACHE).set(value);
+                    CommonAttributes.CACHE.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 case SOCKET_TIMEOUT: {
-                    store.get(ModelKeys.SOCKET_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.SOCKET_TIMEOUT.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 case TCP_NO_DELAY: {
-                    store.get(ModelKeys.TCP_NO_DELAY).set(Boolean.valueOf(value));
+                    CommonAttributes.TCP_NO_DELAY.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -832,7 +834,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case OUTBOUND_SOCKET_BINDING: {
-                    server.get(ModelKeys.OUTBOUND_SOCKET_BINDING).set(value);
+                    CommonAttributes.OUTBOUND_SOCKET_BINDING.parseAndSetParameter(value, server, reader);
                     break;
                 }
                 default: {
@@ -855,7 +857,7 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case DATASOURCE: {
-                    store.get(ModelKeys.DATASOURCE).set(value);
+                    CommonAttributes.DATA_SOURCE.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -893,15 +895,15 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case PREFIX: {
-                    table.get(ModelKeys.PREFIX).set(value);
+                    CommonAttributes.PREFIX.parseAndSetParameter(value, table, reader);
                     break;
                 }
                 case FETCH_SIZE: {
-                    table.get(ModelKeys.FETCH_SIZE).set(Integer.parseInt(value));
+                    CommonAttributes.FETCH_SIZE.parseAndSetParameter(value, table, reader);
                     break;
                 }
                 case BATCH_SIZE: {
-                    table.get(ModelKeys.BATCH_SIZE).set(Integer.parseInt(value));
+                    CommonAttributes.BATCH_SIZE.parseAndSetParameter(value, table, reader);
                     break;
                 }
                 default: {
@@ -956,27 +958,27 @@ public class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<List<M
     private void parseStoreAttribute(XMLExtendedStreamReader reader, int index, Attribute attribute, String value, ModelNode store) throws XMLStreamException {
         switch (attribute) {
             case SHARED: {
-                store.get(ModelKeys.SHARED).set(Boolean.parseBoolean(value));
+                CommonAttributes.SHARED.parseAndSetParameter(value, store, reader);
                 break;
             }
             case PRELOAD: {
-                store.get(ModelKeys.PRELOAD).set(Boolean.parseBoolean(value));
+                CommonAttributes.PRELOAD.parseAndSetParameter(value, store, reader);
                 break;
             }
             case PASSIVATION: {
-                store.get(ModelKeys.PASSIVATION).set(Boolean.parseBoolean(value));
+                CommonAttributes.PASSIVATION.parseAndSetParameter(value, store, reader);
                 break;
             }
             case FETCH_STATE: {
-                store.get(ModelKeys.FETCH_STATE).set(Boolean.parseBoolean(value));
+                CommonAttributes.FETCH_STATE.parseAndSetParameter(value, store, reader);
                 break;
             }
             case PURGE: {
-                store.get(ModelKeys.PURGE).set(Boolean.parseBoolean(value));
+                CommonAttributes.PURGE.parseAndSetParameter(value, store, reader);
                 break;
             }
             case SINGLETON: {
-                store.get(ModelKeys.SINGLETON).set(Boolean.parseBoolean(value));
+                CommonAttributes.SINGLETON.parseAndSetParameter(value, store, reader);
                 break;
             }
             default: {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -1,12 +1,11 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 
 import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.transaction.LockingMode;
@@ -46,7 +45,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case DEFAULT_CACHE_CONTAINER: {
-                    subsystem.get(ModelKeys.DEFAULT_CACHE_CONTAINER).set(value);
+                    CommonAttributes.DEFAULT_CACHE_CONTAINER.parseAndSetParameter(value, subsystem, reader);
                     break;
                 }
                 default: {
@@ -97,32 +96,32 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                     break;
                 }
                 case DEFAULT_CACHE: {
-                    container.get(ModelKeys.DEFAULT_CACHE).set(value);
+                    CommonAttributes.DEFAULT_CACHE.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case JNDI_NAME: {
-                    container.get(ModelKeys.JNDI_NAME).set(value);
+                    CommonAttributes.JNDI_NAME.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case START: {
                     try {
                         StartMode mode = StartMode.valueOf(value);
-                        container.get(ModelKeys.START).set(mode.name());
+                        CommonAttributes.START.parseAndSetParameter(mode.name(), container, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
                     break;
                 }
                 case LISTENER_EXECUTOR: {
-                    container.get(ModelKeys.LISTENER_EXECUTOR).set(value);
+                    CommonAttributes.LISTENER_EXECUTOR.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case EVICTION_EXECUTOR: {
-                    container.get(ModelKeys.EVICTION_EXECUTOR).set(value);
+                    CommonAttributes.EVICTION_EXECUTOR.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case REPLICATION_QUEUE_EXECUTOR: {
-                    container.get(ModelKeys.REPLICATION_QUEUE_EXECUTOR).set(value);
+                    CommonAttributes.REPLICATION_QUEUE_EXECUTOR.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 default: {
@@ -186,15 +185,15 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case STACK: {
-                    transport.get(ModelKeys.STACK).set(value);
+                    CommonAttributes.STACK.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case EXECUTOR: {
-                    transport.get(ModelKeys.EXECUTOR).set(value);
+                    CommonAttributes.EXECUTOR.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 case LOCK_TIMEOUT: {
-                    transport.get(ModelKeys.LOCK_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.LOCK_TIMEOUT.parseAndSetParameter(value, transport, reader);
                     break;
                 }
                 default: {
@@ -216,30 +215,30 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
     private void parseCacheAttribute(XMLExtendedStreamReader reader, int index, Attribute attribute, String value, ModelNode cache) throws XMLStreamException {
         switch (attribute) {
             case NAME: {
-                cache.get(ModelKeys.NAME).set(value);
+                CommonAttributes.NAME.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case START: {
                 try {
                     StartMode mode = StartMode.valueOf(value);
-                    cache.get(ModelKeys.START).set(mode.name());
+                    CommonAttributes.START.parseAndSetParameter(mode.name(), cache, reader);
                 } catch (IllegalArgumentException e) {
                     throw ParseUtils.invalidAttributeValue(reader, index);
                 }
                 break;
             }
             case JNDI_NAME: {
-                cache.get(ModelKeys.JNDI_NAME).set(value);
+                CommonAttributes.JNDI_NAME.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case BATCHING: {
-                cache.get(ModelKeys.BATCHING).set(Boolean.parseBoolean(value));
+                CommonAttributes.BATCHING.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case INDEXING: {
                 try {
                     Indexing indexing = Indexing.valueOf(value);
-                    cache.get(ModelKeys.INDEXING).set(indexing.name());
+                    CommonAttributes.INDEXING.parseAndSetParameter(indexing.name(), cache, reader);
                 } catch (IllegalArgumentException e) {
                     throw ParseUtils.invalidAttributeValue(reader, index);
                 }
@@ -254,19 +253,20 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
     private void parseClusteredCacheAttribute(XMLExtendedStreamReader reader, int index, Attribute attribute, String value, ModelNode cache) throws XMLStreamException {
         switch (attribute) {
             case MODE: {
-                cache.get(ModelKeys.MODE).set(value);
+                // note the use of ClusteredCacheAdd.MODE
+                ClusteredCacheAdd.MODE.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case QUEUE_SIZE: {
-                cache.get(ModelKeys.QUEUE_SIZE).set(Integer.parseInt(value));
+                CommonAttributes.QUEUE_SIZE.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case QUEUE_FLUSH_INTERVAL: {
-                cache.get(ModelKeys.QUEUE_FLUSH_INTERVAL).set(Long.parseLong(value));
+                CommonAttributes.QUEUE_FLUSH_INTERVAL.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case REMOTE_TIMEOUT: {
-                cache.get(ModelKeys.REMOTE_TIMEOUT).set(Long.parseLong(value));
+                CommonAttributes.REMOTE_TIMEOUT.parseAndSetParameter(value, cache, reader);
                 break;
             }
             default: {
@@ -321,15 +321,15 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case OWNERS: {
-                    cache.get(ModelKeys.OWNERS).set(Integer.parseInt(value));
+                    CommonAttributes.OWNERS.parseAndSetParameter(value, cache, reader);
                     break;
                 }
                 case VIRTUAL_NODES: {
-                    cache.get(ModelKeys.VIRTUAL_NODES).set(Integer.parseInt(value));
+                    CommonAttributes.VIRTUAL_NODES.parseAndSetParameter(value, cache, reader);
                     break;
                 }
                 case L1_LIFESPAN: {
-                    cache.get(ModelKeys.L1_LIFESPAN).set(Long.parseLong(value));
+                    CommonAttributes.L1_LIFESPAN.parseAndSetParameter(value, cache, reader);
                     break;
                 }
                 default: {
@@ -514,15 +514,15 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case ENABLED: {
-                    stateTransfer.get(ModelKeys.ENABLED).set(Boolean.parseBoolean(value));
+                    CommonAttributes.ENABLED.parseAndSetParameter(value, stateTransfer, reader);
                     break;
                 }
                 case TIMEOUT: {
-                    stateTransfer.get(ModelKeys.TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.TIMEOUT.parseAndSetParameter(value, stateTransfer, reader);
                     break;
                 }
                 case CHUNK_SIZE: {
-                    stateTransfer.get(ModelKeys.CHUNK_SIZE).set(Integer.parseInt(value));
+                    CommonAttributes.CHUNK_SIZE.parseAndSetParameter(value, stateTransfer, reader);
                     break;
                 }
                 default: {
@@ -549,22 +549,22 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                 case ISOLATION: {
                     try {
                         IsolationLevel level = IsolationLevel.valueOf(value);
-                        locking.get(ModelKeys.ISOLATION).set(level.name());
+                        CommonAttributes.ISOLATION.parseAndSetParameter(level.name(), locking, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
                     break;
                 }
                 case STRIPING: {
-                    locking.get(ModelKeys.STRIPING).set(Boolean.parseBoolean(value));
+                    CommonAttributes.STRIPING.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 case ACQUIRE_TIMEOUT: {
-                    locking.get(ModelKeys.ACQUIRE_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.ACQUIRE_TIMEOUT.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 case CONCURRENCY_LEVEL: {
-                    locking.get(ModelKeys.CONCURRENCY_LEVEL).set(Integer.parseInt(value));
+                    CommonAttributes.CONCURRENCY_LEVEL.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 default: {
@@ -589,12 +589,13 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case STOP_TIMEOUT: {
-                    transaction.get(ModelKeys.STOP_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.STOP_TIMEOUT.parseAndSetParameter(value, transaction, reader);
                     break;
                 }
                 case MODE: {
                     try {
-                        transaction.get(ModelKeys.MODE).set(TransactionMode.valueOf(value).name());
+                        TransactionMode txnMode = TransactionMode.valueOf(value);
+                        CommonAttributes.MODE.parseAndSetParameter(txnMode.name(), transaction, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
@@ -602,7 +603,8 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                 }
                 case LOCKING: {
                     try {
-                        transaction.get(ModelKeys.LOCKING).set(LockingMode.valueOf(value).name());
+                        LockingMode lockingMode = LockingMode.valueOf(value) ;
+                        CommonAttributes.LOCKING.parseAndSetParameter(lockingMode.name(), transaction, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
@@ -631,14 +633,14 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                 case STRATEGY: {
                     try {
                         EvictionStrategy strategy = EvictionStrategy.valueOf(value);
-                        eviction.get(ModelKeys.STRATEGY).set(strategy.name());
+                        CommonAttributes.STRATEGY.parseAndSetParameter(strategy.name(), eviction, reader);
                     } catch (IllegalArgumentException e) {
                         throw ParseUtils.invalidAttributeValue(reader, i);
                     }
                     break;
                 }
                 case MAX_ENTRIES: {
-                    eviction.get(ModelKeys.MAX_ENTRIES).set(Integer.parseInt(value));
+                    CommonAttributes.MAX_ENTRIES.parseAndSetParameter(value, eviction, reader);
                     break;
                 }
                 default: {
@@ -663,15 +665,15 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case MAX_IDLE: {
-                    expiration.get(ModelKeys.MAX_IDLE).set(Long.parseLong(value));
+                    CommonAttributes.MAX_IDLE.parseAndSetParameter(value, expiration, reader);
                     break;
                 }
                 case LIFESPAN: {
-                    expiration.get(ModelKeys.LIFESPAN).set(Long.parseLong(value));
+                    CommonAttributes.LIFESPAN.parseAndSetParameter(value, expiration, reader);
                     break;
                 }
                 case INTERVAL: {
-                    expiration.get(ModelKeys.INTERVAL).set(Long.parseLong(value));
+                    CommonAttributes.INTERVAL.parseAndSetParameter(value, expiration, reader);
                     break;
                 }
                 default: {
@@ -695,7 +697,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case CLASS: {
-                    store.get(ModelKeys.CLASS).set(value);
+                    CommonAttributes.CLASS.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -724,11 +726,11 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case RELATIVE_TO: {
-                    store.get(ModelKeys.RELATIVE_TO).set(value);
+                    CommonAttributes.RELATIVE_TO.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 case PATH: {
-                    store.get(ModelKeys.PATH).set(value);
+                    CommonAttributes.PATH.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -753,15 +755,15 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case CACHE: {
-                    store.get(ModelKeys.CACHE).set(value);
+                    CommonAttributes.CACHE.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 case SOCKET_TIMEOUT: {
-                    store.get(ModelKeys.SOCKET_TIMEOUT).set(Long.parseLong(value));
+                    CommonAttributes.SOCKET_TIMEOUT.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 case TCP_NO_DELAY: {
-                    store.get(ModelKeys.TCP_NO_DELAY).set(Boolean.valueOf(value));
+                    CommonAttributes.TCP_NO_DELAY.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -795,7 +797,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case OUTBOUND_SOCKET_BINDING: {
-                    server.get(ModelKeys.OUTBOUND_SOCKET_BINDING).set(value);
+                    CommonAttributes.OUTBOUND_SOCKET_BINDING.parseAndSetParameter(value, server, reader);
                     break;
                 }
                 default: {
@@ -818,7 +820,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case DATASOURCE: {
-                    store.get(ModelKeys.DATASOURCE).set(value);
+                    CommonAttributes.DATA_SOURCE.parseAndSetParameter(value, store, reader);
                     break;
                 }
                 default: {
@@ -856,15 +858,15 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case PREFIX: {
-                    table.get(ModelKeys.PREFIX).set(value);
+                    CommonAttributes.PREFIX.parseAndSetParameter(value, table, reader);
                     break;
                 }
                 case FETCH_SIZE: {
-                    table.get(ModelKeys.FETCH_SIZE).set(Integer.parseInt(value));
+                    CommonAttributes.FETCH_SIZE.parseAndSetParameter(value, table, reader);
                     break;
                 }
                 case BATCH_SIZE: {
-                    table.get(ModelKeys.BATCH_SIZE).set(Integer.parseInt(value));
+                    CommonAttributes.BATCH_SIZE.parseAndSetParameter(value, table, reader);
                     break;
                 }
                 default: {
@@ -919,27 +921,27 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
     private void parseStoreAttribute(XMLExtendedStreamReader reader, int index, Attribute attribute, String value, ModelNode store) throws XMLStreamException {
         switch (attribute) {
             case SHARED: {
-                store.get(ModelKeys.SHARED).set(Boolean.parseBoolean(value));
+                CommonAttributes.SHARED.parseAndSetParameter(value, store, reader);
                 break;
             }
             case PRELOAD: {
-                store.get(ModelKeys.PRELOAD).set(Boolean.parseBoolean(value));
+                CommonAttributes.PRELOAD.parseAndSetParameter(value, store, reader);
                 break;
             }
             case PASSIVATION: {
-                store.get(ModelKeys.PASSIVATION).set(Boolean.parseBoolean(value));
+                CommonAttributes.PASSIVATION.parseAndSetParameter(value, store, reader);
                 break;
             }
             case FETCH_STATE: {
-                store.get(ModelKeys.FETCH_STATE).set(Boolean.parseBoolean(value));
+                CommonAttributes.FETCH_STATE.parseAndSetParameter(value, store, reader);
                 break;
             }
             case PURGE: {
-                store.get(ModelKeys.PURGE).set(Boolean.parseBoolean(value));
+                CommonAttributes.PURGE.parseAndSetParameter(value, store, reader);
                 break;
             }
             case SINGLETON: {
-                store.get(ModelKeys.SINGLETON).set(Boolean.parseBoolean(value));
+                CommonAttributes.SINGLETON.parseAndSetParameter(value, store, reader);
                 break;
             }
             default: {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -188,6 +188,10 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                     CommonAttributes.STACK.parseAndSetParameter(value, transport, reader);
                     break;
                 }
+                case CLUSTER: {
+                    CommonAttributes.CLUSTER.parseAndSetParameter(value, transport, reader);
+                    break;
+                }
                 case EXECUTOR: {
                     CommonAttributes.EXECUTOR.parseAndSetParameter(value, transport, reader);
                     break;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -104,12 +104,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                     break;
                 }
                 case START: {
-                    try {
-                        StartMode mode = StartMode.valueOf(value);
-                        CommonAttributes.START.parseAndSetParameter(mode.name(), container, reader);
-                    } catch (IllegalArgumentException e) {
-                        throw ParseUtils.invalidAttributeValue(reader, i);
-                    }
+                    CommonAttributes.START.parseAndSetParameter(value, container, reader);
                     break;
                 }
                 case LISTENER_EXECUTOR: {
@@ -188,10 +183,6 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                     CommonAttributes.STACK.parseAndSetParameter(value, transport, reader);
                     break;
                 }
-                case CLUSTER: {
-                    CommonAttributes.CLUSTER.parseAndSetParameter(value, transport, reader);
-                    break;
-                }
                 case EXECUTOR: {
                     CommonAttributes.EXECUTOR.parseAndSetParameter(value, transport, reader);
                     break;
@@ -223,12 +214,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                 break;
             }
             case START: {
-                try {
-                    StartMode mode = StartMode.valueOf(value);
-                    CommonAttributes.START.parseAndSetParameter(mode.name(), cache, reader);
-                } catch (IllegalArgumentException e) {
-                    throw ParseUtils.invalidAttributeValue(reader, index);
-                }
+                CommonAttributes.START.parseAndSetParameter(value, cache, reader);
                 break;
             }
             case JNDI_NAME: {
@@ -240,12 +226,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                 break;
             }
             case INDEXING: {
-                try {
-                    Indexing indexing = Indexing.valueOf(value);
-                    CommonAttributes.INDEXING.parseAndSetParameter(indexing.name(), cache, reader);
-                } catch (IllegalArgumentException e) {
-                    throw ParseUtils.invalidAttributeValue(reader, index);
-                }
+                CommonAttributes.INDEXING.parseAndSetParameter(value, cache, reader);
                 break;
             }
             default: {
@@ -551,12 +532,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case ISOLATION: {
-                    try {
-                        IsolationLevel level = IsolationLevel.valueOf(value);
-                        CommonAttributes.ISOLATION.parseAndSetParameter(level.name(), locking, reader);
-                    } catch (IllegalArgumentException e) {
-                        throw ParseUtils.invalidAttributeValue(reader, i);
-                    }
+                    CommonAttributes.ISOLATION.parseAndSetParameter(value, locking, reader);
                     break;
                 }
                 case STRIPING: {
@@ -597,21 +573,11 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
                     break;
                 }
                 case MODE: {
-                    try {
-                        TransactionMode txnMode = TransactionMode.valueOf(value);
-                        CommonAttributes.MODE.parseAndSetParameter(txnMode.name(), transaction, reader);
-                    } catch (IllegalArgumentException e) {
-                        throw ParseUtils.invalidAttributeValue(reader, i);
-                    }
+                    CommonAttributes.MODE.parseAndSetParameter(value, transaction, reader);
                     break;
                 }
                 case LOCKING: {
-                    try {
-                        LockingMode lockingMode = LockingMode.valueOf(value) ;
-                        CommonAttributes.LOCKING.parseAndSetParameter(lockingMode.name(), transaction, reader);
-                    } catch (IllegalArgumentException e) {
-                        throw ParseUtils.invalidAttributeValue(reader, i);
-                    }
+                    CommonAttributes.LOCKING.parseAndSetParameter(value, transaction, reader);
                     break;
                 }
                 default: {
@@ -635,12 +601,7 @@ public class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<List<M
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case STRATEGY: {
-                    try {
-                        EvictionStrategy strategy = EvictionStrategy.valueOf(value);
-                        CommonAttributes.STRATEGY.parseAndSetParameter(strategy.name(), eviction, reader);
-                    } catch (IllegalArgumentException e) {
-                        throw ParseUtils.invalidAttributeValue(reader, i);
-                    }
+                    CommonAttributes.STRATEGY.parseAndSetParameter(value, eviction, reader);
                     break;
                 }
                 case MAX_ENTRIES: {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -74,6 +74,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                     writer.writeStartElement(Element.TRANSPORT.getLocalName());
                     ModelNode transport = container.get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
                     this.writeOptional(writer, Attribute.STACK, transport, ModelKeys.STACK);
+                    this.writeOptional(writer, Attribute.CLUSTER, transport, ModelKeys.CLUSTER);
                     this.writeOptional(writer, Attribute.EXECUTOR, transport, ModelKeys.EXECUTOR);
                     this.writeOptional(writer, Attribute.LOCK_TIMEOUT, transport, ModelKeys.LOCK_TIMEOUT);
                     this.writeOptional(writer, Attribute.SITE, transport, ModelKeys.SITE);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheAdd.java
@@ -3,6 +3,7 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
 import org.infinispan.configuration.cache.CacheMode;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
@@ -14,7 +15,7 @@ public class InvalidationCacheAdd extends ClusteredCacheAdd {
     static final InvalidationCacheAdd INSTANCE = new InvalidationCacheAdd();
 
     // used to create subsystem description
-    static ModelNode createOperation(ModelNode address, ModelNode model) {
+    static ModelNode createOperation(ModelNode address, ModelNode model) throws OperationFailedException {
         ModelNode operation = Util.getEmptyOperation(ADD, address);
         INSTANCE.populateMode(model, operation);
         INSTANCE.populate(model, operation);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheAdd.java
@@ -21,7 +21,7 @@ public class LocalCacheAdd extends CacheAdd {
     }
 
     // used to create subsystem description
-    static ModelNode createOperation(ModelNode address, ModelNode model) {
+    static ModelNode createOperation(ModelNode address, ModelNode model) throws OperationFailedException {
         ModelNode operation = Util.getEmptyOperation(ADD, address);
         INSTANCE.populate(model, operation);
         return operation;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -37,6 +37,7 @@ public class ModelKeys {
     static final String CACHE_CONTAINER = "cache-container";
     static final String CHUNK_SIZE = "chunk-size";
     static final String CLASS = "class";
+    static final String CLUSTER = "cluster";
     static final String CONCURRENCY_LEVEL = "concurrency-level";
     static final String DATA_COLUMN = "data-column";
     static final String DATASOURCE = "datasource";

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Namespace.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Namespace.java
@@ -38,14 +38,15 @@ public enum Namespace {
     UNKNOWN(0, 0, null),
 
     INFINISPAN_1_0(1, 0, new InfinispanSubsystemXMLReader_1_0()),
-    INFINISPAN_1_1(1, 1, new InfinispanSubsystemXMLReader_1_1());
+    INFINISPAN_1_1(1, 1, new InfinispanSubsystemXMLReader_1_1()),
+    INFINISPAN_1_2(1, 2, new InfinispanSubsystemXMLReader_1_2());
 
     private static final String BASE_URN = "urn:jboss:domain:infinispan:";
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = INFINISPAN_1_1;
+    public static final Namespace CURRENT = INFINISPAN_1_2;
 
     private final int major;
     private final int minor;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheAdd.java
@@ -3,6 +3,7 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
 import org.infinispan.configuration.cache.CacheMode;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 
@@ -14,7 +15,7 @@ public class ReplicatedCacheAdd extends SharedStateCacheAdd {
     static final ReplicatedCacheAdd INSTANCE = new ReplicatedCacheAdd();
 
     // used to create subsystem description
-    static ModelNode createOperation(ModelNode address, ModelNode model) {
+    static ModelNode createOperation(ModelNode address, ModelNode model) throws OperationFailedException {
         ModelNode operation = Util.getEmptyOperation(ADD, address);
         INSTANCE.populateMode(model, operation);
         INSTANCE.populate(model, operation);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheAdd.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -38,23 +40,23 @@ public abstract class SharedStateCacheAdd extends ClusteredCacheAdd {
     }
 
     @Override
-    void processModelNode(String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies) {
+    void processModelNode(OperationContext context, String containerName, ModelNode cache, ConfigurationBuilder builder, List<Dependency<?>> dependencies)
+            throws OperationFailedException{
+
         // process the basic clustered configuration
-        super.processModelNode(containerName, cache, builder, dependencies);
+        super.processModelNode(context, containerName, cache, builder, dependencies);
 
         // state transfer is a child resource
         if (cache.hasDefined(ModelKeys.STATE_TRANSFER) && cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME).isDefined()) {
             ModelNode stateTransfer = cache.get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
 
-            if (stateTransfer.hasDefined(ModelKeys.ENABLED)) {
-                builder.clustering().stateTransfer().fetchInMemoryState(stateTransfer.get(ModelKeys.ENABLED).asBoolean());
-            }
-            if (stateTransfer.hasDefined(ModelKeys.TIMEOUT)) {
-                builder.clustering().stateTransfer().timeout(stateTransfer.get(ModelKeys.TIMEOUT).asLong());
-            }
-            if (stateTransfer.hasDefined(ModelKeys.CHUNK_SIZE)) {
-                builder.clustering().stateTransfer().chunkSize(stateTransfer.get(ModelKeys.CHUNK_SIZE).asInt());
-            }
+            final boolean enabled = CommonAttributes.ENABLED.resolveModelAttribute(context, stateTransfer).asBoolean();
+            final long timeout = CommonAttributes.TIMEOUT.resolveModelAttribute(context, stateTransfer).asLong();
+            final int chunkSize = CommonAttributes.CHUNK_SIZE.resolveModelAttribute(context, stateTransfer).asInt();
+
+            builder.clustering().stateTransfer().fetchInMemoryState(enabled);
+            builder.clustering().stateTransfer().timeout(timeout);
+            builder.clustering().stateTransfer().chunkSize(chunkSize);
         }
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportAdd.java
@@ -21,7 +21,7 @@ public class TransportAdd extends AbstractAddStepHandler {
 
     public static final TransportAdd INSTANCE = new TransportAdd();
 
-    static ModelNode createOperation(ModelNode address, ModelNode existing) {
+    static ModelNode createOperation(ModelNode address, ModelNode existing) throws OperationFailedException {
         ModelNode operation = Util.getEmptyOperation(ADD, address);
         populate(existing, operation);
         return operation;
@@ -46,13 +46,15 @@ public class TransportAdd extends AbstractAddStepHandler {
         context.reloadRequired();
     }
 
-    private static void populate(ModelNode operation, ModelNode model) {
+    private static void populate(ModelNode operation, ModelNode model) throws OperationFailedException {
         // simply transfer the attributes from operation to model
         for (AttributeDefinition attr : CommonAttributes.TRANSPORT_ATTRIBUTES) {
 
-            if (operation.hasDefined(attr.getName())) {
-                model.get(attr.getName()).set(operation.get(attr.getName()));
-            }
+            // replace with AttributeDefinition.validateAndSet
+            attr.validateAndSet(operation, model);
+//            if (operation.hasDefined(attr.getName())) {
+//                model.get(attr.getName()).set(operation.get(attr.getName()));
+//            }
         }
     }
 }

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -21,12 +21,13 @@ infinispan.container.alias.remove-alias=Remove an alias for this cache container
 infinispan.container.transport=The description of the transport used by this cache container
 infinispan.container.transport.add=Add the transport to the cache container
 infinispan.container.transport.remove=Remove the transport from the cache container
+infinispan.container.transport.stack=The jgroups stack to use for the transport
+infinispan.container.transport.cluster=The name of the group communication cluster
 infinispan.container.transport.executor=The executor to use for the transport
 infinispan.container.transport.lock-timeout=The timeout for locks for the transport
 infinispan.container.transport.machine=A machine identifier for the transport
 infinispan.container.transport.rack=A rack identifier for the transport
 infinispan.container.transport.site=A site identifier for the transport
-infinispan.container.transport.stack=The jgroups stack to use for the transport
 infinispan.container.cache=The list of caches available to this cache container
 infinispan.container.singleton=A set of single-instance configuration elements of the cache container.
 #

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -61,7 +61,10 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest {
 
     @Parameters
     public static Collection<Object[]> data() {
-      Object[][] data = new Object[][] { { "subsystem-infinispan_1_0.xml", 31 }, { "subsystem-infinispan_1_1.xml", 31 } };
+      Object[][] data = new Object[][] { { "subsystem-infinispan_1_0.xml", 31 },
+                                         { "subsystem-infinispan_1_1.xml", 31 },
+                                         { "subsystem-infinispan_1_2.xml", 31 }
+                                       };
       return Arrays.asList(data);
     }
 

--- a/clustering/infinispan/src/test/resources/subsystem-infinispan_1_1.xml
+++ b/clustering/infinispan/src/test/resources/subsystem-infinispan_1_1.xml
@@ -3,7 +3,7 @@
         <local-cache name="local"></local-cache>
     </cache-container>
     <cache-container name="maximal" aliases="alias1 alias2" default-cache="local" eviction-executor="infinispan-eviction" jndi-name="java:global/infinispan/maximal" listener-executor="infinispan-listener" replication-queue-executor="infinispan-repl-queue">
-        <transport executor="transport-executor" lock-timeout="120000" stack="tcp"/>
+        <transport cluster="maximal-cluster" executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" indexing="LOCAL" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>

--- a/clustering/infinispan/src/test/resources/subsystem-infinispan_1_2.xml
+++ b/clustering/infinispan/src/test/resources/subsystem-infinispan_1_2.xml
@@ -1,9 +1,9 @@
-<subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="minimal">
+<subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="minimal">
     <cache-container name="minimal">
         <local-cache name="local"></local-cache>
     </cache-container>
     <cache-container name="maximal" aliases="alias1 alias2" default-cache="local" eviction-executor="infinispan-eviction" jndi-name="java:global/infinispan/maximal" listener-executor="infinispan-listener" replication-queue-executor="infinispan-repl-queue">
-        <transport executor="transport-executor" lock-timeout="120000" stack="tcp"/>
+        <transport cluster="maximal-cluster" executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" indexing="LOCAL" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CommonAttributes.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CommonAttributes.java
@@ -18,7 +18,7 @@ public interface CommonAttributes {
     SimpleAttributeDefinition DEFAULT_STACK =
             new SimpleAttributeDefinitionBuilder(ModelKeys.DEFAULT_STACK, ModelType.STRING, false)
                     .setXmlName(Attribute.DEFAULT_STACK.getLocalName())
-                    .setAllowExpression(false)
+                    .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemAdd.java
@@ -71,7 +71,7 @@ public class JGroupsSubsystemAdd extends AbstractAddStepHandler {
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install());
 
-        String stack = CommonAttributes.DEFAULT_STACK.resolveModelAttribute(context, model).asString();
+        final String stack = CommonAttributes.DEFAULT_STACK.resolveModelAttribute(context, model).asString() ;
 
         InjectedValue<ChannelFactory> factory = new InjectedValue<ChannelFactory>();
         ValueService<ChannelFactory> service = new ValueService<ChannelFactory>(factory);


### PR DESCRIPTION
This pull request does the following:
Infinispan subsystem: 
- decouple cache container name from channel name by introducing cluster attribute
- allow expressions for attributes default-cache, default-cache-container, cluster
  JGroups subsystem:
- \- allow expressions for attributes default-stack
