### PR TITLE
AS7-4317 Pass InetAddress.getHostAddress() to jacorb instead of hostname

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2428,4 +2428,5 @@ public interface ControllerMessages {
 
     @Message(id = 14844, value = "Can't have same criteria for both not and inclusion %s")
     String cantHaveSameCriteriaForBothNotAndInclusion(InterfaceCriteria interfaceCriteria);
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/InetAddressMatchInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/InetAddressMatchInterfaceCriteria.java
@@ -34,6 +34,13 @@ public class InetAddressMatchInterfaceCriteria implements InterfaceCriteria {
     private boolean unknownHostLogged;
     private boolean anyLocalLogged;
 
+    public InetAddressMatchInterfaceCriteria(final InetAddress address) {
+        if (address == null)
+            throw MESSAGES.nullVar("address");
+        this.resolved = address;
+        this.address = new ModelNode(resolved.getHostAddress());
+    }
+
     /**
      * Creates a new InetAddressMatchInterfaceCriteria
      *

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/LoopbackAddressInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/LoopbackAddressInterfaceCriteria.java
@@ -41,7 +41,21 @@ public class LoopbackAddressInterfaceCriteria implements InterfaceCriteria {
     private ModelNode address;
     private InetAddress resolved;
     private boolean unknownHostLogged;
-    private boolean anyLocalLogged;
+
+    /**
+     * Creates a new LoopbackAddressInterfaceCriteria
+     *
+     * @param address a valid value to pass to {@link InetAddress#getByName(String)}
+     *                Cannot be {@code null}
+     *
+     * @throws IllegalArgumentException if <code>network</code> is <code>null</code>
+     */
+    public LoopbackAddressInterfaceCriteria(final InetAddress address) {
+        if (address == null)
+            throw MESSAGES.nullVar("address");
+        this.resolved = address;
+        this.address = new ModelNode(resolved.getHostAddress());
+    }
 
     /**
      * Creates a new LoopbackAddressInterfaceCriteria

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceAddHandler.java
@@ -103,7 +103,7 @@ public class InterfaceAddHandler extends AbstractAddStepHandler implements Descr
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
         String name = getInterfaceName(operation);
-        ParsedInterfaceCriteria parsed = getCriteria(operation);
+        ParsedInterfaceCriteria parsed = getCriteria(context, operation);
         if (parsed.getFailureMessage() != null) {
             throw new OperationFailedException(new ModelNode().set(parsed.getFailureMessage()));
         }
@@ -115,8 +115,8 @@ public class InterfaceAddHandler extends AbstractAddStepHandler implements Descr
         return PathAddress.pathAddress(opAddr).getLastElement().getValue();
     }
 
-    protected ParsedInterfaceCriteria getCriteria(ModelNode operation) {
-        return ParsedInterfaceCriteria.parse(operation, specified);
+    protected ParsedInterfaceCriteria getCriteria(OperationContext context, ModelNode operation) {
+        return ParsedInterfaceCriteria.parse(operation, specified, context);
     }
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers, String name, ParsedInterfaceCriteria criteria) {

--- a/controller/src/test/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteriaTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteriaTestCase.java
@@ -28,6 +28,9 @@ import junit.framework.Assert;
 
 import org.jboss.as.controller.parsing.Element;
 import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -51,7 +54,7 @@ public class ParsedInterfaceCriteriaTestCase {
         ModelNode op = new ModelNode();
         op.get(Element.LOOPBACK.getLocalName()).set(true);
         op.get(Element.NOT.getLocalName(), Element.LOOPBACK.getLocalName()).set(true);
-        ParsedInterfaceCriteria criteria = ParsedInterfaceCriteria.parse(op);
+        ParsedInterfaceCriteria criteria = ParsedInterfaceCriteria.parse(op, true);
         Assert.assertNotNull(criteria.getFailureMessage());
     }
 
@@ -60,7 +63,7 @@ public class ParsedInterfaceCriteriaTestCase {
         ModelNode op = new ModelNode();
         op.get(Element.LOOPBACK.getLocalName()).set(true);
         op.get(Element.NOT.getLocalName(), Element.INET_ADDRESS.getLocalName()).set("127.0.0.1");
-        ParsedInterfaceCriteria criteria = ParsedInterfaceCriteria.parse(op);
+        ParsedInterfaceCriteria criteria = ParsedInterfaceCriteria.parse(op, true);
         Assert.assertNull(criteria.getFailureMessage());
     }
 

--- a/jacorb/src/main/java/org/jboss/as/jacorb/service/CorbaORBService.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/service/CorbaORBService.java
@@ -86,14 +86,14 @@ public class CorbaORBService implements Service<ORB> {
             // set the JacORB IIOP and IIOP/SSL ports from the respective socket bindings.
             if (this.jacORBSocketBindingInjector.getValue() != null) {
                 InetSocketAddress address = this.jacORBSocketBindingInjector.getValue().getSocketAddress();
-                properties.setProperty(JacORBSubsystemConstants.ORB_ADDRESS, address.getHostName());
+                properties.setProperty(JacORBSubsystemConstants.ORB_ADDRESS, address.getAddress().getHostAddress());
                 properties.setProperty(JacORBSubsystemConstants.ORB_PORT, String.valueOf(address.getPort()));
             }
             if (this.jacORBSSLSocketBindingInjector.getValue() != null) {
                 InetSocketAddress address = this.jacORBSSLSocketBindingInjector.getValue().getSocketAddress();
                 properties.setProperty(JacORBSubsystemConstants.ORB_SSL_PORT, String.valueOf(address.getPort()));
                 if (!properties.containsKey(JacORBSubsystemConstants.ORB_ADDRESS)) {
-                    properties.setProperty(JacORBSubsystemConstants.ORB_ADDRESS, address.getHostName());
+                    properties.setProperty(JacORBSubsystemConstants.ORB_ADDRESS, address.getAddress().getHostAddress());
                 }
             }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -147,8 +147,9 @@ class HornetQService implements Service<HornetQServer> {
                         if (binding == null) {
                             throw MESSAGES.failedToFindConnectorSocketBinding(tc.getName());
                         }
-                        tc.getParams().put(HOST, binding.getSocketAddress().getHostName());
-                        tc.getParams().put(PORT, "" + binding.getSocketAddress().getPort());
+                        InetSocketAddress socketAddress = binding.getSocketAddress();
+                        tc.getParams().put(HOST, socketAddress.getAddress().getHostAddress());
+                        tc.getParams().put(PORT, "" + socketAddress.getPort());
                     }
                 }
             }

--- a/process-controller/src/main/java/org/jboss/as/process/Main.java
+++ b/process-controller/src/main/java/org/jboss/as/process/Main.java
@@ -26,6 +26,7 @@ import static org.jboss.as.process.ProcessMessages.MESSAGES;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.AccessController;
 import java.util.ArrayList;
@@ -181,7 +182,9 @@ public final class Main {
         }
 
         final ProtocolServer.Configuration configuration = new ProtocolServer.Configuration();
-        configuration.setBindAddress(new InetSocketAddress(pcSocketConfig.getBindAddress(), pcSocketConfig.getBindPort()));
+        InetAddress pcInetAddress = InetAddress.getByName(pcSocketConfig.getBindAddress());
+        InetSocketAddress pcInetSocketAddress = new InetSocketAddress(pcInetAddress, pcSocketConfig.getBindPort());
+        configuration.setBindAddress(pcInetSocketAddress);
         configuration.setSocketFactory(ServerSocketFactory.getDefault());
         final ThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("ProcessController-threads"), Boolean.FALSE, null, "%G - %t", null, null, AccessController.getContext());
         configuration.setThreadFactory(threadFactory);
@@ -204,7 +207,7 @@ public final class Main {
         initialCommand.add("-mp");  // Repeat the module path so HostController's Main sees it
         initialCommand.add(modulePath);
         initialCommand.add(CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR);
-        initialCommand.add(boundAddress.getHostName());
+        initialCommand.add(boundAddress.getAddress().getHostAddress());
         initialCommand.add(CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT);
         initialCommand.add(Integer.toString(boundAddress.getPort()));
         initialCommand.addAll(smOptions);

--- a/server/src/main/java/org/jboss/as/server/DomainServerMain.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerMain.java
@@ -185,23 +185,15 @@ public final class DomainServerMain {
             endpointName = RemotingServices.SUBSYSTEM_ENDPOINT;
         }
 
-        try {
-            final int port = managementSocket.getPort();
-            final String host = NetworkUtils.formatPossibleIpv6Address(InetAddress.getByName(managementSocket.getHostName()).getHostName());
-            final HostControllerServerClient client = new HostControllerServerClient(serverName, serverProcessName, host, port, authKey);
-                    serviceTarget.addService(HostControllerServerClient.SERVICE_NAME, client)
-                        .addDependency(endpointName, Endpoint.class, client.getEndpointInjector())
-                        .addDependency(Services.JBOSS_SERVER_CONTROLLER, ModelController.class, client.getServerControllerInjector())
-                        .addDependency(RemoteFileRepository.SERVICE_NAME, RemoteFileRepository.class, client.getRemoteFileRepositoryInjector())
-                        .setInitialMode(ServiceController.Mode.ACTIVE)
-                        .install();
-
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
-
-
-
+        final int port = managementSocket.getPort();
+        final String host = NetworkUtils.formatPossibleIpv6Address(managementSocket.getAddress().getHostAddress());
+        final HostControllerServerClient client = new HostControllerServerClient(serverName, serverProcessName, host, port, authKey);
+                serviceTarget.addService(HostControllerServerClient.SERVICE_NAME, client)
+                    .addDependency(endpointName, Endpoint.class, client.getEndpointInjector())
+                    .addDependency(Services.JBOSS_SERVER_CONTROLLER, ModelController.class, client.getServerControllerInjector())
+                    .addDependency(RemoteFileRepository.SERVICE_NAME, RemoteFileRepository.class, client.getRemoteFileRepositoryInjector())
+                    .setInitialMode(ServiceController.Mode.ACTIVE)
+                    .install();
     }
 
     public static final class HostControllerCommunicationActivator implements ServiceActivator, Serializable {

--- a/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceResolveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceResolveHandler.java
@@ -66,7 +66,7 @@ public class SpecifiedInterfaceResolveHandler implements OperationStepHandler, D
             validateAndSet(definition, operation, config);
         }
 
-        ParsedInterfaceCriteria parsed = ParsedInterfaceCriteria.parse(config, true);
+        ParsedInterfaceCriteria parsed = ParsedInterfaceCriteria.parse(config, true, context);
         if (parsed.getFailureMessage() != null) {
             throw new OperationFailedException(new ModelNode().set(parsed.getFailureMessage()));
         }


### PR DESCRIPTION
AS7-4318 Pass InetAddress.getHostAddress() to HornetQ instead of hostname
Use InetAddress.getHostAddress() instead of host name for server connecting to HC
Don't discard parsed InetAddress when constructing interface criteria
