### PR TITLE
Fix for AS7-3820

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
@@ -24,8 +24,10 @@ package org.jboss.as.ejb3.remote;
 
 import org.jboss.as.remoting.AbstractOutboundConnectionService;
 import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBReceiver;
 import org.jboss.ejb.client.remoting.IoFutureHelper;
 import org.jboss.ejb.client.remoting.ReconnectHandler;
+import org.jboss.ejb.client.remoting.RemotingConnectionEJBReceiver;
 import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
@@ -39,6 +41,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Connection;
 import org.xnio.IoFuture;
+import org.xnio.OptionMap;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -179,7 +182,8 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
                 // successfully reconnected so unregister this reconnect handler
                 this.clientContext.unregisterReconnectHandler(this);
                 // register the newly reconnected connection
-                this.clientContext.registerConnection(connection);
+                final EJBReceiver receiver = new RemotingConnectionEJBReceiver(connection, this, OptionMap.EMPTY);
+                this.clientContext.registerEJBReceiver(receiver);
             } catch (Exception e) {
                 logger.debug("Reconnect attempt#" + this.reconnectAttemptCount + " failed for outbound connection " + this.outboundConnectionServiceName, e);
             }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
@@ -22,26 +22,30 @@
 
 package org.jboss.as.ejb3.remote;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import org.jboss.as.remoting.AbstractOutboundConnectionService;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.remoting.IoFutureHelper;
+import org.jboss.ejb.client.remoting.ReconnectHandler;
 import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Connection;
 import org.xnio.IoFuture;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A service which sets up the {@link EJBClientContext} with appropriate remoting receivers and local receivers.
@@ -60,7 +64,7 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
     /**
      * The outbound connection references from which the remoting EJB receivers will be created
      */
-    private final List<InjectedValue<AbstractOutboundConnectionService>> remotingOutboundConnections = new ArrayList<InjectedValue<AbstractOutboundConnectionService>>();
+    private final Map<ServiceName, InjectedValue<AbstractOutboundConnectionService>> remotingOutboundConnections = new HashMap<ServiceName, InjectedValue<AbstractOutboundConnectionService>>();
 
     /**
      * (optional) local EJB receiver for the EJB client context
@@ -82,8 +86,9 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
             context.registerEJBReceiver(localEjbReceiver);
             logger.debug("Added a local EJB receiver to descriptor based EJB client context named " + startContext.getController().getName());
         }
+        final ServiceRegistry serviceRegistry = startContext.getController().getServiceContainer();
         // now process the remoting receivers
-        final Collection<Connection> connections = this.createRemotingConnections();
+        final Collection<Connection> connections = this.createRemotingConnections(serviceRegistry, context);
         for (final Connection connection : connections) {
             context.registerConnection(connection);
         }
@@ -104,17 +109,18 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
     public void addRemotingConnectionDependency(final ServiceBuilder<EJBClientContext> serviceBuilder, final ServiceName serviceName) {
         final InjectedValue<AbstractOutboundConnectionService> value = new InjectedValue<AbstractOutboundConnectionService>();
         serviceBuilder.addDependency(serviceName, AbstractOutboundConnectionService.class, value);
-        remotingOutboundConnections.add(value);
+        remotingOutboundConnections.put(serviceName, value);
     }
 
     public Injector<LocalEjbReceiver> getLocalEjbReceiverInjector() {
         return this.localEjbReceiverInjectedValue;
     }
 
-    private Collection<Connection> createRemotingConnections() {
+    private Collection<Connection> createRemotingConnections(final ServiceRegistry serviceRegistry, final EJBClientContext context) {
         final Collection<Connection> connections = new ArrayList<Connection>();
 
-        for (final InjectedValue<AbstractOutboundConnectionService> injectedValue : this.remotingOutboundConnections) {
+        for (final Map.Entry<ServiceName, InjectedValue<AbstractOutboundConnectionService>> entry : this.remotingOutboundConnections.entrySet()) {
+            final InjectedValue<AbstractOutboundConnectionService> injectedValue = entry.getValue();
             final AbstractOutboundConnectionService outboundConnectionService = injectedValue.getValue();
             final String connectionName = outboundConnectionService.getConnectionName();
             logger.debug("Creating remoting EJB receiver for connection " + connectionName);
@@ -125,12 +131,59 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
                 // add it to the successful connection list to be returned
                 connections.add(connection);
 
-            } catch (IOException ioe) {
-                // just log a WARN and move on to the next
-                logger.warn(connectionName + " connection will not be used for EJB client context due " +
-                        "to error during connection creation", ioe);
+            } catch (Exception e) {
+                // just log a message and register a reconnect handler
+                logger.debug("Failed to create a connection for " + connectionName + ". A reconnect handler will be added to the client context", e);
+                final ReconnectHandler reconnectHandler = new OutboundConnectionReconnectHandler(serviceRegistry, entry.getKey(), context);
+                context.registerReconnectHandler(reconnectHandler);
             }
         }
         return connections;
+    }
+
+    /**
+     * A {@link ReconnectHandler} which attempts a reconnection to a outbound connection using the
+     * {@link AbstractOutboundConnectionService}
+     */
+    private class OutboundConnectionReconnectHandler implements ReconnectHandler {
+
+        private final ServiceRegistry serviceRegistry;
+        private final ServiceName outboundConnectionServiceName;
+        private final EJBClientContext clientContext;
+        private volatile int reconnectAttemptCount;
+
+        OutboundConnectionReconnectHandler(final ServiceRegistry serviceRegistry, final ServiceName outboundConnectionServiceName,
+                                           final EJBClientContext clientContext) {
+            this.outboundConnectionServiceName = outboundConnectionServiceName;
+            this.serviceRegistry = serviceRegistry;
+            this.clientContext = clientContext;
+        }
+
+        @Override
+        public void reconnect() throws IOException {
+            this.reconnectAttemptCount++;
+            final ServiceController serviceController = this.serviceRegistry.getService(this.outboundConnectionServiceName);
+            if (serviceController == null) {
+                // the outbound connection service is no longer available, so unregister this
+                // reconnect handler from the EJB client context
+                logger.debug("Unregistering " + this + " since " + this.outboundConnectionServiceName + " is no longer available");
+                this.clientContext.unregisterReconnectHandler(this);
+                return;
+            }
+            final AbstractOutboundConnectionService outboundConnectionService = (AbstractOutboundConnectionService) serviceController.getValue();
+            try {
+                final IoFuture<Connection> futureConnection = outboundConnectionService.connect();
+                // TODO: Make the timeout configurable
+                final Connection connection = IoFutureHelper.get(futureConnection, DEFAULT_CONNECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+                logger.debug("Successful reconnect attempt#" + this.reconnectAttemptCount + " to outbound connection " + this.outboundConnectionServiceName);
+                // successfully reconnected so unregister this reconnect handler
+                this.clientContext.unregisterReconnectHandler(this);
+                // register the newly reconnected connection
+                this.clientContext.registerConnection(connection);
+            } catch (Exception e) {
+                logger.debug("Reconnect attempt#" + this.reconnectAttemptCount + " failed for outbound connection " + this.outboundConnectionServiceName, e);
+            }
+
+        }
     }
 }

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -45,6 +45,29 @@
             <build>
                 <plugins>
 
+                    <!-- Build the server configuration(s) -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>build-manual-mode-servers</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/manualmode-build.xml">
+                                            <target name="build-manual-mode"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+
                     <!-- Surefire. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -66,10 +89,12 @@
 
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
+                                        <arquillian.launch>manual-mode</arquillian.launch>
                                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
+
 
                         </executions>
 

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -59,6 +59,8 @@
                                 <configuration>
                                     <target>
                                         <ant antfile="${jbossas.ts.integ.dir}/src/test/scripts/manualmode-build.xml">
+                                            <property name="node1" value="${node1}" />
+                                            <property name="node0" value="${node0}" />
                                             <target name="build-manual-mode"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -2,15 +2,28 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <container qualifier="jboss" default="true" mode="manual">
-        <configuration>
-            <property name="jbossHome">${basedir}/target/jbossas</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
-            <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
-            <property name="allowConnectingToRunningServer">true</property>
-            <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
-        </configuration>
-    </container>
+
+    <group qualifier="manual-mode">
+        <container qualifier="default-jbossas" default="true" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+				<property name="managementAddress">${node0:127.0.0.1}</property>
+				<property name="managementPort">${as.managementPort:9999}</property>
+            </configuration>
+        </container>
+
+        <container qualifier="jbossas-with-remote-outbound-connection" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-with-remote-outbound-connection</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-with-remote-outbound-connection -Djboss.node.name=jbossas-with-remote-outbound-connection</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementPort">10099</property>
+            </configuration>
+        </container>
+    </group>
 
 </arquillian>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -21,6 +21,7 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-with-remote-outbound-connection -Djboss.node.name=jbossas-with-remote-outbound-connection</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
             </configuration>
         </container>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/Util.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/Util.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+package org.jboss.as.test.manualmode.ejb;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/EchoOnServerOne.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/EchoOnServerOne.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
+
+import javax.ejb.EJB;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(RemoteEcho.class)
+public class EchoOnServerOne implements RemoteEcho {
+    @EJB (lookup = "ejb:/server-two-module//EchoOnServerTwo!org.jboss.as.test.manualmode.ejb.client.outbound.connection.RemoteEcho")
+    private RemoteEcho echoOnServerTwo;
+
+    @Override
+    public String echo(String msg) {
+        return this.echoOnServerTwo.echo(msg);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/EchoOnServerTwo.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/EchoOnServerTwo.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(RemoteEcho.class)
+public class EchoOnServerTwo implements RemoteEcho {
+    public static final String ECHO_PREFIX = "ServerTwo ";
+
+    @Override
+    public String echo(String msg) {
+        return ECHO_PREFIX + msg;
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/IndependentBean.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/IndependentBean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,11 +19,20 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+
+package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
 
 import javax.ejb.Remote;
+import javax.ejb.Stateless;
 
-@Remote
-public interface SimpleCrashBeanRemote {
-    String echo(String message);
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(RemoteEcho.class)
+public class IndependentBean implements RemoteEcho {
+    @Override
+    public String echo(String msg) {
+        return msg;
+    }
 }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/LazyOutboundConnectionReconnectTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/LazyOutboundConnectionReconnectTestCase.java
@@ -1,0 +1,191 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Hashtable;
+import java.util.Properties;
+
+/**
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class LazyOutboundConnectionReconnectTestCase {
+
+    private static final Logger logger = Logger.getLogger(LazyOutboundConnectionReconnectTestCase.class);
+
+    private static final String SERVER_ONE_MODULE_NAME = "server-one-module";
+    private static final String SERVER_TWO_MODULE_NAME = "server-two-module";
+
+    private static final String DEFAULT_JBOSSAS = "default-jbossas";
+    private static final String JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION = "jbossas-with-remote-outbound-connection";
+
+    private static final String DEFAULT_AS_DEPLOYMENT = "default-jbossas-deployment";
+    private static final String DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML = "other-deployment";
+
+    @ArquillianResource
+    private ContainerController container;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    private static Context context;
+    private static ContextSelector<EJBClientContext> previousClientContextSelector;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        context = new InitialContext(props);
+        previousClientContextSelector = setupEJBClientContextSelector();
+
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (previousClientContextSelector != null) {
+            EJBClientContext.setSelector(previousClientContextSelector);
+        }
+    }
+
+    @Deployment(name = DEFAULT_AS_DEPLOYMENT, managed = false, testable = false)
+    @TargetsContainer(DEFAULT_JBOSSAS)
+    public static Archive createContainer1Deployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, SERVER_TWO_MODULE_NAME + ".jar");
+        ejbJar.addClasses(EchoOnServerTwo.class, RemoteEcho.class);
+        return ejbJar;
+    }
+
+    @Deployment(name = DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML, managed = false, testable = false)
+    @TargetsContainer(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION)
+    public static Archive createContainer2Deployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, SERVER_ONE_MODULE_NAME + ".jar");
+        ejbJar.addClasses(EchoOnServerOne.class, RemoteEcho.class, IndependentBean.class);
+        ejbJar.addAsManifestResource(EchoOnServerOne.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        return ejbJar;
+    }
+
+    @Test
+    public void testRemoteServerStartsLate() throws Exception {
+        // First start the server which has a remote-outbound-connection
+        this.container.start(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION);
+        boolean defaultContainerStarted = false;
+        try {
+            // deploy a deployment which contains jboss-ejb-client.xml that contains a EJB receiver pointing
+            // to a server which hasn't yet started. Should succeed without throwing deployment error
+            this.deployer.deploy(DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML);
+            // To make sure deployment succeeded and invocations are possible, call a independent bean
+            final RemoteEcho independentBean = (RemoteEcho) context.lookup("ejb:/" + SERVER_ONE_MODULE_NAME + "//" + IndependentBean.class.getSimpleName() + "!" + RemoteEcho.class.getName());
+            final String msg = "Hellooooo!";
+            final String echoFromIndependentBean = independentBean.echo(msg);
+            Assert.assertEquals("Unexpected echo from independent bean", msg, echoFromIndependentBean);
+
+            // now try invoking the EJB (which calls a delegate bean on other server) on this server. 
+            // should fail with no EJB receivers, since the other server
+            // which can handle the delegate bean invocation hasn't yet started.
+            try {
+                final RemoteEcho dependentBean = (RemoteEcho) context.lookup("ejb:/" + SERVER_ONE_MODULE_NAME + "//" + EchoOnServerOne.class.getSimpleName() + "!" + RemoteEcho.class.getName());
+                final String echoBeforeOtherServerStart = dependentBean.echo(msg);
+                Assert.fail("Invocation on bean when was expected to fail due to other server being down");
+            } catch (Exception e) {
+                // expected 
+                logger.info("Got the expected exception on invoking a bean when other server was down", e);
+            }
+            // now start the main server
+            this.container.start(DEFAULT_JBOSSAS);
+            defaultContainerStarted = true;
+            // deploy to this container
+            this.deployer.deploy(DEFAULT_AS_DEPLOYMENT);
+
+            // now invoke the EJB (which had failed earlier)
+            final RemoteEcho dependentBean = (RemoteEcho) context.lookup("ejb:/" + SERVER_ONE_MODULE_NAME + "//" + EchoOnServerOne.class.getSimpleName() + "!" + RemoteEcho.class.getName());
+            final String echoAfterOtherServerStarted = dependentBean.echo(msg);
+            Assert.assertEquals("Unexpected echo from bean", EchoOnServerTwo.ECHO_PREFIX + msg, echoAfterOtherServerStarted);
+
+        } finally {
+            try {
+                this.deployer.undeploy(DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML);
+                this.container.stop(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION);
+            } catch (Exception e) {
+                logger.debug("Exception during container shutdown", e);
+            }
+            if (defaultContainerStarted) {
+                try {
+                    this.deployer.undeploy(DEFAULT_AS_DEPLOYMENT);
+                    this.container.stop(DEFAULT_JBOSSAS);
+                } catch (Exception e) {
+                    logger.debug("Exception during container shutdown", e);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Sets up the EJB client context to use a selector which processes and sets up EJB receivers
+     * based on this testcase specific jboss-ejb-client.properties file
+     *
+     * @return
+     * @throws java.io.IOException
+     */
+    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+        // setup the selector
+        final String clientPropertiesFile = "org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.properties";
+        final InputStream inputStream = LazyOutboundConnectionReconnectTestCase.class.getClassLoader().getResourceAsStream(clientPropertiesFile);
+        if (inputStream == null) {
+            throw new IllegalStateException("Could not find " + clientPropertiesFile + " in classpath");
+        }
+        final Properties properties = new Properties();
+        properties.load(inputStream);
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+
+        return EJBClientContext.setSelector(selector);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteEcho.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteEcho.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface RemoteEcho {
+    
+    String echo(String msg);
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.properties
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.properties
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=localhost
+remote.connection.default.port=4547
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+
+

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.properties
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.properties
@@ -23,7 +23,7 @@ remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
 
 remote.connections=default
 
-remote.connection.default.host=localhost
+remote.connection.default.host=${node1:localhost}
 remote.connection.default.port=4547
 remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/jboss-ejb-client.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
+    <client-context>
+        <ejb-receivers>
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>
+

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/EJBClientReconnectionTestCase.java
@@ -19,11 +19,12 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+package org.jboss.as.test.manualmode.ejb.client.reconnect;
 
 import org.jboss.arquillian.container.test.api.*;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.manualmode.ejb.Util;
 import org.jboss.ejb.client.EJBClient;
 import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.StatelessEJBLocator;
@@ -55,7 +56,7 @@ public class EJBClientReconnectionTestCase {
     private static final Logger log = Logger.getLogger(EJBClientReconnectionTestCase.class);
 
     private static final String DEPLOYMENT = "ejbclientreconnection";
-    private static final String CONTAINER = "jboss";
+    private static final String CONTAINER = "default-jbossas";
 
     @ArquillianResource
     private ContainerController controller;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/SimpleCrashBean.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/SimpleCrashBean.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.manualmode.ejbclientreconnectiontest;
+package org.jboss.as.test.manualmode.ejb.client.reconnect;
 
 import javax.ejb.Stateless;
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/SimpleCrashBeanRemote.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/reconnect/SimpleCrashBeanRemote.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.ejb.client.reconnect;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface SimpleCrashBeanRemote {
+    String echo(String message);
+}

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project>
+
+    <!-- import shared ant targets -->
+    <import file="common-targets.xml" as="common"/>
+
+    <target name="build-manual-mode" description="Builds server configurations for manual mode tests">
+
+        <echo message="Copying and configuring instance jbossas-with-remote-outbound-connection"/>
+        <copy todir="target/jbossas-with-remote-outbound-connection">
+            <fileset dir="target/jbossas"/>
+        </copy>
+        <ts.config-as.add-remote-outbound-connection name="jbossas-with-remote-outbound-connection" node="${node0}"
+                                                     remotePort="4447" securityRealm="PasswordRealm" userName="user1"/>
+        <ts.config-as.add-identity-realm name="jbossas-with-remote-outbound-connection" realmName="PasswordRealm"
+                                         secret="cGFzc3dvcmQx"/>
+
+        <ts.config-as.add-port-offset name="jbossas-with-remote-outbound-connection" offset="100" nativePort="9999" httpPort="9990"/>
+    </target>
+
+</project>


### PR DESCRIPTION
The commits in this branch fix the issue reported in https://issues.jboss.org/browse/AS7-3820. This branch also contains a testcase for this issue. If a deployment contains references to outbound connections to servers which are not yet up, then it will no longer fail the deployment. Instead it will connect to the outbound connection whenever it's up and ready.
