### PR TITLE
Fix a NP issue in the ErrorState

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ConfirmationChoice.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ConfirmationChoice.java
@@ -52,6 +52,9 @@ public class ConfirmationChoice implements State {
         this.prompt = prompt;
         this.yesState = yesState;
         this.noState = noState;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override
@@ -70,7 +73,7 @@ public class ConfirmationChoice implements State {
             case NO:
                 return noState;
             default:
-                return new ErrorState(null, MESSAGES.invalidConfirmationResponse(), this);
+                return new ErrorState(theConsole, MESSAGES.invalidConfirmationResponse(), this);
         }
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/DuplicateUserCheckState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/DuplicateUserCheckState.java
@@ -37,6 +37,9 @@ public class DuplicateUserCheckState implements State {
     public DuplicateUserCheckState(final ConsoleWrapper theConsole,final StateValues stateValues) {
         this.theConsole = theConsole;
         this.stateValues = stateValues;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ErrorState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ErrorState.java
@@ -50,6 +50,9 @@ public class ErrorState implements State {
         this.nextState = nextState;
         this.stateValues = stateValues;
         this.theConsole = theConsole;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PromptNewUserState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PromptNewUserState.java
@@ -46,6 +46,9 @@ public class PromptNewUserState implements State {
     public PromptNewUserState(ConsoleWrapper theConsole, final StateValues stateValues) {
         this.theConsole = theConsole;
         this.stateValues = stateValues;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PromptPasswordState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PromptPasswordState.java
@@ -43,6 +43,9 @@ public class PromptPasswordState implements State {
     public PromptPasswordState(ConsoleWrapper theConsole, StateValues stateValues) {
         this.theConsole = theConsole;
         this.stateValues = stateValues;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override
@@ -65,7 +68,7 @@ public class PromptPasswordState implements State {
             }
 
             if (Arrays.equals(tempChar, secondTempChar) == false) {
-                return new ErrorState(null, MESSAGES.passwordMisMatch(), this);
+                return new ErrorState(theConsole, MESSAGES.passwordMisMatch(), this);
             }
             stateValues.setPassword(tempChar);
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFileFinder.java
@@ -66,6 +66,9 @@ public class PropertyFileFinder implements State {
     public PropertyFileFinder(ConsoleWrapper theConsole,final StateValues stateValues) {
         this.theConsole = theConsole;
         this.stateValues = stateValues;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFilePrompt.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFilePrompt.java
@@ -43,6 +43,9 @@ public class PropertyFilePrompt implements State {
 
     public PropertyFilePrompt(ConsoleWrapper theConsole) {
         this.theConsole = theConsole;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     @Override
@@ -75,7 +78,7 @@ public class PropertyFilePrompt implements State {
                         stateValues.setRealm(DEFAULT_APPLICATION_REALM);
                         return new PropertyFileFinder(theConsole, stateValues);
                     default:
-                        return new ErrorState(null, MESSAGES.invalidChoiceResponse(), this);
+                        return new ErrorState(theConsole, MESSAGES.invalidChoiceResponse(), this);
                 }
             } else {
                 stateValues.setManagement(true);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/WeakCheckState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/WeakCheckState.java
@@ -43,6 +43,9 @@ public class WeakCheckState implements State {
     public WeakCheckState(ConsoleWrapper theConsole,StateValues stateValues) {
         this.theConsole = theConsole;
         this.stateValues = stateValues;
+        if (theConsole.getConsole() == null) {
+            throw MESSAGES.noConsoleAvailable();
+        }
     }
 
     private boolean isValidPunctuation(char currentChar) {
@@ -55,12 +58,12 @@ public class WeakCheckState implements State {
         State retryState = stateValues.isSilentOrNonInteractive() ? null : new PromptNewUserState(theConsole, stateValues);
 
         if (Arrays.equals(stateValues.getUserName().toCharArray(), stateValues.getPassword())) {
-            return new ErrorState(null, MESSAGES.usernamePasswordMatch(), retryState);
+            return new ErrorState(theConsole, MESSAGES.usernamePasswordMatch(), retryState);
         }
 
         for (char currentChar : stateValues.getUserName().toCharArray()) {
             if ((!isValidPunctuation(currentChar)) && (Character.isLetter(currentChar) || Character.isDigit(currentChar)) == false) {
-                return new ErrorState(null, MESSAGES.usernameNotAlphaNumeric(), retryState);
+                return new ErrorState(theConsole, MESSAGES.usernameNotAlphaNumeric(), retryState);
             }
         }
 

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/AssertConsoleBuilder.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/AssertConsoleBuilder.java
@@ -27,9 +27,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
+import static org.junit.Assert.*;
 
 /**
  *  Assert builder for the console. Use this together with the ConsoleMock object
@@ -55,13 +54,24 @@ import static org.junit.Assert.fail;
 * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
 */
 public class AssertConsoleBuilder {
+    private static String NEW_LINE = "\n";
+    
     private enum Type {
         DISPLAY, INPUT
     }
     
     private class AssertConsole {
+        
         private String text;
         private Type type;
+        
+        private AssertConsole() {    
+        }
+        
+        private AssertConsole(String text, Type type) {
+            this.text = text;
+            this.type = type;
+        }
     }
 
     private Queue<AssertConsole> queue = new LinkedList<AssertConsole>();
@@ -89,6 +99,41 @@ public class AssertConsoleBuilder {
         assertConsole.text = text;
         assertConsole.type = Type.INPUT;
         queue.add(assertConsole);
+        return this;
+    }
+
+    /**
+     * Expected error message
+     * @param text
+     * @return this
+     */
+    public AssertConsoleBuilder expectedErrorMessage(String text) {
+        queue.add(new AssertConsole(NEW_LINE,Type.DISPLAY));
+        queue.add(new AssertConsole(" * ",Type.DISPLAY));
+        queue.add(new AssertConsole(MESSAGES.errorHeader(),Type.DISPLAY));
+        queue.add(new AssertConsole(" * ",Type.DISPLAY));
+        queue.add(new AssertConsole(NEW_LINE,Type.DISPLAY));
+        queue.add(new AssertConsole(text,Type.DISPLAY));
+        queue.add(new AssertConsole(NEW_LINE,Type.DISPLAY));
+        queue.add(new AssertConsole(NEW_LINE,Type.DISPLAY));
+        return this;
+    }
+
+    /**
+     * Expected confirm message and answer
+     * @param messages - expected display text, if none pass in null
+     * @param prompt - expected text for the console prompt
+     * @param answer - expected answer
+     * @return this
+     */
+    public AssertConsoleBuilder expectedConfirmMessage(String messages, String prompt, String answer) {
+        if (messages!=null) {
+            queue.add(new AssertConsole(messages,Type.DISPLAY));
+            queue.add(new AssertConsole(NEW_LINE,Type.DISPLAY));
+        }
+        queue.add(new AssertConsole(prompt,Type.DISPLAY));
+        queue.add(new AssertConsole(" ",Type.DISPLAY));
+        queue.add(new AssertConsole(answer,Type.INPUT));
         return this;
     }
 

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/ConsoleMock.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/ConsoleMock.java
@@ -65,6 +65,6 @@ public class ConsoleMock implements ConsoleWrapper {
 
     @Override
     public Object getConsole() {
-        return null;
+        return this;
     }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/ConfirmationChoiceTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/ConfirmationChoiceTestCase.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.security.state;
+
+import org.jboss.as.domain.management.security.AssertConsoleBuilder;
+import org.jboss.msc.service.StartException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test the confirmation state
+ *
+ * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ */
+public class ConfirmationChoiceTestCase extends PropertyTestHelper {
+
+    public static final String USER_DISPLAY_TEXT = "User display text";
+    public static final String PLEASE_ANSWER = "Please answer";
+
+    @Test
+    public void testState() throws IOException, StartException {
+
+        ErrorState errorState = new ErrorState(consoleMock,null);
+        PromptPasswordState passwordState = new PromptPasswordState(consoleMock,null);
+
+        ConfirmationChoice confirmationChoice = new ConfirmationChoice(consoleMock, USER_DISPLAY_TEXT, PLEASE_ANSWER, passwordState,errorState);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
+                expectedConfirmMessage(USER_DISPLAY_TEXT, PLEASE_ANSWER, "y");
+
+        consoleMock.setResponses(consoleBuilder);
+        State promptPasswordState = confirmationChoice.execute();
+
+        assertTrue("Expected the next state to be PromptPasswordState", promptPasswordState instanceof PromptPasswordState);
+        consoleBuilder.validate();
+    }
+
+    @Test
+    public void testWrongAnswer() throws IOException, StartException {
+
+        ErrorState errorState = new ErrorState(consoleMock,null);
+        PromptPasswordState passwordState = new PromptPasswordState(consoleMock,null);
+
+        ConfirmationChoice confirmationChoice = new ConfirmationChoice(consoleMock, USER_DISPLAY_TEXT, PLEASE_ANSWER, passwordState,errorState);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
+                expectedConfirmMessage(USER_DISPLAY_TEXT,PLEASE_ANSWER,"d").
+                expectedErrorMessage(MESSAGES.invalidConfirmationResponse());
+
+        consoleMock.setResponses(consoleBuilder);
+        State nextState = confirmationChoice.execute();
+
+        assertTrue("Expected the next state to be ErrorState", nextState instanceof ErrorState);
+        nextState.execute();
+        consoleBuilder.validate();
+    }
+}

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/WeakCheckStateTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/WeakCheckStateTestCase.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.domain.management.security.state;
+
+import org.jboss.as.domain.management.security.AssertConsoleBuilder;
+import org.jboss.msc.service.StartException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test the password weakness
+ *
+ * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ */
+public class WeakCheckStateTestCase extends PropertyTestHelper {
+
+    @Test
+    public void testState() throws IOException, StartException {
+
+        WeakCheckState weakCheckState = new WeakCheckState(consoleMock, values);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder();
+        consoleMock.setResponses(consoleBuilder);
+
+        State duplicateUserCheckState = weakCheckState.execute();
+        
+        assertTrue("Expected the next state to be DuplicateUserCheckState", duplicateUserCheckState instanceof DuplicateUserCheckState);
+        consoleBuilder.validate();
+    }
+
+    @Test
+    public void testWeakPassword() {
+        values.setUserName("thesame");
+        values.setPassword("thesame".toCharArray());
+        WeakCheckState weakCheckState = new WeakCheckState(consoleMock, values);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().expectedErrorMessage(MESSAGES.usernamePasswordMatch());
+        consoleMock.setResponses(consoleBuilder);
+
+        State errorState = weakCheckState.execute();
+
+        assertTrue("Expected the next state to be ErrorState", errorState instanceof ErrorState);
+        State promptNewUserState = errorState.execute();
+        assertTrue("Expected the next state to be PromptNewUserState", promptNewUserState instanceof PromptNewUserState);
+        consoleBuilder.validate();
+    }
+
+    @Test
+    public void testUsernameNotAlphaNumeric() {
+        values.setUserName("username&");
+        WeakCheckState weakCheckState = new WeakCheckState(consoleMock, values);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().expectedErrorMessage(MESSAGES.usernameNotAlphaNumeric());
+        consoleMock.setResponses(consoleBuilder);
+
+        State errorState = weakCheckState.execute();
+
+        assertTrue("Expected the next state to be ErrorState", errorState instanceof ErrorState);
+        State promptNewUserState = errorState.execute();
+        assertTrue("Expected the next state to be PromptNewUserState", promptNewUserState instanceof PromptNewUserState);
+        consoleBuilder.validate();
+    }
+
+    @Test
+    public void testBadUsername() {
+        String[] BAD_USER_NAMES = {"admin", "administrator", "root"};
+        for (String userName : BAD_USER_NAMES) {
+
+            values.setUserName(userName);
+            WeakCheckState weakCheckState = new WeakCheckState(consoleMock, values);
+
+            AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
+                    expectedConfirmMessage(MESSAGES.usernameEasyToGuess(userName), MESSAGES.sureToAddUser(userName), "n");
+            consoleMock.setResponses(consoleBuilder);
+
+            State confirmationChoice = weakCheckState.execute();
+
+            assertTrue("Expected the next state to be ConfirmationChoice", confirmationChoice instanceof ConfirmationChoice);
+            State promptNewUserState = confirmationChoice.execute();
+            assertTrue("Expected the next state to be PromptNewUserState", promptNewUserState instanceof PromptNewUserState);
+            consoleBuilder.validate();
+        }
+    }
+
+    @Test
+    public void testUsernameWithValidPunctuation() {
+        values.setUserName("username.@\\=,/");
+        WeakCheckState weakCheckState = new WeakCheckState(consoleMock, values);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder();
+        consoleMock.setResponses(consoleBuilder);
+
+        State duplicateUserCheckState = weakCheckState.execute();
+
+        assertTrue("Expected the next state to be DuplicateUserCheckState", duplicateUserCheckState instanceof DuplicateUserCheckState);
+        consoleBuilder.validate();
+    }
+
+
+}


### PR DESCRIPTION
Fix a NP issue in the ErrorState because the console was not passed correctly from the WeakCheckState.

Add test case for testing the WeakCheckState and ConfirmationChoice
