### PR TITLE
AS7-3939 Don't allow remote invocations on local views of a EJB

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/EjbDeploymentInformation.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/EjbDeploymentInformation.java
@@ -6,7 +6,10 @@ import org.jboss.as.ejb3.iiop.EjbIIOPService;
 import org.jboss.msc.value.InjectedValue;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Runtime information about an EJB in a module
@@ -24,11 +27,45 @@ public class EjbDeploymentInformation {
     private final Map<String, InjectedValue<ComponentView>> componentViews;
 
     private final InjectedValue<EjbIIOPService> iorFactory;
+    private final Set<String> remoteViewClassNames = new HashSet<String>();
 
+    /**
+     * @param ejbName               The EJB name
+     * @param ejbComponent          The EJB component
+     * @param componentViews        The views exposed by the EJB component
+     * @param deploymentClassLoader The deployment classloader of the EJB component
+     * @param iorFactory            The {@link EjbIIOPService}
+     * @deprecated since 7.1.1.Final - Use {@link #EjbDeploymentInformation(String, org.jboss.msc.value.InjectedValue, java.util.Map, java.util.Map, ClassLoader, org.jboss.msc.value.InjectedValue)} instead
+     */
     public EjbDeploymentInformation(final String ejbName, final InjectedValue<EJBComponent> ejbComponent, final Map<String, InjectedValue<ComponentView>> componentViews, final ClassLoader deploymentClassLoader, final InjectedValue<EjbIIOPService> iorFactory) {
         this.ejbName = ejbName;
         this.ejbComponent = ejbComponent;
         this.componentViews = componentViews;
+        this.deploymentClassLoader = deploymentClassLoader;
+        this.iorFactory = iorFactory;
+    }
+
+    /**
+     * @param ejbName               Name of the EJB
+     * @param ejbComponent          The EJB component
+     * @param remoteViews           The component views, which are exposed remotely, by the EJB. Can be null.
+     * @param localViews            The component views which are exposed locally by the EJB. Can be null.
+     * @param deploymentClassLoader The deployment classloader of the EJB component
+     * @param iorFactory            The {@link EjbIIOPService}
+     */
+    public EjbDeploymentInformation(final String ejbName, final InjectedValue<EJBComponent> ejbComponent,
+                                    final Map<String, InjectedValue<ComponentView>> remoteViews, final Map<String, InjectedValue<ComponentView>> localViews,
+                                    final ClassLoader deploymentClassLoader, final InjectedValue<EjbIIOPService> iorFactory) {
+        this.ejbName = ejbName;
+        this.ejbComponent = ejbComponent;
+        this.componentViews = new HashMap<String, InjectedValue<ComponentView>>();
+        if (remoteViews != null) {
+            this.componentViews.putAll(remoteViews);
+            this.remoteViewClassNames.addAll(remoteViews.keySet());
+        }
+        if (localViews != null) {
+            this.componentViews.putAll(localViews);
+        }
         this.deploymentClassLoader = deploymentClassLoader;
         this.iorFactory = iorFactory;
     }
@@ -47,7 +84,7 @@ public class EjbDeploymentInformation {
 
     public ComponentView getView(String name) {
         final InjectedValue<ComponentView> value = componentViews.get(name);
-        if(value == null) {
+        if (value == null) {
             throw new IllegalArgumentException("View " + name + " was not found");
         }
         return value.getValue();
@@ -59,5 +96,16 @@ public class EjbDeploymentInformation {
 
     public EjbIIOPService getIorFactory() {
         return iorFactory.getOptionalValue();
+    }
+
+    /**
+     * Returns true if the passed <code>viewClassName</code> represents a remote view of the EJB component.
+     * Else returns false.
+     *
+     * @param viewClassName The fully qualified classname of the view
+     * @return
+     */
+    public boolean isRemoteView(final String viewClassName) {
+        return this.remoteViewClassNames.contains(viewClassName);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -136,11 +136,11 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                 throw new RuntimeException(e);
             }
             final String viewClassName = locator.getViewType().getName();
-            if (!ejbDeploymentInformation.getViewNames().contains(viewClassName)) {
+            // Make sure it's a remote view
+            if (!ejbDeploymentInformation.isRemoteView(viewClassName)) {
                 this.writeNoSuchEJBFailureMessage(channel, invocationId, appName, moduleName, distinctName, beanName, viewClassName);
                 return;
             }
-            // TODO: Add a check for remote view
             final ComponentView componentView = ejbDeploymentInformation.getView(viewClassName);
             final Method invokedMethod = this.findMethod(componentView, methodName, methodParamTypes);
             if (invokedMethod == null) {

--- a/jsr77/src/main/java/org/jboss/as/jsr77/ejb/ManagementEjbDeploymentInformation.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/ejb/ManagementEjbDeploymentInformation.java
@@ -38,7 +38,7 @@ public class ManagementEjbDeploymentInformation extends EjbDeploymentInformation
 
     public ManagementEjbDeploymentInformation(String ejbName, Map<String, InjectedValue<ComponentView>> componentViews, ClassLoader deploymentClassLoader) {
         // FIXME ManagementEjbDeploymentInformation constructor
-        super(ejbName, new InjectedValue<EJBComponent>(), componentViews, deploymentClassLoader, new InjectedValue<EjbIIOPService>());
+        super(ejbName, new InjectedValue<EJBComponent>(), componentViews, null, deploymentClassLoader, new InjectedValue<EjbIIOPService>());
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/CommonEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/CommonEcho.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.view;
+
+/**
+ * @author Jaikiran Pai
+ */
+abstract class CommonEcho implements LocalEcho {
+
+    @Override
+    public String echo(String message) {
+        return message;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/LocalEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/LocalEcho.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.view;
+
+import javax.ejb.Local;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Local
+public interface LocalEcho {
+    
+    String echo(String message);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/LocalViewRemoteInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/LocalViewRemoteInvocationTestCase.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.view;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ejb.NoSuchEJBException;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.Hashtable;
+
+/**
+ * Tests that a local view exposed by an EJB is <b>not</b> invokable remotely.
+ *
+ * @author Jaikiran Pai
+ * @see https://issues.jboss.org/browse/AS7-3939
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class LocalViewRemoteInvocationTestCase {
+
+    private static final Logger logger = Logger.getLogger(LocalViewRemoteInvocationTestCase.class);
+
+    private static final String APP_NAME = "";
+    private static final String DISTINCT_NAME = "";
+    private static final String MODULE_NAME = "local-view-remote-invocation-test";
+
+    private static Context context;
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        ejbJar.addPackage(LocalViewRemoteInvocationTestCase.class.getPackage());
+        return ejbJar;
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        context = new InitialContext(props);
+    }
+
+    /**
+     * Test that remote invocation on a local view of a stateless bean isn't allowed
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLocalViewInvocationRemotelyOnSLSB() throws Exception {
+        final LocalEcho localEcho = (LocalEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + StatelessEcho.class.getSimpleName() + "!" + LocalEcho.class.getName());
+        final String message = "Silence!";
+        try {
+            final String echo = localEcho.echo(message);
+            Assert.fail("Remote invocation on a local view " + LocalEcho.class.getName() + " was expected to fail");
+        } catch (NoSuchEJBException nsee) {
+            // expected
+            logger.info("Got the expected exception on invoking on a local view, remotely", nsee);
+        }
+    }
+
+    /**
+     * Test that remote invocation on a local view of a stateful bean isn't allowed
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLocalViewInvocationRemotelyOnSFSB() throws Exception {
+        final LocalEcho localEcho = (LocalEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + StatefulEcho.class.getSimpleName() + "!" + LocalEcho.class.getName() + "?stateful");
+        final String message = "Silence!";
+        try {
+            final String echo = localEcho.echo(message);
+            Assert.fail("Remote invocation on a local view " + LocalEcho.class.getName() + " was expected to fail");
+        } catch (NoSuchEJBException nsee) {
+            // expected
+            logger.info("Got the expected exception on invoking on a local view, remotely", nsee);
+        }
+    }
+
+    /**
+     * Test that remote invocation on a local view of a singleton bean isn't allowed
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLocalViewInvocationRemotelyOnSingleton() throws Exception {
+        final LocalEcho localEcho = (LocalEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + SingletonEcho.class.getSimpleName() + "!" + LocalEcho.class.getName());
+        final String message = "Silence!";
+        try {
+            final String echo = localEcho.echo(message);
+            Assert.fail("Remote invocation on a local view " + LocalEcho.class.getName() + " was expected to fail");
+        } catch (NoSuchEJBException nsee) {
+            // expected
+            logger.info("Got the expected exception on invoking on a local view, remotely", nsee);
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/SingletonEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/SingletonEcho.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.view;
+
+import javax.ejb.Local;
+import javax.ejb.LocalBean;
+import javax.ejb.Singleton;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Singleton
+@Local (LocalEcho.class)
+public class SingletonEcho extends CommonEcho {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/StatefulEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/StatefulEcho.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.view;
+
+import javax.ejb.Local;
+import javax.ejb.LocalBean;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+@Local(LocalEcho.class)
+public class StatefulEcho extends CommonEcho {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/StatelessEcho.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/StatelessEcho.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remote.view;
+
+import javax.ejb.Local;
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Local (LocalEcho.class)
+public class StatelessEcho extends CommonEcho {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/jbossappxml/FirstBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/jbossappxml/FirstBean.java
@@ -21,25 +21,28 @@
  */
 package org.jboss.as.test.integration.ejb.security.jbossappxml;
 
+import org.jboss.ejb3.annotation.RunAsPrincipal;
+
 import javax.annotation.security.RunAs;
 import javax.ejb.EJB;
+import javax.ejb.Remote;
 import javax.ejb.Stateless;
-
-import org.jboss.ejb3.annotation.RunAsPrincipal;
 
 /**
  * Simple EJB3 bean that calls another bean with a run as
+ *
  * @author anil saldhana
  */
 @RunAs("Employee")
 @RunAsPrincipal("javajoe")
 @Stateless
+@Remote(BeanInterface.class)
 public class FirstBean implements BeanInterface {
 
     @EJB
     private SecondBean secondBean;
 
-    public String getCallerPrincipal(){
+    public String getCallerPrincipal() {
         return secondBean.getCallerPrincipal();
     }
 


### PR DESCRIPTION
The commits in this branch fix the issue reported in https://issues.jboss.org/browse/AS7-3939. Remote EJB invocations on a local view are no longer permitted with this fix.
