### PR TITLE
[AS7-4342] Use the location of build.sh instead of pwd to find Maven

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,7 +76,7 @@ source_if_exists() {
 find_maven() {
     search="$*"
     for d in $search; do
-        MAVEN_HOME="`pwd`/$d"
+        MAVEN_HOME="${DIRNAME}/$d"
         MVN="$MAVEN_HOME/bin/mvn"
         if [ -x "$MVN" ]; then
             #  Found.


### PR DESCRIPTION
Minor fix to build.sh
