### PR TITLE
[AS7-203] MessagingClientTestCase fix

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerRemove.java
@@ -79,10 +79,10 @@ class HornetQServerRemove implements OperationStepHandler {
             context.removeService(JMSServices.getConnectionFactoryBaseServiceName(hqServiceName).append(cf.getName()));
         }
         for(final Resource.ResourceEntry pcf : resource.getChildren(CommonAttributes.POOLED_CONNECTION_FACTORY)) {
-            context.removeService(hqServiceName.append(JMSServices.getPooledConnectionFactoryBaseServiceName(hqServiceName)).append(pcf.getName()));
+            context.removeService(JMSServices.getPooledConnectionFactoryBaseServiceName(hqServiceName).append(pcf.getName()));
         }
         for(final Resource.ResourceEntry queue : resource.getChildren(CommonAttributes.QUEUE)) {
-            context.removeService(hqServiceName.append(MessagingServices.getQueueBaseServiceName(hqServiceName)).append(queue.getName()));
+            context.removeService(MessagingServices.getQueueBaseServiceName(hqServiceName).append(queue.getName()));
         }
 
         context.removeService(JMSServices.getJmsManagerBaseServiceName(hqServiceName));

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueAdd.java
@@ -60,7 +60,6 @@ public class QueueAdd extends AbstractAddStepHandler implements DescriptionProvi
     }
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-
         ServiceRegistry registry = context.getServiceRegistry(true);
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         ServiceController<?> hqService = registry.getService(hqServiceName);
@@ -69,7 +68,8 @@ public class QueueAdd extends AbstractAddStepHandler implements DescriptionProvi
             final String queueName = address.getLastElement().getValue();
             final CoreQueueConfiguration queueConfiguration = createCoreQueueConfiguration(context, queueName, model);
             final QueueService service = new QueueService(queueConfiguration, false);
-            newControllers.add(context.getServiceTarget().addService(hqServiceName.append(MessagingServices.getQueueBaseServiceName(hqServiceName)).append(queueName), service)
+            final ServiceName queueServiceName = MessagingServices.getQueueBaseServiceName(hqServiceName).append(queueName);
+            newControllers.add(context.getServiceTarget().addService(queueServiceName, service)
                     .addDependency(hqServiceName, HornetQServer.class, service.getHornetQService())
                     .addListener(verificationHandler)
                     .setInitialMode(Mode.ACTIVE)

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueRemove.java
@@ -33,7 +33,8 @@ public class QueueRemove extends AbstractRemoveStepHandler implements Descriptio
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
-        context.removeService(MessagingServices.getQueueBaseServiceName(hqServiceName).append(name));
+        final ServiceName queueServiceName = MessagingServices.getQueueBaseServiceName(hqServiceName).append(name);
+        context.removeService(queueServiceName);
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {


### PR DESCRIPTION
- the test was not checking whether a message was effectively consumed
  => set auto commit / auto ack to produce and consume as expected
- the core queue service was not removed properly because QueueRemove
  was building a different service name that the one used to add the
  queue
- fix Messaging services that were prepending twice HornetQ service name
  to their own names
