### PR TITLE
Fix some TODOs in the EJB remote method invocation handling

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -155,8 +155,9 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                     try {
                         methodParams[i] = unmarshaller.readObject();
                     } catch (ClassNotFoundException cnfe) {
-                        // TODO: Write out invocation failure to channel outstream
-                        throw new RuntimeException(cnfe);
+                        // write out the failure
+                        MethodInvocationMessageHandler.this.writeException(channel, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, cnfe, null);
+                        return;
                     }
                 }
             }
@@ -165,8 +166,9 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             try {
                 attachments = this.readAttachments(unmarshaller);
             } catch (ClassNotFoundException cnfe) {
-                // TODO: Write out invocation failure to channel outstream
-                throw new RuntimeException(cnfe);
+                // write out the failure
+                MethodInvocationMessageHandler.this.writeException(channel, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, cnfe, null);
+                return;
             }
             // done with unmarshalling
             unmarshaller.finish();


### PR DESCRIPTION
The commit fixes an issue where we weren't sending back a failure message if a CNFE error occured during remote method invocation.
