### PR TITLE
[AS7-4269] BindingRegistry failure after unbind()

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -126,4 +126,16 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 11606, value = "Could not close file %s")
     void couldNotCloseFile(String file, @Cause Throwable cause);
+
+    /**
+     * Logs a warning message indicating the messaging object bound to the JNDI name represented by
+     * the {@code jndiName) has not be unbound in a timely fashion.
+     *
+     * @param jndiName the name the messaging object was bound to.
+     * @param timeout  the timeout value
+     * @param timeUnit the timeout time unit
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11607, value = "Failed to unbind messaging object bound to jndi name %s in %d %s")
+    void failedToUnbindJndiName(String jndiName, long timeout, String timeUnit);
 }

--- a/messaging/src/test/java/org/jboss/as/messaging/test/AS7BindingRegistryTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/AS7BindingRegistryTestCase.java
@@ -1,0 +1,67 @@
+package org.jboss.as.messaging.test;
+
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.messaging.jms.AS7BindingRegistry;
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AS7BindingRegistryTestCase {
+
+    private ServiceContainer container;
+
+    @Before
+    public void setUp() {
+        container = ServiceContainer.Factory.create("test");
+    }
+
+    @After
+    public void tearDown() {
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+    }
+
+    /*
+     * https://issues.jboss.org/browse/AS7-4269
+     */
+    @Test
+    public void bindUnbindBind() throws Exception {
+        AS7BindingRegistry registry = new AS7BindingRegistry(container);
+
+        Object obj = new Object();
+        String name = UUID.randomUUID().toString();
+        assertNull(getBinderServiceFor(name));
+
+        assertTrue(registry.bind(name, obj));
+        assertNotNull(getBinderServiceFor(name));
+
+        registry.unbind(name);
+        assertNull(getBinderServiceFor(name));
+
+        assertTrue(registry.bind(name, obj));
+        assertNotNull(getBinderServiceFor(name));
+    }
+
+    private ServiceController<?> getBinderServiceFor(String name) {
+        final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(name);
+        return container.getService(bindInfo.getBinderServiceName());
+    }
+}


### PR DESCRIPTION
- add unit test to track down the failure related to unbind/bind
  sequence when recreating a Connection Factory
- in AS7BindingRegistry.unbind(), use a countdown latch to ensure
  that the binder service is effectively removed when the method
  returns
