### PR TITLE
[AS7-1735] failure when creating JMS resource

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -143,14 +143,16 @@ public interface MessagingMessages {
     IllegalStateException connectorNotDefined(String connectorName);
 
     /**
-     * A message indicating the {@code name} failed to get created.
+     * Create an exception indicating that a messaging resource has failed
+     * to be created
      *
-     * @param name the name.
+     * @param cause  the cause of the error.
+     * @param name the name that failed to be created.
      *
      * @return the message.
      */
     @Message(id = 11639, value = "Failed to create %s")
-    String failedToCreate(String name);
+    StartException failedToCreate(@Cause Throwable cause, String name);
 
     /**
      * Creates an exception indicating a failure to find the SocketBinding for the broadcast binding.

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryService.java
@@ -64,7 +64,7 @@ class ConnectionFactoryService implements Service<Void> {
                 WritableServiceBasedNamingStore.popOwner();
             }
         } catch (Exception e) {
-            throw new StartException(MESSAGES.failedToCreate("connection-factory"), e);
+            throw MESSAGES.failedToCreate(e, "connection-factory");
         }
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
@@ -59,7 +59,7 @@ public class JMSQueueService implements Service<Void> {
         try {
             jmsManager.createQueue(false, queueName, selectorString, durable, jndi);
         } catch (Exception e) {
-            throw new StartException(MESSAGES.failedToCreate("queue"), e);
+            throw MESSAGES.failedToCreate(e, "queue");
         }
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicService.java
@@ -55,7 +55,7 @@ public class JMSTopicService implements Service<Void> {
         try {
             jmsManager.createTopic(false, name, jndi);
         } catch (Exception e) {
-            throw new StartException(MESSAGES.failedToCreate("queue"), e);
+            throw MESSAGES.failedToCreate(e, "queue");
         }
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
@@ -180,7 +180,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
             createService(serviceTarget, context.getController().getServiceContainer());
         }
         catch (Exception e) {
-            throw new StartException(MESSAGES.failedToCreate("resource adapter"), e);
+            throw MESSAGES.failedToCreate(e, "resource adapter");
         }
 
     }


### PR DESCRIPTION
- refactor the code to let failedToCreate() method create
  the StartException and ensure we always attach the root
  cause to it
