### PR TITLE
[AS7-4090] Refactor Infinispan subsystem CacheContainerAdd and CacheAdd to allow reuse of installation and removal of services

### DIFF
--- a/clustering/infinispan/pom.xml
+++ b/clustering/infinispan/pom.xml
@@ -116,9 +116,14 @@
          </dependency>
     </dependencies>
 
-
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/clustering/infinispan/pom.xml
+++ b/clustering/infinispan/pom.xml
@@ -122,6 +122,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <parallel>false</parallel>
                 </configuration>
             </plugin>
             <plugin>

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -48,7 +48,6 @@ import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReferenceInjector;
 import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
-import org.jboss.as.naming.deployment.JndiName;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.server.ServerEnvironment;
@@ -221,11 +220,11 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
         // remove the binder service
         ModelNode resolvedValue = null;
         final String jndiNameString = ((resolvedValue = CommonAttributes.JNDI_NAME.resolveModelAttribute(context, model)).isDefined()) ? resolvedValue.asString() : null;
-        final String jndiName = InfinispanJndiName.createJndiNameOrDefault(jndiNameString, containerName, cacheName);
+        final String jndiName = InfinispanJndiName.createCacheJndiNameOrDefault(jndiNameString, containerName, cacheName);
         ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(jndiName);
         context.removeService(bindInfo.getBinderServiceName()) ;
         // remove the CacheService instance
-        context.removeService(EmbeddedCacheManagerService.getServiceName(containerName).append(cacheName));
+        context.removeService(CacheService.getServiceName(containerName, cacheName));
         // remove the cache configuration service
         context.removeService(CacheConfigurationService.getServiceName(containerName, cacheName));
 
@@ -273,8 +272,7 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
 
         CacheDependencies cacheDependencies = new CacheDependencies(containerInjection);
         CacheService<Object, Object> cacheService = new CacheService<Object, Object>(cacheName, cacheDependencies);
-        ServiceName containerServiceName = EmbeddedCacheManagerService.getServiceName(containerName);
-        ServiceName cacheServiceName = containerServiceName.append(cacheName);
+        ServiceName cacheServiceName = CacheService.getServiceName(containerName, cacheName);
         ServiceName cacheConfigurationServiceName = CacheConfigurationService.getServiceName(containerName, cacheName);
         Configuration config = builder.build();
 
@@ -302,10 +300,9 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
                                                                             String containerName, String cacheName, String jndiNameString,
                                                                             ServiceVerificationHandler verificationHandler) {
 
-        String jndiName = InfinispanJndiName.createJndiNameOrDefault(jndiNameString, containerName, cacheName);
+        String jndiName = InfinispanJndiName.createCacheJndiNameOrDefault(jndiNameString, containerName, cacheName);
 
-        ServiceName containerServiceName = EmbeddedCacheManagerService.getServiceName(containerName);
-        ServiceName cacheServiceName = containerServiceName.append(cacheName);
+        ServiceName cacheServiceName = CacheService.getServiceName(containerName, cacheName);
         ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(jndiName);
 
         BinderService binder = new BinderService(bindInfo.getBindName());

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemove.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemove.java
@@ -90,49 +90,49 @@ public class CacheContainerRemove extends AbstractRemoveStepHandler {
      * Method to reinstall any services associated with existing caches.
      *
      * @param context
-     * @param model
+     * @param containerModel
      * @param containerName
      * @throws OperationFailedException
      */
-    private void reinstallExistingCacheServices(OperationContext context, ModelNode model, String containerName, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
+    private void reinstallExistingCacheServices(OperationContext context, ModelNode containerModel, String containerName, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
 
         // re-install the services of any local caches
-        List<Property> localCacheList = getCachesFromParentModel(ModelKeys.LOCAL_CACHE, model);
+        List<Property> localCacheList = getCachesFromParentModel(ModelKeys.LOCAL_CACHE, containerModel);
         // don't know why extended for loop doesn't detect null list ...
         if (localCacheList != null)
             for (Property localCache : localCacheList) {
                 String localCacheName = localCache.getName();
                 ModelNode localCacheModel = localCache.getValue();
                 ModelNode localCacheAddOp = createCacheAddOperation(ModelKeys.LOCAL_CACHE, containerName, localCacheName);
-                LocalCacheAdd.INSTANCE.installRuntimeServices(context, localCacheAddOp, localCacheModel, verificationHandler, null);
+                LocalCacheAdd.INSTANCE.installRuntimeServices(context, localCacheAddOp, containerModel, localCacheModel, verificationHandler, null);
             }
 
         // re-install the services of any invalidation caches
-        List<Property> invalidationCacheList = getCachesFromParentModel(ModelKeys.INVALIDATION_CACHE, model);
+        List<Property> invalidationCacheList = getCachesFromParentModel(ModelKeys.INVALIDATION_CACHE, containerModel);
         if (invalidationCacheList != null)
             for (Property invCache : invalidationCacheList) {
                 String invCacheName = invCache.getName();
                 ModelNode invCacheModel = invCache.getValue();
                 ModelNode invCacheAddOp = createCacheAddOperation(ModelKeys.INVALIDATION_CACHE, containerName, invCacheName);
-                InvalidationCacheAdd.INSTANCE.installRuntimeServices(context, invCacheAddOp, invCacheModel, verificationHandler, null);
+                InvalidationCacheAdd.INSTANCE.installRuntimeServices(context, invCacheAddOp, containerModel, invCacheModel, verificationHandler, null);
             }
         // re-install the services of any replicated caches
-        List<Property> replCacheList = getCachesFromParentModel(ModelKeys.REPLICATED_CACHE, model);
+        List<Property> replCacheList = getCachesFromParentModel(ModelKeys.REPLICATED_CACHE, containerModel);
         if (replCacheList != null)
             for (Property replCache : replCacheList) {
                 String replCacheName = replCache.getName();
                 ModelNode replCacheModel = replCache.getValue();
                 ModelNode replCacheAddOp = createCacheAddOperation(ModelKeys.REPLICATED_CACHE, containerName, replCacheName);
-                ReplicatedCacheAdd.INSTANCE.installRuntimeServices(context, replCacheAddOp, replCacheModel, verificationHandler, null);
+                ReplicatedCacheAdd.INSTANCE.installRuntimeServices(context, replCacheAddOp, containerModel, replCacheModel, verificationHandler, null);
             }
         // re-install the services of any distributed caches
-        List<Property> distCacheList = getCachesFromParentModel(ModelKeys.DISTRIBUTED_CACHE, model);
+        List<Property> distCacheList = getCachesFromParentModel(ModelKeys.DISTRIBUTED_CACHE, containerModel);
         if (distCacheList != null)
             for (Property distCache : distCacheList) {
                 String distCacheName = distCache.getName();
                 ModelNode distCacheModel = distCache.getValue();
                 ModelNode distCacheAddOp = createCacheAddOperation(ModelKeys.DISTRIBUTED_CACHE, containerName, distCacheName);
-                DistributedCacheAdd.INSTANCE.installRuntimeServices(context, distCacheAddOp, distCacheModel, verificationHandler, null);
+                DistributedCacheAdd.INSTANCE.installRuntimeServices(context, distCacheAddOp, containerModel, distCacheModel, verificationHandler, null);
             }
     }
 
@@ -140,14 +140,14 @@ public class CacheContainerRemove extends AbstractRemoveStepHandler {
      * Method to remove any services associated with existing caches.
      *
      * @param context
-     * @param model
+     * @param containerModel
      * @param containerName
      * @throws OperationFailedException
      */
-    private void removeExistingCacheServices(OperationContext context, ModelNode model, String containerName) throws OperationFailedException {
+    private void removeExistingCacheServices(OperationContext context, ModelNode containerModel, String containerName) throws OperationFailedException {
 
         // remove the services of any local caches
-        List<Property> localCacheList = getCachesFromParentModel(ModelKeys.LOCAL_CACHE, model);
+        List<Property> localCacheList = getCachesFromParentModel(ModelKeys.LOCAL_CACHE, containerModel);
         // don't know why extended for loop doesn't detect null list ...
         if (localCacheList != null)
             for (Property localCache : localCacheList) {
@@ -158,7 +158,7 @@ public class CacheContainerRemove extends AbstractRemoveStepHandler {
             }
 
         // remove the services of any invalidation caches
-        List<Property> invalidationCacheList = getCachesFromParentModel(ModelKeys.INVALIDATION_CACHE, model);
+        List<Property> invalidationCacheList = getCachesFromParentModel(ModelKeys.INVALIDATION_CACHE, containerModel);
         if (invalidationCacheList != null)
             for (Property invCache : invalidationCacheList) {
                 String invCacheName = invCache.getName();
@@ -167,7 +167,7 @@ public class CacheContainerRemove extends AbstractRemoveStepHandler {
                 InvalidationCacheAdd.INSTANCE.removeRuntimeServices(context, invCacheRemoveOp, invCacheModel);
             }
         // remove the services of any replicated caches
-        List<Property> replCacheList = getCachesFromParentModel(ModelKeys.REPLICATED_CACHE, model);
+        List<Property> replCacheList = getCachesFromParentModel(ModelKeys.REPLICATED_CACHE, containerModel);
         if (replCacheList != null)
             for (Property replCache : replCacheList) {
                 String replCacheName = replCache.getName();
@@ -176,7 +176,7 @@ public class CacheContainerRemove extends AbstractRemoveStepHandler {
                 ReplicatedCacheAdd.INSTANCE.removeRuntimeServices(context, replCacheRemoveOp, replCacheModel);
             }
         // remove the services of any distributed caches
-        List<Property> distCacheList = getCachesFromParentModel(ModelKeys.DISTRIBUTED_CACHE, model);
+        List<Property> distCacheList = getCachesFromParentModel(ModelKeys.DISTRIBUTED_CACHE, containerModel);
         if (distCacheList != null)
             for (Property distCache : distCacheList) {
                 String distCacheName = distCache.getName();
@@ -224,17 +224,5 @@ public class CacheContainerRemove extends AbstractRemoveStepHandler {
                 PathElement.pathElement("cache-container", containerName),
                 PathElement.pathElement(cacheType, cacheName));
         return cacheAddr;
-    }
-
-    private void printCacheList(String name, List<Property> list) {
-        System.out.println("Printing list: " + name);
-        if (list != null) {
-            for (Property element : list) {
-                System.out.println("element: name = " + element.getName() +
-                        ", value = " + element.getValue());
-            }
-        } else {
-            System.out.println("<empty>");
-        }
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemove.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemove.java
@@ -33,20 +33,25 @@ public class CacheRemove extends AbstractRemoveStepHandler {
         }
     }
 
-    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode cacheModel) throws OperationFailedException {
+
+        // we also need the containerModel to re-install cache services
+        final PathAddress cacheAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
+        final PathAddress containerAddress = cacheAddress.subAddress(0, cacheAddress.size()-1) ;
+        ModelNode containerModel = context.readResourceFromRoot(containerAddress).getModel();
 
         // re-add the services if the remove failed
         String cacheType = getCacheType(operation) ;
         ServiceVerificationHandler verificationHandler = null ;
 
         if (cacheType.equals(ModelKeys.LOCAL_CACHE)) {
-            LocalCacheAdd.INSTANCE.installRuntimeServices(context, operation, model, verificationHandler, null);
+            LocalCacheAdd.INSTANCE.installRuntimeServices(context, operation, containerModel, cacheModel, verificationHandler, null);
         } else if (cacheType.equals(ModelKeys.INVALIDATION_CACHE)) {
-            InvalidationCacheAdd.INSTANCE.installRuntimeServices(context, operation, model, verificationHandler, null);
+            InvalidationCacheAdd.INSTANCE.installRuntimeServices(context, operation, containerModel, cacheModel, verificationHandler, null);
         } else if (cacheType.equals(ModelKeys.REPLICATED_CACHE)) {
-            ReplicatedCacheAdd.INSTANCE.installRuntimeServices(context, operation, model, verificationHandler, null);
+            ReplicatedCacheAdd.INSTANCE.installRuntimeServices(context, operation, containerModel, cacheModel, verificationHandler, null);
         } else if (cacheType.equals(ModelKeys.DISTRIBUTED_CACHE)) {
-            DistributedCacheAdd.INSTANCE.installRuntimeServices(context, operation, model, verificationHandler, null);
+            DistributedCacheAdd.INSTANCE.installRuntimeServices(context, operation, containerModel, cacheModel, verificationHandler, null);
         }
     }
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanJndiName.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanJndiName.java
@@ -42,12 +42,22 @@ public class InfinispanJndiName {
         return value.startsWith("java:") ? JndiName.of(value) : JndiName.of(DEFAULT_JNDI_NAMESPACE).append(value.startsWith("/") ? value.substring(1) : value);
     }
 
-    public static String createJndiNameOrDefault(String jndiNameString, String containerName, String cacheName) {
+    public static String createCacheJndiNameOrDefault(String jndiNameString, String containerName, String cacheName) {
         JndiName jndiName = null ;
         if (jndiNameString != null) {
            jndiName = InfinispanJndiName.toJndiName(jndiNameString) ;
         } else {
             jndiName = InfinispanJndiName.defaultCacheJndiName(containerName, cacheName);
+        }
+        return jndiName.getAbsoluteName();
+    }
+
+    public static String createCacheContainerJndiNameOrDefault(String jndiNameString, String containerName) {
+        JndiName jndiName = null ;
+        if (jndiNameString != null) {
+           jndiName = InfinispanJndiName.toJndiName(jndiNameString) ;
+        } else {
+            jndiName = InfinispanJndiName.defaultCacheContainerJndiName(containerName);
         }
         return jndiName.getAbsoluteName();
     }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanJndiName.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanJndiName.java
@@ -41,4 +41,14 @@ public class InfinispanJndiName {
     public static JndiName toJndiName(String value) {
         return value.startsWith("java:") ? JndiName.of(value) : JndiName.of(DEFAULT_JNDI_NAMESPACE).append(value.startsWith("/") ? value.substring(1) : value);
     }
+
+    public static String createJndiNameOrDefault(String jndiNameString, String containerName, String cacheName) {
+        JndiName jndiName = null ;
+        if (jndiNameString != null) {
+           jndiName = InfinispanJndiName.toJndiName(jndiNameString) ;
+        } else {
+            jndiName = InfinispanJndiName.defaultCacheJndiName(containerName, cacheName);
+        }
+        return jndiName.getAbsoluteName();
+    }
 }

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
@@ -1,0 +1,159 @@
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import static org.jboss.as.clustering.infinispan.subsystem.ModelKeys.JNDI_NAME;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+* Test case for testing sequences of management operations.
+*
+* @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+*/
+public class OperationSequencesTestCase extends AbstractSubsystemTest {
+
+    static final String SUBSYSTEM_XML_FILE = "subsystem-infinispan_1_2.xml" ;
+
+    public OperationSequencesTestCase() {
+        super(InfinispanExtension.SUBSYSTEM_NAME, new InfinispanExtension());
+    }
+
+    // list the names of the services which have been installed
+    // System.out.println("service names = " + servicesA.getContainer().getServiceNames());
+
+    //ModelNode model = servicesA.readWholeModel();
+    // System.out.println("model = " + model.asString());
+
+    @Test
+    public void testLocalCacheAddRemoveAddSequence() throws Exception {
+
+        // Parse and install the XML into the controller
+        String subsystemXml = getSubsystemXml() ;
+        KernelServices servicesA = super.installInController(subsystemXml) ;
+
+        ModelNode addOp = getLocalCacheAddOperation("maximal", "fred");
+        ModelNode removeOp = getLocalCacheRemoveOperation("maximal", "fred");
+
+        // add a local cache
+        ModelNode result = servicesA.executeOperation(addOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        System.out.println("result = " + result.toString());
+
+        // remove the local cache
+        result = servicesA.executeOperation(removeOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        System.out.println("result = " + result.toString());
+
+        // add the same local cache
+        result = servicesA.executeOperation(addOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        System.out.println("result = " + result.toString());
+
+    }
+
+    @Test
+    public void testLocalCacheRemoveRemoveSequence() throws Exception {
+
+        // Parse and install the XML into the controller
+        String subsystemXml = getSubsystemXml() ;
+        KernelServices servicesA = super.installInController(subsystemXml) ;
+
+        ModelNode addOp = getLocalCacheAddOperation("maximal", "fred");
+        ModelNode removeOp = getLocalCacheRemoveOperation("maximal", "fred");
+
+        // add a local cache
+        ModelNode result = servicesA.executeOperation(addOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        System.out.println("result = " + result.toString());
+
+        // remove the local cache
+        result = servicesA.executeOperation(removeOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        System.out.println("result = " + result.toString());
+
+        // remove the same local cache
+        result = servicesA.executeOperation(removeOp);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        System.out.println("result = " + result.toString());
+    }
+
+
+    private ModelNode getLocalCacheAddOperation(String containerName, String cacheName) {
+
+        // create the address of the cache
+        PathAddress localCacheAddr = getCacheAddress(containerName, cacheName, ModelKeys.LOCAL_CACHE);
+        ModelNode addOp = new ModelNode() ;
+        addOp.get(OP).set(ADD);
+        addOp.get(OP_ADDR).set(localCacheAddr.toModelNode());
+        // required attributes
+        addOp.get(JNDI_NAME).set("java:/fred/was/here");
+
+        return addOp ;
+    }
+
+    private ModelNode getLocalCacheRemoveOperation(String containerName, String cacheName) {
+
+        // create the address of the cache
+        PathAddress localCacheAddr = getCacheAddress(containerName, cacheName, ModelKeys.LOCAL_CACHE);
+        ModelNode removeOp = new ModelNode() ;
+        removeOp.get(OP).set(REMOVE);
+        removeOp.get(OP_ADDR).set(localCacheAddr.toModelNode());
+
+        return removeOp ;
+    }
+
+    private PathAddress getCacheAddress(String containerName, String cacheName, String cacheType) {
+        // create the address of the cache
+        PathAddress cacheAddr = PathAddress.pathAddress(
+                PathElement.pathElement(SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME),
+                PathElement.pathElement("cache-container",containerName),
+                PathElement.pathElement(cacheType, cacheName));
+        return cacheAddr ;
+    }
+
+
+    private String getSubsystemXml() throws IOException {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(SUBSYSTEM_XML_FILE);
+        if (url == null) {
+            throw new IllegalStateException(String.format("Failed to locate %s", SUBSYSTEM_XML_FILE));
+        }
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(new File(url.toURI())));
+            StringWriter writer = new StringWriter();
+            try {
+                String line = reader.readLine();
+                while (line != null) {
+                    writer.write(line);
+                    line = reader.readLine();
+                }
+            } finally {
+                reader.close();
+            }
+            return writer.toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,8 +132,20 @@ public class OperationSequencesTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
 
         // remove the cache container
+        // the remove has OperationContext.setRollbackOnly() injected
+        // and so is expected to fail
         result = servicesA.executeOperation(removeContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+
+        // need to check that all services are correctly re-installed
+        ServiceName containerServiceName = EmbeddedCacheManagerService.getServiceName("maximal2");
+
+        ServiceName cacheConfigurationServiceName = CacheConfigurationService.getServiceName("maximal2", "fred");
+        ServiceName cacheServiceName = CacheService.getServiceName("maximal2", "fred");
+
+        Assert.assertNotNull("cache container service not installed", servicesA.getContainer().getService(containerServiceName));
+        Assert.assertNotNull("cache configuration service not installed", servicesA.getContainer().getService(cacheConfigurationServiceName));
+        Assert.assertNotNull("cache service not installed", servicesA.getContainer().getService(cacheServiceName));
     }
 
     @Test

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -51,6 +51,10 @@
         <module>ejb3-infinispan</module>
     </modules>
 
+    <properties>
+        <version.byteman>2.0.1</version.byteman>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -61,6 +65,37 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+            <version>${version.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-submit</artifactId>
+            <scope>test</scope>
+            <version>${version.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-install</artifactId>
+            <scope>test</scope>
+            <version>${version.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+            <version>${version.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+            <scope>system</scope>
+            <version>1.6</version>
+            <systemPath>/opt/jdk-1.6.0_26/lib/tools.jar</systemPath>
         </dependency>
     </dependencies>
 </project>

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -95,7 +95,7 @@
             <artifactId>tools</artifactId>
             <scope>system</scope>
             <version>1.6</version>
-            <systemPath>/opt/jdk-1.6.0_26/lib/tools.jar</systemPath>
+            <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This pull request:
- tidies up CacheContainerAdd and CacheAdd service installation
- makes reuseable methods installRuntimeServices and removeRuntimeServices available for reuse in CacheContainerRemove and CacheRemove.
- adds in tests for sequences of add/remove operations
- adds in test for testing rollback of CacheContainerRemove
