### PR TITLE
AS7-3495 properly populate jboss.controller.temp.dir

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -432,7 +432,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
 
         tmp = getFileFromProperty(CONTROLLER_TEMP_DIR, props);
         if (tmp == null) {
-            tmp = new File(serverBaseDir, "tmp");
+            tmp = serverTempDir;
         }
         if (tmp.exists()) {
             if (!tmp.isDirectory()) {


### PR DESCRIPTION
Double checked the auth dir if created outside of the AS7 structure and it is still created as the user that is running AS with permissions restricted to make it accessible to only that user so happy for the commit to go in.
