### PR TITLE
AS7-2757 adding functionality to CLI add-user to update a current user and roles

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -488,9 +488,54 @@ public interface DomainManagementMessages {
     @Message(id = 15251, value = "Invalid response. (Valid responses are A, a, B, or b)")
     String invalidChoiceResponse();
 
-    /*
-     * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementLogger also contains messages in
-     * this range commencing 15200.
+    /**
+     * Confirmation if the current user password and roles is about to be updated.
+     *
+     * @param user - The name of the user.
+     *
+     * @return a {@link String} for the message.
      */
+    @Message(value = "User '%s' already exits, would you like to update the existing user password and roles")
+    String aboutToUpdateUser(String user);
 
+    /**
+     * Message to inform user that the user has been updated to the file identified.
+     *
+     * @param username - The new username.
+     * @param fileName - The file the user has been added to.
+     *
+     * @return a {@link String} for the message.
+     */
+    @Message(value = "Updated user '%s' to file '%s'")
+    String updateUser(String userName, String canonicalPath);
+
+
+
+    /**
+    * The error message if updating user to the file fails.
+    *
+    * @param file - The name of the file the add failed for.
+    * @param error - The failure message.
+     *
+     * @return a {@link String} for the message.
+     */
+    @Message(id = 15254, value = "Unable to update user to %s due to error %s")
+    String unableToUpdateUser(String absolutePath, String message);
+
+    /**
+     * Message to inform user that the user has been updated to the roles file identified.
+     *
+     * @param username - The new username.
+     * @param roles - The new roles.
+     * @param fileName - The file the user has been added to.
+     *
+     * @return a {@link String} for the message.
+     */
+    @Message(value = "Updated user '%s' with roles %s to file '%s'")
+    String updatedRoles(String username, String roles, String fileName);
+
+    /*
+    * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementLogger also contains messages in
+    * this range commencing 15200.
+    */
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileLoader.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileLoader.java
@@ -118,7 +118,7 @@ public abstract class PropertiesFileLoader {
         return properties;
     }
 
-    private synchronized void persistProperties() throws IOException {
+    public synchronized void persistProperties() throws IOException {
         Properties toSave = (Properties) properties.clone();
 
         File backup = new File(propertiesFile.getCanonicalPath() + ".bak");


### PR DESCRIPTION
Refactored some of the stats because the user flow started to be strange when a user want to update his  password and roles. Now as soon as he type a user name we check if it exists, and he will be asked if he want to proceed.

I tried to see if could find a way to "pre-input" fields with the current information, but the console API doesn't seem to support it. So I decide just to display the existing roles, and then the user has to retype them. If he leave the field empty it clear his existing roles. 
