### PR TITLE
fixing TimeoutUtil

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TimeoutUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TimeoutUtil.java
@@ -28,6 +28,7 @@ package org.jboss.as.test.shared;
  *
  * @author Ondrej Zizka
  * @author Radoslav Husar
+ * @author Jan Lanik
  */
 public class TimeoutUtil {
 
@@ -44,7 +45,21 @@ public class TimeoutUtil {
      * @return given timeout adjusted by ratio from system property "ts.timeout.factor"
      */
     public static int adjust(int amount) {
-        return amount * factor / 100;
+       if(amount<0){
+          throw new IllegalArgumentException("amount must be non-negative");
+       }
+       int numerator = amount * factor;
+       int finalTimeout;
+       if(numerator % 100 == 0){
+          //in this case there is no lost of accuracy in integer division
+          finalTimeout = numerator / 100;
+       } else {
+          /*in this case there is a lost of accuracy. It's better to round the result up beacuse
+          if we round down, we would get 0 in case that amount<100.
+           */
+          finalTimeout = (numerator / 100) + 1;
+       }
+        return finalTimeout;
     }
 
     /**
@@ -53,7 +68,7 @@ public class TimeoutUtil {
      * @return double factor value
      */
     public static double getFactor() {
-        return factor / 100;
+        return (double)factor / 100;
     }
 
     /**


### PR DESCRIPTION
I fixed following problems in Timeout Utility class:

-no sanity check in adjust()
-potentially erroneous behaviour of adjust() for arguments below 100.
-a significant lost of accuracy in getFactor() 
