### PR TITLE
[AS7-4206] Allow logger categories to contain spaces and other special c...

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -58,7 +58,7 @@ public interface CommonAttributes {
             setDefaultValue(new ModelNode().set(true)).
             build();
 
-    SimpleAttributeDefinition CATEGORY = SimpleAttributeDefinitionBuilder.create("category", ModelType.STRING).build();
+    SimpleAttributeDefinition CATEGORY = SimpleAttributeDefinitionBuilder.create("category", ModelType.STRING, true).build();
 
     SimpleAttributeDefinition CHANGE_LEVEL = SimpleAttributeDefinitionBuilder.create("change-level", ModelType.STRING, true).
             setCorrector(CaseParameterCorrector.TO_UPPER).

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -114,6 +114,9 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static final LoggingSubsystemParser INSTANCE = new LoggingSubsystemParser();
 
+    static final String PATH_PATTERN = "\\*|[*\\p{Space}\\p{Cntrl}]+";
+    static final String REPLACEMENT_CHAR = "_";
+
     private LoggingSubsystemParser() {
         //
     }
@@ -231,7 +234,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Setup the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(LOGGER, name);
+        node.get(OP_ADDR).set(address).add(LOGGER, name.replaceAll(PATH_PATTERN, REPLACEMENT_CHAR));
 
         // Element
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
@@ -1113,7 +1116,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
         if (node.hasDefined(LOGGER)) {
             for (String name : node.get(LOGGER).keys()) {
-                writeLogger(writer, name, node.get(LOGGER, name));
+                writeLogger(writer, node.get(LOGGER, name));
             }
         }
         if (node.hasDefined(ROOT_LOGGER)) {
@@ -1241,9 +1244,9 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         writer.writeEndElement();
     }
 
-    private void writeLogger(final XMLExtendedStreamWriter writer, String name, final ModelNode node) throws XMLStreamException {
+    private void writeLogger(final XMLExtendedStreamWriter writer, final ModelNode node) throws XMLStreamException {
         writer.writeStartElement(Element.LOGGER.getLocalName());
-        writer.writeAttribute(CATEGORY.getXmlName(), name);
+        CATEGORY.marshallAsAttribute(node, writer);
         USE_PARENT_HANDLERS.marshallAsAttribute(node, writer);
         writeLevel(writer, node);
         writeFilter(writer, node);

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -10,13 +10,13 @@ root.logger.assign-handler=Assign a Handler to the root logger.
 root.logger.unassign-handler=Unassign a Handler from the root logger.
 
 logger=Defines a logger category.
-logger.add=Add a new logger category.
+logger.add=Add a new logger category. Note that when adding a logger category contains special characters (space, * or a control character), you must use the category attribute and replace any of those characters with an _ (underscore) in the path name.
 logger.remove=Remove an existing logger category.
 logger.level=The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
 logger.handler=The logging handler.
 logger.handlers=The Handlers associated with this Logger.
 logger.use-parent-handlers=Specifies whether or not this logger should send its output to it's parent Logger.
-logger.category=Specifies the category for the logger.
+logger.category=Specifies the category for the logger. Only needed if the category contains a special character (space, * or a control character).
 logger.change-level=Change the logging level for a logger category.
 logger.assign-handler=Assign a Handler to a Logger.
 logger.unassign-handler=Unassign a Handler from a Logger.

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -99,6 +99,14 @@
         <level name="WARN"/>
     </logger>
 
+    <logger category="spaced logger">
+        <level name="INFO"/>
+    </logger>
+
+    <logger category="asterisk*logger">
+        <level name="INFO"/>
+    </logger>
+
     <root-logger>
         <level name="INFO"/>
         <handlers>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <version.org.jboss.jboss-vfs>3.1.0.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.jsfunit>2.0.0.Beta1</version.org.jboss.jsfunit>
         <version.org.jboss.logging.jboss-logging>3.1.0.GA</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-processor>1.0.0.Final</version.org.jboss.logging.jboss-logging-processor>
+        <version.org.jboss.logging.jboss-logging-processor>1.0.1.Final</version.org.jboss.logging.jboss-logging-processor>
         <version.org.jboss.logmanager.jboss-logmanager>1.2.2.GA</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.jboss-logmanager-log4j>1.0.0.GA</version.org.jboss.logmanager.jboss-logmanager-log4j>
         <version.org.jboss.marshalling.jboss-marshalling>1.3.13.GA</version.org.jboss.marshalling.jboss-marshalling>


### PR DESCRIPTION
Allow logger categories to contain spaces and other special characters not allowed in a path address.

Special characters will be replaced with an _ (underscore) and the category name will always be set in the model. If the category attribute was not defined on the add operation, the last address value is used as the category.
