### PR TITLE
AS7-2929: Add support for unscheduled write-behind cache stores to Infinispan subsytem

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-infinispan_1_2.xsd
@@ -185,22 +185,22 @@
         <xs:sequence>
             <xs:element name="locking" type="tns:locking" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The locking configuration of the cache.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="transaction" type="tns:transaction" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The cache transaction configuration.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="eviction" type="tns:eviction" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The cache eviction configuration.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="expiration" type="tns:expiration" minOccurs="0">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>The cache expiration configuration.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:choice minOccurs="0">
@@ -277,22 +277,22 @@
     <xs:complexType name="locking">
         <xs:attribute name="isolation" type="tns:isolation" default="REPEATABLE_READ">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Sets the cache locking isolation level.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="striping" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, a pool of shared locks is maintained for all entries that need to be locked. Otherwise, a lock is created per entry in the cache. Lock striping helps control memory footprint but may reduce concurrency in the system.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="acquire-timeout" type="xs:long" default="15000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum time to attempt a particular lock acquisition.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="concurrency-level" type="xs:int" default="1000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Concurrency level for lock containers. Adjust this value according to the number of concurrent threads interacting with Infinispan.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -300,17 +300,17 @@
     <xs:complexType name="transaction">
         <xs:attribute name="mode" type="tns:transaction-mode" default="NONE">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Sets the cache transaction mode to one of NONE, NON_XA, NON_DURABLE_XA, FULL_XA.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="stop-timeout" type="xs:long" default="30000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If there are any ongoing transactions when a cache is stopped, Infinispan waits for ongoing remote and local transactions to finish. The amount of time to wait for is defined by the cache stop timeout.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="locking" type="tns:locking-mode" default="OPTIMISTIC">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>The locking mode for this cache, one of OPTIMISTIC or PESSIMISTIC.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -318,12 +318,12 @@
     <xs:complexType name="eviction">
         <xs:attribute name="strategy" type="tns:eviction-strategy" default="NONE">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="max-entries" type="xs:int" default="10000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum number of entries in a cache instance. If selected value is not a power of two the actual value will default to the least power of two larger than selected value. -1 means no limit.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -331,17 +331,17 @@
     <xs:complexType name="expiration">
         <xs:attribute name="max-idle" type="xs:long" default="-1">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum idle time a cache entry will be maintained in the cache, in milliseconds. If the idle time is exceeded, the entry will be expired cluster-wide. -1 means the entries never expire.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="lifespan" type="xs:long" default="-1">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Maximum lifespan of a cache entry, after which the entry is expired cluster-wide, in milliseconds. -1 means the entries never expire.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="interval" type="xs:long" default="5000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>Interval (in milliseconds) between subsequent runs to purge expired entries from memory and any cache stores. If you wish to disable the periodic eviction process altogether, set wakeupInterval to -1.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -358,22 +358,22 @@
                 </xs:attribute>
                 <xs:attribute name="mode" type="tns:mode" use="required">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>Sets the clustered cache mode, ASYNC for asynchronous operation, or SYNC for synchronous operation.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="queue-size" type="xs:int" default="0">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>In ASYNC mode, this attribute can be used to trigger flushing of the queue when it reaches a specific threshold.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="queue-flush-interval" type="xs:long" default="10">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>In ASYNC mode, this attribute controls how often the asynchronous thread used to flush the replication queue runs. This should be a positive integer which represents thread wakeup time in milliseconds.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="remote-timeout" type="xs:long" default="17500">
                     <xs:annotation>
-                        <xs:documentation></xs:documentation>
+                        <xs:documentation>In SYNC mode, the timeout (in ms) used to wait for an acknowledgment when making a remote call, after which the call is aborted and an exception is thrown.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
             </xs:extension>
@@ -393,7 +393,7 @@
                 <xs:sequence>
                     <xs:element name="state-transfer" type="tns:state-transfer" minOccurs="0">
                         <xs:annotation>
-                            <xs:documentation></xs:documentation>
+                            <xs:documentation>The state transfer configuration for distribution and replicated caches.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
@@ -407,7 +407,7 @@
                 <xs:sequence>
                     <xs:element name="state-transfer" type="tns:state-transfer" minOccurs="0">
                         <xs:annotation>
-                            <xs:documentation></xs:documentation>
+                            <xs:documentation>The state transfer configuration for distribution and replicated caches.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
                 </xs:sequence>
@@ -432,40 +432,77 @@
 
     <xs:complexType name="store" abstract="true">
         <xs:sequence>
+            <xs:element name="write-behind" type="tns:write-behind" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Configures a cache store as write-behind instead of write-through.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="property" type="tns:property" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>A cache store property with name and value.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
         <xs:attribute name="shared" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>This setting should be set to true when multiple cache instances share the same cache store (e.g., multiple nodes in a cluster using a JDBC-based CacheStore pointing to the same, shared database.) Setting this to true avoids multiple cache instances writing the same modification multiple times. If enabled, only the node where the modification originated will write to the cache store. If disabled, each individual cache reacts to a potential remote update by storing the data to the cache store.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="preload" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, when the cache starts, data stored in the cache store will be pre-loaded into memory. This is particularly useful when data in the cache store will be needed immediately after startup and you want to avoid cache operations being delayed as a result of loading this data lazily. Can be used to provide a 'warm-cache' on startup, however there is a performance penalty as startup time is affected by this process.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="passivation" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, data is only written to the cache store when it is evicted from memory, a phenomenon known as 'passivation'. Next time the data is requested, it will be 'activated' which means that data will be brought back to memory and removed from the persistent store. f false, the cache store contains a copy of the contents in memory, so writes to cache result in cache store writes. This essentially gives you a 'write-through' configuration.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="fetch-state" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, fetch persistent state when joining a cluster. If multiple cache stores are chained, only one of them can have this property enabled.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="purge" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, purges this cache store when it starts up.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="singleton" type="xs:boolean" default="false">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="write-behind">
+        <xs:attribute name="flush-lock-timeout" type="xs:int" default="1">
+            <xs:annotation>
+                <xs:documentation>
+                    Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modification-queue-size" type="xs:int" default="1024">
+            <xs:annotation>
+                <xs:documentation>
+                    Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through.
+                    until it can accept new entries
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="shutdown-timeout" type="xs:int" default="25000">
+            <xs:annotation>
+                <xs:documentation>
+                    Timeout in milliseconds to stop the cache store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="thread-pool-size" type="xs:int" default="1">
+            <xs:annotation>
+                <xs:documentation>
+                    Size of the thread pool whose threads are responsible for applying the modifications to the cache store.
+                </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -535,7 +572,7 @@
     <xs:complexType name="remote-server">
         <xs:attribute name="outbound-socket-binding" type="xs:string" use="required">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>An outbound socket binding for a remote server.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
@@ -706,17 +743,17 @@
     <xs:complexType name="state-transfer">
         <xs:attribute name="enabled" type="xs:boolean" default="true">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="timeout" type="xs:long" default="60000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="chunk-size" type="xs:integer" default="10000">
             <xs:annotation>
-                <xs:documentation></xs:documentation>
+                <xs:documentation>The size, in bytes, in which to batch the transfer of cache entries.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Attribute.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.AttributeDefinition;
  * Enumerates the attributes used in the Infinispan subsystem schema.
  * @author Paul Ferraro
  * @author Richard Achmatowicz (c) 2011 RedHat Inc.
+ * @author Tristan Tarrant
  */
 public enum Attribute {
     // must be first
@@ -55,6 +56,7 @@ public enum Attribute {
     EXECUTOR(ModelKeys.EXECUTOR),
     FETCH_SIZE(ModelKeys.FETCH_SIZE),
     FETCH_STATE(ModelKeys.FETCH_STATE),
+    FLUSH_LOCK_TIMEOUT(ModelKeys.FLUSH_LOCK_TIMEOUT),
     @Deprecated FLUSH_TIMEOUT("flush-timeout"),
     INDEXING(ModelKeys.INDEXING),
     INTERVAL(ModelKeys.INTERVAL),
@@ -69,6 +71,7 @@ public enum Attribute {
     MAX_ENTRIES(ModelKeys.MAX_ENTRIES),
     MAX_IDLE(ModelKeys.MAX_IDLE),
     MODE(ModelKeys.MODE),
+    MODIFICATION_QUEUE_SIZE(ModelKeys.MODIFICATION_QUEUE_SIZE),
     NAME(ModelKeys.NAME),
     NAMESPACE(XMLConstants.XMLNS_ATTRIBUTE),
     OUTBOUND_SOCKET_BINDING(ModelKeys.OUTBOUND_SOCKET_BINDING),
@@ -85,6 +88,7 @@ public enum Attribute {
     REMOTE_TIMEOUT(ModelKeys.REMOTE_TIMEOUT),
     REPLICATION_QUEUE_EXECUTOR(ModelKeys.REPLICATION_QUEUE_EXECUTOR),
     SHARED(ModelKeys.SHARED),
+    SHUTDOWN_TIMEOUT(ModelKeys.SHUTDOWN_TIMEOUT),
     SINGLETON(ModelKeys.SINGLETON),
     SITE(ModelKeys.SITE),
     SOCKET_TIMEOUT(ModelKeys.SOCKET_TIMEOUT),
@@ -94,6 +98,7 @@ public enum Attribute {
     STRATEGY(ModelKeys.STRATEGY),
     STRIPING(ModelKeys.STRIPING),
     TCP_NO_DELAY(ModelKeys.TCP_NO_DELAY),
+    THREAD_POOL_SIZE(ModelKeys.THREAD_POOL_SIZE),
     TIMEOUT(ModelKeys.TIMEOUT),
     TYPE(ModelKeys.TYPE),
     VIRTUAL_NODES(ModelKeys.VIRTUAL_NODES),

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -21,6 +21,7 @@ import org.jboss.dmr.ModelType;
  * To mark an attribute as required, mark it as not allowing null.
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ * @author Tristan Tarrant
  */
 public interface CommonAttributes {
 
@@ -155,6 +156,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(true))
                     .build();
+    SimpleAttributeDefinition FLUSH_LOCK_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.FLUSH_LOCK_TIMEOUT, ModelType.LONG, true)
+                    .setXmlName(Attribute.FLUSH_LOCK_TIMEOUT.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(1))
+                    .build();
     SimpleAttributeDefinition INDEXING =
             new SimpleAttributeDefinitionBuilder(ModelKeys.INDEXING, ModelType.STRING, true)
                     .setXmlName(Attribute.INDEXING.getLocalName())
@@ -252,6 +260,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new EnumValidator<TransactionMode>(TransactionMode.class, true, false))
                     .setDefaultValue(new ModelNode().set(TransactionMode.NONE.name()))
+                    .build();
+    SimpleAttributeDefinition MODIFICATION_QUEUE_SIZE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.MODIFICATION_QUEUE_SIZE, ModelType.INT, true)
+                    .setXmlName(Attribute.MODIFICATION_QUEUE_SIZE.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(1024))
                     .build();
     SimpleAttributeDefinition NAME =
             new SimpleAttributeDefinitionBuilder(ModelKeys.NAME, ModelType.STRING, true)
@@ -354,6 +369,13 @@ public interface CommonAttributes {
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(false))
                     .build();
+    SimpleAttributeDefinition SHUTDOWN_TIMEOUT =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.SHUTDOWN_TIMEOUT, ModelType.LONG, true)
+                    .setXmlName(Attribute.SHUTDOWN_TIMEOUT.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(25000))
+                    .build();
     SimpleAttributeDefinition SINGLETON =
             new SimpleAttributeDefinitionBuilder(ModelKeys.SINGLETON, ModelType.BOOLEAN, true)
                     .setXmlName(Attribute.SINGLETON.getLocalName())
@@ -428,6 +450,13 @@ public interface CommonAttributes {
                     .setAllowExpression(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(60000))
+                    .build();
+    SimpleAttributeDefinition THREAD_POOL_SIZE =
+            new SimpleAttributeDefinitionBuilder(ModelKeys.THREAD_POOL_SIZE, ModelType.INT, true)
+                    .setXmlName(Attribute.THREAD_POOL_SIZE.getLocalName())
+                    .setAllowExpression(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode().set(1))
                     .build();
     SimpleAttributeDefinition TYPE =
             new SimpleAttributeDefinitionBuilder(ModelKeys.TYPE, ModelType.STRING, true)
@@ -548,13 +577,21 @@ public interface CommonAttributes {
             setAllowNull(true).
             build();
 
-    // AttributeDefinition[] COMMON_STORE_ATTRIBUTES = {SHARED, PRELOAD, PASSIVATION, FETCH_STATE, PURGE, SINGLETON, PROPERTIES};
     AttributeDefinition[] COMMON_STORE_ATTRIBUTES = {SHARED, PRELOAD, PASSIVATION, FETCH_STATE, PURGE, SINGLETON};
     AttributeDefinition[] STORE_ATTRIBUTES = {CLASS};
+    AttributeDefinition[] WRITE_BEHIND_ATTRIBUTES = {FLUSH_LOCK_TIMEOUT, MODIFICATION_QUEUE_SIZE, THREAD_POOL_SIZE, SHUTDOWN_TIMEOUT};
     AttributeDefinition[] FILE_STORE_ATTRIBUTES = {RELATIVE_TO, PATH};
     AttributeDefinition[] COMMON_JDBC_STORE_ATTRIBUTES = {DATA_SOURCE};
     AttributeDefinition[] STRING_KEYED_JDBC_STORE_ATTRIBUTES = {STRING_KEYED_TABLE};
     AttributeDefinition[] BINARY_KEYED_JDBC_STORE_ATTRIBUTES = {BINARY_KEYED_TABLE};
     AttributeDefinition[] MIXED_KEYED_JDBC_STORE_ATTRIBUTES = {STRING_KEYED_TABLE, BINARY_KEYED_TABLE};
     AttributeDefinition[] REMOTE_STORE_ATTRIBUTES = {CACHE, TCP_NO_DELAY, SOCKET_TIMEOUT, REMOTE_SERVERS};
+
+    // store
+    ObjectTypeAttributeDefinition WRITE_BEHIND_OBJECT = ObjectTypeAttributeDefinition.
+            Builder.of(ModelKeys.WRITE_BEHIND, WRITE_BEHIND_ATTRIBUTES).
+            setAllowNull(true).
+            setSuffix("write-behind").
+            build();
+
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Element.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/Element.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.AttributeDefinition;
  *
  * @author Paul Ferraro
  * @author Richard Achmatowicz (c) 2011 RedHat Inc.
+ * @author Tristan Tarrant
  */
 public enum Element {
     // must be first
@@ -67,6 +68,7 @@ public enum Element {
     TIMESTAMP_COLUMN(ModelKeys.TIMESTAMP_COLUMN),
     TRANSACTION(ModelKeys.TRANSACTION),
     TRANSPORT(ModelKeys.TRANSPORT),
+    WRITE_BEHIND(ModelKeys.WRITE_BEHIND)
     ;
 
     private final String name;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
@@ -444,6 +444,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.STORE_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, "infinispan.cache.store", store);
         }
+        addCacheStoreWriteBehindCacheChildren("infinispan.cache.store", store, resources);
         addCacheStorePropertyCacheChildren("infinispan.cache.store", store, resources);
         return store ;
     }
@@ -469,6 +470,31 @@ public class InfinispanDescriptions {
         return op;
     }
 
+    // write-behind element
+    static ModelNode getCacheStoreWriteBehindDescription(Locale locale) {
+        ResourceBundle resources = getResources(locale);
+        final ModelNode writeBehind = createDescription(resources, "infinispan.cache.store.write-behind");
+        for (AttributeDefinition attr : CommonAttributes.WRITE_BEHIND_ATTRIBUTES) {
+            attr.addResourceAttributeDescription(resources, "infinispan.cache.store.write-behind", writeBehind);
+        }
+        return writeBehind ;
+    }
+
+    static ModelNode getCacheStoreWriteBehindAddDescription(Locale locale) {
+        ResourceBundle resources = getResources(locale);
+        final ModelNode op = createOperationDescription(ADD, resources, "infinispan.cache.store.write-behind.add");
+        for (AttributeDefinition attr : CommonAttributes.WRITE_BEHIND_ATTRIBUTES) {
+            attr.addOperationParameterDescription(resources, "infinispan.cache.store.write-behind", op);
+        }
+        return op;
+    }
+
+    static ModelNode getCacheStoreWriteBehindRemoveDescription(Locale locale) {
+        ResourceBundle resources = getResources(locale);
+        final ModelNode op = createOperationDescription(REMOVE, resources, "infinispan.cache.store.write-behind.remove");
+        op.get(REQUEST_PROPERTIES).setEmptyObject();
+        return op;
+    }
 
     // cache store property element
     static ModelNode getCacheStorePropertyDescription(Locale locale) {
@@ -502,6 +528,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.FILE_STORE_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, "infinispan.cache.file-store", store);
         }
+        addCacheStoreWriteBehindCacheChildren("infinispan.cache.store", store, resources);
         addCacheStorePropertyCacheChildren("infinispan.cache.store", store, resources);
         return store ;
     }
@@ -533,6 +560,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.STRING_KEYED_JDBC_STORE_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, "infinispan.cache.jdbc-store", store);
         }
+        addCacheStoreWriteBehindCacheChildren("infinispan.cache.store", store, resources);
         addCacheStorePropertyCacheChildren("infinispan.cache.store", store, resources);
         return store ;
     }
@@ -568,6 +596,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.BINARY_KEYED_JDBC_STORE_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, "infinispan.cache.jdbc-store", store);
         }
+        addCacheStoreWriteBehindCacheChildren("infinispan.cache.store", store, resources);
         addCacheStorePropertyCacheChildren("infinispan.cache.store", store, resources);
         return store ;
     }
@@ -602,6 +631,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.MIXED_KEYED_JDBC_STORE_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, "infinispan.cache.jdbc-store", store);
         }
+        addCacheStoreWriteBehindCacheChildren("infinispan.cache.store", store, resources);
         addCacheStorePropertyCacheChildren("infinispan.cache.store", store, resources);
         return store ;
     }
@@ -633,6 +663,7 @@ public class InfinispanDescriptions {
         for (AttributeDefinition attr : CommonAttributes.REMOTE_STORE_ATTRIBUTES) {
             attr.addResourceAttributeDescription(resources, "infinispan.cache.remote-store", store);
         }
+        addCacheStoreWriteBehindCacheChildren("infinispan.cache.store", store, resources);
         addCacheStorePropertyCacheChildren("infinispan.cache.store", store, resources);
         return store ;
     }
@@ -749,6 +780,15 @@ public class InfinispanDescriptions {
         description.get(CHILDREN, ModelKeys.STATE_TRANSFER, ALLOWED).setEmptyList();
         description.get(CHILDREN, ModelKeys.STATE_TRANSFER, ALLOWED).add(ModelKeys.STATE_TRANSFER_NAME);
         description.get(CHILDREN, ModelKeys.STATE_TRANSFER, MODEL_DESCRIPTION);
+    }
+
+    private static void addCacheStoreWriteBehindCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {
+        // child properties
+        description.get(CHILDREN, ModelKeys.WRITE_BEHIND, DESCRIPTION).set(resources.getString(keyPrefix + ".write-behind"));
+        description.get(CHILDREN, ModelKeys.WRITE_BEHIND, MIN_OCCURS).set(0);
+        description.get(CHILDREN, ModelKeys.WRITE_BEHIND, MAX_OCCURS).set(1);
+        description.get(CHILDREN, ModelKeys.WRITE_BEHIND, ALLOWED).add(ModelKeys.WRITE_BEHIND_NAME);
+        description.get(CHILDREN, ModelKeys.WRITE_BEHIND, MODEL_DESCRIPTION);
     }
 
     private static void addCacheStorePropertyCacheChildren(String keyPrefix, ModelNode description, ResourceBundle resources) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -63,6 +63,7 @@ public class InfinispanExtension implements Extension {
     private static final PathElement expirationPath = PathElement.pathElement(ModelKeys.EXPIRATION, ModelKeys.EXPIRATION_NAME);
     private static final PathElement stateTransferPath = PathElement.pathElement(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
     private static final PathElement storePath = PathElement.pathElement(ModelKeys.STORE, ModelKeys.STORE_NAME);
+    private static final PathElement storeWriteBehindPath = PathElement.pathElement(ModelKeys.WRITE_BEHIND, ModelKeys.WRITE_BEHIND_NAME);
     private static final PathElement storePropertyPath = PathElement.pathElement(ModelKeys.PROPERTY);
     private static final PathElement fileStorePath = PathElement.pathElement(ModelKeys.FILE_STORE, ModelKeys.FILE_STORE_NAME);
     private static final PathElement stringKeyedJdbcStorePath = PathElement.pathElement(ModelKeys.STRING_KEYED_JDBC_STORE, ModelKeys.STRING_KEYED_JDBC_STORE_NAME);
@@ -177,6 +178,7 @@ public class InfinispanExtension implements Extension {
         store.registerOperationHandler(ADD, CacheConfigOperationHandlers.STORE_ADD, InfinispanSubsystemProviders.STORE_ADD);
         store.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_REMOVE);
         CacheConfigOperationHandlers.STORE_ATTR.registerAttributes(store);
+        createStoreWriteBehindRegistration(store);
         createPropertyRegistration(store);
 
         // register the file-store=FILE_STORE handlers
@@ -184,6 +186,7 @@ public class InfinispanExtension implements Extension {
         fileStore.registerOperationHandler(ADD, CacheConfigOperationHandlers.FILE_STORE_ADD, InfinispanSubsystemProviders.FILE_STORE_ADD);
         fileStore.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_REMOVE);
         CacheConfigOperationHandlers.FILE_STORE_ATTR.registerAttributes(fileStore);
+        createStoreWriteBehindRegistration(fileStore);
         createPropertyRegistration(fileStore);
 
         // register the string-keyed-jdbc-store=STRING_KEYED_JDBC_STORE handlers
@@ -191,6 +194,7 @@ public class InfinispanExtension implements Extension {
         stringKeyedJdbcStore.registerOperationHandler(ADD, CacheConfigOperationHandlers.STRING_KEYED_JDBC_STORE_ADD, InfinispanSubsystemProviders.STRING_KEYED_JDBC_STORE_ADD);
         stringKeyedJdbcStore.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_REMOVE);
         CacheConfigOperationHandlers.STRING_KEYED_JDBC_STORE_ATTR.registerAttributes(stringKeyedJdbcStore);
+        createStoreWriteBehindRegistration(stringKeyedJdbcStore);
         createPropertyRegistration(stringKeyedJdbcStore);
 
         // register the string-keyed-jdbc-store=STRING_KEYED_JDBC_STORE handlers
@@ -198,6 +202,7 @@ public class InfinispanExtension implements Extension {
         binaryKeyedJdbcStore.registerOperationHandler(ADD, CacheConfigOperationHandlers.BINARY_KEYED_JDBC_STORE_ADD, InfinispanSubsystemProviders.BINARY_KEYED_JDBC_STORE_ADD);
         binaryKeyedJdbcStore.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_REMOVE);
         CacheConfigOperationHandlers.BINARY_KEYED_JDBC_STORE_ATTR.registerAttributes(binaryKeyedJdbcStore);
+        createStoreWriteBehindRegistration(binaryKeyedJdbcStore);
         createPropertyRegistration(binaryKeyedJdbcStore);
 
         // register the mixed-keyed-jdbc-store=MIXED_KEYED_JDBC_STORE handlers
@@ -205,6 +210,7 @@ public class InfinispanExtension implements Extension {
         mixedKeyedJdbcStore.registerOperationHandler(ADD, CacheConfigOperationHandlers.MIXED_KEYED_JDBC_STORE_ADD, InfinispanSubsystemProviders.MIXED_KEYED_JDBC_STORE_ADD);
         mixedKeyedJdbcStore.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_REMOVE);
         CacheConfigOperationHandlers.MIXED_KEYED_JDBC_STORE_ATTR.registerAttributes(mixedKeyedJdbcStore);
+        createStoreWriteBehindRegistration(mixedKeyedJdbcStore);
         createPropertyRegistration(mixedKeyedJdbcStore);
 
         // register the remote-store=REMOTE_STORE handlers
@@ -212,6 +218,7 @@ public class InfinispanExtension implements Extension {
         remoteStore.registerOperationHandler(ADD, CacheConfigOperationHandlers.REMOTE_STORE_ADD, InfinispanSubsystemProviders.REMOTE_STORE_ADD);
         remoteStore.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_REMOVE);
         CacheConfigOperationHandlers.REMOTE_STORE_ATTR.registerAttributes(remoteStore);
+        createStoreWriteBehindRegistration(remoteStore);
         createPropertyRegistration(remoteStore);
     }
 
@@ -228,6 +235,13 @@ public class InfinispanExtension implements Extension {
         CacheConfigOperationHandlers.STATE_TRANSFER_ATTR.registerAttributes(stateTransfer);
     }
 
+    static void createStoreWriteBehindRegistration(final ManagementResourceRegistration parent) {
+        // register the write-behind=WRITE_BEHIND handlers
+        final ManagementResourceRegistration registration = parent.registerSubModel(storeWriteBehindPath, InfinispanSubsystemProviders.STORE_WRITE_BEHIND);
+        registration.registerOperationHandler(ADD, CacheConfigOperationHandlers.STORE_WRITE_BEHIND_ADD, InfinispanSubsystemProviders.STORE_WRITE_BEHIND_ADD);
+        registration.registerOperationHandler(REMOVE, CacheConfigOperationHandlers.REMOVE, InfinispanSubsystemProviders.STORE_WRITE_BEHIND_REMOVE);
+        CacheConfigOperationHandlers.STORE_WRITE_BEHIND_ATTR.registerAttributes(registration);
+    }
 
     static void createPropertyRegistration(final ManagementResourceRegistration parent) {
         final ManagementResourceRegistration registration = parent.registerSubModel(storePropertyPath, InfinispanSubsystemProviders.STORE_PROPERTY);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
@@ -37,11 +37,13 @@ import org.jboss.dmr.Property;
  *
  * @author Paul Ferraro
  * @author Richard Achmatowicz
+ * @author Tristan Tarrant
  */
 public class InfinispanSubsystemDescribe implements OperationStepHandler {
 
     public static final InfinispanSubsystemDescribe INSTANCE = new InfinispanSubsystemDescribe();
 
+    @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         ModelNode result = context.getResult();
 
@@ -178,6 +180,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             storeAddress.add(ModelKeys.STORE, ModelKeys.STORE_NAME);
             result.add(CacheConfigOperationHandlers.createStoreOperation(CommonAttributes.COMMON_STORE_ATTRIBUTES, storeAddress, store,
                     CommonAttributes.STORE_ATTRIBUTES));
+            addStoreWriteBehindConfigCommands(store, storeAddress, result);
             addCacheStorePropertyCommands(store, storeAddress, result);
         }
         else if (cache.getValue().get(ModelKeys.FILE_STORE, ModelKeys.FILE_STORE_NAME).isDefined()) {
@@ -186,6 +189,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             storeAddress.add(ModelKeys.FILE_STORE, ModelKeys.FILE_STORE_NAME);
             result.add(CacheConfigOperationHandlers.createStoreOperation(CommonAttributes.COMMON_STORE_ATTRIBUTES, storeAddress, store,
                     CommonAttributes.FILE_STORE_ATTRIBUTES));
+            addStoreWriteBehindConfigCommands(store, storeAddress, result);
             addCacheStorePropertyCommands(store, storeAddress, result);
         }
         else if (cache.getValue().get(ModelKeys.STRING_KEYED_JDBC_STORE, ModelKeys.STRING_KEYED_JDBC_STORE_NAME).isDefined()) {
@@ -193,6 +197,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             ModelNode storeAddress = address.clone();
             storeAddress.add(ModelKeys.STRING_KEYED_JDBC_STORE, ModelKeys.STRING_KEYED_JDBC_STORE_NAME);
             result.add(CacheConfigOperationHandlers.createStringKeyedStoreOperation(storeAddress, store));
+            addStoreWriteBehindConfigCommands(store, storeAddress, result);
             addCacheStorePropertyCommands(store, storeAddress, result);
         }
         else if (cache.getValue().get(ModelKeys.BINARY_KEYED_JDBC_STORE, ModelKeys.BINARY_KEYED_JDBC_STORE_NAME).isDefined()) {
@@ -200,6 +205,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             ModelNode storeAddress = address.clone();
             storeAddress.add(ModelKeys.BINARY_KEYED_JDBC_STORE, ModelKeys.BINARY_KEYED_JDBC_STORE_NAME);
             result.add(CacheConfigOperationHandlers.createBinaryKeyedStoreOperation(storeAddress, store));
+            addStoreWriteBehindConfigCommands(store, storeAddress, result);
             addCacheStorePropertyCommands(store, storeAddress, result);
         }
         else if (cache.getValue().get(ModelKeys.MIXED_KEYED_JDBC_STORE, ModelKeys.MIXED_KEYED_JDBC_STORE_NAME).isDefined()) {
@@ -207,6 +213,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             ModelNode storeAddress = address.clone();
             storeAddress.add(ModelKeys.MIXED_KEYED_JDBC_STORE, ModelKeys.MIXED_KEYED_JDBC_STORE_NAME);
             result.add(CacheConfigOperationHandlers.createMixedKeyedStoreOperation(storeAddress, store));
+            addStoreWriteBehindConfigCommands(store, storeAddress, result);
             addCacheStorePropertyCommands(store, storeAddress, result);
         }
         else if (cache.getValue().get(ModelKeys.REMOTE_STORE, ModelKeys.REMOTE_STORE_NAME).isDefined()) {
@@ -215,6 +222,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             storeAddress.add(ModelKeys.REMOTE_STORE, ModelKeys.REMOTE_STORE_NAME);
             result.add(CacheConfigOperationHandlers.createStoreOperation(CommonAttributes.COMMON_STORE_ATTRIBUTES, storeAddress, store,
                     CommonAttributes.REMOTE_STORE_ATTRIBUTES));
+            addStoreWriteBehindConfigCommands(store, storeAddress, result);
             addCacheStorePropertyCommands(store, storeAddress, result);
         }
     }
@@ -234,7 +242,19 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
             ModelNode stateTransfer = cache.getValue().get(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
             ModelNode stateTransferAddress = address.clone();
             stateTransferAddress.add(ModelKeys.STATE_TRANSFER, ModelKeys.STATE_TRANSFER_NAME);
-            result.add(CacheConfigOperationHandlers.createOperation(CommonAttributes.STATE_TRANSFER_ATTRIBUTES, stateTransferAddress, stateTransfer));
+            ModelNode createOperation = CacheConfigOperationHandlers.createOperation(CommonAttributes.STATE_TRANSFER_ATTRIBUTES, stateTransferAddress, stateTransfer);
+            result.add(createOperation);
+        }
+    }
+
+    private void addStoreWriteBehindConfigCommands(ModelNode store, ModelNode address, ModelNode result) throws OperationFailedException {
+        // command to recreate the write-behind configuration
+        if (store.get(ModelKeys.WRITE_BEHIND, ModelKeys.WRITE_BEHIND_NAME).isDefined()) {
+            ModelNode writeBehind = store.get(ModelKeys.WRITE_BEHIND, ModelKeys.WRITE_BEHIND_NAME);
+            ModelNode writeBehindAddress = address.clone();
+            writeBehindAddress.add(ModelKeys.WRITE_BEHIND, ModelKeys.WRITE_BEHIND_NAME);
+            ModelNode createOperation = CacheConfigOperationHandlers.createOperation(CommonAttributes.WRITE_BEHIND_ATTRIBUTES, writeBehindAddress, writeBehind);
+            result.add(createOperation);
         }
     }
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
@@ -11,126 +11,147 @@ import org.jboss.dmr.ModelNode;
 public class InfinispanSubsystemProviders {
 
     static final DescriptionProvider SUBSYSTEM = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getSubsystemDescription(locale);
         }
     };
 
     static final DescriptionProvider SUBSYSTEM_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getSubsystemAddDescription(locale);
         }
     };
 
     static final DescriptionProvider SUBSYSTEM_REMOVE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getSubsystemRemoveDescription(locale);
         }
     };
 
     static final DescriptionProvider SUBSYSTEM_DESCRIBE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getSubsystemDescribeDescription(locale);
         }
     };
 
     static final DescriptionProvider CACHE_CONTAINER = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getCacheContainerDescription(locale);
         }
     };
 
     static final DescriptionProvider CACHE_CONTAINER_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getCacheContainerAddDescription(locale);
         }
     };
 
     static final DescriptionProvider CACHE_CONTAINER_REMOVE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getCacheContainerRemoveDescription(locale);
         }
     };
 
     static final DescriptionProvider REMOVE_ALIAS = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getRemoveAliasCommandDescription(locale);
         }
     };
 
     static final DescriptionProvider ADD_ALIAS = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getAddAliasCommandDescription(locale);
         }
     };
 
     static final DescriptionProvider LOCAL_CACHE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getLocalCacheDescription(locale);
         }
     };
 
     static final DescriptionProvider LOCAL_CACHE_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getLocalCacheAddDescription(locale);
         }
     };
 
     static final DescriptionProvider INVALIDATION_CACHE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getInvalidationCacheDescription(locale);
         }
     };
 
     static final DescriptionProvider INVALIDATION_CACHE_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getInvalidationCacheAddDescription(locale);
         }
     };
 
     static final DescriptionProvider REPLICATED_CACHE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getReplicatedCacheDescription(locale);
         }
     };
 
     static final DescriptionProvider REPLICATED_CACHE_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getReplicatedCacheAddDescription(locale);
         }
     };
 
     static final DescriptionProvider DISTRIBUTED_CACHE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getDistributedCacheDescription(locale);
         }
     };
 
     static final DescriptionProvider DISTRIBUTED_CACHE_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getDistributedCacheAddDescription(locale);
         }
     };
 
     static final DescriptionProvider CACHE_REMOVE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getCacheRemoveDescription(locale);
         }
     };
 
     static final DescriptionProvider TRANSPORT = new DescriptionProvider() {
-         public ModelNode getModelDescription(Locale locale) {
+         @Override
+        public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getTransportDescription(locale);
         }
     };
 
     static final DescriptionProvider TRANSPORT_ADD = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getTransportAddDescription(locale);
         }
     };
 
     static final DescriptionProvider TRANSPORT_REMOVE = new DescriptionProvider() {
+        @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getTransportRemoveDescription(locale);
         }
@@ -266,6 +287,25 @@ public class InfinispanSubsystemProviders {
         @Override
         public ModelNode getModelDescription(Locale locale) {
             return InfinispanDescriptions.getCacheStorePropertyRemoveDescription(locale);
+        }
+    };
+
+    static final DescriptionProvider STORE_WRITE_BEHIND = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheStoreWriteBehindDescription(locale);
+        }
+    };
+    static final DescriptionProvider STORE_WRITE_BEHIND_ADD = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheStoreWriteBehindAddDescription(locale);
+        }
+    };
+    static final DescriptionProvider STORE_WRITE_BEHIND_REMOVE = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheStoreWriteBehindRemoveDescription(locale);
         }
     };
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_2.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_2.java
@@ -688,8 +688,10 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
             throw ParseUtils.missingRequired(reader, EnumSet.of(Attribute.CLASS));
         }
 
-        this.parseStoreProperties(reader, store);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
+        this.parseStoreElements(reader, store, additionalConfigurationOperations);
         operations.add(store);
+        operations.addAll(additionalConfigurationOperations);
     }
 
     private void parseFileStore(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
@@ -717,8 +719,10 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
             }
         }
 
-        this.parseStoreProperties(reader, store);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
+        this.parseStoreElements(reader, store, additionalConfigurationOperations);
         operations.add(store);
+        operations.addAll(additionalConfigurationOperations);
     }
 
     private void parseRemoteStore(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
@@ -727,6 +731,7 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
         storeAddress.add(ModelKeys.REMOTE_STORE,ModelKeys.REMOTE_STORE_NAME) ;
         storeAddress.protect();
         ModelNode store = Util.getEmptyOperation(ModelDescriptionConstants.ADD, storeAddress);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -757,6 +762,10 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
                     this.parseRemoteServer(reader, store.get(ModelKeys.REMOTE_SERVERS).add());
                     break;
                 }
+                case WRITE_BEHIND: {
+                    parseStoreWriteBehind(reader, store, additionalConfigurationOperations);
+                    break;
+                }
                 default: {
                     this.parseStoreProperty(reader, store);
                 }
@@ -767,6 +776,7 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
             throw ParseUtils.missingRequired(reader, Collections.singleton(Element.REMOTE_SERVER));
         }
         operations.add(store);
+        operations.addAll(additionalConfigurationOperations);
     }
 
     private void parseRemoteServer(XMLExtendedStreamReader reader, ModelNode server) throws XMLStreamException {
@@ -792,6 +802,7 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
         storeAddress.add(ModelKeys.STRING_KEYED_JDBC_STORE,ModelKeys.STRING_KEYED_JDBC_STORE_NAME) ;
         storeAddress.protect();
         ModelNode store = Util.getEmptyOperation(ModelDescriptionConstants.ADD, storeAddress);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -818,12 +829,17 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
                     this.parseJDBCStoreTable(reader, store.get(ModelKeys.STRING_KEYED_TABLE).setEmptyObject());
                     break;
                 }
+                case WRITE_BEHIND: {
+                    parseStoreWriteBehind(reader, store, additionalConfigurationOperations);
+                    break;
+                }
                 default: {
                     this.parseStoreProperty(reader, store);
                 }
             }
         }
         operations.add(store);
+        operations.addAll(additionalConfigurationOperations);
     }
 
     private void parseBinaryKeyedJDBCStore(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
@@ -832,6 +848,7 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
         storeAddress.add(ModelKeys.BINARY_KEYED_JDBC_STORE,ModelKeys.BINARY_KEYED_JDBC_STORE_NAME) ;
         storeAddress.protect();
         ModelNode store = Util.getEmptyOperation(ModelDescriptionConstants.ADD, storeAddress);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -858,12 +875,17 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
                     this.parseJDBCStoreTable(reader, store.get(ModelKeys.BINARY_KEYED_TABLE).setEmptyObject());
                     break;
                 }
+                case WRITE_BEHIND: {
+                    parseStoreWriteBehind(reader, store, additionalConfigurationOperations);
+                    break;
+                }
                 default: {
                     this.parseStoreProperty(reader, store);
                 }
             }
         }
         operations.add(store);
+        operations.addAll(additionalConfigurationOperations);
     }
     private void parseMixedKeyedJDBCStore(XMLExtendedStreamReader reader, ModelNode cache, List<ModelNode> operations) throws XMLStreamException {
         // ModelNode for the mixed-keyed jdbc store add operation
@@ -871,6 +893,7 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
         storeAddress.add(ModelKeys.MIXED_KEYED_JDBC_STORE,ModelKeys.MIXED_KEYED_JDBC_STORE_NAME) ;
         storeAddress.protect();
         ModelNode store = Util.getEmptyOperation(ModelDescriptionConstants.ADD, storeAddress);
+        List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             String value = reader.getAttributeValue(i);
@@ -901,12 +924,20 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
                     this.parseJDBCStoreTable(reader, store.get(ModelKeys.BINARY_KEYED_TABLE).setEmptyObject());
                     break;
                 }
-                default: {
-                    this.parseStoreProperty(reader, store);
+                case WRITE_BEHIND: {
+                    parseStoreWriteBehind(reader, store, additionalConfigurationOperations);
+                    break;
                 }
+                case PROPERTY: {
+                    parseStoreProperty(reader, store);
+                    break;
+                }
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
             }
         }
         operations.add(store);
+        operations.addAll(additionalConfigurationOperations);
     }
 
 
@@ -1008,41 +1039,79 @@ public class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<List<M
         }
     }
 
-    private void parseStoreProperties(XMLExtendedStreamReader reader, ModelNode node) throws XMLStreamException {
+    private void parseStoreElements(XMLExtendedStreamReader reader, ModelNode store, List<ModelNode> operations) throws XMLStreamException {
         while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
-            this.parseStoreProperty(reader, node);
+            Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case WRITE_BEHIND: {
+                    parseStoreWriteBehind(reader, store, operations);
+                    break;
+                }
+                case PROPERTY: {
+                    parseStoreProperty(reader, store);
+                    break;
+                }
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
         }
     }
 
-    private void parseStoreProperty(XMLExtendedStreamReader reader, ModelNode node) throws XMLStreamException {
-        Element element = Element.forName(reader.getLocalName());
-        switch (element) {
-            case PROPERTY: {
-                int attributes = reader.getAttributeCount();
-                String property = null;
-                for (int i = 0; i < attributes; i++) {
-                    String value = reader.getAttributeValue(i);
-                    Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
-                    switch (attribute) {
-                        case NAME: {
-                            property = value;
-                            break;
-                        }
-                        default: {
-                            throw ParseUtils.unexpectedAttribute(reader, i);
-                        }
-                    }
+    private void parseStoreWriteBehind(XMLExtendedStreamReader reader, ModelNode store, List<ModelNode> operations) throws XMLStreamException {
+        // ModelNode for the write-behind add operation
+        ModelNode writeBehindAddress = store.get(ModelDescriptionConstants.OP_ADDR).clone() ;
+        writeBehindAddress.add(ModelKeys.WRITE_BEHIND,ModelKeys.WRITE_BEHIND_NAME) ;
+        writeBehindAddress.protect();
+        ModelNode writeBehind = Util.getEmptyOperation(ModelDescriptionConstants.ADD, writeBehindAddress);
+
+        for (int i = 0; i < reader.getAttributeCount(); i++) {
+            String value = reader.getAttributeValue(i);
+            Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case FLUSH_LOCK_TIMEOUT: {
+                    CommonAttributes.FLUSH_LOCK_TIMEOUT.parseAndSetParameter(value, writeBehind, reader);
+                    break;
                 }
-                if (property == null) {
-                    throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.NAME));
+                case MODIFICATION_QUEUE_SIZE: {
+                    CommonAttributes.MODIFICATION_QUEUE_SIZE.parseAndSetParameter(value, writeBehind, reader);
+                    break;
                 }
-                String value = reader.getElementText();
-                node.get(ModelKeys.PROPERTIES).add(property, value);
-                break;
-            }
-            default: {
-                throw ParseUtils.unexpectedElement(reader);
+                case SHUTDOWN_TIMEOUT: {
+                    CommonAttributes.SHUTDOWN_TIMEOUT.parseAndSetParameter(value, writeBehind, reader);
+                    break;
+                }
+                case THREAD_POOL_SIZE: {
+                    CommonAttributes.THREAD_POOL_SIZE.parseAndSetParameter(value, writeBehind, reader);
+                    break;
+                }
+                default:
+                    throw ParseUtils.unexpectedAttribute(reader, i);
             }
         }
+        ParseUtils.requireNoContent(reader);
+        operations.add(writeBehind);
+    }
+
+    private void parseStoreProperty(XMLExtendedStreamReader reader, ModelNode node) throws XMLStreamException {
+        int attributes = reader.getAttributeCount();
+        String property = null;
+        for (int i = 0; i < attributes; i++) {
+            String value = reader.getAttributeValue(i);
+            Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case NAME: {
+                    property = value;
+                    break;
+                }
+                default: {
+                    throw ParseUtils.unexpectedAttribute(reader, i);
+                }
+            }
+        }
+        if (property == null) {
+            throw ParseUtils.missingRequired(reader, Collections.singleton(Attribute.NAME));
+        }
+        String value = reader.getElementText();
+        node.get(ModelKeys.PROPERTIES).add(property, value);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -182,6 +182,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeStartElement(Element.STORE.getLocalName());
                         this.writeRequired(writer, Attribute.CLASS, store, ModelKeys.CLASS);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         writer.writeEndElement();
                     }
@@ -191,6 +192,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         this.writeOptional(writer, Attribute.RELATIVE_TO, store, ModelKeys.RELATIVE_TO);
                         this.writeOptional(writer, Attribute.PATH, store, ModelKeys.PATH);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         writer.writeEndElement();
                     }
@@ -199,6 +201,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeStartElement(Element.STRING_KEYED_JDBC_STORE.getLocalName());
                         this.writeRequired(writer, Attribute.DATASOURCE, store, ModelKeys.DATASOURCE);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         this.writeJDBCStoreTable(writer, Element.STRING_KEYED_TABLE, store, ModelKeys.STRING_KEYED_TABLE);
                         writer.writeEndElement();
@@ -208,6 +211,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeStartElement(Element.BINARY_KEYED_JDBC_STORE.getLocalName());
                         this.writeRequired(writer, Attribute.DATASOURCE, store, ModelKeys.DATASOURCE);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         this.writeJDBCStoreTable(writer, Element.BINARY_KEYED_TABLE, store, ModelKeys.BINARY_KEYED_TABLE);
                         writer.writeEndElement();
@@ -217,6 +221,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         writer.writeStartElement(Element.MIXED_KEYED_JDBC_STORE.getLocalName());
                         this.writeRequired(writer, Attribute.DATASOURCE, store, ModelKeys.DATASOURCE);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         this.writeJDBCStoreTable(writer, Element.STRING_KEYED_TABLE, store, ModelKeys.STRING_KEYED_TABLE);
                         this.writeJDBCStoreTable(writer, Element.BINARY_KEYED_TABLE, store, ModelKeys.BINARY_KEYED_TABLE);
@@ -229,6 +234,7 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
                         this.writeOptional(writer, Attribute.SOCKET_TIMEOUT, store, ModelKeys.SOCKET_TIMEOUT);
                         this.writeOptional(writer, Attribute.TCP_NO_DELAY, store, ModelKeys.TCP_NO_DELAY);
                         this.writeStoreAttributes(writer, store);
+                        this.writeStoreWriteBehind(writer, store);
                         this.writeStoreProperties(writer, store);
                         for (ModelNode remoteServer: store.get(ModelKeys.REMOTE_SERVERS).asList()) {
                             writer.writeStartElement(Element.REMOTE_SERVER.getLocalName());
@@ -311,6 +317,18 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
         this.writeOptional(writer, Attribute.FETCH_STATE, store, ModelKeys.FETCH_STATE);
         this.writeOptional(writer, Attribute.PURGE, store, ModelKeys.PURGE);
         this.writeOptional(writer, Attribute.SINGLETON, store, ModelKeys.SINGLETON);
+    }
+
+    private void writeStoreWriteBehind(XMLExtendedStreamWriter writer, ModelNode store) throws XMLStreamException {
+        if (store.get(ModelKeys.WRITE_BEHIND, ModelKeys.WRITE_BEHIND_NAME).isDefined()) {
+            ModelNode writeBehind = store.get(ModelKeys.WRITE_BEHIND, ModelKeys.WRITE_BEHIND_NAME);
+            writer.writeStartElement(Element.WRITE_BEHIND.getLocalName());
+            this.writeOptional(writer, Attribute.FLUSH_LOCK_TIMEOUT, writeBehind, ModelKeys.FLUSH_LOCK_TIMEOUT);
+            this.writeOptional(writer, Attribute.MODIFICATION_QUEUE_SIZE, writeBehind, ModelKeys.MODIFICATION_QUEUE_SIZE);
+            this.writeOptional(writer, Attribute.SHUTDOWN_TIMEOUT, writeBehind, ModelKeys.SHUTDOWN_TIMEOUT);
+            this.writeOptional(writer, Attribute.THREAD_POOL_SIZE, writeBehind, ModelKeys.THREAD_POOL_SIZE);
+            writer.writeEndElement();
+        }
     }
 
     private void writeStoreProperties(XMLExtendedStreamWriter writer, ModelNode store) throws XMLStreamException {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -24,6 +24,7 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 /**
  * @author Paul Ferraro
+ * @author Tristan Tarrant
  */
 public class ModelKeys {
     static final String ACQUIRE_TIMEOUT = "acquire-timeout";
@@ -60,6 +61,7 @@ public class ModelKeys {
     static final String FETCH_STATE = "fetch-state";
     static final String FILE_STORE = "file-store";
     static final String FILE_STORE_NAME = "FILE_STORE";
+    static final String FLUSH_LOCK_TIMEOUT = "flush-lock-timeout";
     static final String ID_COLUMN = "id-column";
     static final String INDEXING = "indexing";
     static final String INTERVAL = "interval";
@@ -87,6 +89,7 @@ public class ModelKeys {
     static final String MAX_ENTRIES = "max-entries";
     static final String MAX_IDLE = "max-idle";
     static final String MODE = "mode";
+    static final String MODIFICATION_QUEUE_SIZE = "modification-queue-size";
     static final String NAME = "name";
     static final String OUTBOUND_SOCKET_BINDING = "outbound-socket-binding";
     static final String OWNERS = "owners";
@@ -109,6 +112,7 @@ public class ModelKeys {
     static final String REPLICATED_CACHE = "replicated-cache";
     static final String REPLICATION_QUEUE_EXECUTOR = "replication-queue-executor";
     static final String SHARED = "shared";
+    static final String SHUTDOWN_TIMEOUT = "shutdown-timeout";
     static final String SINGLETON = "singleton";
     static final String SITE = "site";
     static final String SOCKET_TIMEOUT = "socket-timeout";
@@ -122,6 +126,7 @@ public class ModelKeys {
     static final String STRATEGY = "strategy";
     static final String STRIPING = "striping";
     static final String TCP_NO_DELAY = "tcp-no-delay";
+    static final String THREAD_POOL_SIZE = "thread-pool-size";
     static final String TIMEOUT = "timeout";
     static final String TIMESTAMP_COLUMN = "timestamp-column";
     static final String TRANSACTION = "transaction";
@@ -131,4 +136,6 @@ public class ModelKeys {
     static final String TYPE = "type";
     static final String VIRTUAL_NODES = "virtual-nodes";
     static final String WAIT = "wait";
+    static final String WRITE_BEHIND = "write-behind";
+    static final String WRITE_BEHIND_NAME = "WRITE_BEHIND";
 }

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -90,6 +90,14 @@ infinispan.cache.store.purge=If true, purges this cache store when it starts up.
 infinispan.cache.store.singleton=If true, the singleton store cache store is enabled. SingletonStore is a delegating cache store used for situations when only one instance in a cluster should interact with the underlying store.
 infinispan.cache.store.class=The custom store implementation class to use for this cache store.
 
+infinispan.cache.store.write-behind=Configures a cache store as write-behind instead of write-through.
+infinispan.cache.store.write-behind.add=Adds a write-behind configuration element to the store.
+infinispan.cache.store.write-behind.remove=Removes a write-behind configuration element from the store.
+infinispan.cache.store.write-behind.flush-lock-timeout=Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.
+infinispan.cache.store.write-behind.modification-queue-size=Maximum number of entries in the asynchronous queue. When the queue is full, the store becomes write-through until it can accept new entries.
+infinispan.cache.store.write-behind.shutdown-timeout=Timeout in milliseconds to stop the cache store.
+infinispan.cache.store.write-behind.thread-pool-size=Size of the thread pool whose threads are responsible for applying the modifications to the cache store.
+
 infinispan.cache.store.properties=A list of cache store properties.
 infinispan.cache.store.property=A cache store property with name and value.
 infinispan.cache.store.property.add=Adds a cache store property.

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -63,7 +63,7 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest {
     public static Collection<Object[]> data() {
       Object[][] data = new Object[][] { { "subsystem-infinispan_1_0.xml", 31 },
                                          { "subsystem-infinispan_1_1.xml", 31 },
-                                         { "subsystem-infinispan_1_2.xml", 31 }
+                                         { "subsystem-infinispan_1_2.xml", 35 }
                                        };
       return Arrays.asList(data);
     }

--- a/clustering/infinispan/src/test/resources/subsystem-infinispan_1_2.xml
+++ b/clustering/infinispan/src/test/resources/subsystem-infinispan_1_2.xml
@@ -9,7 +9,9 @@
             <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="true"/>
+            <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="true">
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+            </file-store>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
@@ -17,6 +19,7 @@
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="true" singleton="true">
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
                 <property name="hotrod.property">value</property>
                 <remote-server outbound-socket-binding="hotrod-server-1" />
                 <remote-server outbound-socket-binding="hotrod-server-2" />
@@ -29,6 +32,7 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
             <store class="org.infinispan.loaders.file.FileCacheStore" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
                 <property name="location">${java.io.tmpdir}</property>
             </store>
         </replicated-cache>
@@ -39,6 +43,7 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="true" singleton="true">
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>


### PR DESCRIPTION
This adds a new element as a child of the various elements.
Unfortunately, because of an Infinispan limitation, this feature does not support injection of an external thread pool.
