### PR TITLE
AS7-4004: fix JMS Queue selector parsing

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.messaging.jms.ConnectionFactoryTypeValidator;
 import org.jboss.as.messaging.jms.JndiEntriesAttribute;
+import org.jboss.as.messaging.jms.SelectorAttribute;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -411,7 +412,7 @@ public interface CommonAttributes {
             new ModelNode().set(ConfigurationImpl.DEFAULT_SECURITY_INVALIDATION_INTERVAL), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS,
             AttributeAccess.Flag.RESTART_ALL_SERVICES);
 
-    SimpleAttributeDefinition SELECTOR = new SimpleAttributeDefinition("selector", ModelType.STRING, true);
+    SelectorAttribute SELECTOR = SelectorAttribute.SELECTOR;
 
     SimpleAttributeDefinition SEND_TO_DLA_ON_NO_ROUTE = new SimpleAttributeDefinition("send-to-dla-on-no-route",
             new ModelNode().set(AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE), ModelType.BOOLEAN, true);
@@ -571,6 +572,7 @@ public interface CommonAttributes {
     String SCHEDULED_COUNT = "scheduled-count";
     String SECURITY_SETTING ="security-setting";
     String SECURITY_SETTINGS ="security-settings";
+    String SELECTOR_STRING = "selector";
     String TOPIC_FACTORY = "TOPIC";
     String HORNETQ_SERVER = "hornetq-server";
     String QUEUE_FACTORY = "QUEUE";

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -2113,7 +2113,9 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                     if(queue.has(SELECTOR.getName())) {
                         throw ParseUtils.duplicateNamedElement(reader, Element.SELECTOR.getLocalName());
                     }
-                    handleElementText(reader, element, queue);
+                    requireSingleAttribute(reader, CommonAttributes.STRING);
+                    final String selector = readStringAttributeElement(reader, CommonAttributes.STRING);
+                    SELECTOR.parseAndSetParameter(selector, queue, reader);
                     break;
                 } case DURABLE: {
                     if(queue.has(DURABLE.getName())) {

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingDeploymentParser_1_0.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingDeploymentParser_1_0.java
@@ -187,7 +187,9 @@ public class MessagingDeploymentParser_1_0 implements XMLStreamConstants, XMLEle
                     if (queue.has(SELECTOR.getName())) {
                         throw ParseUtils.duplicateNamedElement(reader, Element.SELECTOR.getLocalName());
                     }
-                    SELECTOR.parseAndSetParameter(PropertiesValueResolver.replaceProperties(reader.getElementText()), queue, reader);
+                    requireSingleAttribute(reader, CommonAttributes.STRING);
+                    final String selector = PropertiesValueResolver.replaceProperties(readStringAttributeElement(reader, CommonAttributes.STRING));
+                    SELECTOR.parseAndSetParameter(selector, queue, reader);
                     break;
                 }
                 case DURABLE: {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/SelectorAttribute.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/SelectorAttribute.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.messaging.Attribute;
+import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.Element;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@link org.jboss.as.controller.AttributeDefinition} for a JMS resource's {@code selector} attribute.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class SelectorAttribute extends SimpleAttributeDefinition {
+    public static final SelectorAttribute SELECTOR = new SelectorAttribute();
+
+    private SelectorAttribute() {
+        super(CommonAttributes.SELECTOR_STRING, ModelType.STRING, true);
+    }
+
+    @Override
+    public void marshallAsElement(ModelNode resourceModel, XMLStreamWriter writer) throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            String selector = resourceModel.get(getName()).asString();
+            writer.writeEmptyElement(Element.SELECTOR.getLocalName());
+            writer.writeAttribute(Attribute.STRING.getLocalName(), selector);
+        }
+    }
+}

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem.xml
@@ -223,6 +223,7 @@
            <jms-destinations>
               <jms-queue name="testQueue">
                  <entry name="queue/test"/>
+                 <selector string="color='red'"/>
               </jms-queue>
               <jms-topic name="testTopic">
                  <entry name="topic/test"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/xsd10.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/xsd10.xml
@@ -226,6 +226,7 @@
            <jms-destinations>
               <jms-queue name="testQueue">
                  <entry name="queue/test"/>
+                 <selector string="color='red'"/>
               </jms-queue>
               <jms-topic name="testTopic">
                  <entry name="topic/test"/>


### PR DESCRIPTION
- parse the selector element correctly (using its string attribute)
- marshall it to have the same output than the XML input

I fixed it "monkey see, monkey do" style but I am not sure that the SelectorAttribute implementation is "right"... 
