### PR TITLE
include missing messaging tests

### DIFF
--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -64,11 +64,8 @@
                                 <goals><goal>test</goal></goals>
                                 <configuration>
                                     <includes>
-                                        <include>org/jboss/as/test/smoke/embedded/demos/client/jms/**/*TestCase.java</include>
-                                        <include>org/jboss/as/test/smoke/embedded/demos/client/messaging/**/*TestCase.java</include>
-                                        <include>org/jboss/as/test/smoke/embedded/demos/jms/**/*TestCase.java</include>
-                                        <include>org/jboss/as/test/smoke/embedded/demos/messaging/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/smoke/jms/**/*Test.java</include>
+                                        <include>org/jboss/as/test/smoke/messaging/**/*TestCase.java</include>
                                     </includes>
 
                                     <!-- Parameters to test cases. -->
@@ -86,12 +83,8 @@
                                 <goals><goal>test</goal></goals>
                                 <configuration>
                                     <excludes>
-                                        <exclude>org/jboss/as/test/smoke/messaging/**/*</exclude>
-                                        <exclude>org/jboss/as/test/smoke/embedded/demos/client/jms/**/*</exclude>
-                                        <exclude>org/jboss/as/test/smoke/embedded/demos/client/messaging/**/*</exclude>
-                                        <exclude>org/jboss/as/test/smoke/embedded/demos/jms/**/*</exclude>
-                                        <exclude>org/jboss/as/test/smoke/embedded/demos/messaging/**/*</exclude>
                                         <exclude>org/jboss/as/test/smoke/jms/**/*</exclude>
+                                        <exclude>org/jboss/as/test/smoke/messaging/**/*</exclude>
                                     </excludes>
 
                                     <!-- Parameters to test cases. -->


### PR DESCRIPTION
working on JBPAA-8179, I noticed that smoke.messaging tests were not included in the smoke test suite. 

I suppose we forgot to update the pom.xml when we moved the tests from the embedded.demos package...
