### PR TITLE
[AS7-4218] When an authentication is handled first using pure SASL we ne...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/security/UniqueIdUserInfo.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/UniqueIdUserInfo.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.security;
+
+/**
+ * An interface to be implement by UserInfo implementations where a unique identifier
+ * is needed to represent that UserInfo.
+ *
+ * The purpose of this ID is to act as the credential when transitioning from one
+ * authentication mechanism to the next e.g. from SASL to JAAS.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface UniqueIdUserInfo {
+
+    String getId();
+
+}

--- a/remoting/src/main/java/org/jboss/as/remoting/RealmSecurityProvider.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RealmSecurityProvider.java
@@ -38,6 +38,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.Subject;
@@ -50,6 +51,7 @@ import javax.security.sasl.AuthorizeCallback;
 import javax.security.sasl.RealmCallback;
 
 import org.jboss.as.controller.security.SubjectUserInfo;
+import org.jboss.as.controller.security.UniqueIdUserInfo;
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.as.domain.management.security.DomainCallbackHandler;
 import org.jboss.as.domain.management.security.RealmUser;
@@ -445,32 +447,34 @@ public class RealmSecurityProvider implements RemotingSecurityProvider {
         }
     }
 
-    private static class RealmSubjectUserInfo implements SubjectUserInfo, UserInfo {
+    private static class RealmSubjectUserInfo implements SubjectUserInfo, UserInfo, UniqueIdUserInfo {
 
         private final String userName;
         private final Subject subject;
+        private final String id;
 
         private RealmSubjectUserInfo(Subject subject) {
             this.subject = subject;
             Set<RealmUser> userPrinc = subject.getPrincipals(RealmUser.class);
             userName = userPrinc.isEmpty() ? null : userPrinc.iterator().next().getName();
+            id = UUID.randomUUID().toString();
         }
 
         public String getUserName() {
             return userName;
         }
 
-        @Override
         public Collection<Principal> getPrincipals() {
             return subject.getPrincipals();
         }
 
-        @Override
         public Subject getSubject() {
             return subject;
         }
 
-
+        public String getId() {
+            return id;
+        }
 
     }
 

--- a/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -39,6 +39,7 @@ import javax.security.auth.Subject;
 
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.controller.security.SubjectUserInfo;
+import org.jboss.as.controller.security.UniqueIdUserInfo;
 import org.jboss.as.domain.management.security.PasswordCredential;
 import org.jboss.as.security.SecurityMessages;
 import org.jboss.as.security.remoting.RemotingContext;
@@ -268,7 +269,16 @@ public class SimpleSecurityManager implements ServerSecurityManager {
                         credential = new String(pc.getCredential());
                         RemotingContext.clear(); // Now that it has been used clear it.
                     }
+                    if ((p == null || credential == null) && userInfo instanceof UniqueIdUserInfo) {
+                        UniqueIdUserInfo uinfo = (UniqueIdUserInfo) userInfo;
+                        p = new SimplePrincipal(sinfo.getUserName());
+                        credential = uinfo.getId();
+                        // In this case we do not clear the RemotingContext as it is still to be used
+                        // here extracting the ID just ensures we are not continually calling the modules
+                        // for each invocation.
+                    }
                 }
+
                 if (p == null || credential == null) {
                     p = new SimplePrincipal(UUID.randomUUID().toString());
                     credential = UUID.randomUUID().toString();


### PR DESCRIPTION
...ed to make better use of the JAAS

based authentication cache - we don't have access to a genuine credential to use in the cache so we use one
specific to the connection of the user.
