### PR TITLE
AS7-2909 - remove surefire.test.failure.ignore as it's not serving original purpose (not skipping second SF exec). Use -fae instead.

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -130,7 +130,6 @@
         <as.debug.port>8787</as.debug.port>
         <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
         <surefire.forked.process.timeout>900</surefire.forked.process.timeout>
-        <surefire.test.failure.ignore>false</surefire.test.failure.ignore>
 
         <!-- Arquillian dependency versions -->
         <version.arquillian_core>${version.org.jboss.arquillian.core}</version.arquillian_core>
@@ -378,8 +377,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
-                    <!-- don't halt the all test executions if a test fails -->
-                    <testFailureIgnore>${surefire.test.failure.ignore}</testFailureIgnore>
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <systemPropertyVariables>
                         <jboss.options>${surefire.system.args}</jboss.options>


### PR DESCRIPTION
This is set now to false by default anyway, so with this change, we will be using standard 
"maven.test.failure.ignore" for the same behavior.

BTW the original purpose is to be targetted by moving from SureFire to FireSafe plugin (if it proves as good as SF).
