### PR TITLE
[AS7-3525] Update to the JAAS authentication process within the realms t...

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -133,6 +133,11 @@
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.jboss.metadata</groupId>
+            <artifactId>jboss-metadata-ejb</artifactId>
+        </dependency>        
 
     </dependencies>
 

--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -132,11 +132,6 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.jboss.metadata</groupId>
-            <artifactId>jboss-metadata-ejb</artifactId>
         </dependency>        
 
     </dependencies>

--- a/controller/src/main/java/org/jboss/as/controller/security/ServerSecurityManager.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/ServerSecurityManager.java
@@ -29,8 +29,6 @@ import java.util.Set;
 
 import javax.security.auth.Subject;
 
-import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
-
 /**
  * Interface to the servers security manager implementation.
  *
@@ -47,10 +45,7 @@ public interface ServerSecurityManager {
 
     Subject getSubject();
 
-    // TODO - Look to replace SecurityRolesMetaData to eliminate this dependency.
-    boolean isCallerInRole(final SecurityRolesMetaData mappedRoles, final Map<String, Collection<String>> roleLinks,
+    boolean isCallerInRole(final Object mappedRoles, final Map<String, Collection<String>> roleLinks,
             final String... roleNames);
-
-
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/security/ServerSecurityManager.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/ServerSecurityManager.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.security;
+
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+
+import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
+
+/**
+ * Interface to the servers security manager implementation.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface ServerSecurityManager {
+
+    void push(final String securityDomain, final String runAs, final String runAsPrincipal, final Set<String> extraRoles);
+    void push(final String securityDomain, String userName, char[] password, final Subject subject);
+
+    void pop();
+
+    Principal getCallerPrincipal();
+
+    Subject getSubject();
+
+    // TODO - Look to replace SecurityRolesMetaData to eliminate this dependency.
+    boolean isCallerInRole(final SecurityRolesMetaData mappedRoles, final Map<String, Collection<String>> roleLinks,
+            final String... roleNames);
+
+
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -40,6 +40,7 @@ import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentView;
 import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
@@ -282,7 +283,7 @@ public abstract class EJBComponent extends BasicComponent {
         }
     }
 
-    public SimpleSecurityManager getSecurityManager() {
+    public ServerSecurityManager getSecurityManager() {
         return utilities.getSecurityManager();
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -37,8 +37,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.jboss.as.connector.ConnectorServices;
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
-import org.jboss.as.security.service.SimpleSecurityManager;
 import org.jboss.jca.core.spi.rar.Activation;
 import org.jboss.jca.core.spi.rar.Endpoint;
 import org.jboss.jca.core.spi.rar.MessageListener;
@@ -65,7 +65,7 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb", "utilities");
 
     private final InjectedValue<ResourceAdapterRepository> resourceAdapterRepositoryValue = new InjectedValue<ResourceAdapterRepository>();
-    private final InjectedValue<SimpleSecurityManager> securityManagerValue = new InjectedValue<SimpleSecurityManager>();
+    private final InjectedValue<ServerSecurityManager> securityManagerValue = new InjectedValue<ServerSecurityManager>();
     private final InjectedValue<TransactionManager> transactionManagerValue = new InjectedValue<TransactionManager>();
     private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<UserTransaction> userTransactionValue = new InjectedValue<UserTransaction>();
@@ -131,14 +131,14 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
         return resourceAdapterRepositoryValue;
     }
 
-    public SimpleSecurityManager getSecurityManager() {
-        final SimpleSecurityManager securityManager = securityManagerValue.getOptionalValue();
+    public ServerSecurityManager getSecurityManager() {
+        final ServerSecurityManager securityManager = securityManagerValue.getOptionalValue();
         if (securityManager == null)
             throw MESSAGES.securityNotEnabled();
         return securityManager;
     }
 
-    public Injector<SimpleSecurityManager> getSecurityManagerInjector() {
+    public Injector<ServerSecurityManager> getSecurityManagerInjector() {
         return securityManagerValue;
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
@@ -27,10 +27,10 @@ import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 import java.lang.reflect.Method;
 import java.util.Collection;
 
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentView;
 import org.jboss.as.ejb3.component.EJBComponent;
-import org.jboss.as.security.service.SimpleSecurityManager;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
 /**
@@ -95,7 +95,7 @@ public class AuthorizationInterceptor implements Interceptor {
             final Collection<String> allowedRoles = ejbMethodSecurityMetaData.getRolesAllowed();
             if (!allowedRoles.isEmpty()) {
                 // call the security API to do authorization check
-                final SimpleSecurityManager securityManager = ejbComponent.getSecurityManager();
+                final ServerSecurityManager securityManager = ejbComponent.getSecurityManager();
                 final EJBSecurityMetaData ejbSecurityMetaData = ejbComponent.getSecurityMetaData();
                 if (!securityManager.isCallerInRole(ejbSecurityMetaData.getSecurityRoles(), ejbSecurityMetaData.getSecurityRoleLinks(), allowedRoles.toArray(new String[allowedRoles.size()]))) {
                     throw MESSAGES.invocationOfMethodNotAllowed(invokedMethod,ejbComponent.getComponentName());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
@@ -24,10 +24,10 @@ package org.jboss.as.ejb3.security;
 import java.util.Map;
 import java.util.Set;
 
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentInterceptorFactory;
 import org.jboss.as.ejb3.component.EJBComponent;
-import org.jboss.as.security.service.SimpleSecurityManager;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorFactoryContext;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
@@ -46,7 +46,7 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
             throw MESSAGES.unexpectedComponent(component, EJBComponent.class);
         }
         final EJBComponent ejbComponent = (EJBComponent) component;
-        final SimpleSecurityManager securityManager = ejbComponent.getSecurityManager();
+        final ServerSecurityManager securityManager = ejbComponent.getSecurityManager();
         final EJBSecurityMetaData securityMetaData = ejbComponent.getSecurityMetaData();
         final String securityDomain = securityMetaData.getSecurityDomain();
         if (securityDomain == null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorHolder.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorHolder.java
@@ -24,7 +24,7 @@ package org.jboss.as.ejb3.security;
 import java.util.Map;
 import java.util.Set;
 
-import org.jboss.as.security.service.SimpleSecurityManager;
+import org.jboss.as.controller.security.ServerSecurityManager;
 
 /**
  * A simple transfer object
@@ -32,7 +32,7 @@ import org.jboss.as.security.service.SimpleSecurityManager;
  * @author anil saldhana
  */
 class SecurityContextInterceptorHolder {
-    SimpleSecurityManager securityManager;
+    ServerSecurityManager securityManager;
     String securityDomain, runAs, runAsPrincipal;
     Set<String> extraRoles;
     Map<String, Set<String>> principalVsRolesMap;
@@ -40,7 +40,7 @@ class SecurityContextInterceptorHolder {
     public SecurityContextInterceptorHolder() {
     }
 
-    public SecurityContextInterceptorHolder setSecurityManager(SimpleSecurityManager ssm) {
+    public SecurityContextInterceptorHolder setSecurityManager(ServerSecurityManager ssm) {
         this.securityManager = ssm;
         return this;
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ejb3.cache.impl.backing.clustering.ClusteredBackingCacheEntryStoreSourceService;
 import org.jboss.as.ejb3.component.EJBUtilities;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
@@ -95,7 +96,6 @@ import org.jboss.as.jacorb.rmi.DelegatingStubFactoryFactory;
 import org.jboss.as.jacorb.service.CorbaPOAService;
 import org.jboss.as.naming.InitialContext;
 import org.jboss.as.network.ClientMapping;
-import org.jboss.as.security.service.SimpleSecurityManager;
 import org.jboss.as.security.service.SimpleSecurityManagerService;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -289,7 +289,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
             final EJBUtilities utilities = new EJBUtilities();
             newControllers.add(serviceTarget.addService(EJBUtilities.SERVICE_NAME, utilities)
                     .addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class, utilities.getResourceAdapterRepositoryInjector())
-                    .addDependency(SimpleSecurityManagerService.SERVICE_NAME, SimpleSecurityManager.class, utilities.getSecurityManagerInjector())
+                    .addDependency(SimpleSecurityManagerService.SERVICE_NAME, ServerSecurityManager.class, utilities.getSecurityManagerInjector())
                     .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, utilities.getTransactionManagerInjector())
                     .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, utilities.getTransactionSynchronizationRegistryInjector())
                     .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION, UserTransaction.class, utilities.getUserTransactionInjector())

--- a/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -159,8 +159,9 @@ public class SimpleSecurityManager implements ServerSecurityManager {
      * @param roleNames The role names for which the caller is being checked for
      * @return true if the user is in <b>any</b> one of the <code>roleNames</code>. Else returns false
      */
-    public boolean isCallerInRole(final SecurityRolesMetaData mappedRoles, final Map<String, Collection<String>> roleLinks,
+    public boolean isCallerInRole(final Object incommingMappedRoles, final Map<String, Collection<String>> roleLinks,
                                   final String... roleNames) {
+        final SecurityRolesMetaData mappedRoles = (SecurityRolesMetaData) incommingMappedRoles;
         final SecurityContext securityContext = doPrivileged(securityContext());
         if (securityContext == null) {
             return false;

--- a/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManagerService.java
+++ b/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManagerService.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.security.service;
 
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.security.SecurityExtension;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
@@ -35,7 +36,7 @@ import org.jboss.security.ISecurityManagement;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  * @author Anil Saldhana
  */
-public class SimpleSecurityManagerService implements Service<SimpleSecurityManager> {
+public class SimpleSecurityManagerService implements Service<ServerSecurityManager> {
     public static final ServiceName SERVICE_NAME = SecurityExtension.JBOSS_SECURITY.append("simple-security-manager");
 
     private final SimpleSecurityManager securityManager = new SimpleSecurityManager();
@@ -51,7 +52,7 @@ public class SimpleSecurityManagerService implements Service<SimpleSecurityManag
     }
 
     @Override
-    public SimpleSecurityManager getValue() throws IllegalStateException, IllegalArgumentException {
+    public ServerSecurityManager getValue() throws IllegalStateException, IllegalArgumentException {
         return securityManager;
     }
 


### PR DESCRIPTION
...o make use of the same security service as used by EJB3.

This change now means that the same authentication cache is used for all JAAS authentication so regardless of the entry point
or the point of the authentication a user will only be authenticated once and the cached value subsequently used whilst the
cache entry is present.
