### PR TITLE
AS7-3916 Terminate processes on fatal boot errors

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -157,8 +157,6 @@ public abstract class AbstractControllerService implements Service<ModelControll
                                 return target;
                             }
                         });
-                    } catch (ConfigurationPersistenceException e) {
-                        throw new RuntimeException(e);
                     } finally {
                         processState.setRunning();
                     }
@@ -184,12 +182,12 @@ public abstract class AbstractControllerService implements Service<ModelControll
      *          if the configuration failed to be loaded
      */
     protected void boot(final BootContext context) throws ConfigurationPersistenceException {
-        boot(configurationPersister.load());
+        boot(configurationPersister.load(), false);
         finishBoot();
     }
 
-    protected void boot(List<ModelNode> bootOperations) throws ConfigurationPersistenceException {
-        controller.boot(bootOperations, OperationMessageHandler.logging, ModelController.OperationTransactionControl.COMMIT);
+    protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure) throws ConfigurationPersistenceException {
+        return controller.boot(bootOperations, OperationMessageHandler.logging, ModelController.OperationTransactionControl.COMMIT, false);
     }
 
     protected void finishBoot() throws ConfigurationPersistenceException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerLogger.java
@@ -165,4 +165,14 @@ public interface DomainControllerLogger extends BasicLogger {
     @Message(id = 10809, value = "%s caught %s waiting for task %s; returning")
     void caughtExceptionWaitingForTaskReturning(String className, String exceptionName, String task);
 
+    /**
+     * Logs an error message indicating the content for a configured deployment was unavailable at boot but boot
+     * was allowed to proceed because the HC is in admin-only mode.
+     *
+     * @param contentHash    the content hash that could not be found.
+     * @param deploymentName the deployment name.
+     */
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 10810, value = "No deployment content with hash %s is available in the deployment content repository for deployment %s. Because this Host Controller is booting in ADMIN-ONLY mode, boot will be allowed to proceed to provide administrators an opportunity to correct this problem. If this Host Controller were not in ADMIN-ONLY mode this would be a fatal boot failure.")
+    void reportAdminOnlyMissingDeploymentContent(String contentHash, String deploymentName);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
@@ -533,4 +533,17 @@ public interface DomainControllerMessages {
      */
     @Message(id = 10875, value = "No profile called: %s")
     OperationFailedException noProfileCalled(String profile);
+
+    /**
+     * Error message indicating the content for a configured deployment was unavailable at boot, which is a fatal error.
+     *
+     *
+     *
+     * @param contentHash    the content hash that could not be found.
+     *
+     * @param deploymentName the deployment name.
+     * @return the error message
+     */
+    @Message(id = 10876, value = "No deployment content with hash %s is available in the deployment content repository for deployment '%s'. This is a fatal boot error. To correct the problem, either restart with the --admin-only switch set and use the CLI to install the missing content or remove it from the configuration, or remove the deployment from the xml configuraiton file and restart.")
+    String noDeploymentContentWithHashAtBoot(String contentHash, String deploymentName);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerLogger.java
@@ -353,4 +353,16 @@ public interface HostControllerLogger extends BasicLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = 10931, value = "Cannot store the domain model using using --cached-dc")
     void invalidCachedPersisterState();
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 10932, value = "Caught exception during boot")
+    void caughtExceptionDuringBoot(@Cause Exception e);
+
+    @LogMessage(level = Level.FATAL)
+    @Message(id = 10933, value = "Host Controller boot has failed in an unrecoverable manner; exiting. See previous messages for details.")
+    void unsuccessfulBoot();
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 10934, value = "Installation of the domain-wide configuration has failed. Because the running mode of this Host Controller is ADMIN_ONLY boot has been allowed to proceed. If ADMIN_ONLY mode were not in effect the process would be terminated due to a critical boot failure.")
+    void reportAdminOnlyDomainXmlFailure();
 }

--- a/server/src/main/java/org/jboss/as/server/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/ServerLogger.java
@@ -333,4 +333,26 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 15954, value= "Admin console is not enabled")
     void logNoConsole();
+
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 15956, value = "Caught exception during boot")
+    void caughtExceptionDuringBoot(@Cause Exception e);
+
+
+    @LogMessage(level = Logger.Level.FATAL)
+    @Message(id = 15957, value = "Server boot has failed in an unrecoverable manner; exiting. See previous messages for details.")
+    void unsuccessfulBoot();
+
+    /**
+     * Logs an error message indicating the content for a configured deployment was unavailable at boot but boot
+     * was allowed to proceed because the HC is in admin-only mode.
+     *
+     * @param contentHash    the content hash that could not be found.
+     * @param deploymentName the deployment name.
+     */
+    @LogMessage(level = Logger.Level.ERROR)
+    @Message(id = 15958, value = "No deployment content with hash %s is available in the deployment content repository for deployment %s. Because this Host Controller is booting in ADMIN-ONLY mode, boot will be allowed to proceed to provide administrators an opportunity to correct this problem. If this Host Controller were not in ADMIN-ONLY mode this would be a fatal boot failure.")
+    void reportAdminOnlyMissingDeploymentContent(String contentHash, String deploymentName);
+
+    // NOTE
 }

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -416,4 +416,7 @@ public interface ServerMessages {
 
     @Message(id = 18716, value = "Could not create server base directory: %s")
     IllegalStateException couldNotCreateServerBaseDirectory(File file);
+
+    @Message(id = 18717, value = "No deployment content with hash %s is available in the deployment content repository for deployment '%s'. This is a fatal boot error. To correct the problem, either restart with the --admin-only switch set and use the CLI to install the missing content or remove it from the configuration, or remove the deployment from the xml configuraiton file and restart..")
+    OperationFailedException noSuchDeploymentContentAtBoot(String contentHash, String deploymentName);
 }

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -259,9 +259,9 @@ public class ServerControllerUnitTestCase {
         }
 
         @Override
-        protected void boot(List<ModelNode> bootOperations) throws ConfigurationPersistenceException {
+        protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure) throws ConfigurationPersistenceException {
             try {
-                super.boot(persister.bootOperations);
+                return super.boot(persister.bootOperations, rollbackOnRuntimeFailure);
             } catch (Exception e) {
                 error = e;
             } catch (Throwable t) {
@@ -269,6 +269,7 @@ public class ServerControllerUnitTestCase {
             } finally {
                 latch.countDown();
             }
+            return false;
         }
 
         @Override

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -753,12 +753,12 @@ public abstract class AbstractSubsystemTest {
         }
 
         @Override
-        protected void boot(List<ModelNode> bootOperations) throws ConfigurationPersistenceException {
+        protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure) throws ConfigurationPersistenceException {
             try {
                 if (validateOps) {
                     new OperationValidator(rootRegistration).validateOperations(bootOperations);
                 }
-                super.boot(persister.bootOperations);
+                return super.boot(persister.bootOperations, rollbackOnRuntimeFailure);
             } catch (Exception e) {
                 error = e;
             } catch (Throwable t) {
@@ -767,6 +767,8 @@ public abstract class AbstractSubsystemTest {
                 DeployerChainAddHandler.INSTANCE.clearDeployerMap();
                 latch.countDown();
             }
+
+            return false;
         }
 
         @Override


### PR DESCRIPTION
AS7-3916 Don't fail on missing deployment content during admin-only boot

These commits solve issues where processes, particularly Host Controllers were being left alive following major boot errors. The result was the processes were semi-manageable but users would not know they were broken, and any management updates would result in corrupted configuration files.
