### PR TITLE
AS7-3989: upgrade PicketLink to 2.0.2.Final and remove the PL trust jar

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1140,7 +1140,6 @@
             <maven-resource group="org.picketlink" artifact="picketlink-fed" jandex="true"/>
             <maven-resource group="org.picketlink" artifact="picketlink-bindings" jandex="true"/>
             <maven-resource group="org.picketlink" artifact="picketlink-bindings-jboss"/>
-            <maven-resource group="org.picketlink" artifact="picketlink-trust-jbossws"/>
         </module-def>
 
         <module-def name="org.picketbox">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1600,11 +1600,6 @@
                 </dependency>
 
                 <dependency>
-                    <groupId>org.picketlink</groupId>
-                    <artifactId>picketlink-trust-jbossws</artifactId>
-                </dependency>
-
-                <dependency>
                     <groupId>org.projectodd.stilts</groupId>
                     <artifactId>stilts-stomplet-server-bundle</artifactId>
                 </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.org.mockito>1.8.5</version.org.mockito>
         <version.org.picketbox>4.0.6.final</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
-        <version.org.picketlink>2.0.1.final</version.org.picketlink>
+        <version.org.picketlink>2.0.2.Final</version.org.picketlink>
         <version.org.powermock>1.4.11</version.org.powermock>
         <version.org.projectodd.stilts>0.1.26</version.org.projectodd.stilts>
         <version.org.python.jython.standalone>2.5.2</version.org.python.jython.standalone>
@@ -5693,26 +5693,6 @@
                     <exclusion>
                         <groupId>org.picketlink</groupId>
                         <artifactId>picketlink-web</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.picketlink</groupId>
-                <artifactId>picketlink-trust-jbossws</artifactId>
-                <version>${version.org.picketlink}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.logging</groupId>
-                        <artifactId>jboss-logging-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketbox</groupId>
-                        <artifactId>jboss-security-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketbox</groupId>
-                        <artifactId>jbosssx</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
The PicketLink trust jar contains code for AS5/6.  It should not be available to As7
