### PR TITLE
AS7-2929: Add support for unscheduled write-behind cache stores to Infinispan subsytem

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
@@ -185,22 +185,22 @@
         <xs:sequence>
             <xs:element name="locking" type="tns:locking" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The locking configuration of the cache.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="transaction" type="tns:transaction" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The cache transaction configuration.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="eviction" type="tns:eviction" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The cache eviction configuration.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="expiration" type="tns:expiration" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The cache expiration configuration.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:choice minOccurs="0">
@@ -265,22 +265,22 @@
     <xs:complexType name="locking">
         <xs:attribute name="isolation" type="tns:isolation" default="REPEATABLE_READ">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Sets the cache locking isolation level.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="striping" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, a pool of shared locks is maintained for all entries that need to be locked. Otherwise, a lock is created per entry in the cache. Lock striping helps control memory footprint but may reduce concurrency in the system.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="acquire-timeout" type="xs:long" default="15000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum time to attempt a particular lock acquisition.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="concurrency-level" type="xs:int" default="1000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Concurrency level for lock containers. Adjust this value according to the number of concurrent threads interacting with Infinispan.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -288,17 +288,17 @@
     <xs:complexType name="transaction">
         <xs:attribute name="mode" type="tns:transaction-mode" default="NONE">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Sets the cache transaction mode to one of NONE, NON_XA, NON_DURABLE_XA, FULL_XA.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="stop-timeout" type="xs:long" default="30000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing remote and local transactions to finish. The amount of time to wait for is defined by the cache stop timeout.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="locking" type="tns:locking-mode" default="OPTIMISTIC">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>The locking mode for this cache, one of OPTIMISTIC or PESSIMISTIC.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -306,12 +306,12 @@
     <xs:complexType name="eviction">
         <xs:attribute name="strategy" type="tns:eviction-strategy" default="NONE">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="max-entries" type="xs:int" default="10000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum number of entries in a cache instance. If selected value is not a power of two the actual value will default to the least power of two larger than selected value. -1 means no limit.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -319,17 +319,17 @@
     <xs:complexType name="expiration">
         <xs:attribute name="max-idle" type="xs:long" default="-1">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="lifespan" type="xs:long" default="-1">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="interval" type="xs:long" default="5000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set wakeupInterval to -1.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -346,22 +346,22 @@
                 </xs:attribute>
                 <xs:attribute name="mode" type="tns:mode" use="required">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>Sets the clustered cache mode, ASYNC for asynchronous operation, or SYNC for synchronous operation.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="queue-size" type="xs:int" default="0">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>In ASYNC mode, this attribute can be used to trigger flushing of the queue when it reaches a specific threshold.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="queue-flush-interval" type="xs:long" default="10">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>In ASYNC mode, this attribute controls how often the asynchronous thread used to flush the replication queue runs. This should be a positive integer which represents thread wakeup time in milliseconds.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="remote-timeout" type="xs:long" default="17500">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>In SYNC mode, the timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
             </xs:extension>
@@ -381,7 +381,7 @@
                 <xs:sequence>
                     <xs:element name="state-transfer" type="tns:state-transfer" minOccurs="0">
                         <xs:annotation>
-                            <xs:documentation></xs:documentation>
+                            <xs:documentation>The state transfer configuration for distribution and replicated caches.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
@@ -395,7 +395,7 @@
                 <xs:sequence>
                     <xs:element name="state-transfer" type="tns:state-transfer" minOccurs="0">
                         <xs:annotation>
-                            <xs:documentation></xs:documentation>
+                            <xs:documentation>The state transfer configuration for distribution and replicated caches.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
@@ -420,40 +420,77 @@
 
     <xs:complexType name="store" abstract="true">
         <xs:sequence>
+            <xs:element name="write-behind" type="tns:write-behind" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Configures a cache store as write-behind instead of write-through.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="property" type="tns:property" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>A cache store property with name and value.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
         <xs:attribute name="shared" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="preload" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, when the cache starts, data stored in the cache store will be pre-loaded into memory. This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily. Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="passivation" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, data is only written to the cache store when it is evicted from memory, a phenomenon known as 'passivation'. Next time the data is requested, it will be 'activated' which means that data will be brought back to memory and removed from the persistent store. f false, the cache store contains a copy of the contents in memory, so writes to cache result in cache store writes. This essentially gives you a 'write-through' configuration.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="fetch-state" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, fetch persistent state when joining a cluster. If multiple cache stores are chained, only one of them can have this property enabled.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="purge" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="singleton" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="write-behind">
+        <xs:attribute name="flush-lock-timeout" type="xs:int" default="1">
+            <xs:annotation>
+                <xs:documentation>
+                    Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modification-queue-size" type="xs:int" default="1024">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through.
+                    until it can accept new entries
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="shutdown-timeout" type="xs:int" default="25000">
+            <xs:annotation>
+                <xs:documentation>
+                    Timeout in milliseconds to stop the cache store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="thread-pool-size" type="xs:int" default="1">
+            <xs:annotation>
+                <xs:documentation>
+                    Size of the thread pool whose threads are responsible for applying the modifications to the cache store.
+                </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -523,7 +560,7 @@
     <xs:complexType name="remote-server">
         <xs:attribute name="outbound-socket-binding" type="xs:string" use="required">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>An outbound socket binding for a remote server.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -654,17 +691,17 @@
     <xs:complexType name="state-transfer">
         <xs:attribute name="enabled" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="timeout" type="xs:long" default="60000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="chunk-size" type="xs:integer" default="10000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>The size, in bytes, in which to batch the transfer of cache entries.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.AttributeDefinition;
  * Enumerates the attributes used in the Infinispan subsystem schema.
  * @author Paul Ferraro
  * @author Richard Achmatowicz (c) 2011 RedHat Inc.
+ * @author Tristan Tarrant
  */
 public enum Attribute {
     // must be first
@@ -55,6 +56,7 @@ public enum Attribute {
     EXECUTOR(ModelKeys.EXECUTOR),
     FETCH_SIZE(ModelKeys.FETCH_SIZE),
     FETCH_STATE(ModelKeys.FETCH_STATE),
+    FLUSH_LOCK_TIMEOUT(ModelKeys.FLUSH_LOCK_TIMEOUT),
     @Deprecated FLUSH_TIMEOUT("flush-timeout"),
     INDEXING(ModelKeys.INDEXING),
     INTERVAL(ModelKeys.INTERVAL),
@@ -69,6 +71,7 @@ public enum Attribute {
     MAX_ENTRIES(ModelKeys.MAX_ENTRIES),
     MAX_IDLE(ModelKeys.MAX_IDLE),
     MODE(ModelKeys.MODE),
+    MODIFICATION_QUEUE_SIZE(ModelKeys.MODIFICATION_QUEUE_SIZE),
     NAME(ModelKeys.NAME),
     NAMESPACE(XMLConstants.XMLNS_ATTRIBUTE),
     OUTBOUND_SOCKET_BINDING(ModelKeys.OUTBOUND_SOCKET_BINDING),
@@ -85,6 +88,7 @@ public enum Attribute {
     REMOTE_TIMEOUT(ModelKeys.REMOTE_TIMEOUT),
     REPLICATION_QUEUE_EXECUTOR(ModelKeys.REPLICATION_QUEUE_EXECUTOR),
     SHARED(ModelKeys.SHARED),
+    SHUTDOWN_TIMEOUT(ModelKeys.SHUTDOWN_TIMEOUT),
     SINGLETON(ModelKeys.SINGLETON),
     SITE(ModelKeys.SITE),
     SOCKET_TIMEOUT(ModelKeys.SOCKET_TIMEOUT),
@@ -94,6 +98,7 @@ public enum Attribute {
     STRATEGY(ModelKeys.STRATEGY),
     STRIPING(ModelKeys.STRIPING),
     TCP_NO_DELAY(ModelKeys.TCP_NO_DELAY),
+    THREAD_POOL_SIZE(ModelKeys.THREAD_POOL_SIZE),
     TIMEOUT(ModelKeys.TIMEOUT),
     TYPE(ModelKeys.TYPE),
     VIRTUAL_NODES(ModelKeys.VIRTUAL_NODES),

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -404,6 +404,7 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
             final boolean fetchState = CommonAttributes.FETCH_STATE.resolveModelAttribute(context, store).asBoolean();
             final boolean purge = CommonAttributes.PURGE.resolveModelAttribute(context, store).asBoolean();
             final boolean singleton = CommonAttributes.SINGLETON.resolveModelAttribute(context, store).asBoolean();
+            final boolean async = store.hasDefined(ModelKeys.WRITE_BEHIND);
 
             builder.loaders()
                     .shared(shared)
@@ -416,6 +417,16 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
                     .purgeSynchronously(true)
             ;
             storeBuilder.singletonStore().enabled(singleton);
+
+            if(async) {
+                ModelNode writeBehind = store.get(ModelKeys.WRITE_BEHIND);
+                storeBuilder.async().enable()
+                    .flushLockTimeout(CommonAttributes.FLUSH_LOCK_TIMEOUT.resolveModelAttribute(context, writeBehind).asLong())
+                    .modificationQueueSize(CommonAttributes.MODIFICATION_QUEUE_SIZE.resolveModelAttribute(context, writeBehind).asInt())
+                    .shutdownTimeout(CommonAttributes.SHUTDOWN_TIMEOUT.resolveModelAttribute(context, writeBehind).asLong())
+                    .threadPoolSize(CommonAttributes.THREAD_POOL_SIZE.resolveModelAttribute(context, writeBehind).asInt());
+            }
+
             this.buildCacheStore(context, storeBuilder, containerName, store, storeKey, dependencies);
         }
     }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -20,6 +20,7 @@ import org.jboss.dmr.ModelType;
  * To mark an attribute as required, mark it as not allowing null.
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ * @author Tristan Tarrant
  */
 public interface CommonAttributes {
 
@@ -154,6 +155,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(true))
                     .build();
+    SimpleAttributeDefinition FLUSH_LOCK_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.FLUSH_LOCK_TIMEOUT, ModelType.LONG, true)
+                    .setXmlName(Attribute.FLUSH_LOCK_TIMEOUT.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(1))
+                    .build();
     SimpleAttributeDefinition INDEXING =
             new SimpleAttributeDefinitionBuilder(ModelKeys.INDEXING, ModelType.STRING, true)
                     .setXmlName(Attribute.INDEXING.getLocalName())
@@ -251,6 +259,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new EnumValidator<TransactionMode>(TransactionMode.class, true, false))
                     .setDefaultValue(new ModelNode().set("NONE"))
+                    .build();
+    SimpleAttributeDefinition MODIFICATION_QUEUE_SIZE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.MODIFICATION_QUEUE_SIZE, ModelType.INT, true)
+                    .setXmlName(Attribute.MODIFICATION_QUEUE_SIZE.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(1024))
                     .build();
     SimpleAttributeDefinition NAME =
             new SimpleAttributeDefinitionBuilder(ModelKeys.NAME, ModelType.STRING, true)
@@ -353,6 +368,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(false))
                     .build();
+    SimpleAttributeDefinition SHUTDOWN_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.SHUTDOWN_TIMEOUT, ModelType.LONG, true)
+                    .setXmlName(Attribute.SHUTDOWN_TIMEOUT.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(25000))
+                    .build();
     SimpleAttributeDefinition SINGLETON =
             new SimpleAttributeDefinitionBuilder(ModelKeys.SINGLETON, ModelType.BOOLEAN, true)
                     .setXmlName(Attribute.SINGLETON.getLocalName())
@@ -428,6 +450,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(60000))
                     .build();
+    SimpleAttributeDefinition THREAD_POOL_SIZE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.THREAD_POOL_SIZE, ModelType.INT, true)
+                    .setXmlName(Attribute.THREAD_POOL_SIZE.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(1))
+                    .build();
     SimpleAttributeDefinition TYPE =
             new SimpleAttributeDefinitionBuilder(ModelKeys.TYPE, ModelType.STRING, true)
                     .setXmlName(Attribute.TYPE.getLocalName())
@@ -496,6 +525,13 @@ public interface CommonAttributes {
             setSuffix("state-transfer").
             build();
 
+    // common store
+    ObjectTypeAttributeDefinition WRITE_BEHIND = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.WRITE_BEHIND, FLUSH_LOCK_TIMEOUT, MODIFICATION_QUEUE_SIZE, THREAD_POOL_SIZE, SHUTDOWN_TIMEOUT).
+            setAllowNull(true).
+            setSuffix("write-behind").
+            build();
+
     // jdbc store
     SimpleAttributeDefinition COLUMN_NAME = new SimpleAttributeDefinition("name", ModelType.STRING, true);
     SimpleAttributeDefinition COLUMN_TYPE = new SimpleAttributeDefinition("type", ModelType.STRING, true);
@@ -536,9 +572,10 @@ public interface CommonAttributes {
             setAllowNull(true).
             build();
 
-    AttributeDefinition[] COMMON_STORE_ATTRIBUTES = {SHARED, PRELOAD, PASSIVATION, FETCH_STATE, PURGE, SINGLETON, PROPERTIES};
+    AttributeDefinition[] COMMON_STORE_ATTRIBUTES = {SHARED, PRELOAD, PASSIVATION, FETCH_STATE, PURGE, SINGLETON, WRITE_BEHIND, PROPERTIES};
     AttributeDefinition[] STORE_ATTRIBUTES = {CLASS};
     AttributeDefinition[] FILE_STORE_ATTRIBUTES = {RELATIVE_TO, PATH};
     AttributeDefinition[] JDBC_STORE_ATTRIBUTES = {DATA_SOURCE, ENTRY_TABLE, BUCKET_TABLE};
     AttributeDefinition[] REMOTE_STORE_ATTRIBUTES = {CACHE, TCP_NO_DELAY, SOCKET_TIMEOUT, REMOTE_SERVERS};
+
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Element.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Element.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.AttributeDefinition;
  *
  * @author Paul Ferraro
  * @author Richard Achmatowicz (c) 2011 RedHat Inc.
+ * @author Tristan Tarrant
  */
 public enum Element {
     // must be first
@@ -62,6 +63,7 @@ public enum Element {
     TIMESTAMP_COLUMN(ModelKeys.TIMESTAMP_COLUMN),
     TRANSACTION(ModelKeys.TRANSACTION),
     TRANSPORT(ModelKeys.TRANSPORT),
+    WRITE_BEHIND(ModelKeys.WRITE_BEHIND)
     ;
 
     private final String name;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -182,6 +182,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeStartElement(Element.STORE.getLocalName());
                         this.writeRequired(writer, Attribute.CLASS, store, ModelKeys.CLASS);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         writer.writeEndElement();
                     }
@@ -191,6 +192,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         this.writeOptional(writer, Attribute.RELATIVE_TO, store, ModelKeys.RELATIVE_TO);
                         this.writeOptional(writer, Attribute.PATH, store, ModelKeys.PATH);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         writer.writeEndElement();
                     }
@@ -199,6 +201,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeStartElement(Element.JDBC_STORE.getLocalName());
                         this.writeRequired(writer, Attribute.DATASOURCE, store, ModelKeys.DATASOURCE);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         this.writeJDBCStoreTable(writer, Element.BUCKET_TABLE, store, ModelKeys.BUCKET_TABLE);
                         this.writeJDBCStoreTable(writer, Element.ENTRY_TABLE, store, ModelKeys.ENTRY_TABLE);
@@ -211,6 +214,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         this.writeOptional(writer, Attribute.SOCKET_TIMEOUT, store, ModelKeys.SOCKET_TIMEOUT);
                         this.writeOptional(writer, Attribute.TCP_NO_DELAY, store, ModelKeys.TCP_NO_DELAY);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         for (ModelNode remoteServer: store.get(ModelKeys.REMOTE_SERVERS).asList()) {
                             writer.writeStartElement(Element.REMOTE_SERVER.getLocalName());
@@ -293,6 +297,18 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
         this.writeOptional(writer, Attribute.FETCH_STATE, store, ModelKeys.FETCH_STATE);
         this.writeOptional(writer, Attribute.PURGE, store, ModelKeys.PURGE);
         this.writeOptional(writer, Attribute.SINGLETON, store, ModelKeys.SINGLETON);
+    }
+
+    private void writeStoreWriteBehind(XMLExtendedStreamWriter writer, ModelNode store) throws XMLStreamException {
+        if (store.hasDefined(ModelKeys.WRITE_BEHIND)) {
+            ModelNode writeBehind = store.get(ModelKeys.WRITE_BEHIND);
+            writer.writeStartElement(Element.WRITE_BEHIND.getLocalName());
+            this.writeOptional(writer, Attribute.FLUSH_LOCK_TIMEOUT, writeBehind, ModelKeys.FLUSH_LOCK_TIMEOUT);
+            this.writeOptional(writer, Attribute.MODIFICATION_QUEUE_SIZE, writeBehind, ModelKeys.MODIFICATION_QUEUE_SIZE);
+            this.writeOptional(writer, Attribute.SHUTDOWN_TIMEOUT, writeBehind, ModelKeys.SHUTDOWN_TIMEOUT);
+            this.writeOptional(writer, Attribute.THREAD_POOL_SIZE, writeBehind, ModelKeys.THREAD_POOL_SIZE);
+            writer.writeEndElement();
+        }
     }
 
     private void writeStoreProperties(XMLExtendedStreamWriter writer, ModelNode store) throws XMLStreamException {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -24,6 +24,7 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 /**
  * @author Paul Ferraro
+ * @author Tristan Tarrant
  */
 public class ModelKeys {
     static final String ACQUIRE_TIMEOUT = "acquire-timeout";
@@ -58,6 +59,7 @@ public class ModelKeys {
     static final String FETCH_STATE = "fetch-state";
     static final String FILE_STORE = "file-store";
     static final String FILE_STORE_NAME = "FILE_STORE";
+    static final String FLUSH_LOCK_TIMEOUT = "flush-lock-timeout";
     static final String ID_COLUMN = "id-column";
     static final String INDEXING = "indexing";
     static final String INTERVAL = "interval";
@@ -77,6 +79,7 @@ public class ModelKeys {
     static final String MAX_ENTRIES = "max-entries";
     static final String MAX_IDLE = "max-idle";
     static final String MODE = "mode";
+    static final String MODIFICATION_QUEUE_SIZE = "modification-queue-size";
     static final String NAME = "name";
     static final String OUTBOUND_SOCKET_BINDING = "outbound-socket-binding";
     static final String OWNERS = "owners";
@@ -99,6 +102,7 @@ public class ModelKeys {
     static final String REPLICATED_CACHE = "replicated-cache";
     static final String REPLICATION_QUEUE_EXECUTOR = "replication-queue-executor";
     static final String SHARED = "shared";
+    static final String SHUTDOWN_TIMEOUT = "shutdown-timeout";
     static final String SINGLETON = "singleton";
     static final String SITE = "site";
     static final String SOCKET_TIMEOUT = "socket-timeout";
@@ -112,6 +116,7 @@ public class ModelKeys {
     static final String STRATEGY = "strategy";
     static final String STRIPING = "striping";
     static final String TCP_NO_DELAY = "tcp-no-delay";
+    static final String THREAD_POOL_SIZE = "thread-pool-size";
     static final String TIMEOUT = "timeout";
     static final String TIMESTAMP_COLUMN = "timestamp-column";
     static final String TRANSACTION = "transaction";
@@ -121,4 +126,5 @@ public class ModelKeys {
     static final String TYPE = "type";
     static final String VIRTUAL_NODES = "virtual-nodes";
     static final String WAIT = "wait";
+    static final String WRITE_BEHIND = "write-behind";
 }

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -90,6 +90,12 @@ infinispan.cache.store.purge=If true, purges this cache store when it starts up.
 infinispan.cache.store.singleton=If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store.
 infinispan.cache.store.class=The custom store implementation class to use for this cache store.
 
+infinispan.cache.store.write-behind=Configures a cache store as write-behind instead of write-through.
+infinispan.cache.store.write-behind.flush-lock-timeout=Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.
+infinispan.cache.store.write-behind.modification-queue-size=Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through until it can accept new entries.
+infinispan.cache.store.write-behind.shutdown-timeout=Timeout in milliseconds to stop the cache store.
+infinispan.cache.store.write-behind.thread-pool-size=Size of the thread pool whose threads are responsible for applying the modifications to the cache store.
+
 infinispan.cache.store.properties=A list of cache store properties.
 infinispan.cache.store.property=A cache store property with name and value.
 infinispan.cache.store.property.add=Adds a cache store property.

--- a/clustering/infinispan/src/test/resources/subsystem-infinispan_1_2.xml
+++ b/clustering/infinispan/src/test/resources/subsystem-infinispan_1_2.xml
@@ -29,6 +29,7 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
             <store class="org.infinispan.loaders.file.FileCacheStore" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
                 <property name="location">${java.io.tmpdir}</property>
             </store>
         </replicated-cache>


### PR DESCRIPTION
This adds a new <write-behind /> element as a child of the various <store /> elements.
Unfortunately, because of an Infinispan limitation, this feature does not support injection of an external thread pool. 
