### PR TITLE
Add deploy/undeploy dialogs to CLI GUI

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
@@ -34,21 +34,15 @@ import org.jboss.dmr.ModelNode;
 public class CommandExecutor {
 
     private ModelControllerClient client;
-    private DefaultCallbackHandler parsedCmd = new DefaultCallbackHandler(true);
     private CommandContext cmdCtx;
-    private CommandLineParser parser;
 
     public CommandExecutor(CommandContext cmdCtx) {
         this.cmdCtx = cmdCtx;
         this.client = cmdCtx.getModelControllerClient();
-        this.parser = cmdCtx.getCommandLineParser();
     }
 
     public synchronized ModelNode doCommand(String command) throws CommandFormatException, IOException {
-//        System.out.println("command=" + command);
-        parsedCmd.rootNode(0);
-        parser.parse(command, parsedCmd);
-        ModelNode request = parsedCmd.toOperationRequest(cmdCtx);
+        ModelNode request = cmdCtx.buildRequest(command);
         return client.execute(request);
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
@@ -21,8 +21,6 @@ package org.jboss.as.cli.gui;
 import java.io.IOException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
-import org.jboss.as.cli.operation.CommandLineParser;
-import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;
 
@@ -41,9 +39,48 @@ public class CommandExecutor {
         this.client = cmdCtx.getModelControllerClient();
     }
 
+    /**
+     * Submit a command to the server.
+     *
+     * @param command The CLI command
+     * @return The DMR response as a ModelNode
+     * @throws CommandFormatException
+     * @throws IOException
+     */
     public synchronized ModelNode doCommand(String command) throws CommandFormatException, IOException {
         ModelNode request = cmdCtx.buildRequest(command);
         return client.execute(request);
+    }
+
+    public synchronized Response doCommandFullResponse(String command) throws CommandFormatException, IOException {
+        ModelNode request = cmdCtx.buildRequest(command);
+        ModelNode response = client.execute(request);
+        return new Response(command, request, response);
+    }
+
+    public static class Response {
+        private String command;
+        private ModelNode dmrRequest;
+        private ModelNode dmrResponse;
+
+        Response(String command, ModelNode dmrRequest, ModelNode dmrResponse) {
+            this.command = command;
+            this.dmrRequest = dmrRequest;
+            this.dmrResponse = dmrResponse;
+        }
+
+        public String getCommand() {
+            return command;
+        }
+
+        public ModelNode getDmrRequest() {
+            return dmrRequest;
+        }
+
+        public ModelNode getDmrResponse() {
+            return dmrResponse;
+        }
+
     }
 
 }

--- a/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
@@ -18,6 +18,7 @@
  */
 package org.jboss.as.cli.gui;
 
+import java.awt.Cursor;
 import java.io.IOException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
@@ -49,13 +50,24 @@ public class CommandExecutor {
      */
     public synchronized ModelNode doCommand(String command) throws CommandFormatException, IOException {
         ModelNode request = cmdCtx.buildRequest(command);
-        return client.execute(request);
+        return execute(command, request);
     }
 
     public synchronized Response doCommandFullResponse(String command) throws CommandFormatException, IOException {
         ModelNode request = cmdCtx.buildRequest(command);
-        ModelNode response = client.execute(request);
+        ModelNode response = execute(command, request);
         return new Response(command, request, response);
+    }
+
+    private ModelNode execute(String command, ModelNode request) throws IOException {
+        try {
+            if (command.startsWith("deploy")) {
+                GuiMain.getMainWindow().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+            }
+            return client.execute(request);
+        } finally {
+            GuiMain.getMainWindow().setCursor(Cursor.getDefaultCursor());
+        }
     }
 
     public static class Response {

--- a/cli/src/main/java/org/jboss/as/cli/gui/CommandLine.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/CommandLine.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
+import javax.swing.text.JTextComponent;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class CommandLine extends JPanel {
+    private static final String SUBMIT_ACTION = "submit-action";
+
+    private JTextArea cmdText = new JTextArea();
+    private JCheckBox isVerbose = new JCheckBox("Verbose");
+    private JButton submitButton = new JButton("Submit");
+
+    public CommandLine(DoOperationActionListener opListener) {
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridwidth = 1;
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.insets = new Insets(0,0,0,5);
+        add(new JLabel("cmd>"), gbc);
+        cmdText.setText("/");
+        cmdText.setLineWrap(true);
+        cmdText.setRows(1);
+
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 100.0;
+        add(cmdText, gbc);
+
+        KeyStroke enterKey = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0, false);
+        cmdText.getInputMap().put(enterKey, SUBMIT_ACTION);
+        cmdText.getActionMap().put(SUBMIT_ACTION, opListener);
+
+        JPanel submitPanel = new JPanel(new GridLayout(2,1));
+        submitButton.addActionListener(opListener);
+        submitButton.setToolTipText("Submit the command to the server.");
+        submitPanel.add(submitButton);
+
+        isVerbose.setToolTipText("Show the command's DMR request.");
+        submitPanel.add(isVerbose);
+
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.anchor = GridBagConstraints.SOUTHEAST;
+        gbc.weightx = 1.0;
+        add(submitPanel, gbc);
+    }
+
+    public boolean isVerbose() {
+        return isVerbose.isSelected();
+    }
+
+    public JTextComponent getCmdText() {
+        return this.cmdText;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/DoOperationActionListener.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/DoOperationActionListener.java
@@ -24,14 +24,12 @@ import java.util.LinkedList;
 import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.JTabbedPane;
-import javax.swing.JTextField;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
-import org.jboss.dmr.ModelNode;
 
 /**
  * This class executes whatever command is on the command line.
@@ -44,7 +42,6 @@ public class DoOperationActionListener extends AbstractAction {
 
     private CommandExecutor executor;
 
-    private JTextField cmdText;
     private JTextComponent output;
     private JTabbedPane tabs;
 
@@ -52,17 +49,16 @@ public class DoOperationActionListener extends AbstractAction {
 
     public DoOperationActionListener(JTextComponent output, JTabbedPane tabs) {
         this.executor = GuiMain.getExecutor();
-        this.cmdText = GuiMain.getCommandText();
         this.output = output;
         this.tabs = tabs;
     }
 
     public void actionPerformed(ActionEvent ae) {
-        String command = cmdText.getText();
+        String command = GuiMain.getCommandLine().getCmdText().getText();
         try {
             cmdHistory.push(command);
-            ModelNode result = executor.doCommand(command);
-            postOutput(command, result.toString());
+            CommandExecutor.Response response = executor.doCommandFullResponse(command);
+            postOutput(response);
         } catch (Exception e) {
             try {
                 postOutput(command, e.getMessage());
@@ -78,9 +74,24 @@ public class DoOperationActionListener extends AbstractAction {
         return Collections.unmodifiableList(this.cmdHistory);
     }
 
+    private void postOutput(CommandExecutor.Response response) throws BadLocationException {
+        boolean verbose = GuiMain.getCommandLine().isVerbose();
+        if (verbose) {
+            postVerboseOutput(response);
+        } else {
+            postOutput(response.getCommand(), response.getDmrResponse().toString());
+        }
+    }
+
     private void postOutput(String command, String response) throws BadLocationException {
         processOutput(response + "\n\n", null);
         processBoldOutput(command + "\n");
+    }
+
+    private void postVerboseOutput(CommandExecutor.Response response) throws BadLocationException {
+        processOutput(response.getDmrResponse().toString() + "\n\n", null);
+        processOutput(response.getDmrRequest().toString() + "\n\n", null);
+        processBoldOutput(response.getCommand() + "\n");
     }
 
     private void processBoldOutput(String text) throws BadLocationException {

--- a/cli/src/main/java/org/jboss/as/cli/gui/GuiMain.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/GuiMain.java
@@ -21,6 +21,7 @@ package org.jboss.as.cli.gui;
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -34,9 +35,11 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextPane;
+import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.gui.metacommand.DeployAction;
+import org.jboss.as.cli.gui.metacommand.UndeployAction;
 
 /**
  * Static main class for the GUI.
@@ -69,8 +72,8 @@ public class GuiMain {
      * Get the singleton JFrame instance for the GUI
      * @return The JFrame
      */
-    public static JFrame getFrame() {
-        return frame;
+    public static Window getMainWindow() {
+        return SwingUtilities.getWindowAncestor(mainPanel);
     }
 
     /**
@@ -131,6 +134,10 @@ public class GuiMain {
         JMenuItem deploy = new JMenuItem(new DeployAction());
         deploy.setMnemonic(KeyEvent.VK_D);
         metaCmdMenu.add(deploy);
+
+        JMenuItem unDeploy = new JMenuItem(new UndeployAction());
+        deploy.setMnemonic(KeyEvent.VK_U);
+        metaCmdMenu.add(unDeploy);
 
         return menuBar;
     }

--- a/cli/src/main/java/org/jboss/as/cli/gui/ManagementModel.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/ManagementModel.java
@@ -41,11 +41,9 @@ import javax.swing.tree.TreeSelectionModel;
  */
 public class ManagementModel extends JPanel {
 
-    private JTextField cmdText;
     private CommandExecutor executor;
 
     public ManagementModel() {
-        this.cmdText = GuiMain.getCommandText();
         this.executor = GuiMain.getExecutor();
         setLayout(new BorderLayout(10,10));
         add(new JLabel("Right-click a node to choose an operation.  Close/Open a folder to refresh.  Hover for help."), BorderLayout.NORTH);
@@ -91,7 +89,7 @@ public class ManagementModel extends JPanel {
 
         public void valueChanged(TreeSelectionEvent tse) {
             ManagementModelNode selected = (ManagementModelNode) tse.getPath().getLastPathComponent();
-            cmdText.setText(selected.addressPath());
+            GuiMain.getCommandLine().getCmdText().setText(selected.addressPath());
         }
     }
 
@@ -105,7 +103,7 @@ public class ManagementModel extends JPanel {
 
         public ManagementTreeMouseListener(JTree tree) {
             this.tree = tree;
-            this.popup = new OperationMenu(executor, tree, cmdText);
+            this.popup = new OperationMenu(executor, tree);
         }
 
         @Override

--- a/cli/src/main/java/org/jboss/as/cli/gui/OperationDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/OperationDialog.java
@@ -20,6 +20,7 @@ package org.jboss.as.cli.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
+import java.awt.Dialog;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -59,7 +60,7 @@ public class OperationDialog extends JDialog {
     private SortedSet<RequestProp> props;
 
     public OperationDialog(ManagementModelNode node, String opName, String strDescription, ModelNode requestProperties) {
-        super(GuiMain.getFrame(), opName, true);
+        super(GuiMain.getMainWindow(), opName, Dialog.ModalityType.APPLICATION_MODAL);
         this.node = node;
         this.opName = opName;
 

--- a/cli/src/main/java/org/jboss/as/cli/gui/OperationDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/OperationDialog.java
@@ -198,9 +198,10 @@ public class OperationDialog extends JDialog {
             command.append(OperationDialog.this.opName);
             addRequestProps(command, OperationDialog.this.props);
 
-            GuiMain.getCommandText().setText(command.toString());
+            JTextComponent cmdText = GuiMain.getCommandLine().getCmdText();
+            cmdText.setText(command.toString());
             OperationDialog.this.dispose();
-            GuiMain.getCommandText().requestFocus();
+            cmdText.requestFocus();
         }
 
         private void addRequestProps(StringBuilder command, SortedSet<RequestProp> reqProps) {

--- a/cli/src/main/java/org/jboss/as/cli/gui/OperationMenu.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/OperationMenu.java
@@ -24,8 +24,8 @@ import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JPopupMenu;
-import javax.swing.JTextField;
 import javax.swing.JTree;
+import javax.swing.text.JTextComponent;
 import org.jboss.as.cli.gui.ManagementModelNode.UserObject;
 import org.jboss.dmr.ModelNode;
 
@@ -42,12 +42,10 @@ public class OperationMenu extends JPopupMenu {
 
     private CommandExecutor executor;
     private JTree invoker;
-    private JTextField cmdText;
 
-    public OperationMenu(CommandExecutor executor, JTree invoker, JTextField cmdText) {
+    public OperationMenu(CommandExecutor executor, JTree invoker) {
         this.executor = executor;
         this.invoker = invoker;
-        this.cmdText = cmdText;
         setLightWeightPopupEnabled(true);
         setOpaque(true);
     }
@@ -117,6 +115,7 @@ public class OperationMenu extends JPopupMenu {
         }
 
         public void actionPerformed(ActionEvent ae) {
+            JTextComponent cmdText = GuiMain.getCommandLine().getCmdText();
             ModelNode requestProperties = opDescription.get("result", "request-properties");
             if ((requestProperties == null) || (!requestProperties.isDefined()) || requestProperties.asList().isEmpty()) {
                 cmdText.setText(addressPath + ":" + opName);

--- a/cli/src/main/java/org/jboss/as/cli/gui/OperationMenu.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/OperationMenu.java
@@ -131,7 +131,7 @@ public class OperationMenu extends JPopupMenu {
             }
 
             OperationDialog dialog = new OperationDialog(node, opName, strDescription, requestProperties);
-            dialog.setLocationRelativeTo(GuiMain.getFrame());
+            dialog.setLocationRelativeTo(GuiMain.getMainWindow());
             dialog.setVisible(true);
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/gui/SelectPreviousOpMouseAdapter.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/SelectPreviousOpMouseAdapter.java
@@ -36,13 +36,11 @@ import javax.swing.text.Utilities;
  */
 public class SelectPreviousOpMouseAdapter extends MouseAdapter implements ClipboardOwner {
     private JTextPane output;
-    private JTextField cmdText;
     private DoOperationActionListener opListener;
     private Clipboard systemClipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
-    public SelectPreviousOpMouseAdapter(JTextPane output, JTextField cmdText, DoOperationActionListener opListener) {
+    public SelectPreviousOpMouseAdapter(JTextPane output, DoOperationActionListener opListener) {
         this.output = output;
-        this.cmdText = cmdText;
         this.opListener = opListener;
     }
 
@@ -58,7 +56,7 @@ public class SelectPreviousOpMouseAdapter extends MouseAdapter implements Clipbo
             String line = output.getDocument().getText(rowStart, rowEnd - rowStart);
             if (opListener.getCmdHistory().contains(line)) {
                 output.select(rowStart, rowEnd);
-                cmdText.setText(line);
+                GuiMain.getCommandLine().getCmdText().setText(line);
                 systemClipboard.setContents(new StringSelection(line), this);
             }
         } catch (BadLocationException e) {

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/DeploymentChooser.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/DeploymentChooser.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.component;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.swing.ButtonGroup;
+import javax.swing.ButtonModel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.border.TitledBorder;
+import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class DeploymentChooser extends JPanel {
+
+    private ButtonGroup deploymentsButtonGroup = new ButtonGroup();
+    private JPanel deploymentsPanel = new JPanel(new FlowLayout());
+
+    public DeploymentChooser() {
+        setLayout(new BorderLayout());
+        setBorder(new TitledBorder("Deployments"));
+        setDeployments();
+        add(deploymentsPanel, BorderLayout.CENTER);
+    }
+
+    private void setDeployments() {
+        Set<String> deploymentNames = new TreeSet<String>();
+        try {
+            ModelNode deploymentsQuery = GuiMain.getExecutor().doCommand("/:read-children-names(child-type=deployment)");
+            if (deploymentsQuery.get("outcome").asString().equals("failed")) return;
+
+            for (ModelNode node : deploymentsQuery.get("result").asList()) {
+                deploymentNames.add(node.asString());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        for (String name : deploymentNames) {
+            JRadioButton deploymentRadioButton = new JRadioButton(name);
+            deploymentsButtonGroup.add(deploymentRadioButton);
+
+            // set first as selected
+            if (deploymentsButtonGroup.getButtonCount() == 1) {
+                deploymentsButtonGroup.setSelected(deploymentRadioButton.getModel(), true);
+            }
+
+            deploymentsPanel.add(deploymentRadioButton);
+        }
+
+    }
+
+    /**
+     * Get the name of the selected deployment.
+     * @return The name or null if there are no deployments.
+     */
+    public String getSelectedDeployment() {
+        if (!hasDeployments()) return null;
+
+        ButtonModel model = deploymentsButtonGroup.getSelection();
+        Object[] selected = model.getSelectedObjects();
+        return ((JRadioButton)selected[0]).getText();
+    }
+
+    public boolean hasDeployments() {
+        return deploymentsButtonGroup.getButtonCount() > 0;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/DeploymentTable.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/DeploymentTable.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.component;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.util.List;
+import java.util.Vector;
+import javax.swing.DefaultCellEditor;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableModel;
+
+/**
+ * A JTable that displays all deployments for standalone or domain.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class DeploymentTable extends JTable {
+
+    private boolean isStandalone;
+
+    public DeploymentTable(TableModel dm, boolean isStandalone) {
+        super(dm);
+        this.isStandalone = isStandalone;
+
+        setRowHeight(30);
+        setAutoCreateRowSorter(true);
+
+        setDefaultRenderer(String.class,
+                new TableCellRenderer() {
+                    public Component getTableCellRendererComponent(JTable table,
+                            Object value,
+                            boolean isSelected,
+                            boolean hasFocus,
+                            int row,
+                            int column) {
+                        JLabel label = new JLabel((String)value);
+                        JPanel panel = new JPanel(new BorderLayout());
+                        panel.add(label, BorderLayout.CENTER);
+                        return panel;
+                    }
+                });
+
+        setDefaultRenderer(JRadioButton.class,
+                new TableCellRenderer() {
+                    public Component getTableCellRendererComponent(JTable table,
+                            Object value,
+                            boolean isSelected,
+                            boolean hasFocus,
+                            int row,
+                            int column) {
+                        return (JRadioButton) value;
+                    }
+                });
+
+        setDefaultRenderer(List.class,
+                new TableCellRenderer() {
+                    public Component getTableCellRendererComponent(JTable table,
+                            Object value,
+                            boolean isSelected,
+                            boolean hasFocus,
+                            int row,
+                            int column) {
+                        List<String> values = (List<String>)value;
+                        return new JComboBox(new Vector(values));
+                    }
+                });
+
+        setDefaultEditor(JRadioButton.class, new RadioButtonEditor(new JCheckBox()));
+        setDefaultEditor(List.class, new ComboBoxEditor());
+
+        setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    }
+
+    @Override
+    public Dimension getPreferredScrollableViewportSize() {
+        return new Dimension(700, 200);
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int column) {
+        if (column == 0) return true;
+        if ((column == 2) && !isStandalone) return true;
+        return false;
+    }
+
+    @Override
+    public void editingStopped(ChangeEvent e) {
+        super.editingStopped(e);
+        repaint();
+    }
+
+    class ComboBoxEditor extends DefaultCellEditor {
+        ComboBoxEditor() {
+            super(new JComboBox());
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value,
+                boolean isSelected, int row, int column) {
+            return new JComboBox(new Vector((List)value));
+        }
+    }
+
+    class RadioButtonEditor extends DefaultCellEditor implements ItemListener {
+
+        private JRadioButton button;
+
+        public RadioButtonEditor(JCheckBox checkBox) {
+            super(checkBox);
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value,
+                boolean isSelected, int row, int column) {
+            if (value == null)  return null;
+
+            button = (JRadioButton) value;
+            button.addItemListener(this);
+            return (Component) value;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            button.removeItemListener(this);
+            return button;
+        }
+
+        public void itemStateChanged(ItemEvent e) {
+            super.fireEditingStopped();
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/DomainDeploymentTableModel.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/DomainDeploymentTableModel.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.component;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JRadioButton;
+import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A table model appropriate for deployments in a domain.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class DomainDeploymentTableModel extends StandaloneDeploymentTableModel {
+
+    public DomainDeploymentTableModel() {
+        super();
+        colNames = new String[] {"Name", "Runtime Name", "Assigned Server Groups"};
+        initializeServerGroups();
+        setServerGroups();
+    }
+
+    private void initializeServerGroups() {
+        for (Object[] deployment : data) {
+            deployment[2] = new ArrayList<String>();
+        }
+    }
+
+    private void setServerGroups() {
+        ModelNode deploymentsQuery = null;
+        String queryString = "/server-group=*/deployment=*/:read-resource";
+
+        try {
+            deploymentsQuery = GuiMain.getExecutor().doCommand(queryString);
+            if (deploymentsQuery.get("outcome").asString().equals("failed")) return;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        for (ModelNode node : deploymentsQuery.get("result").asList()) {
+            String serverGroup = node.get("address").asPropertyList().get(0).getValue().asString();
+            ModelNode deploymentNode = node.get("result"); // get the inner result
+
+            Object[] deployment = findDeployment(deploymentNode.get("name").asString());
+
+            List<String> serverGroups = (List<String>)deployment[2];
+
+            Boolean enabled = deploymentNode.get("enabled").asBoolean();
+            if (!enabled) serverGroup += " (disabled)";
+            serverGroups.add(serverGroup);
+        }
+    }
+
+    private Object[] findDeployment(String name) {
+        for (Object[] deployment : data) {
+            JRadioButton nameButton = (JRadioButton)deployment[0];
+            if (nameButton.getText().equals(name)) return deployment;
+        }
+
+        throw new IllegalStateException("Deployment " + name + " exists in server group but not in content repository.");
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        if (columnIndex == 0) return JRadioButton.class;
+        if (columnIndex == 2) return List.class;
+        return String.class;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/HelpButton.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/HelpButton.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.component;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.IOException;
+import java.io.InputStream;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JEditorPane;
+import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class HelpButton extends JButton {
+
+    private JScrollPane helpScroller;
+
+    public HelpButton(String helpFile) {
+        super("Help");
+        try {
+            readHelpFile(helpFile);
+        } catch (IOException e) {
+            JOptionPane.showMessageDialog(HelpButton.this, "Unable to read " + helpFile);
+            return;
+        }
+
+        addActionListener(new ActionListener() {
+
+            public void actionPerformed(ActionEvent e) {
+                JOptionPane helpPane = new JOptionPane(helpScroller, JOptionPane.PLAIN_MESSAGE, JOptionPane.DEFAULT_OPTION);
+                JDialog dialog = helpPane.createDialog(HelpButton.this, "Help");
+                dialog.setResizable(true);
+                dialog.setModal(false);
+                dialog.setSize(dialog.getHeight(), helpScroller.getWidth() + 10);
+                dialog.setVisible(true);
+            }
+
+        });
+    }
+
+    private void readHelpFile(String helpFile) throws IOException {
+        InputStream in = getClass().getResourceAsStream("/help/" + helpFile);
+        JEditorPane helpText = new JEditorPane();
+        helpText.read(in, null);
+        helpText.setEditable(false);
+        helpScroller = new JScrollPane(helpText);
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/ServerGroupChooser.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/ServerGroupChooser.java
@@ -31,6 +31,8 @@ import org.jboss.as.cli.gui.GuiMain;
 import org.jboss.dmr.ModelNode;
 
 /**
+ * A Panel that reads and presents all of the server groups with checkboxes.
+ * This is also handy for finding out if we are in standalone mode.
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
  */
@@ -44,7 +46,6 @@ public class ServerGroupChooser extends JPanel {
         setBorder(new TitledBorder("Server Groups"));
         setServerGroups();
         add(serverGroupsPanel, BorderLayout.CENTER);
-        if (!isStandalone()) serverGroups.get(0).setSelected(true);  // at least one must be selected
     }
 
     private void setServerGroups() {
@@ -60,7 +61,7 @@ public class ServerGroupChooser extends JPanel {
             e.printStackTrace();
         }
 
-        // make sorted server gorup names into checkboxes
+        // make sorted server group names into checkboxes
         for (String name : serverGroupNames) {
             JCheckBox serverGroupCheckBox = new JCheckBox(name);
             serverGroups.add(serverGroupCheckBox);
@@ -69,21 +70,37 @@ public class ServerGroupChooser extends JPanel {
 
     }
 
-    // TODO: FixMe.  This is not safe because the caller can change the list
-    // and state of the checkboxes.
-    public List<JCheckBox> getServerGroups() {
-        return this.serverGroups;
+    /**
+     * Return the command line argument
+     *
+     * @return  "  --server-groups=" plus a comma-separated list
+     * of selected server groups.  Return empty String if none selected.
+     */
+    public String getCmdLineArg() {
+        StringBuilder builder = new StringBuilder("  --server-groups=");
+        boolean foundSelected = false;
+        for (JCheckBox serverGroup : serverGroups) {
+            if (serverGroup.isSelected()) {
+                foundSelected = true;
+                builder.append(serverGroup.getText());
+                builder.append(",");
+            }
+        }
+        builder.deleteCharAt(builder.length() - 1); // remove trailing comma
+
+        if (!foundSelected) return "";
+        return builder.toString();
     }
 
     public final boolean isStandalone() {
         return serverGroups.isEmpty();
     }
 
-    public boolean allServerGroupsChecked() {
+    @Override
+    public void setEnabled(boolean isEnabled) {
+        super.setEnabled(isEnabled);
         for (JCheckBox serverGroup : serverGroups) {
-            if (!serverGroup.isSelected()) return false;
+            serverGroup.setEnabled(isEnabled);
         }
-
-        return true;
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/ServerGroupChooser.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/ServerGroupChooser.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.component;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
+import javax.swing.border.TitledBorder;
+import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class ServerGroupChooser extends JPanel {
+
+    private List<JCheckBox> serverGroups = new ArrayList<JCheckBox>();
+    private JPanel serverGroupsPanel = new JPanel(new FlowLayout());;
+
+    public ServerGroupChooser() {
+        setLayout(new BorderLayout());
+        setBorder(new TitledBorder("Server Groups"));
+        setServerGroups();
+        add(serverGroupsPanel, BorderLayout.CENTER);
+        if (!isStandalone()) serverGroups.get(0).setSelected(true);  // at least one must be selected
+    }
+
+    private void setServerGroups() {
+        Set<String> serverGroupNames = new TreeSet<String>();
+        try {
+            ModelNode serverGroupQuery = GuiMain.getExecutor().doCommand("/:read-children-names(child-type=server-group)");
+            if (serverGroupQuery.get("outcome").asString().equals("failed")) return;
+
+            for (ModelNode node : serverGroupQuery.get("result").asList()) {
+                serverGroupNames.add(node.asString());
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // make sorted server gorup names into checkboxes
+        for (String name : serverGroupNames) {
+            JCheckBox serverGroupCheckBox = new JCheckBox(name);
+            serverGroups.add(serverGroupCheckBox);
+            serverGroupsPanel.add(serverGroupCheckBox);
+        }
+
+    }
+
+    // TODO: FixMe.  This is not safe because the caller can change the list
+    // and state of the checkboxes.
+    public List<JCheckBox> getServerGroups() {
+        return this.serverGroups;
+    }
+
+    public final boolean isStandalone() {
+        return serverGroups.isEmpty();
+    }
+
+    public boolean allServerGroupsChecked() {
+        for (JCheckBox serverGroup : serverGroups) {
+            if (!serverGroup.isSelected()) return false;
+        }
+
+        return true;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/component/StandaloneDeploymentTableModel.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/component/StandaloneDeploymentTableModel.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.component;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import javax.swing.ButtonGroup;
+import javax.swing.JRadioButton;
+import javax.swing.table.AbstractTableModel;
+import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A table model appropriate for standalone mode.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class StandaloneDeploymentTableModel extends AbstractTableModel {
+
+    private ButtonGroup deploymentsButtonGroup = new ButtonGroup();
+
+    protected String[] colNames = new String[] {"Name", "Runtime Name", "Enabled"};
+    protected List<Object[]> data = new ArrayList<Object[]>();
+
+    public StandaloneDeploymentTableModel() {
+        // for testing the table with lots of deployments
+  /*    for (int i=0; i < 100; i++) {
+          Object[] obj = new Object[3];
+          JRadioButton button = new JRadioButton("fooname");
+          deploymentsButtonGroup.add(button);
+          obj[0] =  button;
+          obj[1] = "foorulkja;dsfkja;ldskjfqpoeirqpoiewraflkfajpqwoeijrpqowejr;ladsjf;lasjfd;lakjfdspqowiejrpqowejf;alsdkjf;lakdsfntime";
+          obj[2] = "disabled";
+          data.add(obj);
+      } */
+
+      setDeployments();
+    }
+
+    private void setDeployments() {
+        ModelNode deploymentsQuery = null;
+        String queryString = "/deployment=*/:read-resource";
+
+        try {
+            deploymentsQuery = GuiMain.getExecutor().doCommand(queryString);
+            if (deploymentsQuery.get("outcome").asString().equals("failed")) return;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        for (ModelNode node : deploymentsQuery.get("result").asList()) {
+            ModelNode deploymentNode = node.get("result"); // get the inner result
+            Object[] deployment = new Object[3];
+            data.add(deployment);
+
+            String name = deploymentNode.get("name").asString();
+
+            JRadioButton radio = new JRadioButton(name);
+            deployment[0] = radio;
+            deploymentsButtonGroup.add(radio);
+
+            deployment[1] = deploymentNode.get("runtime-name").asString();
+
+            ModelNode enabled = deploymentNode.get("enabled");
+            if (enabled.isDefined()) deployment[2] = deploymentNode.get("enabled").asString();
+        }
+
+        if (data.size() > 0) {
+            JRadioButton first = (JRadioButton)data.get(0)[0];
+            first.setSelected(true);
+        }
+    }
+
+    public int getColumnCount() {
+        return 3;
+    }
+
+    public int getRowCount() {
+        return data.size();
+    }
+
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        return data.get(rowIndex)[columnIndex];
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return colNames[column];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        if (columnIndex == 0) return JRadioButton.class;
+        return String.class;
+    }
+
+    public boolean hasDeployments() {
+        return !data.isEmpty();
+    }
+
+    public String getSelectedDeployment() {
+        if (!hasDeployments()) return null;
+
+        for (Enumeration e=deploymentsButtonGroup.getElements(); e.hasMoreElements();) {
+            JRadioButton radio = (JRadioButton)e.nextElement();
+            if (radio.getModel() == deploymentsButtonGroup.getSelection()) {
+                return radio.getText();
+            }
+        }
+
+        throw new IllegalStateException("No deployment selected");
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployAction.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployAction.java
@@ -23,6 +23,7 @@ import javax.swing.AbstractAction;
 import org.jboss.as.cli.gui.GuiMain;
 
 /**
+ * Action for the deploy menu selection.
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
  */

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployAction.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployAction.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.metacommand;
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import org.jboss.as.cli.gui.GuiMain;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class DeployAction extends AbstractAction {
+
+    public DeployAction() {
+        super("Deploy");
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        DeployCommandDialog dialog = new DeployCommandDialog();
+        dialog.setLocationRelativeTo(GuiMain.getMainWindow());
+        dialog.setVisible(true);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployCommandDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployCommandDialog.java
@@ -221,7 +221,7 @@ public class DeployCommandDialog extends JDialog implements ActionListener {
         if (!name.trim().isEmpty()) builder.append("  --name=").append(name);
 
         String runtimeName = runtimeNameField.getText();
-        if (!runtimeName.trim().isEmpty()) builder.append("  --runtime_name=").append(runtimeName);
+        if (!runtimeName.trim().isEmpty()) builder.append("  --runtime-name=").append(runtimeName);
 
         if (forceCheckBox.isSelected()) builder.append("  --force");
         if (disabledCheckBox.isSelected() && disabledCheckBox.isEnabled()) builder.append("  --disabled");

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployCommandDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/DeployCommandDialog.java
@@ -1,0 +1,203 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.metacommand;
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.IOException;
+import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.text.JTextComponent;
+import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.as.cli.gui.component.HelpButton;
+import org.jboss.as.cli.gui.component.ServerGroupChooser;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class DeployCommandDialog extends JDialog implements ActionListener {
+    // make this static so that it always retains the last directory chosen
+    private static JFileChooser fileChooser = new JFileChooser(new File("."));
+
+    private JPanel inputPanel = new JPanel(new GridBagLayout());
+    private JTextField pathField = new JTextField(40);
+    private JTextField nameField = new JTextField(40);
+    private JTextField runtimeNameField = new JTextField(40);
+    private JCheckBox forceCheckBox = new JCheckBox("force");
+    private JCheckBox disabledCheckBox = new JCheckBox("disabled");
+    private ServerGroupChooser serverGroupChooser = new ServerGroupChooser();
+
+    public DeployCommandDialog() {
+        super(GuiMain.getMainWindow(), "deploy", Dialog.ModalityType.APPLICATION_MODAL);
+
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        Container contentPane = getContentPane();
+        contentPane.setLayout(new BorderLayout(10, 10));
+
+        contentPane.add(makeInputPanel(), BorderLayout.CENTER);
+
+        contentPane.add(makeButtonPanel(), BorderLayout.SOUTH);
+        pack();
+        setResizable(false);
+    }
+
+    private JPanel makeInputPanel() {
+        GridBagConstraints gbConst = new GridBagConstraints();
+        gbConst.anchor = GridBagConstraints.WEST;
+        gbConst.insets = new Insets(5,5,5,5);
+
+        JLabel pathLabel = new JLabel("File Path:");
+
+        gbConst.gridwidth = 1;
+        inputPanel.add(pathLabel, gbConst);
+
+        addStrut();
+        inputPanel.add(pathField, gbConst);
+
+        addStrut();
+        JButton browse = new JButton("Browse ...");
+        browse.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ae) {
+                int returnVal = fileChooser.showOpenDialog(DeployCommandDialog.this);
+                if (returnVal == JFileChooser.APPROVE_OPTION) {
+                    try {
+                        pathField.setText(fileChooser.getSelectedFile().getCanonicalPath());
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        });
+        gbConst.gridwidth = GridBagConstraints.REMAINDER;
+        inputPanel.add(browse, gbConst);
+
+        JLabel nameLabel = new JLabel("Name:");
+        gbConst.gridwidth = 1;
+        inputPanel.add(nameLabel, gbConst);
+        addStrut();
+        gbConst.gridwidth = GridBagConstraints.REMAINDER;
+        inputPanel.add(nameField, gbConst);
+
+        JLabel runtimeNameLabel = new JLabel("Runtime Name:");
+        gbConst.gridwidth = 1;
+        inputPanel.add(runtimeNameLabel, gbConst);
+        addStrut();
+        gbConst.gridwidth = GridBagConstraints.REMAINDER;
+        inputPanel.add(runtimeNameField, gbConst);
+
+        JLabel forceLabel = new JLabel();
+        gbConst.gridwidth = 1;
+        inputPanel.add(forceLabel, gbConst);
+        gbConst.gridwidth = GridBagConstraints.REMAINDER;
+        inputPanel.add(forceCheckBox, gbConst);
+
+        JLabel disabledLabel = new JLabel();
+        gbConst.gridwidth = 1;
+        inputPanel.add(disabledLabel, gbConst);
+        gbConst.gridwidth = GridBagConstraints.REMAINDER;
+        inputPanel.add(disabledCheckBox, gbConst);
+
+        if (serverGroupChooser.isStandalone()) return inputPanel;
+
+        JLabel serverGroupLabel = new JLabel();
+        gbConst.gridwidth = 1;
+        inputPanel.add(serverGroupLabel, gbConst);
+        gbConst.gridwidth = GridBagConstraints.REMAINDER;
+        inputPanel.add(serverGroupChooser, gbConst);
+
+        return inputPanel;
+    }
+
+    private void addStrut() {
+        inputPanel.add(Box.createHorizontalStrut(5));
+    }
+
+    private JPanel makeButtonPanel() {
+        JPanel buttonPanel = new JPanel();
+
+        JButton ok = new JButton("OK");
+        ok.addActionListener(this);
+        ok.setMnemonic(KeyEvent.VK_ENTER);
+
+        JButton cancel = new JButton("Cancel");
+        cancel.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ae) {
+                DeployCommandDialog.this.dispose();
+            }
+        });
+
+        buttonPanel.add(ok);
+        buttonPanel.add(cancel);
+        buttonPanel.add(new HelpButton("deploy.txt"));
+        return buttonPanel;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        StringBuilder builder = new StringBuilder("deploy");
+
+        String path = pathField.getText();
+        if (!path.trim().isEmpty()) builder.append("  ").append(path);
+
+        String name = nameField.getText();
+        if (!name.trim().isEmpty()) builder.append("  --name=").append(name);
+
+        String runtimeName = runtimeNameField.getText();
+        if (!runtimeName.trim().isEmpty()) builder.append("  --runtime_name=").append(runtimeName);
+
+        if (forceCheckBox.isSelected()) builder.append("  --force");
+        if (disabledCheckBox.isSelected()) builder.append("  --disabled");
+
+        if (!serverGroupChooser.isStandalone()) {
+            if (serverGroupChooser.allServerGroupsChecked()) {
+                builder.append("  --all-server-groups");
+            } else {
+                builder.append("  --server-groups=");
+                for (JCheckBox serverGroup : serverGroupChooser.getServerGroups()) {
+                    if (serverGroup.isSelected()) {
+                        builder.append(serverGroup.getText());
+                        builder.append(",");
+                    }
+                }
+                builder.deleteCharAt(builder.length() - 1); // remove trailing comma
+            }
+        }
+
+        JTextComponent cmdText = GuiMain.getCommandLine().getCmdText();
+        cmdText.setText(builder.toString());
+        dispose();
+        cmdText.requestFocus();
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/UndeployAction.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/UndeployAction.java
@@ -23,6 +23,7 @@ import javax.swing.AbstractAction;
 import org.jboss.as.cli.gui.GuiMain;
 
 /**
+ * Action for the undeploy menu selection.
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
  */

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/UndeployAction.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/UndeployAction.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.metacommand;
+
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import org.jboss.as.cli.gui.GuiMain;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class UndeployAction extends AbstractAction {
+
+    public UndeployAction() {
+        super("Undeploy");
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        UndeployCommandDialog dialog = new UndeployCommandDialog();
+        dialog.setLocationRelativeTo(GuiMain.getMainWindow());
+        dialog.setVisible(true);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/UndeployCommandDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/UndeployCommandDialog.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.cli.gui.metacommand;
+
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.as.cli.gui.component.DeploymentChooser;
+import org.jboss.as.cli.gui.component.HelpButton;
+import org.jboss.as.cli.gui.component.ServerGroupChooser;
+
+/**
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class UndeployCommandDialog extends JDialog implements ActionListener {
+
+    private DeploymentChooser deploymentChooser = new DeploymentChooser();
+    private ServerGroupChooser serverGroupChooser = new ServerGroupChooser();
+
+    public UndeployCommandDialog() {
+        super(GuiMain.getMainWindow(), "undeploy", Dialog.ModalityType.APPLICATION_MODAL);
+
+        setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        Container contentPane = getContentPane();
+        contentPane.setLayout(new BorderLayout(10, 10));
+
+        contentPane.add(makeInputPanel(), BorderLayout.CENTER);
+
+        contentPane.add(makeButtonPanel(), BorderLayout.SOUTH);
+        pack();
+        setResizable(false);
+    }
+
+    private JPanel makeInputPanel() {
+        JPanel inputPanel = new JPanel(new GridLayout(4, 1));
+
+        if (deploymentChooser.hasDeployments()) {
+            inputPanel.add(deploymentChooser);
+        } else {
+            inputPanel.add(new JLabel("NO DEPLOYMENTS AVAILABLE TO UNDEPLOY"));
+        }
+
+        if (!serverGroupChooser.isStandalone()) {
+            inputPanel.add(serverGroupChooser);
+        }
+
+        return inputPanel;
+    }
+
+    private JPanel makeButtonPanel() {
+        JPanel buttonPanel = new JPanel();
+
+        JButton ok = new JButton("OK");
+        ok.addActionListener(this);
+        ok.setMnemonic(KeyEvent.VK_ENTER);
+
+        JButton cancel = new JButton("Cancel");
+        cancel.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ae) {
+                UndeployCommandDialog.this.dispose();
+            }
+        });
+
+        if (deploymentChooser.hasDeployments()) {
+            buttonPanel.add(ok);
+        }
+
+        buttonPanel.add(cancel);
+        buttonPanel.add(new HelpButton("undeploy.txt"));
+        return buttonPanel;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+    /*    StringBuilder builder = new StringBuilder("deploy");
+
+        String path = pathField.getText();
+        if (!path.trim().isEmpty()) builder.append("  ").append(path);
+
+        String name = nameField.getText();
+        if (!name.trim().isEmpty()) builder.append("  --name=").append(name);
+
+        String runtimeName = runtimeNameField.getText();
+        if (!runtimeName.trim().isEmpty()) builder.append("  --runtime_name=").append(runtimeName);
+
+        if (forceCheckBox.isSelected()) builder.append("  --force");
+        if (disabledCheckBox.isSelected()) builder.append("  --disabled");
+
+        if (!serverGroupChooser.isStandalone()) {
+            if (serverGroupChooser.allServerGroupsChecked()) {
+                builder.append("  --all-server-groups");
+            } else {
+                builder.append("  --server-groups=");
+                for (JCheckBox serverGroup : serverGroupChooser.getServerGroups()) {
+                    if (serverGroup.isSelected()) {
+                        builder.append(serverGroup.getText());
+                        builder.append(",");
+                    }
+                }
+                builder.deleteCharAt(builder.length() - 1); // remove trailing comma
+            }
+        }
+
+        JTextComponent cmdText = GuiMain.getCommandLine().getCmdText();
+        cmdText.setText(builder.toString());
+        dispose();
+        cmdText.requestFocus(); */
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-4285
For deploy, the CLI GUI provides the ability to select a deployment using a GUI file selector.  For undeploy it provides a table of current deployments so you can select the one you want to undeploy.  For both deploy and undeploy, allow checkbox selection of available server groups.

Also in this pull request:
- Add verbose mode to show DMR request that is generated from the command-line command.
- Create generic help button to display CLI's meta command help text
- Support wrapped display of multi-line commands instead of scrolling off the end of the screen with single-line input
