### PR TITLE
LdapLoginModule test

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -23,7 +23,29 @@
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <version.apacheds>1.5.5</version.apacheds>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jboss</groupId>
+            <artifactId>jnp-client</artifactId>
+            <version>4.2.2.GA</version>
+        </dependency>    
+    
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-server-unit</artifactId>
+            <version>${version.apacheds}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-bootstrap-partition</artifactId>
+            <version>${version.apacheds}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <profiles>
 
@@ -280,11 +302,4 @@
 
     </profiles>
 
-    <dependencies>
-        <dependency>
-            <groupId>jboss</groupId>
-            <artifactId>jnp-client</artifactId>
-            <version>4.2.2.GA</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/common/AbstractLoginModuleStackServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/common/AbstractLoginModuleStackServerSetupTask.java
@@ -1,0 +1,137 @@
+package org.jboss.as.test.integration.security.common;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.security.Constants.FLAG;
+import static org.jboss.as.security.Constants.MODULE_OPTIONS;
+import static org.jboss.as.security.Constants.SECURITY_DOMAIN;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.security.Constants;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * {@link ServerSetupTask} instance for stacking login-modules.
+ * 
+ * @author Josef Cacek
+ */
+public abstract class AbstractLoginModuleStackServerSetupTask extends AbstractSecurityDomainSetup {
+
+    private static String SECURITY_DOMAIN_NAME = "test-security-domain";
+
+    protected ManagementClient managementClient;
+
+    // Protected methods -----------------------------------------------------
+
+    /**
+     * @return
+     * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup#getSecurityDomainName()
+     */
+    @Override
+    protected String getSecurityDomainName() {
+        return SECURITY_DOMAIN_NAME;
+    }
+
+    /**
+     * Returns configuration of the login
+     * 
+     * @return
+     */
+    protected abstract LoginModuleConfiguration[] getLoginModuleConfigurations();
+
+    @Override
+    public void setup(final ManagementClient managementClient, String containerId) throws Exception {
+        this.managementClient = managementClient;
+        final LoginModuleConfiguration[] configurations = getLoginModuleConfigurations();
+        if (ArrayUtils.isEmpty(configurations)) {
+            throw new IllegalStateException("No LoginModuleConfiguration provided.");
+        }
+
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+        ModelNode op = new ModelNode();
+        op.get(OP).set(ADD);
+        op.get(OP_ADDR).add(SUBSYSTEM, "security");
+        final String securityDomainName = getSecurityDomainName();
+        op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomainName);
+        updates.add(op);
+        op = new ModelNode();
+        op.get(OP).set(ADD);
+        op.get(OP_ADDR).add(SUBSYSTEM, "security");
+        op.get(OP_ADDR).add(SECURITY_DOMAIN, securityDomainName);
+
+        op.get(OP_ADDR).add(Constants.AUTHENTICATION, Constants.CLASSIC);
+        for (final LoginModuleConfiguration config : configurations) {
+            final ModelNode loginModule = op.get(Constants.LOGIN_MODULES).add();
+
+            loginModule.get(ModelDescriptionConstants.CODE).set(config.getName());
+            loginModule.get(FLAG).set(StringUtils.defaultIfEmpty(config.getFlag(), "required"));
+
+            Map<String, String> configOptions = config.getOptions();
+            if (configOptions == null) {
+                configOptions = Collections.emptyMap();
+            }
+            final ModelNode moduleOptionsNode = loginModule.get(MODULE_OPTIONS);
+            for (final Map.Entry<String, String> entry : configOptions.entrySet()) {
+                moduleOptionsNode.add(entry.getKey(), entry.getValue());
+            }
+
+            op.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        }
+        updates.add(op);
+        applyUpdates(managementClient.getControllerClient(), updates);
+    }
+
+    /**
+     * 
+     * @param managementClient
+     * @param containerId
+     * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+     *      java.lang.String)
+     */
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) {
+        super.tearDown(managementClient, containerId);
+        this.managementClient = null;
+    }
+
+    // Embedded classes ------------------------------------------------------
+
+    /**
+     * A LoginModuleConfiguration.
+     */
+    public interface LoginModuleConfiguration {
+        /**
+         * Not-null name/code of the LoginModule.
+         * 
+         * @return
+         */
+        String getName();
+
+        /**
+         * Flag of the LoginModule. If it's empty, then "required" is used.
+         * 
+         * @return
+         */
+        String getFlag();
+
+        /**
+         * LoginModule options as a Map.
+         * 
+         * @return
+         */
+        Map<String, String> getOptions();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/common/LDAPServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/common/LDAPServerSetupTask.java
@@ -1,0 +1,396 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+
+import junit.framework.AssertionFailedError;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.directory.server.constants.ServerDNConstants;
+import org.apache.directory.server.core.CoreSession;
+import org.apache.directory.server.core.DefaultDirectoryService;
+import org.apache.directory.server.core.DirectoryService;
+import org.apache.directory.server.core.entry.DefaultServerEntry;
+import org.apache.directory.server.core.entry.ServerEntry;
+import org.apache.directory.server.core.jndi.CoreContextFactory;
+import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmIndex;
+import org.apache.directory.server.core.partition.impl.btree.jdbm.JdbmPartition;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.server.ldap.handlers.bind.MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.cramMD5.CramMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.digestMD5.DigestMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.gssapi.GssapiMechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.ntlm.NtlmMechanismHandler;
+import org.apache.directory.server.ldap.handlers.bind.plain.PlainMechanismHandler;
+import org.apache.directory.server.ldap.handlers.extended.StartTlsHandler;
+import org.apache.directory.server.ldap.handlers.extended.StoredProcedureExtendedOperationHandler;
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.directory.server.xdbm.Index;
+import org.apache.directory.shared.ldap.constants.SupportedSaslMechanisms;
+import org.apache.directory.shared.ldap.entry.Entry;
+import org.apache.directory.shared.ldap.entry.EntryAttribute;
+import org.apache.directory.shared.ldap.entry.Value;
+import org.apache.directory.shared.ldap.exception.LdapConfigurationException;
+import org.apache.directory.shared.ldap.ldif.LdifEntry;
+import org.apache.directory.shared.ldap.ldif.LdifReader;
+import org.apache.mina.util.AvailablePortFinder;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.logging.Logger;
+
+/**
+ * {@link ServerSetupTask} implementation, which starts embedded LDAP server (ApacheDS). The implementation is based on
+ * AbstractServerTestcase class from the ApacheDS.
+ * 
+ * @author Josef Cacek
+ * @see #configureDirectoryService()
+ * @see #configureLdapServer()
+ * @see #getPort()
+ */
+public class LDAPServerSetupTask implements ServerSetupTask {
+    private static final Logger LOGGER = Logger.getLogger(LDAPServerSetupTask.class);
+    private static final List<LdifEntry> EMPTY_LIST = Collections.unmodifiableList(new ArrayList<LdifEntry>(0));
+
+    /** the context root for the rootDSE */
+    protected CoreSession rootDSE;
+
+    /** the context root for the system partition */
+    protected LdapContext sysRoot;
+
+    /** the context root for the schema */
+    protected LdapContext schemaRoot;
+
+    /** flag whether to delete database files for each test or not */
+    protected boolean doDelete = true;
+
+    protected int port = -1;
+
+    protected DirectoryService directoryService;
+    protected LdapServer ldapServer;
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     * Configures and starts ApacheDS LDAP server.
+     * 
+     * @param managementClient
+     * @param containerId
+     * @throws Exception
+     * @see org.jboss.as.arquillian.api.ServerSetupTask#setup(org.jboss.as.arquillian.container.ManagementClient,
+     *      java.lang.String)
+     */
+    public final void setup(ManagementClient managementClient, String containerId) throws Exception {
+        directoryService = new DefaultDirectoryService();
+        directoryService.setShutdownHookEnabled(false);
+        port = getPort();
+        LOGGER.info("Creating LDAP server on port " + port);
+
+        ldapServer = new LdapServer();
+        ldapServer.setTransports(new TcpTransport(port));
+        ldapServer.setDirectoryService(directoryService);
+
+        setupSaslMechanisms();
+
+        doDelete(directoryService.getWorkingDirectory());
+        configureDirectoryService();
+        LOGGER.debug("Starting directory service");
+        directoryService.startup();
+
+        rootDSE = directoryService.getAdminSession();
+
+        configureLdapServer();
+
+        ldapServer.addExtendedOperationHandler(new StartTlsHandler());
+        ldapServer.addExtendedOperationHandler(new StoredProcedureExtendedOperationHandler());
+
+        LOGGER.debug("Starting LDAP server");
+        ldapServer.start();
+
+        setContexts(ServerDNConstants.ADMIN_SYSTEM_DN, "secret");
+    }
+
+    /**
+     * Stops the LDAP server and directory service and sets the system context root to null.
+     * 
+     * @param managementClient
+     * @param containerId
+     * @throws Exception
+     * @see org.jboss.as.arquillian.api.ServerSetupTask#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+     *      java.lang.String)
+     */
+    public final void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        LOGGER.info("Stopping LDAP server");
+        ldapServer.stop();
+        LOGGER.info("Shutting down DirectoryService");
+        directoryService.shutdown();
+        sysRoot = null;
+    }
+
+    // Protected methods -----------------------------------------------------
+
+    /**
+     * Returns port number on which the LDAP server should run.
+     * 
+     * @return port number
+     */
+    protected int getPort() {
+        return port > 0 ? port : AvailablePortFinder.getNextAvailable(1024);
+    }
+
+    /**
+     * Method called just before the directory service is started. Use it to change the directory service configuration.
+     * 
+     * @throws Exception
+     * @see #configureLdapServer()
+     */
+    protected void configureDirectoryService() throws Exception {
+        //nothing to do here, user can override the method
+    }
+
+    /**
+     * Method called after the directory service is started, but before the LDAP is started. Use it to import LDIF for instance.
+     * 
+     * @throws Exception
+     * @see #configureDirectoryService()
+     * @see #importLdif(InputStream)
+     */
+    protected void configureLdapServer() throws Exception {
+        //nothing to do here, user can override the method
+    }
+
+    /**
+     * If there is an LDIF file with the same name as the test class but with the .ldif extension then it is read and the
+     * entries it contains are added to the server. It appears as though the administrator adds these entries to the server.
+     * 
+     * @param verifyEntries whether or not all entry additions are checked to see if they were in fact correctly added to the
+     *        server
+     * @return a list of entries added to the server in the order they were added
+     * @throws NamingException of the load fails
+     */
+    protected final List<LdifEntry> loadTestLdif(boolean verifyEntries) throws Exception {
+        return loadLdif(getClass().getResourceAsStream(getClass().getSimpleName() + ".ldif"), verifyEntries);
+    }
+
+    /**
+     * Loads an LDIF from an input stream and adds the entries it contains to the server. It appears as though the administrator
+     * added these entries to the server.
+     * 
+     * @param in the input stream containing the LDIF entries to load
+     * @param verifyEntries whether or not all entry additions are checked to see if they were in fact correctly added to the
+     *        server
+     * @return a list of entries added to the server in the order they were added
+     * @throws NamingException of the load fails
+     */
+    protected final List<LdifEntry> loadLdif(InputStream in, boolean verifyEntries) throws Exception {
+        if (in == null) {
+            return EMPTY_LIST;
+        }
+
+        LdifReader ldifReader = new LdifReader(in);
+        List<LdifEntry> entries = new ArrayList<LdifEntry>();
+
+        for (LdifEntry entry : ldifReader) {
+            rootDSE.add(new DefaultServerEntry(directoryService.getRegistries(), entry.getEntry()));
+
+            if (verifyEntries) {
+                verify(entry);
+                LOGGER.info("Successfully verified addition of entry " + entry.getDn());
+            } else {
+                LOGGER.info("Added entry without verification " + entry.getDn());
+            }
+
+            entries.add(entry);
+        }
+
+        return entries;
+    }
+
+    /**
+     * Verifies that an entry exists in the directory with the specified attributes.
+     * 
+     * @param entry the entry to verify
+     * @throws NamingException if there are problems accessing the entry
+     */
+    protected final void verify(LdifEntry entry) throws Exception {
+        Entry readEntry = rootDSE.lookup(entry.getDn());
+
+        for (EntryAttribute readAttribute : readEntry) {
+            String id = readAttribute.getId();
+            EntryAttribute origAttribute = entry.getEntry().get(id);
+
+            for (Value<?> value : origAttribute) {
+                if (!readAttribute.contains(value)) {
+                    LOGGER.error("Failed to verify entry addition of " + entry.getDn() + ". " + id + " attribute in original "
+                            + "entry missing from read entry.");
+                    throw new AssertionFailedError("Failed to verify entry addition of " + entry.getDn());
+                }
+            }
+        }
+    }
+
+    /**
+     * Adds a partition with given ID and suffix to the directory.
+     * 
+     * @param id partition ID, e.g. "jboss"
+     * @param suffix partition suffix, e.g. "dc=jboss,dc=org"
+     * @throws Exception
+     */
+    protected final void addPartition(final String id, final String suffix) throws Exception {
+        final JdbmPartition tcPartition = new JdbmPartition();
+        tcPartition.setId(id);
+        tcPartition.setCacheSize(1000);
+
+        // Create some indices
+        Set<Index<?, ServerEntry>> indexedAttrs = new HashSet<Index<?, ServerEntry>>();
+        indexedAttrs.add(new JdbmIndex<Object, ServerEntry>("objectClass"));
+        indexedAttrs.add(new JdbmIndex<Object, ServerEntry>("o"));
+        tcPartition.setIndexedAttributes(indexedAttrs);
+
+        //Add suffix
+        tcPartition.setSuffix(suffix);
+        tcPartition.init(directoryService);
+        directoryService.addPartition(tcPartition);
+    }
+
+    /**
+     * Deletes the Eve working directory.
+     * 
+     * @param wkdir the directory to delete
+     * @throws IOException if the directory cannot be deleted
+     */
+    protected final void doDelete(File wkdir) throws IOException {
+        if (doDelete) {
+            if (wkdir.exists()) {
+                FileUtils.deleteDirectory(wkdir);
+            }
+
+            if (wkdir.exists()) {
+                throw new IOException("Failed to delete: " + wkdir);
+            }
+        }
+    }
+
+    /**
+     * Sets the contexts for this base class. Values of user and password used to set the respective JNDI properties. These
+     * values can be overriden by the overrides properties.
+     * 
+     * @param user the username for authenticating as this user
+     * @param passwd the password of the user
+     * @throws NamingException if there is a failure of any kind
+     */
+    protected final void setContexts(String user, String passwd) throws Exception {
+        final Hashtable<String, Object> env = new Hashtable<String, Object>();
+        env.put(DirectoryService.JNDI_KEY, directoryService);
+        env.put(Context.SECURITY_PRINCIPAL, user);
+        env.put(Context.SECURITY_CREDENTIALS, passwd);
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.INITIAL_CONTEXT_FACTORY, CoreContextFactory.class.getName());
+
+        env.put(Context.PROVIDER_URL, ServerDNConstants.SYSTEM_DN);
+        sysRoot = new InitialLdapContext(env, null);
+        env.put(Context.PROVIDER_URL, ServerDNConstants.OU_SCHEMA_DN);
+        schemaRoot = new InitialLdapContext(env, null);
+    }
+
+    /**
+     * Imports the LDIF entries packaged with the Eve JNDI provider jar into the newly created system partition to prime it up
+     * for operation. Note that only ou=system entries will be added - entries for other partitions cannot be imported and will
+     * blow chunks.
+     * 
+     * @throws NamingException if there are problems reading the ldif file and adding those entries to the system partition
+     * @param in the input stream with the ldif
+     */
+    protected final void importLdif(InputStream in) throws NamingException {
+        try {
+            for (LdifEntry ldifEntry : new LdifReader(in)) {
+                rootDSE.add(new DefaultServerEntry(rootDSE.getDirectoryService().getRegistries(), ldifEntry.getEntry()));
+            }
+        } catch (Exception e) {
+            String msg = "failed while trying to parse system ldif file";
+            NamingException ne = new LdapConfigurationException(msg);
+            ne.setRootCause(e);
+            throw ne;
+        }
+    }
+
+    /**
+     * Inject an ldif String into the server. DN must be relative to the root.
+     * 
+     * @param ldif the entries to inject
+     * @throws NamingException if the entries cannot be added
+     */
+    protected final void injectEntries(String ldif) throws Exception {
+        LdifReader reader = new LdifReader();
+        List<LdifEntry> entries = reader.parseLdif(ldif);
+
+        for (LdifEntry entry : entries) {
+            rootDSE.add(new DefaultServerEntry(rootDSE.getDirectoryService().getRegistries(), entry.getEntry()));
+        }
+    }
+
+    // Private methods -------------------------------------------------------
+
+    /**
+     * Configures supported SASL mechanisms handlers for the LDAP.
+     */
+    private void setupSaslMechanisms() {
+        Map<String, MechanismHandler> mechanismHandlerMap = new HashMap<String, MechanismHandler>();
+
+        mechanismHandlerMap.put(SupportedSaslMechanisms.PLAIN, new PlainMechanismHandler());
+
+        CramMd5MechanismHandler cramMd5MechanismHandler = new CramMd5MechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.CRAM_MD5, cramMd5MechanismHandler);
+
+        DigestMd5MechanismHandler digestMd5MechanismHandler = new DigestMd5MechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.DIGEST_MD5, digestMd5MechanismHandler);
+
+        GssapiMechanismHandler gssapiMechanismHandler = new GssapiMechanismHandler();
+        mechanismHandlerMap.put(SupportedSaslMechanisms.GSSAPI, gssapiMechanismHandler);
+
+        NtlmMechanismHandler ntlmMechanismHandler = new NtlmMechanismHandler();
+        // TODO - set some sort of default NtlmProvider implementation here
+        // ntlmMechanismHandler.setNtlmProvider( provider );
+        // TODO - or set FQCN of some sort of default NtlmProvider implementation here
+        // ntlmMechanismHandler.setNtlmProviderFqcn( "com.foo.BarNtlmProvider" );
+        mechanismHandlerMap.put(SupportedSaslMechanisms.NTLM, ntlmMechanismHandler);
+        mechanismHandlerMap.put(SupportedSaslMechanisms.GSS_SPNEGO, ntlmMechanismHandler);
+
+        ldapServer.setSaslMechanismHandlers(mechanismHandlerMap);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapLoginModuleTestCase.java
@@ -1,0 +1,396 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.loginmodules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.security.common.AbstractLoginModuleStackServerSetupTask;
+import org.jboss.as.test.integration.security.common.LDAPServerSetupTask;
+import org.jboss.as.test.integration.security.loginmodules.common.servlets.AbstractLoginModuleTestServlet;
+import org.jboss.as.test.integration.security.loginmodules.common.servlets.SecuredLdapLoginModuleTestServlet;
+import org.jboss.as.test.integration.security.loginmodules.common.servlets.SimpleUnsecuredServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A LdapLoginModuleTestCase.
+ * 
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ LdapLoginModuleTestCase.LDAPSetup.class, LdapLoginModuleTestCase.SecurityDomainSetup.class })
+@RunAsClient
+public class LdapLoginModuleTestCase {
+
+    private static Logger LOGGER = Logger.getLogger(LdapLoginModuleTestCase.class);
+
+    private static String SECURITY_DOMAIN_NAME = "LDAP-test";
+
+    private static int LDAP_PORT = 1389;
+
+    private static final String INITIAL_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    private static final String SEARCH_BASE = "dc=jboss,dc=org";
+    private static final String SECURITY_AUTHENTICATION = "simple";
+    private static final String SECURITY_CREDENTIALS = "secret";
+    private static final String SECURITY_PRINCIPAL = "uid=admin,ou=system";
+
+    @ArquillianResource
+    URL webAppURL;
+
+    @ArquillianResource
+    ManagementClient mgmtClient;
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     * Creates {@link WebArchive} with the {@link OKServlet}.
+     * 
+     * @return
+     * @throws SQLException
+     */
+    @Deployment
+    public static WebArchive deployment() {
+        LOGGER.info("start deployment");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "ldap-login-module.war");
+        war.addClasses(SecuredLdapLoginModuleTestServlet.class, SimpleUnsecuredServlet.class,
+                AbstractLoginModuleTestServlet.class);
+        war.addAsWebInfResource(LdapLoginModuleTestCase.class.getPackage(), "web-basic-authn.xml", "web.xml");
+        war.addAsWebInfResource(new StringAsset("<jboss-web><security-domain>" + SECURITY_DOMAIN_NAME
+                + "</security-domain></jboss-web>"), "jboss-web.xml");
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(war.toString(true));
+        }
+        return war;
+    }
+
+    /**
+     * Correct login
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSuccesfullAuth() throws Exception {
+        final String urlAsString = webAppURL.toExternalForm() + SecuredLdapLoginModuleTestServlet.SERVLET_PATH;
+        LOGGER.info("Testing successfull authentication - " + urlAsString);
+        final String responseBody = getResponse(urlAsString, "jduke", "theduke", 200);
+        assertEquals("Expected response body doesn't match the returned one.", AbstractLoginModuleTestServlet.RESPONSE_BODY,
+                responseBody);
+    }
+
+    /**
+     * Incorrect login
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUnsucessfulAuthn() throws Exception {
+        final String urlAsString = webAppURL.toExternalForm() + SecuredLdapLoginModuleTestServlet.SERVLET_PATH;
+        LOGGER.info("Testing failed authentication - " + urlAsString);
+        getResponse(urlAsString, "anil", "theduke", 401);
+        getResponse(urlAsString, "jduke", "anil", 401);
+        getResponse(urlAsString, "anil", "anil", 401);
+    }
+
+    /**
+     * Correct login, but without permissions.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUnsucessfulAuthz() throws Exception {
+        final String urlAsString = webAppURL.toExternalForm() + SecuredLdapLoginModuleTestServlet.SERVLET_PATH;
+        LOGGER.info("Testing failed authorization - " + urlAsString);
+        getResponse(urlAsString, "tester", "password", 403);
+    }
+
+    /**
+     * Incorrect login
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUnsecured() throws Exception {
+        final String urlAsString = webAppURL.toExternalForm() + SimpleUnsecuredServlet.SERVLET_PATH;
+        LOGGER.info("Testing access to unprotected resource - " + urlAsString);
+        final String responseBody = getResponse(urlAsString, null, null, 200);
+        assertEquals("Expected response body doesn't match the returned one.", AbstractLoginModuleTestServlet.RESPONSE_BODY,
+                responseBody);
+    }
+
+    /**
+     * Tests ability to connect to a LDAP server.
+     * 
+     * @throws NamingException
+     */
+    @Test
+    public void testLDAPReady() throws NamingException {
+        final DirContext ctx = createDirContext();
+
+        final String searchBase = SEARCH_BASE;
+        final SearchControls sc = new SearchControls();
+        sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+        final String filter = "(objectClass=person)";
+        assertTrue(ctx.search(searchBase, filter, sc).hasMore());
+        ctx.close();
+    }
+
+    /**
+     * Returns initialized DirContext.
+     * 
+     * @return initialized {@link DirContext}
+     * @throws NamingException if creating of {@link DirContext} fails
+     */
+    private DirContext createDirContext() throws NamingException {
+        final Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, INITIAL_CONTEXT_FACTORY);
+        env.put(Context.PROVIDER_URL, getLDAPProviderUrl(mgmtClient));
+        env.put(Context.SECURITY_AUTHENTICATION, SECURITY_AUTHENTICATION);
+        env.put(Context.SECURITY_PRINCIPAL, SECURITY_PRINCIPAL);
+
+        if (LOGGER.isDebugEnabled()) {
+            env.put(Context.SECURITY_CREDENTIALS, "***");
+            LOGGER.debug("Creating InitialDirContext: " + env);
+        }
+
+        env.put(Context.SECURITY_CREDENTIALS, SECURITY_CREDENTIALS);
+        final DirContext ctx = new InitialDirContext(env);
+        return ctx;
+    }
+
+    /**
+     * Returns URL of the LDAP server.
+     * 
+     * @return
+     */
+    private static String getLDAPProviderUrl(final ManagementClient mgmtClient) {
+        return "ldap://" + mgmtClient.getMgmtAddress() + ":" + LDAP_PORT;
+    }
+
+    /**
+     * Returns response body to the given URL as a String. It also checks if the returned HTTP status code is the expected one.
+     * If the server returns {@link HttpServletResponse#SC_UNAUTHORIZED}, then a new request is created with the provided
+     * credentials.
+     * 
+     * @param url
+     * @param user
+     * @param pass
+     * @param expectedStatusCode
+     * @return
+     * @throws ClientProtocolException
+     * @throws IOException
+     */
+    public String getResponse(String url, String user, String pass, int expectedStatusCode) throws ClientProtocolException,
+            IOException {
+        final DefaultHttpClient httpClient = new DefaultHttpClient();
+        try {
+            final HttpGet httpget = new HttpGet(url);
+
+            HttpResponse response = httpClient.execute(httpget);
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (HttpServletResponse.SC_UNAUTHORIZED != statusCode) {
+                assertEquals("Unexpected HTTP response status code.", expectedStatusCode, statusCode);
+                return EntityUtils.toString(response.getEntity());
+            }
+            HttpEntity entity = response.getEntity();
+            if (entity != null)
+                EntityUtils.consume(entity);
+
+            final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(user, pass);
+            httpClient.getCredentialsProvider().setCredentials(new AuthScope(webAppURL.getHost(), webAppURL.getPort()),
+                    credentials);
+
+            response = httpClient.execute(httpget);
+            statusCode = response.getStatusLine().getStatusCode();
+            assertEquals("Unexpected status code returned after the authentication.", expectedStatusCode, statusCode);
+            return EntityUtils.toString(response.getEntity());
+        } finally {
+            // When HttpClient instance is no longer needed,
+            // shut down the connection manager to ensure
+            // immediate deallocation of all system resources
+            httpClient.getConnectionManager().shutdown();
+        }
+    }
+
+    // Embedded classes ------------------------------------------------------
+
+    /**
+     * A LDAPSetup.
+     * 
+     * @author Josef Cacek
+     */
+    static class LDAPSetup extends LDAPServerSetupTask {
+
+        /**
+         * @see org.jboss.qa.security.ldap.loginmodule.LDAPServerSetupTask#configureLdapServer()
+         */
+        @Override
+        protected void configureLdapServer() throws Exception {
+            super.configureLdapServer();
+            LOGGER.info("Importing LDIF file.");
+            importLdif(LdapLoginModuleTestCase.class.getResourceAsStream("LdapLoginModuleTestCase.ldif"));
+        }
+
+        /**
+         * @see org.jboss.qa.security.ldap.loginmodule.LDAPServerSetupTask#configureDirectoryService()
+         */
+        @Override
+        protected void configureDirectoryService() throws Exception {
+            super.configureDirectoryService();
+            LOGGER.info("Creating 'jboss' DirectoryService partition.");
+            addPartition("jboss", "dc=jboss,dc=org");
+        }
+
+        /**
+         * @see org.jboss.qa.security.ldap.loginmodule.LDAPServerSetupTask#getPort()
+         */
+        @Override
+        protected int getPort() {
+            return LDAP_PORT;
+        }
+
+    }
+
+    /**
+     * A SecurityDomainSetup.
+     */
+    static class SecurityDomainSetup extends AbstractLoginModuleStackServerSetupTask {
+
+        /**
+         * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup#getSecurityDomainName()
+         */
+        @Override
+        protected String getSecurityDomainName() {
+            return SECURITY_DOMAIN_NAME;
+        }
+
+        /**
+         * @see org.jboss.as.test.integration.security.common.AbstractLoginModuleStackServerSetupTask#getLoginModuleConfigurations()
+         */
+        @Override
+        protected LoginModuleConfiguration[] getLoginModuleConfigurations() {
+            LoginModuleConfiguration ldapLoginModule = new LoginModuleConfiguration() {
+
+                public String getName() {
+                    return "Ldap";
+                }
+
+                public String getFlag() {
+                    return "sufficient";
+                }
+
+                public Map<String, String> getOptions() {
+                    Map<String, String> moduleOptions = new HashMap<String, String>();
+
+                    //InitialContextFactory implementation class name. This defaults to the Sun LDAP provider implementation com.sun.jndi.ldap.LdapCtxFactory.
+                    moduleOptions.put("java.naming.factory.initial", INITIAL_CONTEXT_FACTORY);
+
+                    //LDAP URL for the LDAP server.
+                    moduleOptions.put("java.naming.provider.url", getLDAPProviderUrl(managementClient));
+
+                    //Security level to use. This defaults to simple.
+                    moduleOptions.put("java.naming.security.authentication", SECURITY_AUTHENTICATION);
+
+                    //Transport protocol to use for secure access, such as, SSL.
+                    //            moduleOptions.put("java.naming.security.protocol","");
+
+                    //Principal for authenticating the caller to the service. This is built from other properties as described below.
+                    moduleOptions.put("java.naming.security.principal", SECURITY_PRINCIPAL);
+
+                    //Authentication scheme to use. For example, hashed password, clear-text password, key, certificate, and so on.
+                    moduleOptions.put("java.naming.security.credentials", SECURITY_CREDENTIALS);
+
+                    //Prefix added to the username to form the user distinguished name. See principalDNSuffix for more info.
+                    moduleOptions.put("principalDNPrefix", "uid=");
+
+                    //Suffix added to the username when forming the user distinguished name. This is useful if you prompt a user for a username and you don't want the user to have to enter the fully distinguished name. Using this property and principalDNSuffix the userDN will be formed as principalDNPrefix + username + principalDNSuffix
+                    moduleOptions.put("principalDNSuffix", ",ou=People,dc=jboss,dc=org");
+
+                    //Value that indicates the credential should be obtained as an opaque Object using the org.jboss.security.auth.callback.ObjectCallback type of Callback rather than as a char[] password using a JAAS PasswordCallback. This allows for passing non-char[] credential information to the LDAP server. The available values are true and false.
+                    //            moduleOptions.put("useObjectCredential","");
+
+                    //Fixed, distinguished name to the context to search for user roles.
+                    moduleOptions.put("rolesCtxDN", "ou=Roles,dc=jboss,dc=org");
+
+                    //Name of an attribute in the user object that contains the distinguished name to the context to search for user roles. This differs from rolesCtxDN in that the context to search for a user's roles can be unique for each user.
+                    //            moduleOptions.put("userRolesCtxDNAttributeName","");
+
+                    //Name of the attribute containing the user roles. If not specified, this defaults to roles.
+                    //            moduleOptions.put("roleAttributeID","");            
+
+                    // Flag indicating whether the roleAttributeID contains the fully distinguished name of a role object, or the role name. The role name is taken from the value of the roleNameAttributeId attribute of the context name by the distinguished name.
+                    //If true, the role attribute represents the distinguished name of a role object. If false, the role name is taken from the value of roleAttributeID. The default is false.
+                    //Note: In certain directory schemas (e.g., MS ActiveDirectory), role attributes in the user object are stored as DNs to role objects instead of simple names. For implementations that use this schema type, roleAttributeIsDN must be set to true.
+                    moduleOptions.put("roleAttributeIsDN", "false");
+
+                    // Name of the attribute containing the user roles. If not specified, this defaults to roles.
+                    moduleOptions.put("roleAttributeID", "cn");
+
+                    //Name of the attribute in the object containing the user roles that corresponds to the userid. This is used to locate the user roles. If not specified this defaults to uid.
+                    moduleOptions.put("uidAttributeID", "member");
+
+                    //Flag that specifies whether the search for user roles should match on the user's fully distinguished name. If true, the full userDN is used as the match value. If false, only the username is used as the match value against the uidAttributeName attribute. The default value is false.
+                    moduleOptions.put("matchOnUserDN", "true");
+
+                    //A flag indicating if empty (length 0) passwords should be passed to the LDAP server. An empty password is treated as an anonymous login by some LDAP servers and this may not be a desirable feature. To reject empty passwords, set this to false. If set to true, the LDAP server will validate the empty password. The default is true.
+                    //            moduleOptions.put("allowEmptyPasswords","");
+                    return moduleOptions;
+                }
+
+            };
+            return new LoginModuleConfiguration[] { ldapLoginModule };
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapLoginModuleTestCase.ldif
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapLoginModuleTestCase.ldif
@@ -1,0 +1,41 @@
+dn: dc=jboss,dc=org
+objectclass: top
+objectclass: dcObject
+objectclass: organization
+dc: jboss
+o: JBoss
+
+dn: ou=People,dc=jboss,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: People
+
+dn: uid=jduke,ou=People,dc=jboss,dc=org
+objectclass: top
+objectclass: uidObject
+objectclass: person
+uid: jduke
+cn: Java Duke
+sn: Duke
+userPassword: theduke
+
+dn: uid=tester,ou=People,dc=jboss,dc=org
+objectclass: top
+objectclass: uidObject
+objectclass: person
+uid: tester
+cn: Tester Testerovic
+sn: Testerovic
+userPassword: password
+
+dn: ou=Roles,dc=jboss,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: Roles
+
+dn: cn=JBossAdmin,ou=Roles,dc=jboss,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: JBossAdmin
+member: uid=jduke,ou=People,dc=jboss,dc=org
+description: the JBossAdmin group

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/servlets/AbstractLoginModuleTestServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/servlets/AbstractLoginModuleTestServlet.java
@@ -21,25 +21,42 @@
  */
 package org.jboss.as.test.integration.security.loginmodules.common.servlets;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.Writer;
 
 /**
+ * Abstract simple servlet class which implements {@link #doGet(HttpServletRequest, HttpServletResponse)} method and writes a
+ * plain-text response ({@link #RESPONSE_BODY}).
+ * 
  * @author Jan Lanik
- *         <p/>
- *         Servlet class to be used in DatabaseLoginModule test cases
+ * 
  */
 public abstract class AbstractLoginModuleTestServlet extends HttpServlet {
 
-   private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-   @Override
-   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-      Writer writer = resp.getWriter();
-      writer.write("GOOD");
-   }
+    /** The String returned in the HTTP response body. */
+    public static final String RESPONSE_BODY = "GOOD";
+
+    /**
+     * Writes simple text response.
+     * 
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        writer.write(RESPONSE_BODY);
+        writer.close();
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/servlets/SecuredLdapLoginModuleTestServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/servlets/SecuredLdapLoginModuleTestServlet.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.loginmodules.common.servlets;
+
+import javax.annotation.security.DeclareRoles;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+
+/**
+ * A SecuredLdapLoginModuleTestServlet.
+ * 
+ * @author Josef Cacek
+ */
+@DeclareRoles({ "JBossAdmin" })
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "JBossAdmin" }))
+@WebServlet(SecuredLdapLoginModuleTestServlet.SERVLET_PATH)
+public class SecuredLdapLoginModuleTestServlet extends AbstractLoginModuleTestServlet {
+
+    /** The serialVersionUID */
+    private static final long serialVersionUID = 1L;
+    public static final String SERVLET_PATH = "/ldapTest";
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/servlets/SimpleUnsecuredServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/servlets/SimpleUnsecuredServlet.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.loginmodules.common.servlets;
+
+import javax.servlet.annotation.WebServlet;
+
+/**
+ * A simple servlet that just writes back a string.
+ * 
+ * @author Josef Cacek
+ * @see AbstractLoginModuleTestServlet#RESPONSE_BODY
+ */
+@WebServlet(urlPatterns = { SimpleUnsecuredServlet.SERVLET_PATH })
+public class SimpleUnsecuredServlet extends AbstractLoginModuleTestServlet {
+    private static final long serialVersionUID = 1L;
+    public static final String SERVLET_PATH = "/unsecured";
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/web-basic-authn.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/web-basic-authn.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">  
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>Test realm</realm-name>
+  </login-config>
+  
+</web-app>


### PR DESCRIPTION
JBQA-5135 PicketBox Integration: Login modules tests. New test was added - LdapLoginModuleTestCase. The test introduces a new dependency on ApacheDS, which allows to use embedded LDAP server within the tests.
