### PR TITLE
AS7-3340 Destroy only the RootPOA on service shutdown.

### DIFF
--- a/jacorb/src/main/java/org/jboss/as/jacorb/service/CorbaPOAService.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/service/CorbaPOAService.java
@@ -183,8 +183,10 @@ public class CorbaPOAService implements Service<POA> {
     @Override
     public void stop(StopContext context) {
         JacORBLogger.ROOT_LOGGER.debugServiceStop(context.getController().getName().getCanonicalName());
-        // destroy the created POA.
-        this.poa.destroy(false, false);
+
+        // destroy parent POAs, letting they destroy their children POAs in the process.
+        if (this.poa.the_parent() == null)
+           this.poa.destroy(false, false);
     }
 
     @Override


### PR DESCRIPTION
By terminating only parent POAs (such as RootPOA) we make sure we don't run into race conditions that can lead to an NPE when a parent POA is iterating through its children in order to destroy them. JacORB's POA destruction code handles child POA destruction for us.
