### PR TITLE
[AS7-2342] Allow tmp, log and data directories to be organized by type.

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
@@ -91,8 +91,9 @@ public class AppClientXml extends CommonXml {
                 readServerElement_1_0(reader, address, operationList);
                 break;
             }
-            case DOMAIN_1_1: {
-                readServerElement_1_1(reader, address, operationList);
+            case DOMAIN_1_1:
+            case DOMAIN_1_2: {
+                readServerElement_1_1(readerNS, reader, address, operationList);
                 break;
             }
             default: {
@@ -203,7 +204,7 @@ public class AppClientXml extends CommonXml {
      * @param list the list of boot operations to which any new operations should be added
      * @throws XMLStreamException if a parsing error occurs
      */
-    private void readServerElement_1_1(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
+    private void readServerElement_1_1(final Namespace namespace, final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
             throws XMLStreamException {
 
         parseNamespaces(reader, address, list);
@@ -252,41 +253,41 @@ public class AppClientXml extends CommonXml {
 
         // elements - sequence
 
-        Element element = nextElement(reader, DOMAIN_1_1);
+        Element element = nextElement(reader, namespace);
         if (element == Element.EXTENSIONS) {
-            extensionXml.parseExtensions(reader, address, DOMAIN_1_1, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            extensionXml.parseExtensions(reader, address, namespace, list);
+            element = nextElement(reader, namespace);
         }
         // System properties
         if (element == Element.SYSTEM_PROPERTIES) {
-            parseSystemProperties(reader, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseSystemProperties(reader, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
         if (element == Element.PATHS) {
-            parsePaths(reader, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parsePaths(reader, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
 
         if (element == Element.VAULT) {
-            parseVault(reader, address, DOMAIN_1_1, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseVault(reader, address, namespace, list);
+            element = nextElement(reader, namespace);
         }
         // Single profile
         if (element == Element.PROFILE) {
             parseServerProfile(reader, address, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            element = nextElement(reader, namespace);
         }
 
         // Interfaces
         final Set<String> interfaceNames = new HashSet<String>();
         if (element == Element.INTERFACES) {
-            parseInterfaces(reader, interfaceNames, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseInterfaces(reader, interfaceNames, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
         // Single socket binding group
         if (element == Element.SOCKET_BINDING_GROUP) {
-            parseSocketBindingGroup(reader, interfaceNames, address, DOMAIN_1_1, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseSocketBindingGroup(reader, interfaceNames, address, namespace, list);
+            element = nextElement(reader, namespace);
         }
 
         if (element != null) {

--- a/build/src/main/resources/appclient/configuration/appclient.xml
+++ b/build/src/main/resources/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/build/src/main/resources/configuration/domain/template.xml
+++ b/build/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.1">
+<domain xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <?EXTENSIONS?>
@@ -38,7 +38,7 @@
         <interface name="public"/>
         <interface name="unsecure"/>
     </interfaces>
-   
+
     <socket-binding-groups>
         <socket-binding-group name="standard-sockets" default-interface="public">
             <!-- Needed for server groups using the 'default' profile  -->
@@ -57,7 +57,7 @@
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
     </socket-binding-groups>
-    
+
     <server-groups>
         <server-group name="main-server-group" profile="full">
             <jvm name="default">
@@ -72,5 +72,5 @@
             <socket-binding-group ref="ha-sockets"/>
         </server-group>
     </server-groups>
-    
+
 </domain>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/domain.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/domain.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.1">
+<domain xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-hornetq-colocated.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-hornetq-colocated.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-jts.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-jts.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-minimalistic.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-osgi-only.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-osgi-only.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-xts.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/examples/standalone-xts.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full-ha.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full-ha.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone-full.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone-ha.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone-ha.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/retired-delete-once-stable/standalone.xml
+++ b/build/src/main/resources/configuration/retired-delete-once-stable/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/docs/examples/configs/standalone-minimalistic.xml
+++ b/build/src/main/resources/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/build/src/main/resources/docs/schema/jboss-as-config_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_2.xsd
@@ -1,0 +1,2114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:1.2"
+           targetNamespace="urn:jboss:domain:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+
+    <xs:element name="domain">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the master document specifying the core configuration
+                for the servers in a domain. There should be one such master
+                document per domain, available to the host controller that
+                is configured to act as the domain controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="paths" type="named-pathsType" minOccurs="0" maxOccurs="1" />
+                <xs:element name="profiles" type="profilesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="interfaces" type="named-interfacesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="socket-binding-groups" type="socket-binding-groupsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployments" type="domain-deploymentsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="server-groups" type="server-groupsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management-client-content" type="management-client-contentType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="host">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for a document configuring a host controller and
+                the group of servers under the control of that host controller.
+                The standard usage would be for a domain to have one such host controller
+                on each physical (or virtual) host machine. Emphasis in this
+                document is on enumerating the servers, configuring items that
+                are specific to the host environment (e.g. IP addresses), and
+                on any server-specific configuration settings.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0"/>
+                <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1" />
+                <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management" type="host-managementType" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="domain-controller" type="domain-controllerType"/>
+                <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0"/>
+                <xs:element name="jvms" type="jvmsType" minOccurs="0"/>
+                <xs:element name="servers" type="serversType" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for this host's host controller. Must be unique across the domain.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="server">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for a document specifying the configuration
+                of a single "standalone" server that does not operate
+                as part of a domain.
+
+                Note that this element is distinct from the 'serverType'
+                specified in this schema. The latter type forms part of the
+                configuration of a server that operates as part of a domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management" type="server-managementType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="profile" type="standalone-profileType" minOccurs="0"/>
+                <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployments" type="mapped-deploymentsType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for this server.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="domain-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                Domain-wide default configuration settings for the management of standalone servers and a Host Controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="security-realms" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="security-realm" type="security-realmType" minOccurs="1"
+                                    maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outbound-connections" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="ldap" type="ldapType" minOccurs="1" /> <!-- TODO minOccurs only while ldap is only supported connection. -->
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="host-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for the management of a Host Controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="domain-managementType">
+                <xs:sequence>
+                    <xs:element name="management-interfaces" type="host-management-interfacesType" minOccurs="1"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="server-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for the management of standalone server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="domain-managementType">
+                <xs:sequence>
+                    <xs:element name="management-interfaces" type="server-management-interfacesType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ldapType">
+        <xs:annotation>
+            <xs:documentation>
+                The LDAP connection definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The URL to connect to ldap.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <!-- TODO - Later will be optional if we support GSSAPI to connect to LDAP -->
+        <xs:attribute name="search-dn" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The distinguished name to use when connecting to LDAP to perform searches.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-credential" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The credential to use when connecting to perform a search.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-context-factory" type="xs:string" default="com.sun.jndi.ldap.LdapCtxFactory">
+            <xs:annotation>
+                <xs:documentation>
+                    The initial context factory to establish the LdapContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="security-realmType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a security realm for securing access to the management interfaces.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-identities" type="server-identitiesType" minOccurs="0" />
+            <xs:element name="authentication" type="authenticationType" minOccurs="0" />
+            <xs:element name="authorization" type="authorizationType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this security-realm, each security-realm must be assigned a unique name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authorizationType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration defining how to load the authorization information for the authenticated user.
+
+                After a user has been authenticated additional information such as roles can be loaded and
+                associated with the user for subsequent authorization checks, this type is used to define
+                how the roles are loaded.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties" type="propertiesFileType" minOccurs="1" />  <!-- minOccurs="1" while this is the only mech -->
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-identitiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the identities that represent the server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element name="ssl" type="sslType" minOccurs="0" />
+          <xs:element name="secret" type="secretType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="secretType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the secret/password-based identity of this server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The secret / password - Base64 Encoded
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="sslType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the SSL identity of this server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="keystore" type="keystoreType" />
+        </xs:sequence>
+        <xs:attribute name="protocol" type="xs:string" default="TLS">
+            <xs:annotation>
+                <xs:documentation>
+                    The protocol to use when creating the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keystoreType">
+        <xs:annotation>
+            <xs:documentation>
+                The keystore configuration for the server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The path of the keystore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="password" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The password to open the keystore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the server side authentication mechanisms.
+
+                Optionally one truststore can be defined and one username/password based store can be defined.
+                Authentication will first attempt to use the truststore and if this is not available will fall back
+                to the username/password authentication.
+
+                If none of these are specified the only available mechanism will be the local mechanism for the
+                Native interface and the HTTP interface will not be accessible.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="truststore" type="keystoreType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of a keystore to use to create a trust manager to verify clients.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0">
+                <xs:element name="jaas" type="jaasAuthenticationType" minOccurs="0" />
+                <xs:element name="ldap" type="ldapAuthenticationType" minOccurs="0" />
+                <xs:element name="properties" type="propertiesAuthenticationType" minOccurs="0" />
+                <xs:element name="users" type="usersAuthenticationType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jaasAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to use a JAAS based configuration for authentication.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name identifying the jaas configuration of LoginModules.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to use LDAP as the user repository.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="username-filter">
+                <xs:complexType>
+                    <xs:attribute name="attribute" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The name of the attribute to search for the user, this filter will then perform
+                                a simple search where the username entered by the user matches the attribute
+                                specified here.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="advanced-filter">
+                <xs:complexType>
+                    <xs:attribute name="filter" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully defined filter to be used to search for the user based on their entered
+                                user ID. The filter should contain a variable in the form {0} - this will be
+                                replaced with the username supplied by the user.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+
+        <xs:attribute name="connection" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the connection to use to connect to LDAP.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="base-dn" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The base distinguished name to commence the search for the user.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recursive" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should the search be recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="user-dn" type="xs:string" default="dn">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the attribute which is the users distinguished name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="usersAuthenticationType">
+           <xs:annotation>
+            <xs:documentation>
+                A set of users
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="user" type="userType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="userType">
+        <xs:annotation>
+            <xs:documentation>
+                A single user.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="password" type="xs:string" />
+        </xs:choice>
+        <xs:attribute name="username" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The users username.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesFileType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of a location of a properties file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The path of the properties file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of users stored within properties files.
+
+                The entries within the properties file are username={credentials} with each user
+                being specified on it's own line.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="propertiesFileType">
+                <xs:attribute name="plain-text" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Are the credentials within the properties file stored in plain text, if not
+                            the {credential} is expected to be the hex encoded Digest hash
+                            of 'username : realm : password'.
+                        </xs:documentation>
+                    </xs:annotation>
+            </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-management-interfacesType">
+        <xs:sequence>
+            <xs:element name="native-interface" type="host-native-management-interfaceType"/>
+            <xs:element name="http-interface" type="host-http-management-interfaceType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="management-interfaceType">
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The security realm to use for this management interface, the capabilities
+                    of the security realm will be queried to identify the authentication mechanism(s) to
+                    offer.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="host-native-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a host's exposed native management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="socket" type="native-management-socketType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Network interface on which the host's socket for
+                    management communication should be opened.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-socketType">
+                <xs:attribute name="port" type="xs:int" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for native
+                            management communication should be opened.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-http-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a host's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="socket" type="http-management-socketType"/>
+                </xs:sequence>
+                <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-socketType">
+                <xs:attribute name="port" type="xs:int" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for
+                            management communication should be opened.
+
+                            If not specified the port will not be opened.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="secure-port" type="xs:int" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for HTTPS
+                            management communication should be opened.
+
+                            If not specified the port will not be opened.
+
+                            If specified the security-realm will be required to obtain
+                            the SSL configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="server-management-interfacesType">
+        <xs:sequence>
+            <xs:element name="native-remoting-interface" type="management-remoting-interfaceType" minOccurs="0"/>
+            <xs:element name="native-interface" type="server-native-management-interfaceType" minOccurs="0"/>
+            <xs:element name="http-interface" type="server-http-management-interfaceType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-native-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the socket to use for the native management interface is a choice
+                        between a direct configuration of the address and port, or a reference to a socket-binding
+                        configuration in the server's socket-binding-group element. The latter is the recommended
+                        approach is it makes it easier to avoid port conflicts by taking advantage of the
+                        socket-binding-group's port-offset configuration. Direct configuration of the address and
+                        ports is provided to preserve backward compatibility.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:choice>
+                    <xs:element name="socket" type="native-management-socketType"/>
+                    <xs:element name="socket-binding" type="native-management-socket-binding-refType"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-socket-binding-refType">
+        <xs:annotation>
+            <xs:documentation>
+                Reference to the configuration of the socket to be used by a standalone server's exposed native management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="native" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-http-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a standalone server's exposed HTTP/HTTPS management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the socket to use for the HTTP/HTTPS management interface is a choice
+                        between a direct configuration of the address and ports, or a reference to socket-binding
+                        configurations in the server's socket-binding-group element. The latter is the recommended
+                        approach is it makes it easier to avoid port conflicts by taking advantage of the
+                        socket-binding-group's port-offset configuration. Direct configuration of the address and
+                        ports is provided to preserve backward compatibility.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:choice>
+                    <xs:element name="socket" type="http-management-socketType"/>
+                    <xs:element name="socket-binding" type="http-management-socket-binding-refType"/>
+                </xs:choice>
+                <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-socket-binding-refType">
+        <xs:annotation>
+            <xs:documentation>
+                Reference to the configurations of the sockets to be used by a standalone server's exposed HTTP and HTTPS management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="http" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group to use for a HTTP socket.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="https" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group to use for a HTTPS socket.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="management-remoting-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Makes the native management interface available via the connectors set up in the remoting subsystem,
+                using the remoting subsystem's endpoint. This should only be used for a server not for a HC/DC.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controllerType">
+        <xs:choice>
+            <xs:element name="local" type="domain-controller-localType"/>
+            <xs:element name="remote" type="domain-controller-remoteType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controller-localType" />
+
+    <xs:complexType name="domain-controller-remoteType">
+        <xs:sequence>
+            <xs:element name="ignored-resources" type="ignored-resourcesType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="host" type="xs:string" use="required" />
+        <xs:attribute name="port" type="xs:integer" use="required" />
+        <xs:attribute name="security-realm" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="ignored-resourcesType">
+        <xs:annotation>
+            <xs:documentation>
+                Provides names of direct child resources of the domain root resource requests for which the
+                Host Controller should ignore. Only relevant on a slave Host Controller. Configuring such
+                "ignored resources" may help allow a Host Controller from an earlier release to function as a
+                slave to a master Host Controller running a later release, by letting the slave ignore portions
+                of the configuration its version of the software cannot understand. This strategy can only be
+                successful if the servers managed by the slave Host Controller do not reference any of the
+                ignored configuration.
+
+                Supports the following attributes:
+
+                type -- the type of resource (e.g. 'profile' or 'socket-binding-group') certain instances of which
+                        should be ignored. The value corresponds to the 'key' portion of the first element in the
+                        resource's address (e.g. 'profile' in the address /profile=ha/subsystem=web)
+
+                wildcard -- if 'true', all resources of the given type should be ignored.
+
+                Child elements list the names of specific instances of the given type of resource
+                that should be ignored. Each element in the list corresponds to the 'value' portion of
+                the first element in the resource's address (e.g. 'ha' in the address /profile=ha/subsystem=web.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="instance" type="ignored-resource-instanceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="wildcard" type="xs:boolean" use="optional" default="false" />
+        <xs:attribute name="names" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="ignored-resource-instanceType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a specific instances of a particular type of resource that should be ignored.
+                The 'name' attribute corresponds to the 'value' portion of the first element in the resource's address
+                (e.g. 'ha' in the address /profile=ha/subsystem=web.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="serversType">
+        <xs:sequence>
+            <xs:element name="server" type="serverType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="directory-grouping" default="by-server" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="by-server">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Groups each servers directory structure in the domain/servers directory. This is the
+                                default option.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="by-type">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Groups each servers directory structure by the type, e.g. domain/data/servers/server-name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverType">
+        <xs:all>
+            <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1" />
+
+            <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0"/>
+            <xs:element name="socket-bindings" type="server-socket-bindingsType" minOccurs="0"/>
+
+            <!--<xs:element name="loggers" type="loggersType" minOccurs="0"/>-->
+            <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0"/>
+            <xs:element name="jvm" minOccurs="0" type="serverJvmType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="group" type="xs:string" use="required"/>
+        <xs:attribute name="auto-start" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="server-socket-bindingsType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Server-specific overrides to the default socket binding configuration inherited from the server group.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding-group" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                <![CDATA[
+                    The socket binding group to use for the server. If undefined, the socket binding group
+                    specified for the server group is used.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                <![CDATA[
+                    Increment to apply to the base port values defined in the
+                    referenced socket binding group to derive the values to use on this
+                    server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="extensionsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of extension modules.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="extension" type="extensionType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="extensionType">
+        <xs:annotation>
+            <xs:documentation>
+                A module that extends the standard capabilities of a domain
+                or a standalone server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="module" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The name of the module</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupsType">
+        <xs:sequence>
+            <xs:element name="server-group" type="server-groupType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupType">
+        <xs:sequence>
+            <xs:element name="jvm" type="namedJvmType" minOccurs="0"/>
+            <xs:element name="socket-binding-group" type="socket-binding-group-refType" minOccurs="1"/>
+
+            <xs:element name="deployments" type="mapped-deploymentsType" minOccurs="0"/>
+
+            <xs:element name="system-properties" minOccurs="0" type="properties-with-boottime"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the server group
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="profile" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the profile this server is running.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="management-subsystem-endpoint" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Set to true to have servers belonging to the server group connect back to the host controller using the
+                    endpoint from their remoting subsystem. The subsystem must be preset for this to
+                    work.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="mapped-deploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of deployments that have been mapped to a server-group.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="mapped-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mapped-deploymentType">
+        <xs:annotation>
+            <xs:documentation>A deployment that has been mapped to a server group.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <!-- TODO: maxOccurs should be unbounded once overlays are in place -->
+            <xs:choice maxOccurs="1">
+                <xs:element name="content" type="contentType"/>
+                <xs:element name="fs-archive" type="fs-archiveType"/>
+                <xs:element name="fs-exploded" type="fs-explodedType"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>Unique identifier of the deployment. Must be unique across all deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="runtime-name" use="required">
+            <xs:annotation>
+                <xs:documentation>Name by which the deployment will be known within a running server.of the deployment.
+                    Does not need to be unique across all deployments in the domain, although it must be unique within
+                    an individual server. For example, two different deployments running on different servers in
+                    the domain could both have a 'runtime-name' of 'example.war', with one having a 'name'
+                    of 'example.war_v1' and another with an 'name' of 'example.war_v2'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <!--  TODO clarify what a value of 'false' means -->
+        <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>Whether the deployment deploy automatically when the server starts up.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="contentType">
+        <xs:attribute name="sha1" use="required">
+            <xs:annotation>
+                <xs:documentation>The checksum of the content</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="fs-archiveType">
+        <xs:annotation>
+            <xs:documentation>Archived content found on the filesystem</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fs-baseType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="fs-baseType">
+        <xs:complexContent>
+            <xs:extension base="pathType"/>
+        </xs:complexContent>
+        <!-- TODO: make path required
+        <xs:complexContent>
+            <xs:restriction base="pathType">
+                <xs:attribute name="path" use="required"/>
+            </xs:restriction>
+        </xs:complexContent>
+        -->
+    </xs:complexType>
+
+    <xs:complexType name="fs-explodedType">
+        <xs:annotation>
+            <xs:documentation>Exploded content found on the filesystem</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fs-baseType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of domain-level deployments</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="deploymentType">
+        <xs:annotation>
+            <xs:documentation>Deployment represents anything that can be deployed (e.g. an application such as EJB-JAR,
+                WAR, EAR,
+                any kind of standard archive such as RAR or JBoss-specific deployment),
+                which can be enabled or disabled on a domain level.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="mapped-deploymentType" />
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- TODO this is not used anywhere yet -->
+    <xs:complexType name="clustersType">
+        <xs:complexContent>
+            <xs:extension base="server-groupType">
+                <xs:sequence>
+                    <xs:element name="partition-name" type="xs:string"/>
+                    <xs:element name="state-transfer-timeout" type="xs:integer"/>
+                    <xs:element name="method-call-timeout" type="xs:integer"/>
+                </xs:sequence>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- domain-configuration related definitions -->
+    <xs:complexType name="domain-configurationType">
+        <xs:annotation>
+            <xs:documentation>The domain controller/server bootstrap configuration</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="bootstrapURI"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="bootstrapURI" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>The URI for bootstrapping a domain server</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="profilesType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of profiles available for use in the domain</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="profile" type="domain-profileType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A profile declaration may include configuration
+                        elements from other namespaces for the subsystems that make up the profile.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Name of the profile</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:any namespace="##other">
+                    <xs:annotation>
+                        <xs:documentation>A profile declaration may include configuration
+                            elements from other namespaces for the subsystems that make up the profile.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- general socket definition -->
+    <xs:complexType name="socket-binding-groupsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket binding groups</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding-group" type="socket-binding-groupType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+	    <xs:attribute name="port-offset" type="xs:int" use="optional" default="0">
+	        <xs:annotation>
+                <xs:documentation>
+	                    Increment to apply to the base port values defined in the
+	                    socket group to derive the values to use on this
+	                    server.
+	            </xs:documentation>
+	        </xs:annotation>
+	    </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-bindingType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a socket.</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="client-mapping" type="socket-binding-client-mappingType"
+                        minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies zero or more client mappings for this socket binding.
+                        A client connecting to this socket should use the destination address
+                        specified in the mapping that matches its desired outbound interface.
+                        This allows for advanced network topologies that use either network
+                        address translation, or have bindings on multiple network interfaces
+                        to function.
+
+                        Each mapping should be evaluated in declared order, with the first successful
+                        match used to determine the destination.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the interface to which the socket should be bound, or, for multicast
+                    sockets, the interface on which it should listen. This should
+                    be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:unsignedShort" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Number of the port to which the socket should be bound.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the port value should remain fixed even if numerically offsets
+                    are applied to the other sockets in the socket group..
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-address" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Multicast address on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Port on which the socket should receive multicast
+                    traffic. Must be configured if 'multicast-address' is configured.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-client-mappingType">
+        <xs:annotation>
+                <xs:documentation>
+                    Type definition for a client mapping on a socket binding. A client
+                    mapping specifies how external clients should connect to this
+                    socket's port, provided that the client's outbound interface
+                    match the specified source network value.
+                </xs:documentation>
+            </xs:annotation>
+        <xs:attribute name="source-network" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Source network the client connection binds on. This value is in
+                    the form of ip/netmask. A client should match this value against
+                    the desired client host network interface, and if matched the
+                    client should connect to the corresponding destination values.
+
+                    If omitted this mapping should match any interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="destination-address" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The destination address that a client should connect to if the
+                    source-network matches. This value can either be a hostname or
+                    an ip address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="destination-port" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The destination port that a client should connect to if the
+                    source-network matches.
+
+                    If omitted this mapping will reuse the effective socket binding
+                    port.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-socket-bindingType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a outbound socket.</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="remote-destination" type="remote-destinationType" maxOccurs="1"/>
+            <xs:element name="local-destination" type="local-destinationType" maxOccurs="1"/>
+        </xs:choice>
+
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the outbound socket binding
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="source-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the interface that should be used for setting up the source address of the
+                    outbound socket. This should be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+
+        </xs:attribute>
+        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    source-interface attribute has been specified and the source-port attribute is absent,
+                    then the system uses a ephemeral port while binding the socket to a source address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-source-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the source-port value should remain fixed even if the socket binding group specifies
+                    a port offset
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remote-destinationType">
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote server address to which the outbound socket has to be connect.
+                    The address can be either a IP address of the host server of the hostname of the server
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:positiveInteger" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote port to which the outbound socket has to connect.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="local-destinationType">
+        <xs:attribute name="socket-binding-ref" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The reference to a socket binding that has to be used as the destination for the outbound
+                    socket binding. This socket binding name should belong to the same socket binding group
+                    to which this local destination client socket belongs.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-group-refType">
+        <xs:attribute name="ref" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The socket group to use for the server group or server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Increment to apply to the base port values defined in the
+                    referenced socket group to derive the values to use on this
+                    server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="named-interfacesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named network interfaces. The interfaces may or may
+                not be fully specified (i.e. include criteria on how to determine
+                their IP address.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="named-interfaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- TODO make this and specified-interfaceType the same except for interface-criteriaGroup minOccurs -->
+    <xs:complexType name="named-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named network interface, but without any criteria
+                for determining the IP address to associate with that interface.
+                Acts as a placeholder in the model (e.g. at the domain level)
+                until a fully specified interface definition is applied at a
+                lower level (e.g. at the server level, where available addresses
+                are known.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="interface-criteriaGroup" minOccurs="0"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="specified-interfacesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of fully specified named network interfaces.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="specified-interfaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named network interface, along with required criteria
+                for determining the IP address to associate with that interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="interface-criteriaGroup" minOccurs="1"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:group name="interface-criteriaGroup">
+        <xs:annotation>
+            <xs:documentation>
+                A set of criteria that can be used at runtime to determine
+                what IP address to use for an interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="any-address" type="any-addressType"/>
+            <xs:element name="any-ipv6-address" type="any-ipv6-addressType"/>
+            <xs:element name="any-ipv4-address" type="any-ipv4-addressType"/>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="inet-address" type="inet-addressType"/>
+                <xs:element name="loopback" type="loopbackType"/>
+                <xs:element name="loopback-address" type="loopback-addressType"/>
+                <xs:element name="multicast" type="multicastType"/>
+                <xs:element name="point-to-point" type="point-to-pointType"/>
+                <xs:element name="virtual" type="interface-virtualType"/>
+                <xs:element name="up" type="interface-upType"/>
+                <xs:element name="public-address" type="public-addressType"/>
+                <xs:element name="link-local-address" type="link-local-addressType"/>
+                <xs:element name="site-local-address" type="site-local-addressType"/>
+                <xs:element name="nic" type="nicType"/>
+                <xs:element name="nic-match" type="nic-matchType"/>
+                <xs:element name="subnet-match" type="subnet-matchType"/>
+                <xs:element name="not" type="address-exclusionType"/>
+                <xs:element name="any" type="address-exclusionType"/>
+            </xs:choice>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="inet-addressType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Either a IP address in IPv6 or IPv4 dotted decimal notation,
+                    or a hostname that can be resolved to an IP address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="nicType">
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a network interface (e.g. eth0, eth1, lo).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="nic-matchType">
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A regular expression against which the names of the network
+                    interfaces available on the machine can be matched to find
+                    an acceptable interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="subnet-matchType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A network IP address and the number of bits in the
+                    address' network prefix, written in "slash notation";
+                    e.g. "192.168.0.0/16".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="address-exclusionType">
+        <xs:choice>
+            <xs:element name="inet-address" type="inet-addressType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="loopback" type="loopbackType"/>
+            <xs:element name="loopback-address" type="loopback-addressType"/>
+            <xs:element name="multicast" type="multicastType"/>
+            <xs:element name="point-to-point" type="point-to-pointType"/>
+            <xs:element name="virtual" type="interface-virtualType"/>
+            <xs:element name="up" type="interface-upType"/>
+            <xs:element name="public-address" type="public-addressType"/>
+            <xs:element name="link-local-address" type="link-local-addressType"/>
+            <xs:element name="site-local-address" type="site-local-addressType"/>
+            <xs:element name="nic" type="nicType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="nic-match" type="nic-matchType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="subnet-match" type="subnet-matchType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="loopbackType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a loopback
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="loopback-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                A loopback address that may not actually be configured on the machine's loopback interface.
+                Differs from inet-addressType in that the given value will be used even if no NIC can
+                be found that has the IP address associated with it.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An IP address in IPv6 or IPv4 dotted decimal notation.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="multicastType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it supports
+                multicast.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="point-to-pointType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a point-to-point
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="interface-upType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is currently up.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="interface-virtualType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a virtual
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="public-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it has a publicly
+                routable address.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="site-local-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not an address associated
+                with it is site-local.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="link-local-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not an address associated
+                with it is link-local.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-ipv6-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to the IPv6 wildcard address (::).
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-ipv4-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to the IPv4 wildcard address (0.0.0.0).
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to a wildcard address. The IPv6 wildcard
+                address (::) will be used unless the java.net.preferIpV4Stack
+                system property is set to true, in which case the IPv4
+                wildcard address (0.0.0.0) will be used. If a socket is
+                bound to an IPv6 anylocal address on a dual-stack machine,
+                it can accept both IPv6 and IPv4 traffic; if it is bound to
+                an IPv4 (IPv4-mapped) anylocal address, it can only accept
+                IPv4 traffic.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="socketType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a socket.</xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the interface to which the socket should be bound, or, for multicast
+                    sockets, the interface on which it should listen. This should
+                    be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:unsignedShort" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Number of the port to which the socket should be bound.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the port value should remain fixed even if numerically offsets
+                    are applied to the other sockets in the socket group..
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-address" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Multicast address on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Port on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Path configurations -->
+    <xs:complexType name="named-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named filesystem paths. The paths may or may
+                not be fully specified (i.e. include the actual paths.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="named-pathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="named-pathType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem path, but without a requirement to specify
+                the actual path. If no actual path is specified, acts as a
+                as a placeholder in the model (e.g. at the domain level)
+                until a fully specified path definition is applied at a
+                lower level (e.g. at the host level, where available addresses
+                are known.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="pathType">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                        The name of the path. Cannot be one of the standard fixed paths
+                        provided by the system:
+
+                        jboss.home - the root directory of the JBoss AS distribution
+                        user.home - user's home directory
+                        user.dir - user's current working directory
+                        java.home - java installation directory
+                        jboss.server.base.dir - root directory for an individual server
+                                                instance
+
+                        Note that the system provides other standard paths that can be
+                        overridden by declaring them in the configuration file. See
+                        the 'relative-to' attribute documentation for a complete
+                        list of standard paths.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="path">
+            <xs:annotation>
+                <xs:documentation>
+                The actual filesystem path. Treated as an absolute path, unless the
+                'relative-to' attribute is specified, in which case the value
+                is treated as relative to that path.
+
+                If treated as an absolute path, the actual runtime pathname specified
+                by the value of this attribute will be determined as follows:
+
+                If this value is already absolute, then the value is directly
+                used.  Otherwise the runtime pathname is resolved in a
+                system-dependent way.  On UNIX systems, a relative pathname is
+                made absolute by resolving it against the current user directory.
+                On Microsoft Windows systems, a relative pathname is made absolute
+                by resolving it against the current directory of the drive named by the
+                pathname, if any; if not, it is resolved against the current user
+                directory.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                The name of another previously named path, or of one of the
+                standard paths provided by the system. If 'relative-to' is
+                provided, the value of the 'path' attribute is treated as
+                relative to the path specified by this attribute. The standard
+                paths provided by the system include:
+
+                jboss.home - the root directory of the JBoss AS distribution
+                user.home - user's home directory
+                user.dir - user's current working directory
+                java.home - java installation directory
+                jboss.server.base.dir - root directory for an individual server
+                                        instance
+                jboss.server.data.dir - directory the server will use for persistent
+                                        data file storage
+                jboss.server.log.dir - directory the server will use for
+                                       log file storage
+                jboss.server.temp.dir - directory the server will use for
+                                       temporary file storage
+                jboss.domain.servers.dir - directory under which a host controller
+                                           will create the working area for
+                                           individual server instances
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="specified-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named filesystem paths.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="specified-pathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-pathType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem path.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                The name of the path. Cannot be one of the standard fixed paths
+                provided by the system:
+
+                jboss.home.dir - the root directory of the JBoss AS distribution
+                user.home - user's home directory
+                user.dir - user's current working directory
+                java.home - java installation directory
+                jboss.server.base.dir - root directory for an individual server
+                                        instance
+
+                Note that the system provides other standard paths that can be
+                overridden by declaring them in the configuration file. See
+                the 'relative-to' attribute documentation for a complete
+                list of standard paths.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                The actual filesystem path. Treated as an absolute path, unless the
+                'relative-to' attribute is specified, in which case the value
+                is treated as relative to that path.
+
+                If treated as an absolute path, the actual runtime pathname specified
+                by the value of this attribute will be determined as follows:
+
+                If this value is already absolute, then the value is directly
+                used.  Otherwise the runtime pathname is resolved in a
+                system-dependent way.  On UNIX systems, a relative pathname is
+                made absolute by resolving it against the current user directory.
+                On Microsoft Windows systems, a relative pathname is made absolute
+                by resolving it against the current directory of the drive named by the
+                pathname, if any; if not, it is resolved against the current user
+                directory.
+
+                Note relative path declarations have to use '/' as file separator.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                The name of another previously named path, or of one of the
+                standard paths provided by the system. If 'relative-to' is
+                provided, the value of the 'path' attribute is treated as
+                relative to the path specified by this attribute. The standard
+                paths provided by the system include:
+
+                jboss.home.dir - the root directory of the JBoss AS distribution
+                user.home - user's home directory
+                user.dir - user's current working directory
+                java.home - java installation directory
+                jboss.server.base.dir - root directory for an individual server
+                                        instance
+                jboss.server.data.dir - directory the server will use for persistent
+                                        data file storage
+                jboss.server.log.dir - directory the server will use for
+                                       log file storage
+                jboss.server.temp.dir - directory the server will use for
+                                       temporary file storage
+                jboss.domain.servers.dir - directory under which a host controller
+                                           will create the working area for
+                                           individual server instances
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--  JVM configurations -->
+    <xs:complexType name="jvmsType">
+        <xs:sequence>
+            <xs:element name="jvm" type="namedJvmType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jvmType">
+        <xs:all minOccurs="0" maxOccurs="1">
+            <xs:element name="heap" type="heapType" minOccurs="0"/>
+            <!-- XX:PermSize, XX:MaxPermSize -->
+            <xs:element name="permgen" type="bounded-memory-sizeType" minOccurs="0"/>
+            <!-- Xss -->
+            <xs:element name="stack" type="memory-sizeType" minOccurs="0"/>
+            <xs:element name="agent-lib" type="jvm-agentLibType" minOccurs="0"/>
+            <xs:element name="agent-path" type="jvm-agentPathType" minOccurs="0"/>
+            <xs:element name="javaagent" type="jvm-javaagentType" minOccurs="0"/>
+            <xs:element name="jvm-options" type="jvm-optionsType" minOccurs="0"/>
+            <xs:element name="environment-variables" type="environmentVariablesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="java-home" type="xs:string"/>
+        <xs:attribute name="type" default="SUN">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="SUN">
+			            <xs:annotation>
+			                <xs:documentation>Allows the full set of JVM options to be set via the jvm schema elements</xs:documentation>
+			            </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="IBM">
+                        <xs:annotation>
+                            <xs:documentation>Sets a subset of the JVM options via the jvm schema elements</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="env-classpath-ignored" default="true" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedJvmType">
+        <xs:complexContent>
+            <xs:extension base="jvmType">
+                <xs:attribute name="name" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serverJvmType">
+        <xs:complexContent>
+            <xs:extension base="namedJvmType">
+                <xs:attribute name="debug-enabled" type="xs:boolean" default="false"/>
+                <xs:attribute name="debug-options" type="xs:string" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="heapType">
+        <xs:attribute name="size" use="optional">
+            <xs:annotation>
+                <xs:documentation>Initial JVM heap size</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-size" use="optional">
+            <xs:annotation>
+                <xs:documentation>Maximum JVM heap size</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-optionsType">
+        <xs:sequence>
+            <xs:element name="option" type="jvm-optionType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-optionType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM option value</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-agentLibType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM agent lib value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-agentPathType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM agent path value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-javaagentType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM javaagent value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bounded-memory-sizeType">
+        <xs:attribute name="size" type="xs:string"/>
+        <xs:attribute name="max-size" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="memory-sizeType">
+        <xs:attribute name="size" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="properties-with-boottime">
+        <xs:sequence>
+            <xs:element name="property" type="boottimePropertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="properties">
+        <xs:sequence>
+            <xs:element name="property" type="propertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="environmentVariablesType">
+        <xs:sequence>
+            <xs:element name="variable" type="propertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:attribute name="name" use="required"/>
+        <xs:attribute name="value" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="boottimePropertyType">
+        <xs:complexContent>
+            <xs:extension base="propertyType">
+                <xs:attribute name="boot-time" type="xs:boolean" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+   <xs:complexType name="vaultType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Vault Configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="vault-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+    <xs:complexType name="management-client-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Storage information about re-usable chunks of data useful to management clients that are stored
+                   in the domain content repository.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="rollout-plans" type="contentType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                           Storage information about a set of named management update rollout plans useful to management
+                           clients that are stored in the domain content repository. The management API exposed by the domain
+                           controller provides access to these plans to management clients, allowing clients to use the plans
+                           by referencing them by name, avoiding the need to recreate them for each use.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+
+</xs:schema>

--- a/build/src/main/resources/domain/configuration/host-master.xml
+++ b/build/src/main/resources/domain/configuration/host-master.xml
@@ -4,7 +4,7 @@
    A simple configuration for a Host Controller that only acts as the master domain controller
    and does not itself directly control any servers.
 -->
-<host name="master" xmlns="urn:jboss:domain:1.1">
+<host name="master" xmlns="urn:jboss:domain:1.2">
 
     <management>
         <security-realms>

--- a/build/src/main/resources/domain/configuration/host-slave.xml
+++ b/build/src/main/resources/domain/configuration/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:1.1">
+<host xmlns="urn:jboss:domain:1.2">
 
     <management>
         <security-realms>

--- a/build/src/main/resources/domain/configuration/host.xml
+++ b/build/src/main/resources/domain/configuration/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.1">
+<host name="master" xmlns="urn:jboss:domain:1.2">
 
     <management>
         <security-realms>

--- a/config-assembly/src/test/resources/org/jboss/as/config/assembly/domain-template.xml
+++ b/config-assembly/src/test/resources/org/jboss/as/config/assembly/domain-template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <?EXTENSIONS?>

--- a/config-assembly/src/test/resources/org/jboss/as/config/assembly/standalone-template.xml
+++ b/config-assembly/src/test/resources/org/jboss/as/config/assembly/standalone-template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.1">
+<server xmlns="urn:jboss:domain:1.2">
 
     <extensions>
         <?EXTENSIONS?>

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -78,6 +78,7 @@ public class ModelDescriptionConstants {
     public static final String DESTINATION_ADDRESS = "destination-address";
     public static final String DESTINATION_PORT = "destination-port";
     public static final String DIRECTORY = "directory";
+    public static final String DIRECTORY_GROUPING = "directory-grouping";
     public static final String DISABLE = "disable";
     public static final String DOMAIN_FAILURE_DESCRIPTION = "domain-failure-description";
     public static final String DOMAIN_CONTROLLER = "domain-controller";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -51,6 +51,7 @@ public enum Attribute {
     DEBUG_ENABLED("debug-enabled"),
     DEBUG_OPTIONS("debug-options"),
     DESTINATION_ADDRESS("destination-address"),
+    DIRECTORY_GROUPING("directory-grouping"),
     DESTINATION_PORT("destination-port"),
     ENABLED("enabled"),
     ENV_CLASSPATH_IGNORED("env-classpath-ignored"),

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
@@ -43,12 +43,14 @@ public enum Namespace {
     // domain versions, oldest to newest
     DOMAIN_1_0("urn:jboss:domain:1.0"),
 
-    DOMAIN_1_1("urn:jboss:domain:1.1"), ;
+    DOMAIN_1_1("urn:jboss:domain:1.1"),
+
+    DOMAIN_1_2("urn:jboss:domain:1.2"), ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DOMAIN_1_1;
+    public static final Namespace CURRENT = DOMAIN_1_2;
 
     private final String name;
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -60,6 +60,7 @@ public class ConfigurationPersisterFactory {
     public static ExtensibleConfigurationPersister createHostXmlConfigurationPersister(final ConfigurationFile file, String defaultHostControllerName) {
         HostXml hostXml = new HostXml(defaultHostControllerName);
         BackupXmlConfigurationPersister persister =  new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "host"), hostXml, hostXml);
+        persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_1.getUriString(), "host"), hostXml);
         persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "host"), hostXml);
         return persister;
     }
@@ -68,6 +69,7 @@ public class ConfigurationPersisterFactory {
     public static ExtensibleConfigurationPersister createDomainXmlConfigurationPersister(final ConfigurationFile file, ExecutorService executorService, ExtensionRegistry extensionRegistry) {
         DomainXml domainXml = new DomainXml(Module.getBootModuleLoader(), executorService, extensionRegistry);
         BackupXmlConfigurationPersister persister = new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "domain"), domainXml, domainXml);
+        persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_1.getUriString(), "domain"), domainXml);
         persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "domain"), domainXml);
         extensionRegistry.setWriterRegistry(persister);
         return persister;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DirectoryGrouping.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DirectoryGrouping.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.host.controller;
+
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * The directory grouping types for the domains; {@code tmp}, {@code log} and {@code data} directories.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public enum DirectoryGrouping {
+
+
+    BY_TYPE("by-type"),
+    BY_SERVER("by-server");
+
+    private final String localName;
+
+    DirectoryGrouping(final String localName) {
+        this.localName = localName;
+    }
+
+    @Override
+    public String toString() {
+        return localName;
+    }
+
+    /**
+     * Converts the value of the directory grouping to a model node.
+     *
+     * @return a new model node for the value.
+     */
+    public ModelNode toModelNode() {
+        return new ModelNode().set(toString());
+    }
+
+    /**
+     * Returns the default directory grouping.
+     *
+     * @return the default directory grouping.
+     */
+    public static DirectoryGrouping defaultValue() {
+        return BY_SERVER;
+    }
+
+    /**
+     * Returns the value of found in the model.
+     *
+     * @param model the model that contains the key and value.
+     *
+     * @return the directory grouping found in the model.
+     *
+     * @throws IllegalArgumentException if the {@link ModelDescriptionConstants#DIRECTORY_GROUPING directory grouping}
+     *                                  was not found in the model.
+     */
+    public static DirectoryGrouping fromModel(final ModelNode model) {
+        if (model.hasDefined(ModelDescriptionConstants.DIRECTORY_GROUPING)) {
+            return DirectoryGrouping.valueOf(model.get(ModelDescriptionConstants.DIRECTORY_GROUPING).asString());
+        }
+        return defaultValue();
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
@@ -619,5 +619,4 @@ public interface HostControllerMessages {
 
     @Message(id = 15861, value = "Could not create domain temp directory: %s")
     IllegalStateException couldNotCreateDomainTempDirectory(File file);
-
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -51,9 +51,13 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRI
 
 import java.util.EnumSet;
 
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.descriptions.common.CommonProviders;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.InterfaceAddHandler;
@@ -127,6 +131,7 @@ import org.jboss.as.server.services.security.AbstractVaultReader;
 import org.jboss.as.server.services.security.VaultAddHandler;
 import org.jboss.as.server.services.security.VaultRemoveHandler;
 import org.jboss.as.server.services.security.VaultWriteAttributeHandler;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -135,6 +140,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:jperkins@jboss.com">James R. Perkins</a>
  */
 public class HostModelUtil {
 
@@ -175,6 +181,8 @@ public class HostModelUtil {
         // Host root resource operations
         XmlMarshallingHandler xmh = new HostXmlMarshallingHandler(configurationPersister.getHostPersister(), hostControllerInfo);
         hostRegistration.registerOperationHandler(XmlMarshallingHandler.OPERATION_NAME, xmh, xmh, false, OperationEntry.EntryType.PUBLIC, flags);
+
+        hostRegistration.registerReadWriteAttribute(HostRootDescription.DIRECTORY_GROUPING, null, new ReloadRequiredWriteAttributeHandler(HostRootDescription.DIRECTORY_GROUPING));
 
         hostRegistration.registerOperationHandler(NamespaceAddHandler.OPERATION_NAME, NamespaceAddHandler.INSTANCE, NamespaceAddHandler.INSTANCE, false);
         hostRegistration.registerOperationHandler(NamespaceRemoveHandler.OPERATION_NAME, NamespaceRemoveHandler.INSTANCE, NamespaceRemoveHandler.INSTANCE, false);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/descriptions/HostRootDescription.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/descriptions/HostRootDescription.java
@@ -71,9 +71,15 @@ import static org.jboss.as.server.controller.descriptions.ServerDescriptionConst
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.common.CommonDescriptions;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.registry.AttributeAccess.Flag;
+import org.jboss.as.host.controller.DirectoryGrouping;
 import org.jboss.as.host.controller.operations.HostShutdownHandler;
 import org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler;
 import org.jboss.dmr.ModelNode;
@@ -85,6 +91,11 @@ import org.jboss.dmr.ModelType;
  * @author Brian Stansberry
  */
 public class HostRootDescription {
+    public static final AttributeDefinition DIRECTORY_GROUPING = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DIRECTORY_GROUPING, ModelType.STRING).
+            addFlag(Flag.RESTART_ALL_SERVICES).
+            setDefaultValue(DirectoryGrouping.defaultValue().toModelNode()).
+            setValidator(EnumValidator.create(DirectoryGrouping.class, false, false)).
+            build();
 
     private static final String RESOURCE_NAME = HostRootDescription.class.getPackage().getName() + ".LocalDescriptions";
 
@@ -171,6 +182,8 @@ public class HostRootDescription {
 
         root.get(ATTRIBUTES, MASTER, DESCRIPTION).set(bundle.getString("host.master"));
         root.get(ATTRIBUTES, MASTER, TYPE).set(ModelType.BOOLEAN);
+
+        DIRECTORY_GROUPING.addResourceAttributeDescription(bundle, "host", root);
 
         root.get(OPERATIONS).setEmptyObject();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -116,7 +116,8 @@ public class DomainXml extends CommonXml {
                 readDomainElement1_0(reader, new ModelNode(), readerNS, nodes);
                 break;
             }
-            case DOMAIN_1_1: {
+            case DOMAIN_1_1:
+            case DOMAIN_1_2: {
                 readDomainElement1_1(reader, new ModelNode(), readerNS, nodes);
                 break;
             }
@@ -338,6 +339,7 @@ public class DomainXml extends CommonXml {
                             this.parseSocketBindingGroup_1_0(reader, interfaces, address, expectedNs, list);
                             break;
                         case DOMAIN_1_1:
+                        case DOMAIN_1_2:
                             // parse 1.1 socket binding group
                             this.parseSocketBindingGroup_1_1(reader, interfaces, address, expectedNs, list);
                             break;
@@ -620,7 +622,8 @@ public class DomainXml extends CommonXml {
                         break;
                     }
                     case DOMAIN_1_0:
-                    case DOMAIN_1_1: {
+                    case DOMAIN_1_1:
+                    case DOMAIN_1_2: {
                         requireNamespace(reader, expectedNs);
                         // include should come first
                         if (configuredSubsystemTypes.size() > 0) {

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -10,6 +10,7 @@ host.management-minor-version=The minor version of the JBoss AS management inter
 host.running-mode=The current running mode of the Host Controller. Either NORMAL (normal operations) or ADMIN_ONLY.  An ADMIN_ONLY server will start any configured management interfaces and accept management requests, but will not start servers or, if this host controller is the master for the domain, accept incoming connections from slave host controllers.
 host.management=Configuration of the host's management system.
 host.management.interface=Interface on which the host's socket for intra-domain management communication should be opened.
+host.directory-grouping=Describes how the directory structure should be setup.
 host.management.port=Port on which the host's socket for intra-domain management communication should be opened.
 host.domain-controller=Configuration of how the host should interact with the Domain Controller
 host.domain-controller.local=Configure a local Domain Controller

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -166,6 +166,7 @@ public interface Bootstrap {
                             QName rootElement = new QName(Namespace.CURRENT.getUriString(), "server");
                             StandaloneXml parser = new StandaloneXml(Module.getBootModuleLoader(), executorService, extensionRegistry);
                             BackupXmlConfigurationPersister persister = new BackupXmlConfigurationPersister(serverEnvironment.getServerConfigurationFile(), rootElement, parser, parser);
+                            persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_1.getUriString(), "server"), parser);
                             persister.registerAdditionalRootElement(new QName(Namespace.DOMAIN_1_0.getUriString(), "server"), parser);
                             extensionRegistry.setWriterRegistry(persister);
                             return persister;

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -122,8 +122,9 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
                 readServerElement_1_0(reader, address, operationList);
                 break;
             }
-            case DOMAIN_1_1: {
-                readServerElement_1_1(reader, address, operationList);
+            case DOMAIN_1_1:
+            case DOMAIN_1_2: {
+                readServerElement_1_1(readerNS, reader, address, operationList);
                 break;
             }
             default: {
@@ -250,7 +251,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
      * @param list the list of boot operations to which any new operations should be added
      * @throws XMLStreamException if a parsing error occurs
      */
-    private void readServerElement_1_1(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
+    private void readServerElement_1_1(final Namespace namespace, final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
             throws XMLStreamException {
 
         parseNamespaces(reader, address, list);
@@ -299,51 +300,51 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
 
         // elements - sequence
 
-        Element element = nextElement(reader, DOMAIN_1_1);
+        Element element = nextElement(reader, namespace);
         if (element == Element.EXTENSIONS) {
-            extensionXml.parseExtensions(reader, address, DOMAIN_1_1, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            extensionXml.parseExtensions(reader, address, namespace, list);
+            element = nextElement(reader, namespace);
         }
         // System properties
         if (element == Element.SYSTEM_PROPERTIES) {
-            parseSystemProperties(reader, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseSystemProperties(reader, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
         if (element == Element.PATHS) {
-            parsePaths(reader, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parsePaths(reader, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
 
         if (element == Element.VAULT) {
-            parseVault(reader, address, DOMAIN_1_1, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseVault(reader, address, namespace, list);
+            element = nextElement(reader, namespace);
         }
 
         if (element == Element.MANAGEMENT) {
             ManagementXml managementXml = new ManagementXml(this);
-            managementXml.parseManagement(reader, address, DOMAIN_1_1, list, true, false);
-            element = nextElement(reader, DOMAIN_1_1);
+            managementXml.parseManagement(reader, address, namespace, list, true, false);
+            element = nextElement(reader, namespace);
         }
         // Single profile
         if (element == Element.PROFILE) {
             parseServerProfile(reader, address, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            element = nextElement(reader, namespace);
         }
 
         // Interfaces
         final Set<String> interfaceNames = new HashSet<String>();
         if (element == Element.INTERFACES) {
-            parseInterfaces(reader, interfaceNames, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseInterfaces(reader, interfaceNames, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
         // Single socket binding group
         if (element == Element.SOCKET_BINDING_GROUP) {
-            parseSocketBindingGroup_1_1(reader, interfaceNames, address, DOMAIN_1_1, list);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseSocketBindingGroup_1_1(reader, interfaceNames, address, namespace, list);
+            element = nextElement(reader, namespace);
         }
         if (element == Element.DEPLOYMENTS) {
-            parseDeployments(reader, address, DOMAIN_1_1, list, true);
-            element = nextElement(reader, DOMAIN_1_1);
+            parseDeployments(reader, address, namespace, list, true);
+            element = nextElement(reader, namespace);
         }
 
         if (element != null) {

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.1"
+<domain xmlns="urn:jboss:domain:1.2"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.1"
+<domain xmlns="urn:jboss:domain:1.2"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.1"
+<host xmlns="urn:jboss:domain:1.2"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.1 jboss-as-config_1_1.xsd"
+      xsi:schemaLocation="urn:jboss:domain:1.2 jboss-as-config_1_2.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.1"
+<host xmlns="urn:jboss:domain:1.2"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.1 jboss-as-config_1_1.xsd"
+      xsi:schemaLocation="urn:jboss:domain:1.2 jboss-as-config_1_2.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.1"
+<host xmlns="urn:jboss:domain:1.2"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.1 jboss-as-config_1_1.xsd"
+      xsi:schemaLocation="urn:jboss:domain:1.2 jboss-as-config_1_2.xsd"
       name="master">
 
     <paths>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSManagementTestCase.java
@@ -83,7 +83,7 @@ public class DeployedXmlJMSManagementTestCase {
         public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
             final ServerDeploymentManager manager = ServerDeploymentManager.Factory.create(managementClient.getControllerClient());
             final DeploymentPlan undeployPlan = manager.newDeploymentPlan().undeploy(TEST_JMS_XML).andRemoveUndeployed().build();
-            manager.execute(undeployPlan);
+            manager.execute(undeployPlan).get();
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/xmldeployment/DeployedXmlJMSTestCase.java
@@ -80,7 +80,7 @@ public class DeployedXmlJMSTestCase {
         public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
             final ServerDeploymentManager manager = ServerDeploymentManager.Factory.create(managementClient.getControllerClient());
             final DeploymentPlan undeployPlan = manager.newDeploymentPlan().undeploy(TEST_JMS_XML).andRemoveUndeployed().build();
-            manager.execute(undeployPlan);
+            manager.execute(undeployPlan).get();
         }
     }
 

--- a/testsuite/integration/basic/src/test/xslt/passwdMaskConfig.xsl
+++ b/testsuite/integration/basic/src/test/xslt/passwdMaskConfig.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Edited by XMLSpy® -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:do="urn:jboss:domain:1.1"
+                xmlns:do="urn:jboss:domain:1.2"
                 xmlns:ds="urn:jboss:domain:datasources:1.0"
-                xmlns="urn:jboss:domain:1.1"
+                xmlns="urn:jboss:domain:1.2"
         >
     <xsl:output indent="yes"/>
 

--- a/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
+++ b/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.1">
+                xmlns:d="urn:jboss:domain:1.2">
     <xsl:output method="xml" indent="yes"/>
 
     <xsl:param name="realmName"/>
@@ -23,7 +23,7 @@
             <xsl:apply-templates select="node()|@*"/>
         </xsl:copy>
     </xsl:template>
-     
+
     <!-- Prevent duplicates -->
     <xsl:template match="//d:management/d:security-realms/d:security-realm[@name=$realmName]"/>
 

--- a/testsuite/integration/src/test/xslt/addJmsDestinations.xsl
+++ b/testsuite/integration/src/test/xslt/addJmsDestinations.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.1"
+                xmlns:d="urn:jboss:domain:1.2"
                 xmlns:jms="urn:jboss:domain:messaging:1.1"
     >
     <xsl:output method="xml" indent="yes"/>
@@ -14,13 +14,13 @@
                        <jms:entry name="queue/test"/>
                        <jms:entry name="java:jboss/exported/jms/queue/test"/>
                    </jms:jms-queue>
-                   <jms:jms-topic>      
+                   <jms:jms-topic>
                        <xsl:attribute name="name"><xsl:value-of select="$topicName"/></xsl:attribute>
                        <jms:entry name="topic/test"/>
                        <jms:entry name="java:jboss/exported/jms/topic/test"/>
                    </jms:jms-topic>
     </xsl:variable>
-    
+
     <!-- If jms-destinations exists, append the queue and topic. -->
     <xsl:template match="//jms:hornetq-server/jms:jms-destinations">
         <xsl:copy>
@@ -38,7 +38,7 @@
                     </jms:jms-destinations>
                 </xsl:copy>
     </xsl:template>
-    
+
     <!-- Prevent duplicates. -->
     <xsl:template match="//jms:hornetq-server/jms:jms-destinations/jms:jms-queue[@name=$queueName]"/>
     <xsl:template match="//jms:hornetq-server/jms:jms-destinations/jms:jms-topic[@name=$topicName]"/>
@@ -49,5 +49,5 @@
             <xsl:apply-templates select="node()|@*"/>
         </xsl:copy>
     </xsl:template>
-     
+
 </xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/addPortOffset.xsl
+++ b/testsuite/integration/src/test/xslt/addPortOffset.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.1">
+                xmlns:d="urn:jboss:domain:1.2">
 
     <!--
         An XSLT style sheet which will add a port offset to a standalone-ha.xml config.

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.1"
+                xmlns:d="urn:jboss:domain:1.2"
                 xmlns:r="urn:jboss:domain:remoting:1.1">
     <xsl:output method="xml" indent="yes"/>
 

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -1,8 +1,8 @@
 
 <xsl:stylesheet version="2.0"
 		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns="urn:jboss:domain:1.1"
-		xmlns:d="urn:jboss:domain:1.1"
+		xmlns="urn:jboss:domain:1.2"
+		xmlns:d="urn:jboss:domain:1.2"
         xmlns:ws11="urn:jboss:domain:webservices:1.1"
                 >
 
@@ -98,13 +98,13 @@
             <xsl:apply-templates select="node()|@*"/>
         </xsl:copy>
     </xsl:template>
-    
+
     <!-- Change WSDL host. -->
     <xsl:template match="//ws11:wsdl-host">
         <xsl:copy>${jboss.bind.address:<xsl:value-of select="$publicIPAddress"/>}</xsl:copy>
     </xsl:template>
-    
-    
+
+
 
     <!-- Copy everything else. -->
     <xsl:template match="node()|@*">


### PR DESCRIPTION
Allows managed domain servers writable directories to be written under ${jboss.domain.xxx.dir}/servers/${serverName}. This is only the case for tmp, log and data directories.
