### PR TITLE
Fix for AS7-4099

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_1.xsd
@@ -1,0 +1,279 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:ejb-client:1.1"
+            xmlns="urn:jboss:ejb-client:1.1"
+            elementFormDefault="unqualified"
+            attributeFormDefault="unqualified"
+            version="1.1">
+
+    <!-- Root element -->
+    <xsd:element name="jboss-ejb-client" type="jboss-ejb-clientType">
+        <xsd:annotation>
+            <xsd:documentation>
+                Root element for a jboss-ejb-client.xml file
+            </xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+
+    <xsd:complexType name="jboss-ejb-clientType">
+        <xsd:annotation>
+            <xsd:documentation>
+                The EJB client configurations
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:all>
+            <xsd:element name="client-context" type="client-contextType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configurations that will be used to setup an EJB client context for the
+                        deployment.
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:all>
+
+    </xsd:complexType>
+
+    <xsd:complexType name="client-contextType">
+        <xsd:all>
+            <xsd:element name="ejb-receivers" type="ejb-receiversType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures EJB receivers for the client context
+                    </documentation>
+                </annotation>
+            </xsd:element>
+            <xsd:element name="clusters" type="clustersType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Cluster configurations applicable for this client context
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+
+    <xsd:complexType name="ejb-receiversType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="remoting-ejb-receiver" type="remoting-ejb-receiverType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures a remoting based EJB receiver
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:choice>
+        <xsd:attribute name="exclude-local-receiver" type="xsd:boolean" use="optional" default="false">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    Set to true if the local receiver which gets added to the EJB client context by default, has to be
+                    excluded from the context
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="local-receiver-pass-by-value" type="xsd:boolean" use="optional" default="true">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    Set to false if the local receiver that's available in the EJB client context, should use
+                    pass-by-reference (instead of pass-by-value) semantics for the EJB invocations.
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+
+    <xsd:complexType name="remoting-ejb-receiverType">
+        <xsd:attribute name="outbound-connection-ref" type="xsd:string" use="required">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    Reference to an outbound connection configured in the remoting subsytem
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="clustersType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="cluster" type="clusterType">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures a cluster in the client context
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="clusterType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="channel-creation-options" type="channel-creation-optionsType" maxOccurs="1">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures the channel creation options for the nodes in this cluster
+                    </documentation>
+                </annotation>
+            </xsd:element>
+            <xsd:element name="connection-creation-options" type="connection-creation-optionsType" maxOccurs="1">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures the connection creation options for the nodes in this cluster
+                    </documentation>
+                </annotation>
+            </xsd:element>
+            <xsd:element name="node" type="clusterNodeType" maxOccurs="unbounded">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures the channel creation options for the nodes in this cluster
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:choice>
+        <xsd:attribute name="name" type="xsd:string" use="required">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The name of the cluster
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="connect-timeout" type="xsd:long" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The timeout in milli seconds while creating a connection for the nodes in the cluster
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="max-allowed-connected-nodes" type="xsd:long" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The maximum number of nodes to which the connection will be established in the cluster
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="cluster-node-selector" type="xsd:string" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The fully qualified classname of the class which implements the
+                    org.jboss.ejb.client.ClusterNodeSelector
+                    interface. The instance of this class will be used for selecting nodes, within the cluster, for
+                    handling
+                    invocations
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="username" type="xsd:string" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The username that will be used for authentication during connection creation for nodes in the
+                    cluster
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="security-realm" type="xsd:string" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The security-realm that will be used for authentication during connection creation for nodes in the
+                    cluster
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="clusterNodeType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="channel-creation-options" type="channel-creation-optionsType" maxOccurs="1">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures the channel creation options for the node
+                    </documentation>
+                </annotation>
+            </xsd:element>
+            <xsd:element name="connection-creation-options" type="connection-creation-optionsType" maxOccurs="1">
+                <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                    <documentation>
+                        Configures the connection creation options for the node
+                    </documentation>
+                </annotation>
+            </xsd:element>
+        </xsd:choice>
+        <xsd:attribute name="name" type="xsd:string" use="required">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The name of the cluster node
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="connect-timeout" type="xsd:long" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The timeout in milli seconds while creating a connection for the node
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="username" type="xsd:string" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The username that will be used for authentication during connection creation for the node
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="security-realm" type="xsd:string" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The security-realm that will be used for authentication during connection creation for the node
+                    cluster
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+
+    <xsd:complexType name="channel-creation-optionsType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="property" type="propertyType"/>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="connection-creation-optionsType">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="property" type="propertyType"/>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="propertyType">
+        <xsd:attribute name="name" type="xsd:string" use="required">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The name of the property. Example org.xnio.Options.SASL_POLICY_NOANONYMOUS
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+        <xsd:attribute name="value" type="xsd:string" use="required">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The value of the property.
+                </documentation>
+            </annotation>
+        </xsd:attribute>
+
+    </xsd:complexType>
+</xsd:schema>
+

--- a/build/src/main/resources/modules/org/jboss/as/ejb3/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/ejb3/main/module.xml
@@ -50,6 +50,9 @@
         <module name="org.jboss.as.weld"/>
         <!-- So we can access its integration API -->
         <module name="org.jboss.as.connector"/>
+        <!-- Need access to org.jboss.as.domain.management.SecurityRealm for authentication of EJB cluster nodes
+         in EJB client context-->
+        <module name="org.jboss.as.domain-management"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.jacorb"/>
         <module name="org.jboss.as.naming"/>

--- a/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
@@ -23,7 +23,9 @@
 package org.jboss.as.ee.metadata;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -37,6 +39,8 @@ public class EJBClientDescriptorMetaData {
     private Boolean localReceiverPassByValue;
 
     private Set<String> remotingReceiverConnectionRefs = new HashSet<String>();
+    private Set<ClusterConfig> clusterConfigs = new HashSet<ClusterConfig>();
+
 
     /**
      * Adds a outbound connection reference used by a remoting receivers in the client context represented
@@ -98,5 +102,153 @@ public class EJBClientDescriptorMetaData {
      */
     public boolean isLocalReceiverExcluded() {
         return this.excludeLocalReceiver;
+    }
+
+    public Collection<ClusterConfig> getClusterConfigs() {
+        return Collections.unmodifiableSet(this.clusterConfigs);
+    }
+
+    public ClusterConfig newClusterConfig(final String clusterName) {
+        final ClusterConfig clusterConfig = new ClusterConfig(clusterName);
+        this.clusterConfigs.add(clusterConfig);
+        return clusterConfig;
+    }
+
+    public class ClusterConfig extends CommonConnectionConfig {
+
+        private final String clusterName;
+        private final Set<ClusterNodeConfig> nodes = new HashSet<ClusterNodeConfig>();
+        private long maxAllowedConnectedNodes;
+        private String nodeSelector;
+
+
+        ClusterConfig(final String clusterName) {
+            this.clusterName = clusterName;
+        }
+
+        public ClusterNodeConfig newClusterNode(final String nodeName) {
+            final ClusterNodeConfig node = new ClusterNodeConfig(nodeName);
+            this.nodes.add(node);
+            return node;
+        }
+
+        public Collection<ClusterNodeConfig> getClusterNodeConfigs() {
+            return Collections.unmodifiableSet(this.nodes);
+        }
+
+        public String getClusterName() {
+            return this.clusterName;
+        }
+
+        public long getMaxAllowedConnectedNodes() {
+            return this.maxAllowedConnectedNodes;
+        }
+
+        public void setMaxAllowedConnectedNodes(final long maxAllowedConnectedNodes) {
+            this.maxAllowedConnectedNodes = maxAllowedConnectedNodes;
+        }
+
+        public void setNodeSelector(final String nodeSelector) {
+            this.nodeSelector = nodeSelector;
+        }
+
+        public String getNodeSelector() {
+            return this.nodeSelector;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ClusterConfig that = (ClusterConfig) o;
+
+            if (!clusterName.equals(that.clusterName)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return clusterName.hashCode();
+        }
+    }
+
+    public class ClusterNodeConfig extends CommonConnectionConfig {
+
+        private final String nodeName;
+
+        ClusterNodeConfig(final String nodeName) {
+            this.nodeName = nodeName;
+        }
+
+        public String getNodeName() {
+            return this.nodeName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            ClusterNodeConfig that = (ClusterNodeConfig) o;
+
+            if (!nodeName.equals(that.nodeName)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return nodeName.hashCode();
+        }
+    }
+
+    private class CommonConnectionConfig {
+        private Properties connectionOptions;
+        private Properties channelCreationOptions;
+        private long connectTimeout;
+        private String userName;
+        private String securityRealm;
+
+        public void setConnectionOptions(final Properties connectionOptions) {
+            this.connectionOptions = connectionOptions;
+        }
+
+        public void setChannelCreationOptions(final Properties channelCreationOptions) {
+            this.channelCreationOptions = channelCreationOptions;
+        }
+
+        public long getConnectTimeout() {
+            return this.connectTimeout;
+        }
+
+        public void setConnectTimeout(final long timeout) {
+            this.connectTimeout = timeout;
+        }
+
+        public Properties getConnectionOptions() {
+            return this.connectionOptions;
+        }
+
+        public Properties getChannelCreationOptions() {
+            return this.channelCreationOptions;
+        }
+
+        public void setUserName(final String userName) {
+            this.userName = userName;
+        }
+
+        public String getUserName() {
+            return this.userName;
+        }
+
+        public void setSecurityRealm(final String realm) {
+            this.securityRealm = realm;
+        }
+
+        public String getSecurityRealm() {
+            return this.securityRealm;
+        }
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor11Parser.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor11Parser.java
@@ -1,0 +1,623 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ee.structure;
+
+import org.jboss.as.ee.EeMessages;
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static javax.xml.stream.XMLStreamConstants.*;
+
+/**
+ * Parser for urn:jboss:ejb-client:1.0:jboss-ejb-client
+ *
+ * @author Jaikiran Pai
+ */
+class EJBClientDescriptor11Parser implements XMLElementReader<EJBClientDescriptorMetaData> {
+
+    public static final String NAMESPACE_1_1 = "urn:jboss:ejb-client:1.1";
+
+    public static final EJBClientDescriptor11Parser INSTANCE = new EJBClientDescriptor11Parser();
+
+
+    private EJBClientDescriptor11Parser() {
+    }
+
+
+    enum Element {
+        CLIENT_CONTEXT,
+        NODE,
+        EJB_RECEIVERS,
+        JBOSS_EJB_CLIENT,
+        REMOTING_EJB_RECEIVER,
+        CLUSTERS,
+        CLUSTER,
+        CHANNEL_CREATION_OPTIONS,
+        CONNECTION_CREATION_OPTIONS,
+        PROPERTY,
+        // default unknown element
+        UNKNOWN;
+
+        private static final Map<QName, Element> elements;
+
+        static {
+            Map<QName, Element> elementsMap = new HashMap<QName, Element>();
+            elementsMap.put(new QName(NAMESPACE_1_1, "jboss-ejb-client"), Element.JBOSS_EJB_CLIENT);
+            elementsMap.put(new QName(NAMESPACE_1_1, "client-context"), Element.CLIENT_CONTEXT);
+            elementsMap.put(new QName(NAMESPACE_1_1, "ejb-receivers"), Element.EJB_RECEIVERS);
+            elementsMap.put(new QName(NAMESPACE_1_1, "remoting-ejb-receiver"), Element.REMOTING_EJB_RECEIVER);
+            elementsMap.put(new QName(NAMESPACE_1_1, "clusters"), Element.CLUSTERS);
+            elementsMap.put(new QName(NAMESPACE_1_1, "cluster"), Element.CLUSTER);
+            elementsMap.put(new QName(NAMESPACE_1_1, "node"), Element.NODE);
+            elementsMap.put(new QName(NAMESPACE_1_1, "channel-creation-options"), Element.CHANNEL_CREATION_OPTIONS);
+            elementsMap.put(new QName(NAMESPACE_1_1, "connection-creation-options"), Element.CONNECTION_CREATION_OPTIONS);
+            elementsMap.put(new QName(NAMESPACE_1_1, "property"), Element.PROPERTY);
+            elements = elementsMap;
+        }
+
+        static Element of(QName qName) {
+            QName name;
+            if (qName.getNamespaceURI().equals("")) {
+                name = new QName(NAMESPACE_1_1, qName.getLocalPart());
+            } else {
+                name = qName;
+            }
+            final Element element = elements.get(name);
+            return element == null ? UNKNOWN : element;
+        }
+    }
+
+    enum Attribute {
+        EXCLUDE_LOCAL_RECEIVER,
+        LOCAL_RECEIVER_PASS_BY_VALUE,
+        CONNECT_TIMEOUT,
+        NAME,
+        OUTBOUND_CONNECTION_REF,
+        VALUE,
+        MAX_ALLOWED_CONNECTED_NODES,
+        CLUSTER_NODE_SELECTOR,
+        USERNAME,
+        SECURITY_REALM,
+        // default unknown attribute
+        UNKNOWN;
+
+        private static final Map<QName, Attribute> attributes;
+
+        static {
+            Map<QName, Attribute> attributesMap = new HashMap<QName, Attribute>();
+            attributesMap.put(new QName("exclude-local-receiver"), EXCLUDE_LOCAL_RECEIVER);
+            attributesMap.put(new QName("local-receiver-pass-by-value"), LOCAL_RECEIVER_PASS_BY_VALUE);
+            attributesMap.put(new QName("name"), NAME);
+            attributesMap.put(new QName("value"), VALUE);
+            attributesMap.put(new QName("outbound-connection-ref"), OUTBOUND_CONNECTION_REF);
+            attributesMap.put(new QName("connect-timeout"), CONNECT_TIMEOUT);
+            attributesMap.put(new QName("max-allowed-connected-nodes"), MAX_ALLOWED_CONNECTED_NODES);
+            attributesMap.put(new QName("cluster-node-selector"), CLUSTER_NODE_SELECTOR);
+            attributesMap.put(new QName("username"), USERNAME);
+            attributesMap.put(new QName("security-realm"), SECURITY_REALM);
+            attributes = attributesMap;
+        }
+
+        static Attribute of(QName qName) {
+            final Attribute attribute = attributes.get(qName);
+            return attribute == null ? UNKNOWN : attribute;
+        }
+    }
+
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+
+                    switch (element) {
+                        case CLIENT_CONTEXT:
+                            this.parseClientContext(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    this.unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseClientContext(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        final Set<Element> visited = EnumSet.noneOf(Element.class);
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    if (visited.contains(element)) {
+                        this.unexpectedElement(reader);
+                    }
+                    visited.add(element);
+                    switch (element) {
+                        case EJB_RECEIVERS:
+                            this.parseEJBReceivers(reader, ejbClientDescriptorMetaData);
+                            break;
+                        case CLUSTERS:
+                            this.parseClusters(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseEJBReceivers(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+
+        // initialize the local-receiver-pass-by-value to the default true
+        Boolean localReceiverPassByValue = null;
+
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            final String val = reader.getAttributeValue(i);
+            switch (attribute) {
+                case EXCLUDE_LOCAL_RECEIVER:
+                    final boolean excludeLocalReceiver = Boolean.parseBoolean(val.trim());
+                    ejbClientDescriptorMetaData.setExcludeLocalReceiver(excludeLocalReceiver);
+                    break;
+                case LOCAL_RECEIVER_PASS_BY_VALUE:
+                    localReceiverPassByValue = Boolean.parseBoolean(val.trim());
+                    break;
+                default:
+                    unexpectedContent(reader);
+            }
+        }
+        // set the local receiver pass by value into the metadata
+        ejbClientDescriptorMetaData.setLocalReceiverPassByValue(localReceiverPassByValue);
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case REMOTING_EJB_RECEIVER:
+                            this.parseRemotingReceiver(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseRemotingReceiver(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        String outboundConnectionRef = null;
+        final Set<Attribute> required = EnumSet.of(Attribute.OUTBOUND_CONNECTION_REF);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case OUTBOUND_CONNECTION_REF:
+                    outboundConnectionRef = reader.getAttributeValue(i).trim();
+                    ejbClientDescriptorMetaData.addRemotingReceiverConnectionRef(outboundConnectionRef);
+                    break;
+                default:
+                    unexpectedContent(reader);
+            }
+        }
+        if (!required.isEmpty()) {
+            missingAttributes(reader.getLocation(), required);
+        }
+        // This element is just composed of attributes which we already processed, so no more content
+        // is expected
+        if (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            unexpectedContent(reader);
+        }
+    }
+
+    private void parseClusters(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case CLUSTER:
+                            this.parseCluster(reader, ejbClientDescriptorMetaData);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private void parseCluster(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws XMLStreamException {
+        final Set<Attribute> required = EnumSet.of(Attribute.NAME);
+        final int count = reader.getAttributeCount();
+        String clusterName = null;
+        String clusterNodeSelector = null;
+        long connectTimeout = 5000;
+        long maxAllowedConnectedNodes = 10;
+        String userName = null;
+        String securityRealm = null;
+        for (int i = 0; i < count; i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME:
+                    clusterName = reader.getAttributeValue(i).trim();
+                    break;
+                case CONNECT_TIMEOUT:
+                    connectTimeout = reader.getLongAttributeValue(i);
+                    break;
+                case CLUSTER_NODE_SELECTOR:
+                    clusterNodeSelector = reader.getAttributeValue(i).trim();
+                    break;
+                case MAX_ALLOWED_CONNECTED_NODES:
+                    maxAllowedConnectedNodes = reader.getLongAttributeValue(i);
+                    break;
+                case USERNAME:
+                    userName = reader.getAttributeValue(i).trim();
+                    break;
+                case SECURITY_REALM:
+                    securityRealm = reader.getAttributeValue(i).trim();
+                    break;
+                default:
+                    unexpectedContent(reader);
+            }
+        }
+        if (!required.isEmpty()) {
+            missingAttributes(reader.getLocation(), required);
+        }
+        // add a new cluster config to the client configuration metadata
+        final EJBClientDescriptorMetaData.ClusterConfig clusterConfig = ejbClientDescriptorMetaData.newClusterConfig(clusterName);
+        clusterConfig.setConnectTimeout(connectTimeout);
+        clusterConfig.setNodeSelector(clusterNodeSelector);
+        clusterConfig.setMaxAllowedConnectedNodes(maxAllowedConnectedNodes);
+        clusterConfig.setSecurityRealm(securityRealm);
+        clusterConfig.setUserName(userName);
+
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case CONNECTION_CREATION_OPTIONS:
+                            final Properties connectionCreationOptions = this.parseConnectionCreationOptions(reader);
+                            clusterConfig.setConnectionOptions(connectionCreationOptions);
+                            break;
+                        case CHANNEL_CREATION_OPTIONS:
+                            final Properties channelCreationOptions = this.parseChannelCreationOptions(reader);
+                            clusterConfig.setChannelCreationOptions(channelCreationOptions);
+                            break;
+                        case NODE:
+                            this.parseClusterNode(reader, clusterConfig);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private Properties parseConnectionCreationOptions(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        final Properties connectionCreationOptions = new Properties();
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return connectionCreationOptions;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case PROPERTY:
+                            connectionCreationOptions.putAll(this.parseProperty(reader));
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+        // unreachable
+        return connectionCreationOptions;
+    }
+
+    private Properties parseChannelCreationOptions(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        final Properties channelCreationOptions = new Properties();
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return channelCreationOptions;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case PROPERTY:
+                            channelCreationOptions.putAll(this.parseProperty(reader));
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+        // unreachable
+        return channelCreationOptions;
+    }
+
+    private void parseClusterNode(final XMLExtendedStreamReader reader, final EJBClientDescriptorMetaData.ClusterConfig clusterConfig) throws XMLStreamException {
+        final Set<Attribute> required = EnumSet.of(Attribute.NAME);
+        final int count = reader.getAttributeCount();
+        String nodeName = null;
+        long connectTimeout = 5000;
+        String userName = null;
+        String securityRealm = null;
+        for (int i = 0; i < count; i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME:
+                    nodeName = reader.getAttributeValue(i).trim();
+                    break;
+                case CONNECT_TIMEOUT:
+                    connectTimeout = reader.getLongAttributeValue(i);
+                    break;
+                case USERNAME:
+                    userName = reader.getAttributeValue(i).trim();
+                    break;
+                case SECURITY_REALM:
+                    securityRealm = reader.getAttributeValue(i).trim();
+                    break;
+                default:
+                    unexpectedContent(reader);
+            }
+        }
+        if (!required.isEmpty()) {
+            missingAttributes(reader.getLocation(), required);
+        }
+        // add a new node config to the cluster config
+        final EJBClientDescriptorMetaData.ClusterNodeConfig clusterNodeConfig = clusterConfig.newClusterNode(nodeName);
+        clusterNodeConfig.setConnectTimeout(connectTimeout);
+        clusterNodeConfig.setSecurityRealm(securityRealm);
+        clusterNodeConfig.setUserName(userName);
+
+        while (reader.hasNext()) {
+            switch (reader.nextTag()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    final Element element = Element.of(reader.getName());
+                    switch (element) {
+                        case CONNECTION_CREATION_OPTIONS:
+                            final Properties connectionCreationOptions = this.parseConnectionCreationOptions(reader);
+                            clusterNodeConfig.setConnectionOptions(connectionCreationOptions);
+                            break;
+                        case CHANNEL_CREATION_OPTIONS:
+                            final Properties channelCreationOptions = this.parseChannelCreationOptions(reader);
+                            clusterNodeConfig.setChannelCreationOptions(channelCreationOptions);
+                            break;
+                        default:
+                            this.unexpectedElement(reader);
+                    }
+                    break;
+                }
+                default: {
+                    unexpectedContent(reader);
+                }
+            }
+        }
+        unexpectedEndOfDocument(reader.getLocation());
+    }
+
+    private Properties parseProperty(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        final Set<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.VALUE);
+        final int count = reader.getAttributeCount();
+        String name = null;
+        String value = null;
+        for (int i = 0; i < count; i++) {
+            final Attribute attribute = Attribute.of(reader.getAttributeName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME:
+                    name = reader.getAttributeValue(i).trim();
+                    break;
+                case VALUE:
+                    value = reader.getAttributeValue(i).trim();
+                    break;
+                default:
+                    unexpectedContent(reader);
+            }
+        }
+        if (!required.isEmpty()) {
+            missingAttributes(reader.getLocation(), required);
+        }
+        // no child elements allowed
+        this.requireNoContent(reader);
+
+        final Properties property = new Properties();
+        property.put(name, value);
+        return property;
+    }
+
+    private static void unexpectedEndOfDocument(final Location location) throws XMLStreamException {
+        throw EeMessages.MESSAGES.errorParsingEJBClientDescriptor("Unexpected end of document", location);
+    }
+
+    private static void missingAttributes(final Location location, final Set<Attribute> required) throws XMLStreamException {
+        final StringBuilder b = new StringBuilder("Missing one or more required attributes:");
+        for (Attribute attribute : required) {
+            b.append(' ').append(attribute);
+        }
+        throw EeMessages.MESSAGES.errorParsingEJBClientDescriptor(b.toString(), location);
+    }
+
+    /**
+     * Consumes the remainder of the current element, throwing an
+     * {@link javax.xml.stream.XMLStreamException} if it contains any child
+     * elements.
+     * @param reader the reader
+     * @throws javax.xml.stream.XMLStreamException if an error occurs
+     */
+    public static void requireNoContent(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        if (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            unexpectedElement(reader);
+        }
+    }
+
+    /**
+     * Throws a XMLStreamException for the unexpected element that was encountered during the parse
+     *
+     * @param reader the stream reader
+     * @throws javax.xml.stream.XMLStreamException
+     *
+     */
+    public static void unexpectedElement(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        throw EeMessages.MESSAGES.unexpectedElement(reader.getName(), reader.getLocation());
+    }
+
+    private static void unexpectedContent(final XMLStreamReader reader) throws XMLStreamException {
+        final String kind;
+        switch (reader.getEventType()) {
+            case ATTRIBUTE:
+                kind = "attribute";
+                break;
+            case CDATA:
+                kind = "cdata";
+                break;
+            case CHARACTERS:
+                kind = "characters";
+                break;
+            case COMMENT:
+                kind = "comment";
+                break;
+            case DTD:
+                kind = "dtd";
+                break;
+            case END_DOCUMENT:
+                kind = "document end";
+                break;
+            case END_ELEMENT:
+                kind = "element end";
+                break;
+            case ENTITY_DECLARATION:
+                kind = "entity declaration";
+                break;
+            case ENTITY_REFERENCE:
+                kind = "entity ref";
+                break;
+            case NAMESPACE:
+                kind = "namespace";
+                break;
+            case NOTATION_DECLARATION:
+                kind = "notation declaration";
+                break;
+            case PROCESSING_INSTRUCTION:
+                kind = "processing instruction";
+                break;
+            case SPACE:
+                kind = "whitespace";
+                break;
+            case START_DOCUMENT:
+                kind = "document start";
+                break;
+            case START_ELEMENT:
+                kind = "element start";
+                break;
+            default:
+                kind = "unknown";
+                break;
+        }
+        final StringBuilder b = new StringBuilder("Unexpected content of type '").append(kind).append('\'');
+        if (reader.hasName()) {
+            b.append(" named '").append(reader.getName()).append('\'');
+        }
+        if (reader.hasText()) {
+            b.append(", text is: '").append(reader.getText()).append('\'');
+        }
+        throw EeMessages.MESSAGES.errorParsingEJBClientDescriptor(b.toString(), reader.getLocation());
+    }
+
+}

--- a/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptorParsingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptorParsingProcessor.java
@@ -61,6 +61,7 @@ public class EJBClientDescriptorParsingProcessor implements DeploymentUnitProces
 
 
     private static final QName ROOT_1_0 = new QName(EJBClientDescriptor10Parser.NAMESPACE_1_0, "jboss-ejb-client");
+    private static final QName ROOT_1_1 = new QName(EJBClientDescriptor11Parser.NAMESPACE_1_1, "jboss-ejb-client");
     private static final QName ROOT_NO_NAMESPACE = new QName("jboss-ejb-client");
 
 
@@ -71,7 +72,8 @@ public class EJBClientDescriptorParsingProcessor implements DeploymentUnitProces
     public EJBClientDescriptorParsingProcessor() {
         mapper = XMLMapper.Factory.create();
         mapper.registerRootElement(ROOT_1_0, EJBClientDescriptor10Parser.INSTANCE);
-        mapper.registerRootElement(ROOT_NO_NAMESPACE, EJBClientDescriptor10Parser.INSTANCE);
+        mapper.registerRootElement(ROOT_1_1, EJBClientDescriptor11Parser.INSTANCE);
+        mapper.registerRootElement(ROOT_NO_NAMESPACE, EJBClientDescriptor11Parser.INSTANCE);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -449,6 +449,13 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 14148, value = "")
     UnsupportedCallbackException unsupportedCallback(@Param Callback current);
 
+    @Message(id = 14149, value = "Could not create an instance of cluster node selector %s for cluster %s")
+    RuntimeException failureDuringLoadOfClusterNodeSelector(final String clusterNodeSelectorName, final String clusterName, @Cause Exception e);
+
+    @LogMessage(level = WARN)
+    @Message(id = 14150, value = "Failed to parse property %s due to %s")
+    void failedToCreateOptionForProperty(String propertyName, String reason);
+
     // Don't add message ids greater that 14299!!! If you need more first check what EjbMessages is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is
     // all used, go to https://community.jboss.org/docs/DOC-16810 and allocate another block for this subsystem

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -36,10 +36,13 @@ import org.jboss.logging.LogMessage;
 import org.jboss.logging.Logger;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageLogger;
+import org.jboss.logging.Param;
 import org.jboss.remoting3.Channel;
 
 import javax.ejb.Timer;
 import javax.resource.ResourceException;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Date;
@@ -442,6 +445,9 @@ public interface EjbLogger extends BasicLogger {
      */
     @Message(id = 14147, value = "Could not deactive endpoint for message driven component %s")
     RuntimeException failureDuringEndpointDeactivation(final String componentName, @Cause ResourceException cause);
+
+    @Message(id = 14148, value = "")
+    UnsupportedCallbackException unsupportedCallback(@Param Callback current);
 
     // Don't add message ids greater that 14299!!! If you need more first check what EjbMessages is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
@@ -23,6 +23,7 @@
 package org.jboss.as.ejb3.remote;
 
 import org.jboss.as.remoting.AbstractOutboundConnectionService;
+import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBReceiver;
 import org.jboss.ejb.client.remoting.IoFutureHelper;
@@ -74,15 +75,21 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
      */
     private final InjectedValue<LocalEjbReceiver> localEjbReceiverInjectedValue = new InjectedValue<LocalEjbReceiver>();
 
+    private final EJBClientConfiguration ejbClientConfiguration;
+
     /**
      * The client context
      */
     private volatile EJBClientContext ejbClientContext;
 
+    public DescriptorBasedEJBClientContextService(final EJBClientConfiguration ejbClientConfiguration) {
+        this.ejbClientConfiguration = ejbClientConfiguration;
+    }
+
     @Override
     public synchronized void start(StartContext startContext) throws StartException {
         // setup the context with the receivers
-        final EJBClientContext context = EJBClientContext.create();
+        final EJBClientContext context = EJBClientContext.create(this.ejbClientConfiguration);
         // add the (optional) local EJB receiver
         final LocalEjbReceiver localEjbReceiver = this.localEjbReceiverInjectedValue.getOptionalValue();
         if (localEjbReceiver != null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterConfig.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.ejb.client.ClusterNodeSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceRegistry;
+import org.xnio.OptionMap;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class EJBClientClusterConfig extends EJBClientCommonConnectionConfig implements EJBClientConfiguration.ClusterConfiguration {
+
+    private static final Logger logger = Logger.getLogger(EJBClientClusterConfig.class);
+
+    private final EJBClientDescriptorMetaData.ClusterConfig delegate;
+    private final Map<String, EJBClientConfiguration.ClusterNodeConfiguration> nodes = new HashMap<String, EJBClientConfiguration.ClusterNodeConfiguration>();
+
+    public EJBClientClusterConfig(final EJBClientDescriptorMetaData.ClusterConfig clusterConfig, final ClassLoader deploymentClassLoader, final ServiceRegistry serviceRegistry) {
+        this.delegate = clusterConfig;
+        this.setConnectionTimeout(clusterConfig.getConnectTimeout());
+        // setup the channel creation options
+        final Properties channelProps = clusterConfig.getChannelCreationOptions();
+        if (channelProps != null) {
+            // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
+            // module CL
+            final OptionMap channelCreationOptions = getOptionMapFromProperties(channelProps, this.getClass().getClassLoader());
+            logger.debug("Channel creation options for cluster " + clusterConfig.getClusterName() + " are " + channelCreationOptions);
+            this.setChannelCreationOptions(channelCreationOptions);
+        }
+
+        // setup connection creation options
+        final Properties connectionProps = clusterConfig.getConnectionOptions();
+        if (connectionProps != null) {
+            // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
+            // module CL
+            final OptionMap connectionCreationOptions = getOptionMapFromProperties(connectionProps, this.getClass().getClassLoader());
+            logger.debug("Connection creation options for cluster " + clusterConfig.getClusterName() + " are " + connectionCreationOptions);
+            this.setConnectionCreationOptions(connectionCreationOptions);
+        }
+
+        this.setCallbackHandler(serviceRegistry, clusterConfig.getUserName(), clusterConfig.getSecurityRealm());
+
+    }
+
+    @Override
+    public String getClusterName() {
+        return this.delegate.getClusterName();
+    }
+
+    @Override
+    public long getMaximumAllowedConnectedNodes() {
+        return this.delegate.getMaxAllowedConnectedNodes();
+    }
+
+    @Override
+    public ClusterNodeSelector getClusterNodeSelector() {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public Iterator<EJBClientConfiguration.ClusterNodeConfiguration> getNodeConfigurations() {
+        return this.nodes.values().iterator();
+    }
+
+    @Override
+    public EJBClientConfiguration.ClusterNodeConfiguration getNodeConfiguration(String nodeName) {
+        return this.nodes.get(nodeName);
+    }
+
+    public void addClusterNode(final EJBClientConfiguration.ClusterNodeConfiguration node) {
+        this.nodes.put(node.getNodeName(), node);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterNodeConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterNodeConfig.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceRegistry;
+import org.xnio.OptionMap;
+
+import java.util.Properties;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class EJBClientClusterNodeConfig extends EJBClientCommonConnectionConfig implements EJBClientConfiguration.ClusterNodeConfiguration {
+
+    private static final Logger logger = Logger.getLogger(EJBClientClusterNodeConfig.class);
+
+    private final EJBClientDescriptorMetaData.ClusterNodeConfig delegate;
+
+    public EJBClientClusterNodeConfig(final EJBClientDescriptorMetaData.ClusterNodeConfig clusterNodeConfig, final ClassLoader deploymentClassLoader, final ServiceRegistry serviceRegistry) {
+        this.delegate = clusterNodeConfig;
+
+        this.setConnectionTimeout(clusterNodeConfig.getConnectTimeout());
+
+        final Properties channelProps = clusterNodeConfig.getChannelCreationOptions();
+        if (channelProps != null) {
+            // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
+            // module CL
+            final OptionMap channelOpts = getOptionMapFromProperties(channelProps, this.getClass().getClassLoader());
+            logger.debug("Channel creation options for node " + clusterNodeConfig.getNodeName() + " are " + channelOpts);
+            this.setChannelCreationOptions(channelOpts);
+        }
+
+        final Properties connectionProps = clusterNodeConfig.getConnectionOptions();
+        if (connectionProps != null) {
+            // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
+            // module CL
+            final OptionMap connectOpts = getOptionMapFromProperties(connectionProps, this.getClass().getClassLoader());
+            logger.debug("Connection creation options for node " + clusterNodeConfig.getNodeName() + " are " + connectOpts);
+            this.setConnectionCreationOptions(connectOpts);
+        }
+
+        this.setCallbackHandler(serviceRegistry, clusterNodeConfig.getUserName(), clusterNodeConfig.getSecurityRealm());
+
+    }
+
+    @Override
+    public String getNodeName() {
+        return this.delegate.getNodeName();
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
@@ -1,0 +1,149 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.domain.management.CallbackHandlerFactory;
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.as.domain.management.security.SecurityRealmService;
+import org.jboss.as.ejb3.EjbLogger;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.xnio.Option;
+import org.xnio.OptionMap;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import java.io.IOException;
+import java.util.Properties;
+
+
+/**
+ * @author Jaikiran Pai
+ */
+class EJBClientCommonConnectionConfig implements EJBClientConfiguration.CommonConnectionCreationConfiguration {
+
+    private static final Logger logger = Logger.getLogger(EJBClientCommonConnectionConfig.class);
+
+    private OptionMap connectionCreationOptions = OptionMap.EMPTY;
+    private OptionMap channelCreationOptions = OptionMap.EMPTY;
+    private long connectionTimeout = 5000;
+    private CallbackHandlerProvider callbackHandlerProvider;
+
+    @Override
+    public OptionMap getConnectionCreationOptions() {
+        return this.connectionCreationOptions;
+    }
+
+    @Override
+    public CallbackHandler getCallbackHandler() {
+        return callbackHandlerProvider == null ? new AnonymousCallbackHandler() : callbackHandlerProvider.getCallbackHandler();
+    }
+
+    @Override
+    public long getConnectionTimeout() {
+        return this.connectionTimeout;
+    }
+
+    @Override
+    public OptionMap getChannelCreationOptions() {
+        return this.channelCreationOptions;
+    }
+
+    protected void setChannelCreationOptions(final OptionMap channelCreationOptions) {
+        this.channelCreationOptions = channelCreationOptions;
+    }
+
+    protected void setConnectionCreationOptions(final OptionMap connectionCreationOptions) {
+        this.connectionCreationOptions = connectionCreationOptions;
+    }
+
+    protected void setConnectionTimeout(final long timeout) {
+        this.connectionTimeout = timeout;
+    }
+
+    protected void setCallbackHandler(final ServiceRegistry serviceRegistry, final String username, final String securityRealmName) {
+        this.callbackHandlerProvider = new CallbackHandlerProvider(serviceRegistry, username, securityRealmName);
+    }
+
+    protected static OptionMap getOptionMapFromProperties(final Properties properties, final ClassLoader classLoader) {
+        final OptionMap.Builder optionMapBuilder = OptionMap.builder();
+        for (final String propertyName : properties.stringPropertyNames()) {
+            try {
+                final Option<?> option = Option.fromString(propertyName, classLoader);
+                optionMapBuilder.parse(option, properties.getProperty(propertyName), classLoader);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Could not parse property " + propertyName + " while creating OptionMap", e);
+            }
+        }
+        return optionMapBuilder.getMap();
+    }
+
+
+    private class CallbackHandlerProvider {
+
+        private final ServiceRegistry serviceRegistry;
+        private final String userName;
+        private final String securityRealmName;
+        private final ServiceName securityRealmServiceName;
+
+        CallbackHandlerProvider(final ServiceRegistry serviceRegistry, final String userName, final String securityRealm) {
+            this.serviceRegistry = serviceRegistry;
+            this.userName = userName;
+            this.securityRealmName = securityRealm;
+            this.securityRealmServiceName = SecurityRealmService.BASE_SERVICE_NAME.append(securityRealm);
+        }
+
+        CallbackHandler getCallbackHandler() {
+            final ServiceController<SecurityRealm> securityRealmController = (ServiceController<SecurityRealm>) this.serviceRegistry.getService(this.securityRealmServiceName);
+            if (securityRealmController == null) {
+                return new AnonymousCallbackHandler();
+            }
+            final SecurityRealm securityRealm = securityRealmController.getValue();
+            final CallbackHandlerFactory cbhFactory;
+            if (securityRealm != null && (cbhFactory = securityRealm.getSecretCallbackHandlerFactory()) != null && this.userName != null) {
+                return cbhFactory.getCallbackHandler(this.userName);
+            } else {
+                return new AnonymousCallbackHandler();
+            }
+        }
+    }
+
+    private class AnonymousCallbackHandler implements CallbackHandler {
+
+        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+            for (Callback current : callbacks) {
+                if (current instanceof NameCallback) {
+                    NameCallback ncb = (NameCallback) current;
+                    ncb.setName("anonymous");
+                } else {
+                    throw EjbLogger.ROOT_LOGGER.unsupportedCallback(current);
+                }
+            }
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
@@ -38,6 +38,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
 import java.io.IOException;
 import java.util.Properties;
 
@@ -97,7 +98,7 @@ class EJBClientCommonConnectionConfig implements EJBClientConfiguration.CommonCo
                 final Option<?> option = Option.fromString(propertyName, classLoader);
                 optionMapBuilder.parse(option, properties.getProperty(propertyName), classLoader);
             } catch (IllegalArgumentException e) {
-                logger.warn("Could not parse property " + propertyName + " while creating OptionMap", e);
+                EjbLogger.EJB3_LOGGER.failedToCreateOptionForProperty(propertyName, e.getMessage());
             }
         }
         return optionMapBuilder.getMap();
@@ -140,6 +141,9 @@ class EJBClientCommonConnectionConfig implements EJBClientConfiguration.CommonCo
                 if (current instanceof NameCallback) {
                     NameCallback ncb = (NameCallback) current;
                     ncb.setName("anonymous");
+                } else if (current instanceof RealmCallback) {
+                    RealmCallback rcb = (RealmCallback) current;
+                    rcb.setText(rcb.getDefaultText());
                 } else {
                     throw EjbLogger.ROOT_LOGGER.unsupportedCallback(current);
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
@@ -40,26 +40,33 @@ public class JBossEJBClientXmlConfiguration implements EJBClientConfiguration {
 
     @Override
     public String getEndpointName() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        // The jboss-ejb-client.xml will *not* be used to create endpoints
+        return null;
     }
 
     @Override
     public OptionMap getEndpointCreationOptions() {
+        // The jboss-ejb-client.xml will *not* be used to create endpoints
         return OptionMap.EMPTY;
     }
 
     @Override
     public OptionMap getRemoteConnectionProviderCreationOptions() {
+        // The jboss-ejb-client.xml will *not* be used to register connection providers
         return OptionMap.EMPTY;
     }
 
     @Override
     public CallbackHandler getCallbackHandler() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
+        // The appropriate callback handler will either be available on the remote-outbound-connection
+        // reference or in the cluster configuration of this client context
+        return null;
     }
 
     @Override
     public Iterator<RemotingConnectionConfiguration> getConnectionConfigurations() {
+        // The jboss-ejb-client.xml will *not* be used for auto creating connections to remote servers.
+        // Instead we let the remote-outbound-connection to handle the connection creation/configuration
         return Collections.EMPTY_SET.iterator();
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.xnio.OptionMap;
+
+import javax.security.auth.callback.CallbackHandler;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class JBossEJBClientXmlConfiguration implements EJBClientConfiguration {
+
+    private final Map<String, ClusterConfiguration> clusterConfigs = new HashMap<String, ClusterConfiguration>();
+
+    @Override
+    public String getEndpointName() {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public OptionMap getEndpointCreationOptions() {
+        return OptionMap.EMPTY;
+    }
+
+    @Override
+    public OptionMap getRemoteConnectionProviderCreationOptions() {
+        return OptionMap.EMPTY;
+    }
+
+    @Override
+    public CallbackHandler getCallbackHandler() {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public Iterator<RemotingConnectionConfiguration> getConnectionConfigurations() {
+        return Collections.EMPTY_SET.iterator();
+    }
+
+    @Override
+    public Iterator<ClusterConfiguration> getClusterConfigurations() {
+        return this.clusterConfigs.values().iterator();
+    }
+
+    @Override
+    public ClusterConfiguration getClusterConfiguration(String nodeName) {
+        return this.clusterConfigs.get(nodeName);
+    }
+
+    public void addClusterConfiguration(final EJBClientClusterConfig clusterConfig) {
+        this.clusterConfigs.put(clusterConfig.getClusterName(), clusterConfig);
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -180,18 +180,19 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_SESSION_BEAN_DD, new SessionBeanXmlDescriptorProcessor(appclient));
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_ANNOTATION_EJB, new EjbAnnotationProcessor());
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_INJECTION_ANNOTATION, new EjbResourceInjectionAnnotationProcessor(appclient));
-                processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_CLIENT_METADATA, new EJBClientDescriptorMetaDataProcessor());
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_ENTITY_BEAN_CREATE_COMPONENT_DESCRIPTIONS, new EntityBeanComponentDescriptionFactory(appclient));
                 processorTarget.addDeploymentProcessor(Phase.PARSE, Phase.PARSE_EJB_ASSEMBLY_DESC_DD, new AssemblyDescriptorProcessor());
 
                 processorTarget.addDeploymentProcessor(Phase.DEPENDENCIES, Phase.DEPENDENCIES_EJB, new EjbDependencyDeploymentUnitProcessor());
                 processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_HOME_MERGE, new HomeViewMergingProcessor(appclient));
                 processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_REF, new EjbRefProcessor(appclient));
-                processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_CLIENT_CONTEXT_SETUP, new EjbClientContextSetupProcessor());
                 processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_BUSINESS_VIEW_ANNOTATION, new BusinessViewAnnotationProcessor(appclient));
                 processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_ORB_BIND, new IIOPJndiBindingProcessor());
                 processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_JNDI_BINDINGS, new EjbJndiBindingsDeploymentUnitProcessor(appclient));
+                processorTarget.addDeploymentProcessor(Phase.POST_MODULE, Phase.POST_MODULE_EJB_CLIENT_METADATA, new EJBClientDescriptorMetaDataProcessor());
 
+
+                processorTarget.addDeploymentProcessor(Phase.INSTALL, Phase.INSTALL_EJB_CLIENT_CONTEXT, new EjbClientContextSetupProcessor());
                 processorTarget.addDeploymentProcessor(Phase.INSTALL, Phase.INSTALL_EJB_JACC_PROCESSING, new JaccEjbDeploymentProcessor());
 
                 processorTarget.addDeploymentProcessor(Phase.CLEANUP, Phase.CLEANUP_EJB, new EjbCleanUpProcessor());

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -224,7 +224,6 @@ public enum Phase {
     // create and attach EJB metadata for EJB deployments
     public static final int PARSE_EJB_DEPLOYMENT                        = 0x1100;
     public static final int PARSE_APP_CLIENT_XML                        = 0x1101;
-    public static final int PARSE_EJB_CLIENT_METADATA                   = 0x1102;
     public static final int PARSE_CREATE_COMPONENT_DESCRIPTIONS         = 0x1150;
     // described EJBs must be created after annotated EJBs
     public static final int PARSE_ENTITY_BEAN_CREATE_COMPONENT_DESCRIPTIONS = 0x1152;
@@ -352,6 +351,7 @@ public enum Phase {
     // should come before ejb jndi bindings processor
     public static final int POST_MODULE_EJB_IMPLICIT_NO_INTERFACE_VIEW  = 0x1000;
     public static final int POST_MODULE_EJB_JNDI_BINDINGS               = 0x1100;
+    public static final int POST_MODULE_EJB_CLIENT_METADATA             = 0x1102;
     public static final int POST_MODULE_EJB_APPLICATION_EXCEPTIONS      = 0x1200;
     public static final int POST_INITIALIZE_IN_ORDER                    = 0x1300;
     public static final int POST_MODULE_ENV_ENTRY                       = 0x1400;
@@ -369,7 +369,6 @@ public enum Phase {
     public static final int POST_MODULE_APPLICATION_CLIENT_ACTIVE       = 0x2000;
     public static final int POST_MODULE_APP_CLIENT_METHOD_RESOLUTION    = 0x2020;
     public static final int POST_MODULE_EJB_ORB_BIND                    = 0x2100;
-    public static final int POST_MODULE_EJB_CLIENT_CONTEXT_SETUP        = 0x2200;
     public static final int POST_MODULE_CMP_PARSE                       = 0x2300;
     public static final int POST_MODULE_CMP_ENTITY_METADATA             = 0x2400;
     public static final int POST_MODULE_CMP_STORE_MANAGER               = 0x2500;
@@ -385,7 +384,8 @@ public enum Phase {
     public static final int INSTALL_JACC_POLICY                         = 0x0350;
     public static final int INSTALL_COMPONENT_AGGREGATION               = 0x0400;
     public static final int INSTALL_RESOLVE_MESSAGE_DESTINATIONS        = 0x0403;
-    public static final int INSTALL_EJB_JACC_PROCESSING                 = 0x0403;
+    public static final int INSTALL_EJB_CLIENT_CONTEXT                  = 0x0404;
+    public static final int INSTALL_EJB_JACC_PROCESSING                 = 0x0405;
     public static final int INSTALL_SERVICE_ACTIVATOR                   = 0x0500;
     public static final int INSTALL_OSGI_DEPLOYMENT                     = 0x0600;
     public static final int INSTALL_OSGI_MODULE                         = 0x0650;

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -92,7 +92,7 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <arquillian.launch>manual-mode</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -7,8 +7,8 @@
         <container qualifier="default-jbossas" default="true" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
-                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.node.name=default-jbossas</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9999}</property>
@@ -19,7 +19,7 @@
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-with-remote-outbound-connection</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-with-remote-outbound-connection -Djboss.node.name=jbossas-with-remote-outbound-connection</property>
-                <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/ApplicationSpecificClusterNodeSelector.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/ApplicationSpecificClusterNodeSelector.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.cluster;
+
+import org.jboss.ejb.client.ClusterNodeSelector;
+
+import java.util.Random;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class ApplicationSpecificClusterNodeSelector implements ClusterNodeSelector {
+    @Override
+    public String selectNode(final String clusterName, final String[] connectedNodes, final String[] availableNodes) {
+        final Random random = new Random();
+        // check if there are any connected nodes. If there are then just reuse them
+        if (connectedNodes.length > 0) {
+            if (connectedNodes.length == 1) {
+                return connectedNodes[0];
+            }
+            final int randomConnectedNode = random.nextInt(connectedNodes.length);
+            return connectedNodes[randomConnectedNode];
+        }
+        // there are no connected nodes. so use the available nodes and let the cluster context
+        // establish a connection for the selected node
+        if (availableNodes.length == 1) {
+            return availableNodes[0];
+        }
+        final int randomSelection = random.nextInt(availableNodes.length);
+        return availableNodes[randomSelection];
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/ClusteredStatefulNodeNameEcho.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/ClusteredStatefulNodeNameEcho.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.cluster;
+
+import org.jboss.ejb3.annotation.Clustered;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+@Clustered
+@Remote(NodeNameEcho.class)
+public class ClusteredStatefulNodeNameEcho implements NodeNameEcho {
+    @Override
+    public String getNodeName(boolean preferOtherNode) {
+        return System.getProperty("jboss.node.name");
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -115,7 +115,7 @@ public class EJBClientClusterConfigurationTestCase {
     @TargetsContainer(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION)
     public static Archive createContainer2Deployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
-        ejbJar.addClasses(ClusteredStatefulNodeNameEcho.class, NonClusteredStatefulNodeNameEcho.class, NodeNameEcho.class);
+        ejbJar.addClasses(ClusteredStatefulNodeNameEcho.class, NonClusteredStatefulNodeNameEcho.class, NodeNameEcho.class, ApplicationSpecificClusterNodeSelector.class);
         ejbJar.addAsManifestResource(NonClusteredStatefulNodeNameEcho.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return ejbJar;
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -1,0 +1,201 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.cluster;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Hashtable;
+import java.util.Properties;
+
+/**
+ * Tests that clustered EJB remote invocations between the server and client, where the client itself
+ * is another server instance, work correctly and the clustering failover capabilities are available. This
+ * further tests that the cluster configurations in the jboss-ejb-client.xml are honoured.
+ *
+ * @author Jaikiran Pai
+ * @see https://issues.jboss.org/browse/AS7-4099
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EJBClientClusterConfigurationTestCase {
+
+    private static final Logger logger = Logger.getLogger(EJBClientClusterConfigurationTestCase.class);
+
+    private static final String MODULE_NAME = "server-to-server-clustered-ejb-invocation";
+
+    private static final String DEFAULT_JBOSSAS = "default-jbossas";
+    private static final String JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION = "jbossas-with-remote-outbound-connection";
+
+    private static final String DEFAULT_AS_DEPLOYMENT = "default-jbossas-deployment";
+    private static final String DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML = "other-deployment";
+
+    // These should match what's configured in arquillian.xml for -Djboss.node.name of each server instance
+    private static final String DEFAULT_JBOSSAS_NODE_NAME = "default-jbossas";
+    private static final String JBOSSAS_WITH_OUTBOUND_CONNECTION_NODE_NAME = "jbossas-with-remote-outbound-connection";
+
+    @ArquillianResource
+    private ContainerController container;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    private static Context context;
+    private static ContextSelector<EJBClientContext> previousClientContextSelector;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Hashtable props = new Hashtable();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        context = new InitialContext(props);
+        // setup the client context selector
+        previousClientContextSelector = setupEJBClientContextSelector();
+
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (previousClientContextSelector != null) {
+            EJBClientContext.setSelector(previousClientContextSelector);
+        }
+    }
+
+    @Deployment(name = DEFAULT_AS_DEPLOYMENT, managed = false, testable = false)
+    @TargetsContainer(DEFAULT_JBOSSAS)
+    public static Archive createContainer1Deployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        ejbJar.addClasses(ClusteredStatefulNodeNameEcho.class, NodeNameEcho.class);
+        return ejbJar;
+    }
+
+    @Deployment(name = DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML, managed = false, testable = false)
+    @TargetsContainer(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION)
+    public static Archive createContainer2Deployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        ejbJar.addClasses(ClusteredStatefulNodeNameEcho.class, NonClusteredStatefulNodeNameEcho.class, NodeNameEcho.class);
+        ejbJar.addAsManifestResource(NonClusteredStatefulNodeNameEcho.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        return ejbJar;
+    }
+
+    /**
+     * 1) Start a server (A) which has a remote outbound connection to another server (B).
+     * 2) Both server A and B have clustering capability and have a deployment containing a clustered SFSB.
+     * 3) Server A furthermore has a non-clustered SFSB too.
+     * 4) This test invokes on the non-clustered SFSB on server A which inturn invokes on the clustered
+     * SFSB on server B (this is done by disabling local ejb receiver in the jboss-ejb-client.xml).
+     * 5) Invocation works fine and at the same time (asynchronously) server B sends back a cluster topology
+     * to server A containing, both server A and B and the nodes.
+     * 6) The test then stops server B and invokes on the same non-clustered SFSB instance of server A, which inturn
+     * invokes on the stateful clustered SFSB which it had injected earlier. This time since server B (which owns the session)
+     * is down the invocation is expected to end up on server A itself (since server A is part of the cluster too)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testServerToServerClusterFormation() throws Exception {
+        // First start the default server
+        this.container.start(DEFAULT_JBOSSAS);
+        try {
+            // deploy a deployment which contains a clustered EJB
+            this.deployer.deploy(DEFAULT_AS_DEPLOYMENT);
+
+            // start the other server
+            this.container.start(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION);
+            // deploy the deployment containing a non-clustered EJB
+            this.deployer.deploy(DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML);
+
+            // invoke on the non-clustered bean which internally calls the clustered bean on a remote server
+            final NodeNameEcho nonClusteredBean = (NodeNameEcho) context.lookup("ejb:/" + MODULE_NAME + "//" + NonClusteredStatefulNodeNameEcho.class.getSimpleName() + "!" + NodeNameEcho.class.getName() + "?stateful");
+            final String nodeNameBeforeShutdown = nonClusteredBean.getNodeName(true);
+            Assert.assertEquals("EJB invocation ended up on unexpected node", DEFAULT_JBOSSAS_NODE_NAME, nodeNameBeforeShutdown);
+
+            // now shutdown the default server
+            this.container.stop(DEFAULT_JBOSSAS);
+
+            // now invoke again. this time the internal invocation on the clustered bean should end up on
+            // one of the cluster nodes instead of the default server, since it was shutdown
+            final String nodeNameAfterShutdown = nonClusteredBean.getNodeName(false);
+            Assert.assertEquals("EJB invocation ended up on unexpected node after shutdown", JBOSSAS_WITH_OUTBOUND_CONNECTION_NODE_NAME, nodeNameAfterShutdown);
+
+        } finally {
+            try {
+                this.deployer.undeploy(DEPLOYMENT_WITH_JBOSS_EJB_CLIENT_XML);
+                this.container.stop(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION);
+            } catch (Exception e) {
+                logger.debug("Exception during container shutdown", e);
+            }
+            try {
+                this.deployer.undeploy(DEFAULT_AS_DEPLOYMENT);
+                this.container.stop(DEFAULT_JBOSSAS);
+            } catch (Exception e) {
+                logger.debug("Exception during container shutdown", e);
+            }
+        }
+
+    }
+
+    /**
+     * Sets up the EJB client context to use a selector which processes and sets up EJB receivers
+     * based on this testcase specific jboss-ejb-client.properties file
+     *
+     * @return
+     * @throws java.io.IOException
+     */
+    private static ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
+        // setup the selector
+        final String clientPropertiesFile = "org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.properties";
+        final InputStream inputStream = EJBClientClusterConfigurationTestCase.class.getClassLoader().getResourceAsStream(clientPropertiesFile);
+        if (inputStream == null) {
+            throw new IllegalStateException("Could not find " + clientPropertiesFile + " in classpath");
+        }
+        final Properties properties = new Properties();
+        properties.load(inputStream);
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
+        final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
+
+        return EJBClientContext.setSelector(selector);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/NodeNameEcho.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/NodeNameEcho.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.cluster;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface NodeNameEcho {
+    
+    String getNodeName(boolean preferOtherNode);
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/NonClusteredStatefulNodeNameEcho.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/NonClusteredStatefulNodeNameEcho.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.cluster;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+@Remote(NodeNameEcho.class)
+public class NonClusteredStatefulNodeNameEcho implements NodeNameEcho {
+
+    private NodeNameEcho clusteredDelegate;
+
+    @Override
+    public String getNodeName(final boolean preferOtherNode) {
+        final String me = System.getProperty("jboss.node.name");
+        if (this.clusteredDelegate == null) {
+            this.lookupClusteredBean();
+        }
+        String nodeName = this.clusteredDelegate.getNodeName(false);
+        if (preferOtherNode && me.equals(nodeName)) {
+            for (int i = 0; i < 10; i++) {
+                // do another lookup to try creating a SFSB instance on a different node
+                this.lookupClusteredBean();
+                nodeName = this.clusteredDelegate.getNodeName(false);
+                if (!me.equals(nodeName)) {
+                    return nodeName;
+                }
+            }
+            throw new RuntimeException("Invocation on clustered bean always (10 times) ended up picking current node " + me);
+        }
+        return nodeName;
+    }
+
+    private void lookupClusteredBean() {
+        final Properties props = new Properties();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        try {
+            final Context context = new InitialContext(props);
+            this.clusteredDelegate = (NodeNameEcho) context.lookup("ejb:/server-to-server-clustered-ejb-invocation//ClusteredStatefulNodeNameEcho!org.jboss.as.test.manualmode.ejb.client.cluster.NodeNameEcho?stateful");
+        } catch (NamingException ne) {
+            throw new RuntimeException(ne);
+        }
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.properties
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.properties
@@ -1,0 +1,28 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=${node1:localhost}
+remote.connection.default.port=4547
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.1">
+    <client-context>
+        <ejb-receivers exclude-local-receiver="true">
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
+        </ejb-receivers>
+        <clusters>
+            <cluster name="ejb" max-allowed-connected-nodes="20" connect-timeout="5000" username="user1" security-realm="PasswordRealm">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>
+                </connection-creation-options>
+            </cluster>
+        </clusters>
+    </client-context>
+</jboss-ejb-client>
+

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
@@ -25,7 +25,8 @@
             <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
         </ejb-receivers>
         <clusters>
-            <cluster name="ejb" max-allowed-connected-nodes="20" connect-timeout="5000" username="user1" security-realm="PasswordRealm">
+            <cluster name="ejb" max-allowed-connected-nodes="20" cluster-node-selector="org.jboss.as.test.manualmode.ejb.client.cluster.ApplicationSpecificClusterNodeSelector"
+                     connect-timeout="5000" username="user1" security-realm="PasswordRealm">
                 <connection-creation-options>
                     <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
                     <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>


### PR DESCRIPTION
The commit in this branch fixes https://issues.jboss.org/browse/AS7-4099 (which is blocking 7.1.1 release).

The commit adds the ability for deployments to configure cluster connection configurations to their jboss-ejb-client.xml. This branch also introduces a testcase to ensure that the cluster configurations are taken into account while communicating with a secured remote cluster node.
