### PR TITLE
Enabling ignored JPA 2LC tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JPA2LCTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JPA2LCTestCase.java
@@ -170,7 +170,6 @@ public class JPA2LCTestCase {
 
  	// Check if evicting entity second level cache is working as expected
 	@Test
-	@Ignore  //FIXME AS7-3541, fixed in Hibernate 4.1.0
  	public void testEvictEntityCache() throws Exception {
 
  		SFSB2LC sfsb = lookup("SFSB2LC", SFSB2LC.class);
@@ -230,7 +229,6 @@ public class JPA2LCTestCase {
  	
  	// Check if evicting query cache is working as expected
  	@Test
-	@Ignore  //FIXME HHH-7127, fixed in Hibernate 4.1.1
  	public void testEvictQueryCache() throws Exception {
 
  		SFSB2LC sfsb = lookup("SFSB2LC", SFSB2LC.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JPA2LCTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/JPA2LCTestCase.java
@@ -245,7 +245,7 @@ public class JPA2LCTestCase {
  		// evict query cache
  		sfsb.evictQueryCache();
  		
- 		message = sfsb.queryCacheCheck(id);
+ 		message = sfsb.queryCacheCheckIfEmpty(id);
 
  		if (!message.equals("OK")){
  			fail(message);


### PR DESCRIPTION
Tests needed Hibernate 4.1.1 to pass.
