### PR TITLE
AS7-3993  Testsuite IP configuration changes.

### DIFF
--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -137,7 +137,7 @@
                     <systemPropertyVariables combine.children="append">
                         <node0>${node0}</node0>
                         <node1>${node1}</node1>
-                        <udpGroup>${udpGroup}</udpGroup>
+                        <mcast>${mcast}</mcast>
 
                         <jbossas.ts.submodule.dir>${basedir}</jbossas.ts.submodule.dir>
                         <jbossas.ts.integ.dir>${jbossas.ts.integ.dir}</jbossas.ts.integ.dir>
@@ -149,7 +149,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -65,7 +65,7 @@
                                         <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
                                             <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
                                             <property name="node1" value="${node1}"/>
-                                            <property name="udpGroup" value="${udpGroup}"/>
+                                            <property name="mcast" value="${mcast}"/>
                                             <target name="build-clustering-udp"/>
                                         </ant>
                                     </target>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -227,7 +227,7 @@
                     <systemPropertyVariables combine.children="append">
                         <node0>${node0}</node0>
                         <node1>${node1}</node1>
-                        <udpGroup>${udpGroup}</udpGroup>
+                        <mcast>${mcast}</mcast>
 
                         <jbossas.ts.submodule.dir>${basedir}</jbossas.ts.submodule.dir>
                         <jbossas.ts.integ.dir>${jbossas.ts.integ.dir}</jbossas.ts.integ.dir>
@@ -239,7 +239,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -DudpGroup=${udpGroup} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -12,7 +12,7 @@
         <copy todir="target/jbossas-clustering-udp-0" overwrite="true">
             <fileset dir="${basedir}/target/jbossas"/>
         </copy>
-        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-0" node="${node0}" mcastaddr="${udpGroup}"/>
+        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-0" node="${node0}" mcastaddr="${mcast}"/>
         <ts.config-as.add-port-offset name="jbossas-clustering-udp-0" />
 
 
@@ -22,7 +22,7 @@
         <copy todir="target/jbossas-clustering-udp-1" overwrite="true">
             <fileset dir="${basedir}/target/jbossas"/>
         </copy>
-        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-1" node="${node1}" mcastaddr="${udpGroup}"/>
+        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-1" node="${node1}" mcastaddr="${mcast}"/>
         <ts.config-as.add-port-offset name="jbossas-clustering-udp-1" offset="100" nativePort="9999" httpPort="9990"/>
 
     </target>
@@ -35,7 +35,7 @@
             <fileset dir="${basedir}/target/jbossas"/>
         </copy>
         <ts.config-as.add-cache-container name="jbossas-clustering-udp-0-jdbc-store" containerdef="${cache.container.def}" />
-        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-0-jdbc-store" node="${node0}" mcastaddr="${udpGroup}"/>
+        <ts.config-as.ip-with-multicast name="jbossas-clustering-udp-0-jdbc-store" node="${node0}" mcastaddr="${mcast}"/>
         <ts.config-as.add-port-offset name="jbossas-clustering-udp-0-jdbc-store" />
 
     </target>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -44,7 +44,7 @@
                 <filterset begintoken="${" endtoken="}">
                     <filter token="node0" value="${node0}"/>
                     <filter token="node1" value="${node1}"/>
-                    <filter token="udpGroup" value="${udpGroup}"/>
+                    <filter token="mcast" value="${mcast}"/>
                     <filter-elements/>
                 </filterset>
             </copy>
@@ -64,7 +64,7 @@
         <attribute name="output.dir" default="${project.build.directory}"/>
         <attribute name="config.dir.name" default="standalone/configuration"/>
         <attribute name="node" default="${node0}"/>
-        <attribute name="mcastaddr" default="${udpGroup}"/>
+        <attribute name="mcastaddr" default="${mcast}"/>
 
         <sequential>
             <echo message="Changing IP addresses for config @{name}"/>

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -102,6 +102,10 @@
         </xsl:attribute>
     </xsl:template>
 
+    <!-- Mail SMTP -->
+    <xsl:template match="//d:outbound-socket-binding[@name='mail-smtp']/d:remote-destination/@host">
+        <xsl:attribute name="host"><xsl:value-of select="$publicIPAddress"/></xsl:attribute>
+    </xsl:template>
 
     <!-- Copy everything else. -->
     <xsl:template match="node()|@*">

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -52,19 +52,16 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//d:interfaces/d:interface[@name='public' or @name='unsecure']/d:inet-address">
-        <xsl:copy>
-            <xsl:attribute name="value">
-                <xsl:value-of select="$publicIPAddress"/>
-            </xsl:attribute>
-        </xsl:copy>
+    <xsl:template match="//d:interfaces/d:interface[@name='public']/d:inet-address">
+        <xsl:copy><xsl:attribute name="value">${jboss.bind.address:<xsl:value-of select="$publicIPAddress"/>}</xsl:attribute></xsl:copy>
+    </xsl:template>
+    <xsl:template match="//d:interfaces/d:interface[@name='unsecure']/d:inet-address">
+        <xsl:copy><xsl:attribute name="value">${jboss.bind.address.unsecure:<xsl:value-of select="$publicIPAddress"/>}</xsl:attribute></xsl:copy>
     </xsl:template>
 
     <!-- Change UDP multicast addresses. -->
     <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-udp']/@multicast-address">
-        <xsl:attribute name="multicast-address">
-            <xsl:value-of select="$udpMcastAddress"/>
-        </xsl:attribute>
+        <xsl:attribute name="multicast-address">${jboss.default.multicast.address:<xsl:value-of select="$udpMcastAddress"/>}</xsl:attribute>
     </xsl:template>
 
     <!-- Change diagnostics multicast addresses. -->
@@ -76,9 +73,7 @@
 
     <!-- Change MPING multicast addresses. -->
     <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-mping']/@multicast-address">
-        <xsl:attribute name="multicast-address">
-            <xsl:value-of select="$mpingMcastAddress"/>
-        </xsl:attribute>
+        <xsl:attribute name="multicast-address">${jboss.default.multicast.address:<xsl:value-of select="$mpingMcastAddress"/>}</xsl:attribute>
     </xsl:template>
 
     <!-- Change modcluster multicast addresses. -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -99,6 +99,7 @@
         <node1>127.0.0.1</node1>
         <mcast>230.0.0.4</mcast> <!-- Default multicast address. -->
         <mcast.jgroupsDiag>224.0.75.75</mcast.jgroupsDiag>  <!-- for <socket-binding name="jgroups-diagnostics" .../> -->
+        <mcast.modcluster >224.0.1.105</mcast.modcluster>   <!-- for <socket-binding name="modcluster" .../> -->
 
         <!-- IP stack configs. -->
         <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
@@ -359,9 +360,13 @@
                                         <include>standalone*.xml</include>
                                     </includes>
                                     <parameters>
-                                        <parameter><name>managementIPAddress</name><value>${node0}</value></parameter>
-                                        <parameter><name>publicIPAddress</name><value>${node0}</value></parameter>
-                                        <parameter><name>udpMcastAddress</name><value>${mcast}</value></parameter>
+                                        <parameter><name>managementIPAddress</name>    <value>${node0}</value></parameter>
+                                        <parameter><name>publicIPAddress</name>        <value>${node0}</value></parameter>
+                                        
+                                        <parameter><name>udpMcastAddress</name>        <value>${mcast}</value></parameter>
+                                        <parameter><name>diagnosticsMcastAddress</name><value>${mcast.jgroupsDiag}</value></parameter>
+                                        <parameter><name>mpingMcastAddress</name>      <value>${mcast}</value></parameter>
+                                        <parameter><name>modclusterMcastAddress</name> <value>${mcast.modcluster}</value></parameter>
                                     </parameters>
                                 </transformationSet>
                                 <!-- JMS destinations. -->
@@ -611,12 +616,12 @@
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
 
-                <!-- IP address defaults. -->
+                <!-- Override IPv4 defaults from the top. -->
                 <node0>::1</node0>
                 <node1>::1</node1>
-                <mcast>ff01::1</mcast> <!-- Default multicast address.  ff01::1  is IPv6 Node-Local scope mcast addr. -->
-                <mcast.jgroupsDiag>ff01::2</mcast.jgroupsDiag>  <!-- for jgroups-diagnostics -->
-
+                <mcast            >ff01::1</mcast>      <!-- ff01::1  is IPv6 Node-Local scope mcast addr. -->
+                <mcast.jgroupsDiag>ff01::2</mcast.jgroupsDiag>
+                <mcast.modcluster >ff01::3</mcast.modcluster>
             </properties>
         </profile>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -97,7 +97,8 @@
         <!-- IP address defaults. -->
         <node0>127.0.0.1</node0>
         <node1>127.0.0.1</node1>
-        <udpGroup>230.0.0.4</udpGroup>
+        <mcast>230.0.0.4</mcast> <!-- Default multicast address. -->
+        <mcast.jgroupsDiag>224.0.75.75</mcast.jgroupsDiag>  <!-- for <socket-binding name="jgroups-diagnostics" .../> -->
 
         <!-- IP stack configs. -->
         <jvm.args.ip>-Djava.net.preferIPv4Stack=true -Djava.net.preferIPv6Addresses=false</jvm.args.ip>
@@ -360,7 +361,7 @@
                                     <parameters>
                                         <parameter><name>managementIPAddress</name><value>${node0}</value></parameter>
                                         <parameter><name>publicIPAddress</name><value>${node0}</value></parameter>
-                                        <parameter><name>udpMcastAddress</name><value>${udpGroup}</value></parameter><!-- Only somewhere - TODO. -->
+                                        <parameter><name>udpMcastAddress</name><value>${mcast}</value></parameter>
                                     </parameters>
                                 </transformationSet>
                                 <!-- JMS destinations. -->
@@ -609,6 +610,13 @@
             <activation><property><name>ipv6</name></property></activation>
             <properties>
                 <jvm.args.ip>-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true</jvm.args.ip>
+
+                <!-- IP address defaults. -->
+                <node0>::1</node0>
+                <node1>::1</node1>
+                <mcast>ff01::1</mcast> <!-- Default multicast address.  ff01::1  is IPv6 Node-Local scope mcast addr. -->
+                <mcast.jgroupsDiag>ff01::2</mcast.jgroupsDiag>  <!-- for jgroups-diagnostics -->
+
             </properties>
         </profile>
 


### PR DESCRIPTION
Adds props for jgroups bindings which need to be separated.
Also, adds defaults for IPv6 profile (-Dipv6):

```
            <!-- Override IPv4 defaults from the top. -->
            <node0>::1</node0>
            <node1>::1</node1>
            <mcast            >ff01::1</mcast>      <!-- ff01::1  is IPv6 Node-Local scope mcast addr. -->
            <mcast.jgroupsDiag>ff01::2</mcast.jgroupsDiag>
            <mcast.modcluster >ff01::3</mcast.modcluster>
```

Locally, with IPv6, I only see cluster module failures, TBD.
