### PR TITLE
AS7-4329 eclipse IDE support for cmp project

### DIFF
--- a/cmp/pom.xml
+++ b/cmp/pom.xml
@@ -81,6 +81,7 @@
                         <configuration>
                             <sources>
                                 <source>${project.build.directory}/generated-sources/javacc</source>
+                                <source>${project.build.directory}/generated-sources/jjtree</source>
                             </sources>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,7 @@
                                         <goals>
                                             <goal>jjtree</goal>
                                             <goal>javacc</goal>
+                                            <goal>jjtree-javacc</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>


### PR DESCRIPTION
Enhanced IDE support for cmp project:
1. Added the jjtree as a source path
2. Ignore jjtree-javacc goal
