### PR TITLE
AS7-4110 Remoting subsystem shouldn't prematurely read jboss.node.name

### DIFF
--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -101,11 +101,7 @@ public class RemotingExtension implements Extension {
 
     private static final String RESOURCE_NAME = RemotingExtension.class.getPackage().getName() + ".LocalDescriptions";
 
-    private static final String NODE_NAME_PROPERTY = "jboss.node.name";
-    static final String NODE_NAME;
-    static {
-        NODE_NAME = SecurityActions.getSystemProperty(RemotingExtension.NODE_NAME_PROPERTY);
-    }
+    static final String NODE_NAME_PROPERTY = "jboss.node.name";
 
     static ResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
         return new StandardResourceDescriptionResolver(keyPrefix, RESOURCE_NAME, RemotingExtension.class.getClassLoader(), true, false);

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
@@ -77,7 +77,8 @@ class RemotingSubsystemAdd extends AbstractAddStepHandler {
 
     void launchServices(OperationContext context, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         // create endpoint
-        final EndpointService endpointService = new EndpointService(RemotingExtension.NODE_NAME, EndpointService.EndpointType.SUBSYSTEM);
+        final String nodeName = SecurityActions.getSystemProperty(RemotingExtension.NODE_NAME_PROPERTY);
+        final EndpointService endpointService = new EndpointService(nodeName, EndpointService.EndpointType.SUBSYSTEM);
         // todo configure option map
         final OptionMap map = OptionMap.builder()
                 .set(Options.WORKER_READ_THREADS, RemotingSubsystemRootResource.WORKER_READ_THREADS.resolveModelAttribute(context, model).asInt())

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -498,7 +498,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         }
     }
 
-    // TODO why is this not done in the constructor?
+    // TODO AS7-3617 why is this not done in the constructor?
     @SuppressWarnings("deprecation")
     void install() {
         SecurityActions.setSystemProperty(QUALIFIED_HOST_NAME, qualifiedHostName);

--- a/server/src/main/java/org/jboss/as/server/ServerStartTask.java
+++ b/server/src/main/java/org/jboss/as/server/ServerStartTask.java
@@ -93,8 +93,18 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         properties.setProperty(ServerEnvironment.DOMAIN_BASE_DIR, SecurityActions.getSystemProperty(ServerEnvironment.DOMAIN_BASE_DIR));
         properties.setProperty(ServerEnvironment.DOMAIN_CONFIG_DIR, SecurityActions.getSystemProperty(ServerEnvironment.DOMAIN_CONFIG_DIR));
 
-        // Set the optional properties
+        // Provide any other properties that standalone Main.determineEnvironment() would read
+        // from system properties and pass in to ServerEnvironment
+        setPropertyIfFound(launchProperties, ServerEnvironment.JAVA_EXT_DIRS, properties);
+        setPropertyIfFound(launchProperties, ServerEnvironment.QUALIFIED_HOST_NAME, properties);
+        setPropertyIfFound(launchProperties, ServerEnvironment.HOST_NAME, properties);
+        setPropertyIfFound(launchProperties, ServerEnvironment.NODE_NAME, properties);
+        @SuppressWarnings("deprecation")
+        String deprecated = ServerEnvironment.MODULES_DIR;
+        setPropertyIfFound(launchProperties, deprecated, properties);
+        setPropertyIfFound(launchProperties, ServerEnvironment.BUNDLES_DIR, properties);
         setPropertyIfFound(launchProperties, ServerEnvironment.SERVER_DATA_DIR, properties);
+        setPropertyIfFound(launchProperties, ServerEnvironment.SERVER_CONTENT_DIR, properties);
         setPropertyIfFound(launchProperties, ServerEnvironment.SERVER_LOG_DIR, properties);
         setPropertyIfFound(launchProperties, ServerEnvironment.SERVER_TEMP_DIR, properties);
     }
@@ -104,7 +114,8 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         final Bootstrap bootstrap = Bootstrap.Factory.newInstance();
         final ProductConfig productConfig = new ProductConfig(Module.getBootModuleLoader(), home);
         // Create server environment on the server, so that the system properties are getting initialized on the right side
-        final ServerEnvironment providedEnvironment = new ServerEnvironment(hostControllerName, properties, SecurityActions.getSystemEnvironment(), null, ServerEnvironment.LaunchType.DOMAIN, RunningMode.NORMAL, productConfig);
+        final ServerEnvironment providedEnvironment = new ServerEnvironment(hostControllerName, properties,
+                SecurityActions.getSystemEnvironment(), null, ServerEnvironment.LaunchType.DOMAIN, RunningMode.NORMAL, productConfig);
         final Bootstrap.Configuration configuration = new Bootstrap.Configuration(providedEnvironment);
         final ExtensionRegistry extensionRegistry = configuration.getExtensionRegistry();
         final Bootstrap.ConfigurationPersisterFactory configurationPersisterFactory = new Bootstrap.ConfigurationPersisterFactory() {


### PR DESCRIPTION
Also, in a managed domain, provide all props to ServerEnvironment that it would normally get from system properties in a standalone server
