### PR TITLE
AS7-2203 Add Arquillian support for Managed/Remote Domain Server

### DIFF
--- a/arquillian/common-domain/pom.xml
+++ b/arquillian/common-domain/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ JBoss, Home of Professional Open Source. ~ Copyright 2010, Red Hat,
+    Inc., and individual contributors ~ as indicated by the @author tags. See
+    the copyright.txt file in the ~ distribution for a full listing of individual
+    contributors. ~ ~ This is free software; you can redistribute it and/or modify
+    it ~ under the terms of the GNU Lesser General Public License as ~ published
+    by the Free Software Foundation; either version 2.1 of ~ the License, or
+    (at your option) any later version. ~ ~ This software is distributed in the
+    hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the
+    implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU ~ Lesser General Public License for more details. ~ ~ You should
+    have received a copy of the GNU Lesser General Public ~ License along with
+    this software; if not, write to the Free ~ Software Foundation, Inc., 51
+    Franklin St, Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site:
+    http://www.fsf.org. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-arquillian</artifactId>
+        <version>7.1.2.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jboss-as-arquillian-common-domain</artifactId>
+
+    <name>JBoss Application Server: Arquillian Common Domain</name>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-cdi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-ejb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-initialcontext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-resource</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss.arquillian.container</groupId>
+          <artifactId>arquillian-container-test-impl-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-controller-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-jmx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.osgi.spi</groupId>
+            <artifactId>jbosgi-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.remotingjmx</groupId>
+            <artifactId>remoting-jmx</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.sasl</groupId>
+            <artifactId>jboss-sasl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ArchiveDeployer.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ArchiveDeployer.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Future;
+
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.as.controller.client.helpers.domain.DeploymentAction;
+import org.jboss.as.controller.client.helpers.domain.DeploymentPlan;
+import org.jboss.as.controller.client.helpers.domain.DeploymentPlanBuilder;
+import org.jboss.as.controller.client.helpers.domain.DeploymentPlanResult;
+import org.jboss.as.controller.client.helpers.domain.DomainDeploymentManager;
+import org.jboss.as.controller.client.helpers.domain.InitialDeploymentPlanBuilder;
+import org.jboss.as.controller.client.helpers.domain.ServerDeploymentPlanResult;
+import org.jboss.as.controller.client.helpers.domain.ServerGroupDeploymentPlanResult;
+import org.jboss.as.controller.client.helpers.domain.ServerUpdateResult;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+/**
+ * A deployer that uses the {@link ServerDeploymentManager}
+ *
+ * @author Thomas.Diesler@jboss.com
+ * @since 17-Nov-2010
+ */
+public class ArchiveDeployer {
+
+    private static final Logger log = Logger.getLogger(ArchiveDeployer.class);
+
+    private DomainDeploymentManager deploymentManager;
+
+    public ArchiveDeployer(DomainDeploymentManager deploymentManager) {
+        this.deploymentManager = deploymentManager;
+    }
+
+    public String deploy(Archive<?> archive, String target) throws DeploymentException {
+        try {
+            final InputStream input = archive.as(ZipExporter.class).exportAsInputStream();
+            try {
+                InitialDeploymentPlanBuilder builder = deploymentManager.newDeploymentPlan();
+                DeploymentPlan plan = builder.add(archive.getName(), input).andDeploy().toServerGroup(target).build();
+                DeploymentAction deployAction = plan.getDeploymentActions().get(plan.getDeploymentActions().size() - 1);
+                return executeDeploymentPlan(plan, deployAction);
+            } finally {
+                if (input != null)
+                    try {
+                        input.close();
+                    } catch (IOException e) {
+                        log.warnf(e, "Failed to close resource %s", input);
+                    }
+            }
+
+        } catch (Exception e) {
+            throw new DeploymentException("Could not deploy to container", e);
+        }
+    }
+
+    public void undeploy(String runtimeName, String target) throws DeploymentException {
+        try {
+            DeploymentPlanBuilder builder = deploymentManager.newDeploymentPlan();
+            DeploymentPlan plan = builder.undeploy(runtimeName).remove(runtimeName).toServerGroup(target).build();
+            Future<DeploymentPlanResult> future = deploymentManager.execute(plan);
+            future.get();
+        } catch (Exception ex) {
+            log.warn("Cannot undeploy: " + runtimeName + ":" + ex.getMessage());
+        }
+    }
+
+    private String executeDeploymentPlan(DeploymentPlan plan, DeploymentAction deployAction) throws Exception {
+        Future<DeploymentPlanResult> future = deploymentManager.execute(plan);
+        DeploymentPlanResult planResult = future.get();
+
+        Map<String, ServerGroupDeploymentPlanResult> actionResults = planResult.getServerGroupResults();
+        for (Entry<String, ServerGroupDeploymentPlanResult> result : actionResults.entrySet()) {
+            for (Entry<String, ServerDeploymentPlanResult> planServerResult : result.getValue().getServerResults().entrySet()) {
+                ServerUpdateResult actionResult = planServerResult.getValue().getDeploymentActionResults()
+                        .get(deployAction.getId());
+                if (actionResult != null) {
+                    Exception deploymentException = (Exception) actionResult.getFailureResult();
+                    if (deploymentException != null)
+                        throw deploymentException;
+                }
+            }
+        }
+
+        return deployAction.getDeploymentUnitUniqueName();
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/Authentication.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/Authentication.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+/**
+ * Factory to supply an Authenticator or CallbackHandler for use during tests.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class Authentication {
+
+    public static String username = "";
+    public static String password = "";
+
+    public static CallbackHandler getCallbackHandler() {
+        return new CallbackHandler() {
+
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback current : callbacks) {
+                    if (current instanceof NameCallback) {
+                        NameCallback ncb = (NameCallback) current;
+                        ncb.setName(username);
+                    } else if (current instanceof PasswordCallback) {
+                        PasswordCallback pcb = (PasswordCallback) current;
+                        pcb.setPassword(password.toCharArray());
+                    } else if (current instanceof RealmCallback) {
+                        RealmCallback rcb = (RealmCallback) current;
+                        rcb.setText(rcb.getDefaultText());
+                    } else {
+                        throw new UnsupportedCallbackException(current);
+                    }
+                }
+            }
+        };
+    }
+
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonContainerExtension.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonContainerExtension.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+/**
+ * The extensions used by the any jboss container.
+ *
+ * @author Thomas.Diesler@jboss.com
+ * @since 02-Jun-2011
+ */
+public class CommonContainerExtension implements LoadableExtension {
+
+    @Override
+    public void register(final ExtensionBuilder builder) {
+        builder.service(DeploymentExceptionTransformer.class, ExceptionTransformer.class);
+        builder.service(ResourceProvider.class, ManagementClientProvider.class);
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
@@ -1,0 +1,183 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.arquillian.container.spi.ConfigurationException;
+import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class CommonDomainContainerConfiguration implements ContainerConfiguration {
+
+    private InetAddress managementAddress;
+    private int managementPort;
+
+    private String username;
+    private String password;
+
+    private Map<String, String> containerNameMap;
+
+    private Map<String, String> containerModeMap;
+
+    private int serverGroupOperationTimeoutInSeconds = 60;
+
+    private int serverOperationTimeoutInSeconds = 60;
+
+    public CommonDomainContainerConfiguration() {
+        managementAddress = getInetAddress("127.0.0.1");
+        managementPort = 9999;
+    }
+
+    public InetAddress getManagementAddress() {
+        return managementAddress;
+    }
+
+    public void setManagementAddress(String host) {
+        this.managementAddress = getInetAddress(host);
+    }
+
+    public int getManagementPort() {
+        return managementPort;
+    }
+
+    public void setManagementPort(int managementPort) {
+        this.managementPort = managementPort;
+    }
+
+    private InetAddress getInetAddress(String name) {
+        try {
+            return InetAddress.getByName(name);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Unknown host: " + name);
+        }
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * @return the containerNameMap
+     */
+    public Map<String, String> getContainerNameMap() {
+        if (containerNameMap == null) {
+            return new HashMap<String, String>();
+        }
+        return containerNameMap;
+    }
+
+    /**
+     * Change the container name as seen by Arquillian of the Servers or ServerGroups in the Domain.
+     * format: host:server-name=new-name,server-group-name=crm-servers
+     *
+     * @param containerNameMap
+     */
+    public void setContainerNameMap(String containerNameMap) {
+        this.containerNameMap = convertToMap(containerNameMap);
+    }
+
+    /**
+     * @return the containerModeMap
+     */
+    public Map<String, String> getContainerModeMap() {
+        if (containerModeMap == null) {
+            return new HashMap<String, String>();
+        }
+        return containerModeMap;
+    }
+
+    /**
+     * Change the container mode of the Servers or ServerGroups in the Domain.
+     * format: host:server-name=manual,host:.*=suite
+     *
+     * @param containerModeMap
+     */
+    public void setContainerModeMap(String containerModeString) {
+        this.containerModeMap = convertToMap(containerModeString);
+    }
+
+    /**
+     * The number of seconds to wait before failing when starting/stopping a server group in the Domain.
+     *
+     * @param serverGroupStartupTimeoutInSeconds
+     */
+    public void setServerGroupOperationTimeoutInSeconds(int serverGroupStartupTimeoutInSeconds) {
+        this.serverGroupOperationTimeoutInSeconds = serverGroupStartupTimeoutInSeconds;
+    }
+
+    public int getServerGroupOperationTimeoutInSeconds() {
+        return serverGroupOperationTimeoutInSeconds;
+    }
+
+    /**
+     * The number of seconds to wait before failing when starting/stopping a single server in the Domain.
+     *
+     * @param serverStartupTimeoutInSeconds
+     */
+    public void setServerOperationTimeoutInSeconds(int serverStartupTimeoutInSeconds) {
+        this.serverOperationTimeoutInSeconds = serverStartupTimeoutInSeconds;
+    }
+
+    public int getServerOperationTimeoutInSeconds() {
+        return serverOperationTimeoutInSeconds;
+    }
+
+    @Override
+    public void validate() throws ConfigurationException {
+        if (username != null && password == null) {
+            throw new ConfigurationException("username has been set, but no password given");
+        }
+    }
+
+    private Map<String, String> convertToMap(String data) {
+        Map<String, String> map = new HashMap<String, String>();
+        String[] values = data.split(",");
+
+        for (String value : values) {
+            String[] content = value.split("=");
+            if(content.length != 2) {
+                throw new IllegalArgumentException("Could not parse map data from '" + data +"'. Missing value or key in '" + value + "'");
+            }
+            map.put(clean(content[0]), clean(content[1]));
+        }
+        return map;
+    }
+
+    private String clean(String data) {
+        return data.replaceAll("\\r\\n|\\r|\\n", " ").trim();
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainDeployableContainer.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainDeployableContainer.java
@@ -1,0 +1,301 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
+import org.jboss.arquillian.config.descriptor.impl.ContainerDefImpl;
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.Container.State;
+import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
+import org.jboss.arquillian.container.spi.event.SetupContainer;
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+import org.jboss.as.arquillian.container.domain.Domain.ServerGroup;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public abstract class CommonDomainDeployableContainer<T extends CommonDomainContainerConfiguration> implements
+        DeployableContainer<T> {
+
+    @Inject
+    private Instance<ContainerRegistry> containerRegistryInstance;
+
+    @Inject
+    private Instance<ServiceLoader> serviceLoaderInstance;
+
+    @Inject
+    private Instance<Injector> injectorInst;
+
+    @Inject // we need to fire setup events to trigger the container context creation
+    private Event<SetupContainer> setupEvent;
+
+    private final Logger log = Logger.getLogger(CommonDomainDeployableContainer.class.getName());
+    private T containerConfig;
+    private ManagementClient managementClient;
+
+    @Inject
+    @ContainerScoped
+    private InstanceProducer<ArchiveDeployer> archiveDeployerInst;
+
+    @Inject
+    @ContainerScoped
+    private InstanceProducer<ManagementClient> managementClientInst;
+
+    @Inject
+    @ContainerScoped
+    private InstanceProducer<Domain> domainInst;
+
+    @Override
+    public ProtocolDescription getDefaultProtocol() {
+        return new ProtocolDescription("Servlet 3.0");
+    }
+
+    @Override
+    public void setup(T config) {
+        containerConfig = config;
+    }
+
+    @Override
+    public void start() throws LifecycleException {
+
+        if (containerConfig.getUsername() != null) {
+            Authentication.username = containerConfig.getUsername();
+            Authentication.password = containerConfig.getPassword();
+        }
+
+        DomainClient domainClient = DomainClient.Factory.create(containerConfig.getManagementAddress(),
+                containerConfig.getManagementPort(), Authentication.getCallbackHandler());
+
+        managementClient = new ManagementClient(domainClient, containerConfig.getManagementAddress().getHostAddress(),
+                containerConfig.getManagementPort());
+
+        managementClientInst.set(managementClient);
+
+        ArchiveDeployer archiveDeployer = new ArchiveDeployer(domainClient.getDeploymentManager());
+        archiveDeployerInst.set(archiveDeployer);
+
+        try {
+            startInternal();
+        } catch (LifecycleException e) {
+            safeCloseClient();
+            throw e;
+        }
+
+        ContainerRegistry registry = containerRegistryInstance.get();
+
+        Map<String, String> containerNameMap = containerConfig.getContainerNameMap();
+        Map<String, String> modeMap = containerConfig.getContainerModeMap();
+
+        Domain domain = managementClient.createDomain(containerNameMap);
+        domainInst.set(domain);
+
+        waitForStart(domain, managementClient);
+
+        // Register all ServerGroups
+        for (ServerGroup serverGroup: domain.getServerGroups()) {
+            Container serverContainer = createServerGroupContainer(registry, archiveDeployer, domain, serverGroup,
+                    containerConfig.getServerGroupOperationTimeoutInSeconds());
+            String mode = mapMode(modeMap, serverContainer.getName());
+            if(mode != null) {
+                serverContainer.getContainerConfiguration().setMode(mode);
+            }
+            setupEvent.fire(new SetupContainer(serverContainer));
+            serverContainer.setState(Container.State.STARTED);
+        }
+
+        // Register all Servers
+        for (Server server : domain.getServers()) {
+            Container serverContainer = createServerContainer(registry, server, containerConfig.getServerOperationTimeoutInSeconds());
+            String mode = mapMode(modeMap, serverContainer.getName());
+            if(mode != null) {
+                serverContainer.getContainerConfiguration().setMode(mode);
+            }
+            String serverStatus = managementClient.getServerState(server);
+
+            setupEvent.fire(new SetupContainer(serverContainer));
+            if (serverStatus.equals("STARTED")) {
+                serverContainer.setState(Container.State.STARTED);
+            } else {
+                serverContainer.setState(Container.State.STOPPED);
+            }
+        }
+    }
+
+    @Override
+    public final void stop() throws LifecycleException {
+        try {
+            stopInternal();
+
+            updateDomainMembersState(State.STOPPED);
+        } finally {
+            safeCloseClient();
+        }
+    }
+
+    protected abstract void startInternal() throws LifecycleException;
+
+    protected abstract void waitForStart(Domain domain, ManagementClient client) throws LifecycleException;
+
+    protected abstract void stopInternal() throws LifecycleException;
+
+    @Override
+    public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not deploy directly from a Domain Controller");
+    }
+
+    @Override
+    public void undeploy(Archive<?> archive) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not undeploy directly from a Domain Controller");
+    }
+
+    @Override
+    public void deploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not deploy directly from a Domain Controller");
+    }
+
+    @Override
+    public void undeploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not undeploy directly from a Domain Controller");
+    }
+
+    protected T getContainerConfiguration() {
+        return containerConfig;
+    }
+
+    protected ManagementClient getManagementClient() {
+        return managementClient;
+    }
+
+    protected ModelControllerClient getModelControllerClient() {
+        return managementClient.getControllerClient();
+    }
+
+    private void safeCloseClient() {
+        try {
+            managementClient.close();
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Caught exception closing ModelControllerClient", e);
+        }
+    }
+
+    private Container createServerContainer(ContainerRegistry registry, final Server server, final int operationTimeout) {
+        ContainerDef def = new ContainerDefImpl("arquillian")
+                                .container(server.getContainerName())
+                                .setMode("custom");
+
+        return registry.create(def, new ServiceLoader() {
+
+            @Override
+            public <X> X onlyOne(Class<X> serviceClass, Class<? extends X> defaultServiceClass) {
+                return serviceLoaderInstance.get().onlyOne(serviceClass, defaultServiceClass);
+            }
+
+            @Override
+            public <X> X onlyOne(Class<X> serviceClass) {
+                if (serviceClass == DeployableContainer.class) {
+                    return serviceClass.cast(injectorInst.get().inject(new ServerContainer(managementClient, server, operationTimeout)));
+                }
+                return serviceLoaderInstance.get().onlyOne(serviceClass);
+            }
+
+            @Override
+            public <X> Collection<X> all(Class<X> serviceClass) {
+                return serviceLoaderInstance.get().all(serviceClass);
+            }
+        });
+    }
+
+    private Container createServerGroupContainer(ContainerRegistry registry, final ArchiveDeployer archiveDeployer,
+            final Domain domain, final ServerGroup serverGroup, final int operationTimeout) {
+        ContainerDef def = new ContainerDefImpl("arquillian")
+                                .container(serverGroup.getContainerName())
+                                .setMode("suite");
+
+        return registry.create(def, new ServiceLoader() {
+
+            @Override
+            public <X> X onlyOne(Class<X> serviceClass, Class<? extends X> defaultServiceClass) {
+                return serviceLoaderInstance.get().onlyOne(serviceClass, defaultServiceClass);
+            }
+
+            @Override
+            public <X> X onlyOne(Class<X> serviceClass) {
+                if (serviceClass == DeployableContainer.class) {
+                    return serviceClass.cast(injectorInst.get().inject(
+                            new ServerGroupContainer(managementClient, archiveDeployer, domain, serverGroup, operationTimeout)));
+                }
+                return serviceLoaderInstance.get().onlyOne(serviceClass);
+            }
+
+            @Override
+            public <X> Collection<X> all(Class<X> serviceClass) {
+                return serviceLoaderInstance.get().all(serviceClass);
+            }
+        });
+    }
+
+    /**
+     * Update all Arquillian Containers in the Domain (group and server) with the new State.
+     *
+     * The Domain Controller can start/stop nodes outside of Arquillian's control.
+     */
+    private void updateDomainMembersState(State newState) {
+        ContainerRegistry registry = containerRegistryInstance.get();
+        Domain domain = domainInst.get();
+
+        for (Server server : domain.getServers()) {
+            registry.getContainer(server.getContainerName()).setState(newState);
+        }
+
+        for (ServerGroup group : domain.getServerGroups()) {
+            registry.getContainer(group.getContainerName()).setState(newState);
+        }
+    }
+
+    private String mapMode(Map<String, String> modeMap, String name) {
+        for(Map.Entry<String, String> entry : modeMap.entrySet()) {
+            if(name.matches(entry.getKey())) {
+                log.info("Mapping " + name + " to container mode " + entry.getValue() + " based on expression " + entry.getKey());
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/Domain.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/Domain.java
@@ -1,0 +1,253 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Simple Object that holds a flat version of the Domain
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class Domain {
+
+    private Set<Server> servers = new HashSet<Server>();
+    private Set<ServerGroup> serverGroups = new HashSet<ServerGroup>();
+
+    public void addServer(Server server) {
+        servers.add(server);
+    }
+
+    public void addServerGroup(ServerGroup group) {
+        serverGroups.add(group);
+    }
+
+    public Set<Server> getServers() {
+        return servers;
+    }
+
+    public Set<ServerGroup> getServerGroups() {
+        return serverGroups;
+    }
+
+    public Set<String> getHosts() {
+        Set<String> unique = new HashSet<String>();
+
+        for (Server server : servers) {
+            unique.add(server.host);
+        }
+        return unique;
+    }
+
+    public Set<Server> getServersInGroup(ServerGroup group) {
+        return getServersInGroup(group.getName());
+    }
+
+    public Set<Server> getServersInGroup(String group) {
+        Set<Server> unique = new HashSet<Domain.Server>();
+
+        for (Server server : servers) {
+            if (group.equals(server.group)) {
+                unique.add(server);
+            }
+        }
+        return unique;
+    }
+
+    public Set<Server> getAutoStartServers() {
+        Set<Server> auto = new HashSet<Domain.Server>();
+
+        for (Server server : servers) {
+            if (server.autostart) {
+                auto.add(server);
+            }
+        }
+        return auto;
+    }
+
+    public static class ServerGroup {
+        private String name;
+        private String containerName;
+
+        public ServerGroup(String name) {
+            if (name == null) {
+                throw new IllegalArgumentException("Name must be specified");
+            }
+            this.name = name;
+        }
+
+        /**
+         * @return the Group Name as known to the Domain Controller
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * @return the Container name as known to Arquillian
+         */
+        public String getContainerName() {
+            if (containerName != null) {
+                return containerName;
+            }
+            return getName();
+        }
+
+        public void setContainerName(String containerName) {
+            this.containerName = containerName;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((name == null) ? 0 : name.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            ServerGroup other = (ServerGroup) obj;
+            if (name == null) {
+                if (other.name != null)
+                    return false;
+            } else if (!name.equals(other.name))
+                return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ServerGroup [name=" + name + ", containerName=" + getContainerName() + "]";
+        }
+    }
+
+    public static class Server {
+        private String name;
+        private String containerName;
+        private String host;
+        private String group;
+        private boolean autostart = false;
+
+        public Server(String name, String host, String group, boolean autostart) {
+            if (name == null || host == null) {
+                throw new IllegalArgumentException("Server name and host can not be null. name[" + name + "], host[" + host+ "]");
+            }
+            this.name = name;
+            this.host = host;
+            this.group = group;
+            this.autostart = autostart;
+        }
+
+        /**
+         * @return The server group this server belongs to
+         */
+        public String getGroup() {
+            return group;
+        }
+
+        /**
+         * @return The host of this server
+         */
+        public String getHost() {
+            return host;
+        }
+
+        /**
+         * @return Server name as known to the Domain Controller
+         */
+        public String getName() {
+            return name;
+        }
+
+        public String getUniqueName() {
+            return host + ":" + name;
+        }
+
+        /**
+         * @return Server/Container name as known to Arquillian
+         */
+        public String getContainerName() {
+            if (containerName != null) {
+                return containerName;
+            }
+            return getUniqueName();
+        }
+
+        public void setContainerName(String containerName) {
+            this.containerName = containerName;
+        }
+
+        /**
+         * @return Is this server marked to autostart during Domain Controller startup
+         */
+        public boolean isAutostart() {
+            return autostart;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((group == null) ? 0 : group.hashCode());
+            result = prime * result + ((host == null) ? 0 : host.hashCode());
+            result = prime * result + ((name == null) ? 0 : name.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Server other = (Server) obj;
+            if (group == null) {
+                if (other.group != null)
+                    return false;
+            } else if (!group.equals(other.group))
+                return false;
+            if (host == null) {
+                if (other.host != null)
+                    return false;
+            } else if (!host.equals(other.host))
+                return false;
+            if (name == null) {
+                if (other.name != null)
+                    return false;
+            } else if (!name.equals(other.name))
+                return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "[host=" + host + ", name=" + name + ", group=" + group + ", containerName=" + getContainerName() + "]";
+        }
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/EmptyConfiguration.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/EmptyConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import org.jboss.arquillian.container.spi.ConfigurationException;
+import org.jboss.arquillian.container.spi.client.container.ContainerConfiguration;
+
+/**
+ * DomainControllerContainerConfiguration
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class EmptyConfiguration implements ContainerConfiguration {
+
+    @Override
+    public void validate() throws ConfigurationException {
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ExceptionTransformer.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ExceptionTransformer.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
+
+/**
+ *
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+public class ExceptionTransformer implements DeploymentExceptionTransformer {
+
+    @Override
+    public Throwable transform(final Throwable exception) {
+        // NOOP Base impl
+        return exception;
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/LazyHttpContext.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/LazyHttpContext.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.util.List;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+
+/**
+ * We lookup deployment context lazy because the server in the server-group might not be started during deploy time.
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class LazyHttpContext extends HTTPContext {
+
+    private Server server;
+    private String deploymentName;
+    private ManagementClient client;
+
+    private HTTPContext context = null;
+
+    public LazyHttpContext(Server server, String deploymentName, ManagementClient client) {
+        super("localhost", -1);
+
+        this.server = server;
+        this.deploymentName = deploymentName;
+        this.client = client;
+    }
+
+    @Override
+    public String getName() {
+        return server.getContainerName();
+    }
+
+    @Override
+    public String getHost() {
+        initiateContext();
+        return context.getHost();
+    }
+
+    @Override
+    public int getPort() {
+        initiateContext();
+        return context.getPort();
+    }
+
+    @Override
+    public HTTPContext add(Servlet servlet) {
+        initiateContext();
+        return context.add(servlet);
+    }
+
+    @Override
+    public List<Servlet> getServlets() {
+        initiateContext();
+        return context.getServlets();
+    }
+
+    @Override
+    public Servlet getServletByName(String name) {
+        initiateContext();
+        return context.getServletByName(name);
+    }
+
+    private void initiateContext() {
+        if (context == null) {
+            context = client.getHTTPDeploymentMetaData(server, deploymentName);
+        }
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -1,0 +1,462 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATUS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.MBeanServerConnection;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+import org.jboss.as.arquillian.container.domain.Domain.ServerGroup;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A helper class to join management related operations, like extract sub system ip/port (web/jmx) and deployment introspection.
+ *
+ * @author <a href="aslak@redhat.com">Aslak Knutsen</a>
+ */
+public class ManagementClient {
+
+    private static final String SUBDEPLOYMENT = "subdeployment";
+    private static final String WEB = "web";
+
+    private static final String JMX = "jmx";
+
+    private static final String PROTOCOL_HTTP = "http";
+
+    private static final String NAME = "name";
+    private static final String SERVLET = "servlet";
+
+    private static final String POSTFIX_WEB = ".war";
+    private static final String POSTFIX_EAR = ".ear";
+
+    private final String mgmtAddress;
+    private final int mgmtPort;
+    private final ModelControllerClient client;
+    private final Map<String, URI> subsystemURICache;
+
+    // cache static RootNode
+    private ModelNode rootNode = null;
+
+    private MBeanServerConnection connection;
+    private JMXConnector connector;
+
+    public ManagementClient(ModelControllerClient client, final String mgmtAddress, final int managementPort) {
+        if (client == null) {
+            throw new IllegalArgumentException("Client must be specified");
+        }
+        this.client = client;
+        this.mgmtAddress = mgmtAddress;
+        this.subsystemURICache = new HashMap<String, URI>();
+        this.mgmtPort = managementPort;
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // Public API -------------------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    public ModelControllerClient getControllerClient() {
+        return client;
+    }
+
+    public Domain createDomain(Map<String, String> containerNameMap) {
+        lazyLoadRootNode();
+
+        Domain domain = new Domain();
+        for (String hostNodeName : rootNode.get(HOST).keys()) {
+
+            for (String serverConfigName : rootNode.get(HOST).get(hostNodeName).get(SERVER_CONFIG).keys()) {
+                ModelNode serverConfig = rootNode.get(HOST).get(hostNodeName).get(SERVER_CONFIG).get(serverConfigName);
+
+                Server server = new Server(
+                        serverConfig.get(NAME).asString(),
+                        hostNodeName,
+                        serverConfig.get(GROUP).asString(),
+                        serverConfig.get(AUTO_START).asBoolean());
+
+                if(containerNameMap.containsKey(server.getUniqueName())) {
+                    server.setContainerName(containerNameMap.get(server.getUniqueName()));
+                }
+                domain.addServer(server);
+            }
+        }
+        for (String serverGroupName : rootNode.get(SERVER_GROUP).keys()) {
+
+            ServerGroup group = new ServerGroup(serverGroupName);
+            if(containerNameMap.containsKey(group.getName())) {
+                group.setContainerName(containerNameMap.get(group.getName()));
+            }
+            domain.addServerGroup(group);
+        }
+        return domain;
+    }
+
+    public String getServerState(Domain.Server server) {
+        lazyLoadRootNode();
+
+        ModelNode hostNode = rootNode.get(HOST).get(server.getHost());
+        if (!hostNode.isDefined()) {
+            throw new IllegalArgumentException("Host not found on domain " + server.getHost());
+        }
+
+        ModelNode serverConfig = hostNode.get(SERVER_CONFIG).get(server.getName());
+        if (!serverConfig.isDefined()) {
+            throw new IllegalArgumentException("Server " + server + " not found on host " + server.getHost());
+        }
+        return serverConfig.get(STATUS).asString();
+    }
+
+    public HTTPContext getHTTPDeploymentMetaData(Server server, String uniqueDeploymentName) {
+
+        URI webURI = getProtocolURI(server, PROTOCOL_HTTP);
+        HTTPContext context = new HTTPContext(webURI.getHost(), webURI.getPort());
+        try {
+            ModelNode deploymentNode = readResource(createHostServerDeploymentAddress(
+                    server.getHost(), server.getName(), uniqueDeploymentName), false); // don't include runtime information, workaround for bug in web statistics
+
+            if (isWebArchive(uniqueDeploymentName)) {
+                extractWebArchiveContexts(context, deploymentNode);
+            } else if (isEnterpriseArchive(uniqueDeploymentName)) {
+                extractEnterpriseArchiveContexts(context, deploymentNode);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Could not extract deployment information for server: " + server + " on deployment: "
+                    + uniqueDeploymentName, e);
+        }
+        return context;
+    }
+
+    public void startServerGroup(String groupName) {
+        try {
+            executeOperation("start-servers", new ModelNode().add(SERVER_GROUP, groupName));
+        } catch (Exception e) {
+            throw new RuntimeException("Could not start server-group " + groupName, e);
+        }
+    }
+
+    public void stopServerGroup(String groupName) {
+        try {
+            executeOperation("stop-servers", new ModelNode().add(SERVER_GROUP, groupName));
+        } catch (Exception e) {
+            throw new RuntimeException("Could not stop server-group " + groupName, e);
+        }
+    }
+
+    public void startServer(Server server) {
+        try {
+            executeOperation("start", new ModelNode().add(HOST, server.getHost()).add(SERVER_CONFIG, server.getName()));
+        } catch (Exception e) {
+            throw new RuntimeException("Could not start server " + server, e);
+        }
+    }
+
+    public void stopServer(Server server) {
+        try {
+            executeOperation("stop", new ModelNode().add(HOST, server.getHost()).add(SERVER_CONFIG, server.getName()));
+        } catch (Exception e) {
+            throw new RuntimeException("Could not stop server " + server, e);
+        }
+    }
+
+    public boolean isServerStarted(Server server) {
+        try {
+
+            ModelNode result = readAttribute("status", createHostServerConfigAddress(server.getHost(), server.getName()));
+            if(result.asString().equalsIgnoreCase("STARTED")) {
+                result = readAttribute("server-state", createHostServerAddress(server.getHost(), server.getName()));
+                if(result.asString().equalsIgnoreCase("running")) {
+                    return true;
+                }
+            }
+            return false;
+
+        } catch (Exception ignored) { }
+        return false;
+    }
+
+    public boolean isDomainInRunningState() {
+        try {
+            // some random values to read in hopes the domain controller is up and running..
+            ModelNode op = Util.getEmptyOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS.toModelNode());
+            op.get(CHILD_TYPE).set("server-group");
+            ModelNode rsp = client.execute(op);
+
+            return SUCCESS.equals(rsp.get(OUTCOME).asString()) && rsp.get("result").asList().size() > 0;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    public void close() {
+        try {
+            getControllerClient().close();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not close connection", e);
+        } finally {
+            if (connector != null) {
+                try {
+                    connector.close();
+                } catch (IOException e) {
+                    throw new RuntimeException("Could not close JMX connection", e);
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // Subsystem URI Lookup ---------------------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    private URI getProtocolURI(Server server, String subsystem) {
+        String cacheKey = server + subsystem;
+        URI subsystemURI = subsystemURICache.get(cacheKey);
+        if (subsystemURI != null) {
+            return subsystemURI;
+        }
+        subsystemURI = extractProtocolURI(server, subsystem);
+        subsystemURICache.put(cacheKey, subsystemURI);
+        return subsystemURI;
+    }
+
+    private URI extractProtocolURI(Server server, String protocol) {
+        try {
+            ModelNode node = readResource(createHostServerSocketBindingsAddress(server.getHost(), server.getName(),
+                    getSocketBindingGroup(server.getGroup())));
+
+            ModelNode socketBinding = node.get(SOCKET_BINDING).get(protocol);
+            return URI.create(protocol + "://" + socketBinding.get("bound-address").asString() + ":"
+                    + socketBinding.get("bound-port"));
+
+        } catch (Exception e) {
+            throw new RuntimeException("Could not extract address information from server: " + server + " for protocol "
+                    + protocol + ". Is the server running?", e);
+        }
+    }
+
+    private void readRootNode() throws Exception {
+        rootNode = readResource(new ModelNode());
+    }
+
+    private String getSocketBindingGroup(String serverGroup) {
+        lazyLoadRootNode();
+        return rootNode.get(SERVER_GROUP).get(serverGroup).get(SOCKET_BINDING_GROUP).asString();
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // Metadata Extraction Operations -----------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    private boolean isEnterpriseArchive(String deploymentName) {
+        return deploymentName.endsWith(POSTFIX_EAR);
+    }
+
+    private boolean isWebArchive(String deploymentName) {
+        return deploymentName.endsWith(POSTFIX_WEB);
+    }
+
+    private ModelNode createHostServerAddress(String host, String server) {
+        return new ModelNode().add(HOST, host).add(SERVER, server);
+    }
+
+    private ModelNode createHostServerConfigAddress(String host, String server) {
+        return new ModelNode().add(HOST, host).add(SERVER_CONFIG, server);
+    }
+
+    private ModelNode createHostServerDeploymentAddress(String host, String server, String deploymentName) {
+        return new ModelNode().add(HOST, host).add(SERVER, server).add(DEPLOYMENT, deploymentName);
+    }
+
+    private ModelNode createHostServerSocketBindingsAddress(String host, String server, String socketBindingGroup) {
+        return new ModelNode().add(HOST, host).add(SERVER, server).add(SOCKET_BINDING_GROUP, socketBindingGroup);
+    }
+
+    private void extractEnterpriseArchiveContexts(HTTPContext context, ModelNode deploymentNode) {
+        if (deploymentNode.hasDefined(SUBDEPLOYMENT)) {
+            for (ModelNode subdeployment : deploymentNode.get(SUBDEPLOYMENT).asList()) {
+                String deploymentName = subdeployment.keys().iterator().next();
+                if (isWebArchive(deploymentName)) {
+                    extractWebArchiveContexts(context, deploymentName, subdeployment.get(deploymentName));
+                }
+            }
+        }
+    }
+
+    private void extractWebArchiveContexts(HTTPContext context, ModelNode deploymentNode) {
+        extractWebArchiveContexts(context, deploymentNode.get(NAME).asString(), deploymentNode);
+    }
+
+    private void extractWebArchiveContexts(HTTPContext context, String deploymentName, ModelNode deploymentNode) {
+        if (deploymentNode.hasDefined(SUBSYSTEM)) {
+            ModelNode subsystem = deploymentNode.get(SUBSYSTEM);
+            if (subsystem.hasDefined(WEB)) {
+                ModelNode webSubSystem = subsystem.get(WEB);
+                if (webSubSystem.isDefined() && webSubSystem.hasDefined("context-root")) {
+                    final String contextName = webSubSystem.get("context-root").asString();
+                    if (webSubSystem.hasDefined(SERVLET)) {
+                        for (final ModelNode servletNode : webSubSystem.get(SERVLET).asList()) {
+                            for (final String servletName : servletNode.keys()) {
+                                context.add(new Servlet(servletName, toContextName(contextName)));
+                            }
+                        }
+                    }
+                    /*
+                     * This is a WebApp, it has some form of webcontext whether it has a Servlet or not. AS7 does not expose jsp
+                     * / default servlet in mgm api
+                     */
+                    context.add(new Servlet("default", toContextName(contextName)));
+                }
+            }
+        }
+    }
+
+    private String toContextName(String deploymentName) {
+        String correctedName = deploymentName;
+        if (correctedName.startsWith("/")) {
+            correctedName = correctedName.substring(1);
+        }
+        if (correctedName.indexOf(".") != -1) {
+            correctedName = correctedName.substring(0, correctedName.lastIndexOf("."));
+        }
+        return correctedName;
+    }
+
+    // -------------------------------------------------------------------------------------||
+    // Common Management API Operations ---------------------------------------------------||
+    // -------------------------------------------------------------------------------------||
+
+    private void lazyLoadRootNode() {
+        try {
+            if (rootNode == null) {
+                readRootNode();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ModelNode readResource(ModelNode address) throws Exception {
+        return readResource(address, true);
+    }
+
+    private ModelNode readResource(ModelNode address, boolean includeRuntime) throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(RECURSIVE).set("true");
+        operation.get(INCLUDE_RUNTIME).set(includeRuntime);
+        operation.get(OP_ADDR).set(address);
+
+        return executeForResult(operation);
+    }
+
+    private ModelNode readAttribute(String attribute, ModelNode address) throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(NAME).set(attribute);
+        operation.get(OP_ADDR).set(address);
+
+        return executeForResult(operation);
+    }
+
+    private ModelNode executeOperation(String operation, ModelNode address) throws Exception {
+        final ModelNode request = new ModelNode();
+        request.get(OP).set(operation);
+        request.get(OP_ADDR).set(address);
+
+        return executeForResult(request);
+    }
+
+    private ModelNode executeForResult(final ModelNode operation) throws Exception {
+        final ModelNode result = client.execute(operation);
+        checkSuccessful(result, operation);
+        return result.get(RESULT);
+    }
+
+    private void checkSuccessful(final ModelNode result, final ModelNode operation) throws UnSuccessfulOperationException {
+        if (!SUCCESS.equals(result.get(OUTCOME).asString())) {
+            System.out.println(result);
+            throw new UnSuccessfulOperationException(result.get(FAILURE_DESCRIPTION).toString());
+        }
+    }
+
+    private static class UnSuccessfulOperationException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public UnSuccessfulOperationException(String message) {
+            super(message);
+        }
+    }
+
+    private MBeanServerConnection getConnection() {
+        if (connection == null) {
+            try {
+                final HashMap<String, Object> env = new HashMap<String, Object>();
+                env.put(CallbackHandler.class.getName(), Authentication.getCallbackHandler());
+                connection = JMXConnectorFactory.connect(getRemoteJMXURL(), env).getMBeanServerConnection();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return connection;
+    }
+
+    private JMXServiceURL getRemoteJMXURL() {
+        try {
+            return new JMXServiceURL("service:jmx:remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":"
+                    + mgmtPort);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create JMXServiceURL:" + this, e);
+        }
+    }
+
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClientProvider.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClientProvider.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.arquillian.container.test.impl.enricher.resource.OperatesOnDeploymentAwareProvider;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+
+/**
+ * {@link OperatesOnDeploymentAwareProvider} implementation to
+ * provide {@link ManagementClient} injection to {@link ArquillianResource}-
+ * annotated fields.
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+public class ManagementClientProvider extends OperatesOnDeploymentAwareProvider {
+
+    @Inject
+    private Instance<ManagementClient> managementClient;
+
+    /**
+     * {@inheritDoc}
+     * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider#canProvide(java.lang.Class)
+     */
+    @Override
+    public boolean canProvide(final Class<?> type) {
+        return type.isAssignableFrom(ManagementClient.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see org.jboss.arquillian.container.test.impl.enricher.resource.OperatesOnDeploymentAwareProvider#doLookup(org.jboss.arquillian.test.api.ArquillianResource, java.lang.annotation.Annotation[])
+     */
+    @Override
+    public Object doLookup(final ArquillianResource resource, final Annotation... qualifiers) {
+        return managementClient.get();
+    }
+
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/NetworkUtils.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/NetworkUtils.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.arquillian.container.domain;
+
+/**
+ * Utility methods related to networking.
+ *
+ * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ */
+public class NetworkUtils {
+
+    public static String formatPossibleIpv6Address(String address) {
+        if (address == null) {
+            return address;
+        }
+        if (!address.contains(":")) {
+            return address;
+        }
+        if (address.startsWith("[") && address.endsWith("]")) {
+            return address;
+        }
+        return "[" + address + "]";
+    }
+
+    // No instantiation
+    private NetworkUtils() {
+
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ServerContainer.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ServerContainer.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServerContainer implements DeployableContainer<EmptyConfiguration> {
+
+    private ManagementClient client;
+    private Server server;
+    private int operationTimeout;
+
+    public ServerContainer(ManagementClient client, Server server, int operationTimeout) {
+        this.client = client;
+        this.server = server;
+        this.operationTimeout = operationTimeout;
+    }
+
+    @Override
+    public Class<EmptyConfiguration> getConfigurationClass() {
+        return EmptyConfiguration.class;
+    }
+
+    @Override
+    public void setup(EmptyConfiguration configuration) {
+    }
+
+    @Override
+    public void start() throws LifecycleException {
+        client.startServer(server);
+
+        waitForServerToStart();
+    }
+
+    @Override
+    public void stop() throws LifecycleException {
+        client.stopServer(server);
+
+        waitForServerToStop();
+    }
+
+    @Override
+    public ProtocolDescription getDefaultProtocol() {
+        return new ProtocolDescription("Servlet 3.0");
+    }
+
+    @Override
+    public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not deploy to a single server in the domain, target server-group " + server.getGroup());
+    }
+
+    @Override
+    public void undeploy(Archive<?> archive) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not undeploy from a single server in the domain, target server-group " + server.getGroup());
+    }
+
+    @Override
+    public void deploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not deploy to a single server in the domain, target server-group " + server.getGroup());
+    }
+
+    @Override
+    public void undeploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Can not undeploy from a single server in the domain, target server-group " + server.getGroup());
+    }
+
+    private void waitForServerToStart() {
+        waitForServerState(true);
+    }
+
+    private void waitForServerToStop() {
+        waitForServerState(false);
+    }
+
+    private void waitForServerState(boolean shouldBeStarted) {
+        long timeout = operationTimeout * 1000;
+        long sleep = 100;
+
+        while (timeout > 0) {
+            if (shouldBeStarted == client.isServerStarted(server)) {
+                break;
+            }
+            try {
+                Thread.sleep(sleep);
+                timeout -= sleep;
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Failed waiting for server to " + (shouldBeStarted ? "start" : "stop"), e);
+            }
+        }
+        if(timeout <= 0) {
+            throw new RuntimeException(
+                    "Server did not " + (shouldBeStarted ? "start":"stop") +
+                    " within set timeout [serverOperationTimeoutInSeconds=" + operationTimeout + "]. " + server);
+        }
+    }
+}

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ServerGroupContainer.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ServerGroupContainer.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.jboss.arquillian.container.spi.Container.State;
+import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+import org.jboss.as.arquillian.container.domain.Domain.ServerGroup;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+import org.jboss.util.NotImplementedException;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ServerGroupContainer implements DeployableContainer<EmptyConfiguration> {
+
+    @Inject @ContainerScoped
+    private InstanceProducer<ArchiveDeployer> archiveDeployerInst;
+
+    @Inject @ContainerScoped
+    private InstanceProducer<ModelControllerClient> clientInst;
+
+    @Inject
+    private Instance<ContainerRegistry> containerRegistryInst;
+
+    private ManagementClient client;
+    private ArchiveDeployer deployer;
+    private ServerGroup serverGroup;
+    private Domain domain;
+    private int operationTimeout;
+
+    public ServerGroupContainer(ManagementClient client, ArchiveDeployer deployer, Domain domain, ServerGroup serverGroup, int operationTimeout) {
+        this.client = client;
+        this.deployer = deployer;
+        this.domain = domain;
+        this.serverGroup = serverGroup;
+        this.operationTimeout = operationTimeout;
+    }
+
+    @Override
+    public Class<EmptyConfiguration> getConfigurationClass() {
+        return EmptyConfiguration.class;
+    }
+
+    @Override
+    public void setup(EmptyConfiguration configuration) {
+        archiveDeployerInst.set(deployer);
+        clientInst.set(client.getControllerClient());
+    }
+
+    @Override
+    public void start() throws LifecycleException {
+        client.startServerGroup(serverGroup.getName());
+
+        waitForGroupMembers(true);
+        updateGroupMembersContainerState(State.STARTED);
+    }
+
+    @Override
+    public void stop() throws LifecycleException {
+        client.stopServerGroup(serverGroup.getName());
+
+        waitForGroupMembers(false);
+        updateGroupMembersContainerState(State.STOPPED);
+    }
+
+    @Override
+    public ProtocolDescription getDefaultProtocol() {
+        return new ProtocolDescription("Servlet 3.0");
+    }
+
+    @Override
+    public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+        String uniqueName = deployer.deploy(archive, serverGroup.getName());
+
+        ProtocolMetaData metaData = new ProtocolMetaData();
+        for (Server server : domain.getServersInGroup(serverGroup)) {
+            metaData.addContext(new LazyHttpContext(server, uniqueName, client));
+        }
+        return metaData;
+    }
+
+    @Override
+    public void undeploy(Archive<?> archive) throws DeploymentException {
+        deployer.undeploy(archive.getName(), serverGroup.getName());
+    }
+
+    @Override
+    public void deploy(Descriptor descriptor) throws DeploymentException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void undeploy(Descriptor descriptor) throws DeploymentException {
+        throw new NotImplementedException();
+    }
+
+    private void waitForGroupMembers(boolean shouldBeStarted) {
+        Set<Server> servers = domain.getServersInGroup(serverGroup);
+
+        long timeout = operationTimeout * 1000;
+        long sleep = 100;
+
+        while (timeout > 0 && servers.size() > 0) {
+            Iterator<Server> serverIterator = servers.iterator();
+            while (serverIterator.hasNext()) {
+                Server server = serverIterator.next();
+                if (shouldBeStarted == client.isServerStarted(server)) {
+                    serverIterator.remove();
+                }
+            }
+            try {
+                Thread.sleep(sleep);
+                timeout -= sleep;
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Failed waiting for servers to " + (shouldBeStarted ? "start" : "stop"), e);
+            }
+        }
+        if(timeout <= 0) {
+            throw new RuntimeException(
+                    "Servers in group did not " + (shouldBeStarted ? "start":"stop") +
+                    " within set timeout [serverGroupOperationTimeoutInSeconds=" + operationTimeout + "]. " + servers);
+        }
+    }
+
+    /**
+     * Update all Arquillian Containers in the Group with the new State.
+     *
+     * The Group can start/stop nodes outside of Arquillian's control.
+     */
+    private void updateGroupMembersContainerState(State newState) {
+        Set<Server> servers = domain.getServersInGroup(serverGroup);
+
+        ContainerRegistry registry = containerRegistryInst.get();
+
+        for (Server server : servers) {
+            registry.getContainer(server.getContainerName()).setState(newState);
+        }
+    }
+}

--- a/arquillian/common-domain/src/test/java/org/jboss/as/arquillian/container/domain/ManagementClientManualTestCase.java
+++ b/arquillian/common-domain/src/test/java/org/jboss/as/arquillian/container/domain/ManagementClientManualTestCase.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * ManagementClientTestCase
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ManagementClientManualTestCase {
+
+    private ManagementClient client;
+    private ArchiveDeployer deployer;
+
+    @Test
+    public void shouldBeAbleToGetDomain() throws Exception {
+
+        Map<String, String> rename = new HashMap<String, String>();
+        rename.put("master:server-one", "backend-1");
+        rename.put("master:server-two", "backend-2");
+        rename.put("master:server-three", "front-1");
+        rename.put("main-server-group", "backend");
+        rename.put("other-server-group", "front");
+        
+        System.out.println("Domain");
+        Domain domain = client.createDomain(rename);
+        for(Server server: domain.getServers()) {
+            System.out.println(server);
+            
+            System.out.println("Started: " + client.isServerStarted(server));
+        }
+        
+        System.out.println(domain.getHosts());
+        System.out.println(domain.getServerGroups());
+        
+    }
+
+
+    @Test
+    public void shouldBeAbleToReadMetadata() throws Exception {
+        String uniqueName = null; 
+        try {
+            uniqueName = deployer.deploy(
+                    ShrinkWrap.create(EnterpriseArchive.class, "test1.ear")
+                        .addAsModule(
+                                ShrinkWrap.create(WebArchive.class)
+                                    .addClass(ManualTestServlet.class)),  
+                    "main-server-group");
+            
+            HTTPContext context = client.getHTTPDeploymentMetaData(
+                    new Server("server-one", "master", "main-server-group", false), 
+                    "test1.ear");
+            
+            System.out.println(context);
+        }
+        finally {
+            if(uniqueName != null) {
+                deployer.undeploy(uniqueName, "main-server-group");
+            }
+        }
+    }
+    
+    //@Test
+    public void shouldbeAbleToStopAndStartServerGroup() throws Exception
+    {
+        client.stopServerGroup("main-server-group");
+        
+        Thread.sleep(5000);
+        
+        client.startServerGroup("main-server-group");
+    }
+    
+    @Test
+    public void shouldbeAbleToStpAndStartServer() throws Exception
+    {
+        Server server = new Server("server-one", "master", "main-server-group", false);
+        client.stopServer(server);
+        System.out.println("stopped");
+        
+        Thread.sleep(5000);
+        
+        client.startServer(server);
+    }
+
+    @Before
+    public void createClient() throws Exception {
+        InetAddress address = InetAddress.getLocalHost();
+        int port = 9999;
+        
+        DomainClient domainClient = DomainClient.Factory.create(
+                address,
+                port,
+                Authentication.getCallbackHandler());
+
+        client = new ManagementClient(
+                domainClient, 
+                address.getHostAddress(), 
+                port);
+        
+        deployer = new ArchiveDeployer(domainClient.getDeploymentManager());
+    }
+    
+    @After
+    public void closeClient() throws Exception {
+        if(client != null) {
+            client.close();
+        }
+    }
+}

--- a/arquillian/common-domain/src/test/java/org/jboss/as/arquillian/container/domain/ManualTestServlet.java
+++ b/arquillian/common-domain/src/test/java/org/jboss/as/arquillian/container/domain/ManualTestServlet.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * TestServlet
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@WebServlet(urlPatterns = "/test")
+public class ManualTestServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().write("test");
+    }
+
+}

--- a/arquillian/container-managed-domain/pom.xml
+++ b/arquillian/container-managed-domain/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-arquillian</artifactId>
+        <version>7.1.2.Final-SNAPSHOT</version>
+    </parent>
+    <artifactId>jboss-as-arquillian-container-domain-managed</artifactId>
+
+    <name>JBoss Application Server: Arquillian Managed Domain Container</name>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <jboss.home>${project.basedir}/../../build/target/jboss-as-${jboss.as.release.version}</jboss.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-arquillian-common-domain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.sasl</groupId>
+            <artifactId>jboss-sasl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-ejb-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${jboss.home}</directory>
+                                    <excludes>
+                                        <exclude>modules/</exclude>
+                                        <exclude>bundles/</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                          <name>java.util.logging.manager</name>
+                          <value>org.jboss.logmanager.LogManager</value>
+                        </property>
+                        <property>
+                          <name>jboss.home</name>
+                          <value>${basedir}/target/jbossas</value>
+                        </property>
+                        <property>
+                          <name>module.path</name>
+                          <value>${jboss.home}/modules</value>
+                        </property>
+                    </systemProperties>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
@@ -1,0 +1,213 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.managed;
+
+import java.io.File;
+
+import org.jboss.arquillian.container.spi.ConfigurationException;
+import org.jboss.arquillian.container.spi.client.deployment.Validate;
+import org.jboss.as.arquillian.container.domain.CommonDomainContainerConfiguration;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ManagedDomainContainerConfiguration extends CommonDomainContainerConfiguration {
+
+    private String jbossHome = System.getenv("JBOSS_HOME");
+
+    private String javaHome = System.getenv("JAVA_HOME");
+
+    private String modulePath = System.getProperty("module.path");
+
+    private String javaVmArguments = System.getProperty("jboss.options", "-Xmx512m -XX:MaxPermSize=128m");
+
+    private int startupTimeoutInSeconds = 60;
+
+    private int autoServerStartupTimeoutInSeconds = 60;
+
+    private boolean outputToConsole = true;
+
+    private String domainConfig = System.getProperty("jboss.domain.default.config", "domain.xml");
+
+    private String hostConfig = System.getProperty("jboss.host.default.config", "host.xml");
+
+    private boolean allowConnectingToRunningServer = false;
+
+    private boolean enableAssertions = true;
+
+    public ManagedDomainContainerConfiguration() {
+        // if no javaHome is set use java.home of already running jvm
+        if (javaHome == null || javaHome.isEmpty()) {
+            javaHome = System.getProperty("java.home");
+        }
+    }
+
+    @Override
+    public void validate() throws ConfigurationException {
+        super.validate();
+
+        Validate.configurationDirectoryExists(jbossHome, "jbossHome '" + jbossHome + "' must exist");
+        if (javaHome != null) {
+            Validate.configurationDirectoryExists(javaHome, "javaHome must exist");
+        }
+    }
+
+    /**
+     * @return the jbossHome
+     */
+    public String getJbossHome() {
+        return jbossHome;
+    }
+
+    /**
+     * @param jbossHome the jbossHome to set
+     */
+    public void setJbossHome(String jbossHome) {
+        this.jbossHome = new File(jbossHome).getAbsolutePath();
+    }
+
+    /**
+     * @return the javaHome
+     */
+    public String getJavaHome() {
+        return javaHome;
+    }
+
+    /**
+     * @param javaHome the javaHome to set
+     */
+    public void setJavaHome(String javaHome) {
+        this.javaHome = javaHome;
+    }
+
+    /**
+     * @return the javaVmArguments
+     */
+    public String getJavaVmArguments() {
+        return javaVmArguments;
+    }
+
+    /**
+     * @param javaVmArguments the javaVmArguments to set
+     */
+    public void setJavaVmArguments(String javaVmArguments) {
+        this.javaVmArguments = javaVmArguments;
+    }
+
+    /**
+     * The number of seconds to wait before failing when starting domain controller process
+     *
+     * @param startupTimeoutInSeconds
+     */
+    public void setStartupTimeoutInSeconds(int startupTimeoutInSeconds) {
+        this.startupTimeoutInSeconds = startupTimeoutInSeconds;
+    }
+
+    /**
+     * @return the startupTimeoutInSeconds
+     */
+    public int getStartupTimeoutInSeconds() {
+        return startupTimeoutInSeconds;
+    }
+
+    /**
+     * The number of seconds to wait before failing when starting servers in Auto start mode
+     *
+     * @param autoServerStartupTimeoutInSeconds
+     */
+    public void setAutoServerStartupTimeoutInSeconds(int autoServerStartupTimeoutInSeconds) {
+        this.autoServerStartupTimeoutInSeconds = autoServerStartupTimeoutInSeconds;
+    }
+
+    /**
+     * @return the autoServerStartupTimeoutInSeconds
+     */
+    public int getAutoServerStartupTimeoutInSeconds() {
+        return autoServerStartupTimeoutInSeconds;
+    }
+
+    /**
+     * @param outputToConsole the outputToConsole to set
+     */
+    public void setOutputToConsole(boolean outputToConsole) {
+        this.outputToConsole = outputToConsole;
+    }
+
+    /**
+     * @return the outputToConsole
+     */
+    public boolean isOutputToConsole() {
+        return outputToConsole;
+    }
+
+    /**
+     * Get the server configuration file name. Equivalent to [-server-config=...] on the command line.
+     *
+     * @return the server config
+     */
+    public String getDomainConfig() {
+        return domainConfig;
+    }
+
+    /**
+     * Set the server configuration file name. Equivalent to [-Djboss.domain.default.config=...] on the command line.
+     *
+     * @param domainConfig the domain xml file name
+     */
+    public void setDomainConfig(String domainConfig) {
+        this.domainConfig = domainConfig;
+    }
+
+    public String getModulePath() {
+        return modulePath;
+    }
+
+    public String getHostConfig() {
+        return hostConfig;
+    }
+
+    /**
+     * Set the server configuration file name. Equivalent to [-Djboss.host.default.config=...] on the command line.
+     *
+     * @param domainConfig the host xml file name
+     */
+    public void setHostConfig(String hostConfig) {
+        this.hostConfig = hostConfig;
+    }
+
+    public void setModulePath(final String modulePath) {
+        this.modulePath = modulePath;
+    }
+
+    public boolean isAllowConnectingToRunningServer() {
+        return allowConnectingToRunningServer;
+    }
+
+    public void setAllowConnectingToRunningServer(final boolean allowConnectingToRunningServer) {
+        this.allowConnectingToRunningServer = allowConnectingToRunningServer;
+    }
+
+    public boolean isEnableAssertions() {
+        return enableAssertions;
+    }
+
+    public void setEnableAssertions(final boolean enableAssertions) {
+        this.enableAssertions = enableAssertions;
+    }
+}

--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerExtension.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerExtension.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.managed;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.as.arquillian.container.domain.CommonContainerExtension;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ManagedDomainContainerExtension extends CommonContainerExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        super.register(builder);
+        builder.service(DeployableContainer.class, ManagedDomainDeployableContainer.class);
+    }
+}

--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -1,0 +1,298 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.managed;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.as.arquillian.container.domain.CommonDomainDeployableContainer;
+import org.jboss.as.arquillian.container.domain.Domain;
+import org.jboss.as.arquillian.container.domain.ManagementClient;
+import org.jboss.as.arquillian.container.domain.Domain.Server;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class ManagedDomainDeployableContainer extends CommonDomainDeployableContainer<ManagedDomainContainerConfiguration> {
+
+    private static final String CONFIG_PATH = "/domain/configuration/";
+
+    private final Logger log = Logger.getLogger(ManagedDomainDeployableContainer.class.getName());
+
+    private Thread shutdownThread;
+    private Process process;
+
+    @Override
+    public Class<ManagedDomainContainerConfiguration> getConfigurationClass() {
+        return ManagedDomainContainerConfiguration.class;
+    }
+
+    @Override
+    protected void startInternal() throws LifecycleException {
+        ManagedDomainContainerConfiguration config = getContainerConfiguration();
+
+        if (isServerRunning()) {
+            if (config.isAllowConnectingToRunningServer()) {
+                return;
+            } else {
+                failDueToRunning();
+            }
+        }
+
+        try {
+
+            List<String> cmd = createCommandLine(config);
+
+            log.info("Starting container with: " + cmd.toString());
+            ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+            processBuilder.redirectErrorStream(true);
+            process = processBuilder.start();
+            new Thread(new ConsoleConsumer()).start();
+            final Process proc = process;
+            shutdownThread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    if (proc != null) {
+                        proc.destroy();
+                        try {
+                            proc.waitFor();
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            });
+            Runtime.getRuntime().addShutdownHook(shutdownThread);
+
+            long startupTimeout = getContainerConfiguration().getStartupTimeoutInSeconds();
+            long timeout = startupTimeout * 1000;
+            boolean serverAvailable = false;
+            long sleep = 1000;
+            while (timeout > 0 && serverAvailable == false) {
+                serverAvailable = getManagementClient().isDomainInRunningState();
+                if (!serverAvailable) {
+                    if (processHasDied(proc))
+                        break;
+                    Thread.sleep(sleep);
+                    timeout -= sleep;
+                    sleep = Math.max(sleep / 2, 100);
+                }
+            }
+            if (!serverAvailable) {
+                destroyProcess();
+                throw new TimeoutException(String.format("Managed Domain server was not started within [%d] s",
+                        config.getStartupTimeoutInSeconds()));
+            }
+        } catch (Exception e) {
+            throw new LifecycleException("Could not start container", e);
+        }
+    }
+
+    @Override
+    protected void waitForStart(Domain domain, ManagementClient client) throws LifecycleException {
+        waitForAutoStartServersToStart(domain, client);
+    }
+
+    @Override
+    protected void stopInternal() throws LifecycleException {
+        if (shutdownThread != null) {
+            Runtime.getRuntime().removeShutdownHook(shutdownThread);
+            shutdownThread = null;
+        }
+        try {
+            if (process != null) {
+                process.destroy();
+                process.waitFor();
+                process = null;
+            }
+        } catch (Exception e) {
+            throw new LifecycleException("Could not stop container", e);
+        }
+    }
+
+    private List<String> createCommandLine(ManagedDomainContainerConfiguration config) throws Exception {
+
+        final String jbossHomeDir = config.getJbossHome();
+        String modulesPath = config.getModulePath();
+        if (modulesPath == null || modulesPath.isEmpty()) {
+            modulesPath = jbossHomeDir + File.separatorChar + "modules";
+        }
+        File modulesDir = new File(modulesPath);
+        if (modulesDir.isDirectory() == false)
+            throw new IllegalStateException("Cannot find: " + modulesDir);
+
+        String bundlesPath = modulesDir.getParent() + File.separator + "bundles";
+        File bundlesDir = new File(bundlesPath);
+        if (bundlesDir.isDirectory() == false)
+            throw new IllegalStateException("Cannot find: " + bundlesDir);
+
+        final String additionalJavaOpts = config.getJavaVmArguments();
+
+        File modulesJar = new File(jbossHomeDir + File.separatorChar + "jboss-modules.jar");
+        if (!modulesJar.exists())
+            throw new IllegalStateException("Cannot find: " + modulesJar);
+
+        List<String> cmd = new ArrayList<String>();
+        String javaExec = config.getJavaHome() + File.separatorChar + "bin" + File.separatorChar + "java";
+        if (config.getJavaHome().contains(" ")) {
+            javaExec = "\"" + javaExec + "\"";
+        }
+        cmd.add(javaExec);
+        if (additionalJavaOpts != null) {
+            for (String opt : additionalJavaOpts.split("\\s+")) {
+                cmd.add(opt);
+            }
+        }
+
+        if (config.isEnableAssertions()) {
+            cmd.add("-ea");
+        }
+
+        cmd.add("-Djboss.home.dir=" + jbossHomeDir);
+        cmd.add("-Dorg.jboss.boot.log.file=" + jbossHomeDir + "/domain/log/host-controller.log");
+        cmd.add("-Dlogging.configuration=file:" + jbossHomeDir + CONFIG_PATH + "logging.properties");
+        cmd.add("-Djboss.modules.dir=" + modulesDir.getCanonicalPath());
+        cmd.add("-Djboss.bundles.dir=" + bundlesDir.getCanonicalPath());
+        cmd.add("-Djboss.domain.default.config=" + config.getDomainConfig());
+        cmd.add("-Djboss.host.default.config=" + config.getHostConfig());
+        cmd.add("-jar");
+        cmd.add(modulesJar.getAbsolutePath());
+        cmd.add("-mp");
+        cmd.add(modulesPath);
+        cmd.add("-jaxpmodule");
+        cmd.add("javax.xml.jaxp-provider");
+        cmd.add("org.jboss.as.process-controller");
+
+        return cmd;
+    }
+
+    private static boolean processHasDied(final Process process) {
+        try {
+            process.exitValue();
+            return true;
+        } catch (IllegalThreadStateException e) {
+            // good
+            return false;
+        }
+    }
+
+    private boolean isServerRunning() {
+        Socket socket = null;
+        try {
+            socket = new Socket(getContainerConfiguration().getManagementAddress(), getContainerConfiguration()
+                    .getManagementPort());
+        } catch (Exception ignored) { // nothing is running on defined ports
+            return false;
+        } finally {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (Exception e) {
+                    throw new RuntimeException("Could not close isServerStarted socket", e);
+                }
+            }
+        }
+        return true;
+    }
+
+    private void failDueToRunning() throws LifecycleException {
+        throw new LifecycleException("The server is already running! "
+                + "Managed containers does not support connecting to running server instances due to the "
+                + "possible harmful effect of connecting to the wrong server. Please stop server before running or "
+                + "change to another type of container.\n"
+                + "To disable this check and allow Arquillian to connect to a running server, "
+                + "set allowConnectingToRunningServer to true in the container configuration");
+    }
+
+    private int destroyProcess() {
+        if (process == null)
+            return 0;
+        process.destroy();
+        try {
+            return process.waitFor();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void waitForAutoStartServersToStart(Domain domain, ManagementClient client) {
+        Set<Server> servers = domain.getAutoStartServers();
+
+        long startupTimeout = getContainerConfiguration().getAutoServerStartupTimeoutInSeconds();
+        long timeout = startupTimeout * 1000;
+        long sleep = 100;
+
+        while (timeout > 0 && servers.size() > 0) {
+            Iterator<Server> serverIterator = servers.iterator();
+            while (serverIterator.hasNext()) {
+                Server server = serverIterator.next();
+                if (client.isServerStarted(server)) {
+                    serverIterator.remove();
+                }
+            }
+            try {
+                Thread.sleep(sleep);
+                timeout -= sleep;
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Failed waiting for servers to start", e);
+            }
+        }
+        if(timeout <= 0) {
+            throw new RuntimeException(
+                    "Auto started servers did not start within set timeout [autoServerStartupTimeoutInSeconds=" + startupTimeout + "]. " + servers);
+        }
+    }
+
+    /**
+     * Runnable that consumes the output of the process. If nothing consumes the output the AS will hang on some platforms
+     *
+     * @author Stuart Douglas
+     */
+    private class ConsoleConsumer implements Runnable {
+
+        @Override
+        public void run() {
+            final InputStream stream = process.getInputStream();
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+            final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
+
+            String line = null;
+            try {
+                while ((line = reader.readLine()) != null) {
+                    if (writeOutput) {
+                        System.out.println(line);
+                    }
+                }
+            } catch (IOException e) {
+            }
+        }
+
+    }
+}

--- a/arquillian/container-managed-domain/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/arquillian/container-managed-domain/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.as.arquillian.container.domain.managed.ManagedDomainContainerExtension

--- a/arquillian/container-managed-domain/src/test/java/org/jboss/as/arquillian/container/domain/managed/test/ManagedDomainTestCase.java
+++ b/arquillian/container-managed-domain/src/test/java/org/jboss/as/arquillian/container/domain/managed/test/ManagedDomainTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.managed.test;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * For Domain server DeployableContianer implementations, the DeployableContainer will register 
+ * all groups/individual servers it controls as Containers in Arquillians Registry during start.
+ * 
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@RunWith(Arquillian.class)
+public class ManagedDomainTestCase {
+
+    @Deployment(name = "dep1") @TargetsContainer("backend")
+    public static WebArchive create1() {
+        return ShrinkWrap.create(WebArchive.class);
+    }
+
+    @Deployment(name = "dep2") @TargetsContainer("other-server-group")
+    public static WebArchive create2() {
+        return ShrinkWrap.create(WebArchive.class);
+    }
+
+    @ArquillianResource
+    private ContainerController controller;
+    
+    /*
+     * ProtocolMetaData returned by deploy to main-server-group contains multiple HttpContext 
+     * named after the individual servers in the group. Adding @TargetsContainer specifies which 
+     * server info to use (container names can be overwritten using containerNameMap in configuration)
+     */
+    @Test @InSequence(1) @OperateOnDeployment("dep1") @TargetsContainer("backend-1")
+    public void shouldBeAbleToRunInTargetedServer() throws Exception {
+        System.out.println("in..container");
+    }
+
+    @Test @InSequence(2)
+    public void shouldBeAbleToStartServer() {
+        // server-groups are registered as STARTED by default for managed deployments to work.. 
+        // In the eyes of the Domain they are always 'started' it's the servers in their group that are started or stopped, 
+        // but Arquillian see them as one Container and won't actually call start unless it is registered as stopped.... ??
+        //controller.stop("other-server-group");
+        //controller.start("other-server-group");
+        controller.start("frontend-1");
+    }
+
+    @Test @InSequence(3) @OperateOnDeployment("dep2")
+    public void shouldBeAbleToRunInUndefinedServer() throws Exception {
+        System.out.println("in..container 2");
+    }
+
+    @Test @InSequence(4)
+    public void shouldBeAbleToStopServer() {
+        controller.stop("frontend-1");
+    }
+}

--- a/arquillian/container-managed-domain/src/test/java/org/jboss/as/arquillian/container/domain/managed/test/ManagedDomainTwoTestCase.java
+++ b/arquillian/container-managed-domain/src/test/java/org/jboss/as/arquillian/container/domain/managed/test/ManagedDomainTwoTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.managed.test;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * For Domain server DeployableContianer implementations, the DeployableContainer will register 
+ * all groups/individual servers it controls as Containers in Arquillians Registry during start.
+ * 
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+@RunWith(Arquillian.class)
+public class ManagedDomainTwoTestCase {
+
+    @Deployment @TargetsContainer("backend")
+    public static WebArchive create1() {
+        return ShrinkWrap.create(WebArchive.class);
+    }
+
+    @ArquillianResource
+    private ContainerController controller;
+    
+    @Test @InSequence(1) @RunAsClient
+    public void shouldBeAbleToStartServer() throws Exception {
+        controller.start("backend-2");
+    }
+
+    @Test @InSequence(2) @TargetsContainer("backend-2")
+    public void shouldBeAbleToRunInStartedServer() {
+        System.out.println(".. in container ..");
+    }
+}

--- a/arquillian/container-managed-domain/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed-domain/src/test/resources/arquillian.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">target/jbossas</property>
+            <property name="containerNameMap">
+              main-server-group=backend,
+              master:server-one=backend-1,
+              master:server-two=backend-2,
+              master:server-three=frontend-1
+            </property>
+            <property name="containerModeMap">
+              other.*=manual
+            </property>
+        </configuration>
+    </container>
+</arquillian>

--- a/arquillian/container-remote-domain/pom.xml
+++ b/arquillian/container-remote-domain/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-arquillian</artifactId>
+        <version>7.1.2.Final-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.jboss.as</groupId>
+    <artifactId>jboss-as-arquillian-container-domain-remote</artifactId>
+
+    <name>JBoss Application Server: Arquillian Remote Domain Container</name>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <!-- Don't execute unit tests; the "remote" profile needs to be
+             enabled to execute them -->
+        <skipTests>true</skipTests>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-arquillian-common-domain</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>remote</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/arquillian/container-remote-domain/src/main/java/org/jboss/as/arquillian/container/domain/remote/RemoteDomainContainerConfiguration.java
+++ b/arquillian/container-remote-domain/src/main/java/org/jboss/as/arquillian/container/domain/remote/RemoteDomainContainerConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.remote;
+
+import org.jboss.as.arquillian.container.domain.CommonDomainContainerConfiguration;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RemoteDomainContainerConfiguration extends CommonDomainContainerConfiguration {
+
+}

--- a/arquillian/container-remote-domain/src/main/java/org/jboss/as/arquillian/container/domain/remote/RemoteDomainContainerExtension.java
+++ b/arquillian/container-remote-domain/src/main/java/org/jboss/as/arquillian/container/domain/remote/RemoteDomainContainerExtension.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.remote;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.as.arquillian.container.domain.CommonContainerExtension;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RemoteDomainContainerExtension extends CommonContainerExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        super.register(builder);
+        builder.service(DeployableContainer.class, RemoteDomainDeployableContainer.class);
+    }
+
+}

--- a/arquillian/container-remote-domain/src/main/java/org/jboss/as/arquillian/container/domain/remote/RemoteDomainDeployableContainer.java
+++ b/arquillian/container-remote-domain/src/main/java/org/jboss/as/arquillian/container/domain/remote/RemoteDomainDeployableContainer.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.remote;
+
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.as.arquillian.container.domain.CommonDomainDeployableContainer;
+import org.jboss.as.arquillian.container.domain.Domain;
+import org.jboss.as.arquillian.container.domain.ManagementClient;
+
+/**
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public class RemoteDomainDeployableContainer extends CommonDomainDeployableContainer<RemoteDomainContainerConfiguration> {
+
+    @Override
+    public Class<RemoteDomainContainerConfiguration> getConfigurationClass() {
+        return RemoteDomainContainerConfiguration.class;
+    }
+
+    @Override
+    protected void startInternal() throws LifecycleException {
+        // no-op
+    }
+
+    @Override
+    protected void waitForStart(Domain domain, ManagementClient client) throws LifecycleException {
+        // no-po
+    }
+
+    @Override
+    protected void stopInternal() throws LifecycleException {
+        // no-op
+    }
+}

--- a/arquillian/container-remote-domain/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/arquillian/container-remote-domain/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.as.arquillian.container.domain.remote.RemoteDomainContainerExtension

--- a/arquillian/container-remote-domain/src/test/java/org/jboss/as/arquillian/container/domain/remote/test/RemoteDomainTestCase.java
+++ b/arquillian/container-remote-domain/src/test/java/org/jboss/as/arquillian/container/domain/remote/test/RemoteDomainTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.domain.remote.test;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * For Domain server DeployableContianer implementations, the DeployableContainer will register 
+ * all groups/individual servers it controls as Containers in Arquillians Registry during start.
+ * 
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+
+
+@RunWith(Arquillian.class)
+public class RemoteDomainTestCase {
+
+    @Deployment(name = "dep1") @TargetsContainer("main-server-group") 
+    public static JavaArchive create1() {
+        return ShrinkWrap.create(JavaArchive.class);
+    }
+
+    @Test @InSequence(1) @OperateOnDeployment("dep1") @TargetsContainer("master:server-one")
+    public void shouldRunInContainer1() throws Exception {
+        System.out.println("in..container");
+    }
+
+    @Test @InSequence(2) @OperateOnDeployment("dep1") @TargetsContainer("master:server-one")
+    public void shouldStartContainer(@ArquillianResource ContainerController controller) throws Exception {
+        Assert.assertFalse(controller.isStarted("master:server-two"));
+        controller.start("master:server-two");
+    }
+
+    @Test @InSequence(3) @OperateOnDeployment("dep1") @TargetsContainer("master:server-two")
+    public void shouldRunInContainer2(@ArquillianResource ContainerController controller) throws Exception {
+        Assert.assertTrue(controller.isStarted("master:server-two"));
+    }
+
+    @Test @InSequence(4) @RunAsClient
+    public void shouldBeAbleToStop(@ArquillianResource ContainerController controller) throws Exception {
+        controller.stop("master:server-two");
+        Assert.assertFalse(controller.isStarted("master:server-two"));
+    }
+}

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -43,6 +43,11 @@
         <module>protocol-jmx</module>
         <module>testenricher-msc</module>
         <module>testng-integration</module>
+
+        <module>common-domain</module>
+        <module>container-remote-domain</module>
+        <module>container-managed-domain</module>
+
         <!--
         <module>container-embedded</module>
         <module>protocol-servlet</module>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <version.org.jacorb>2.3.1.jbossorg-1</version.org.jacorb>
         <version.org.javassist>3.15.0-GA</version.org.javassist>
         <version.org.jdom>1.1.2</version.org.jdom>
-        <version.org.jboss.arquillian.core>1.0.0.CR7</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.core>1.0.0.CR8</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.osgi>1.0.2.Final</version.org.jboss.arquillian.osgi>
         <version.org.jboss.as.console>1.2.0.Final</version.org.jboss.as.console>
         <version.org.jboss.as.jbossweb-native>2.0.10.Final</version.org.jboss.as.jbossweb-native>
@@ -687,6 +687,24 @@
             <dependency>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-arquillian-container-remote</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-common-domain</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-container-domain-managed</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-container-domain-remote</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
The DomainServer Container will register all ServerGroups and Servers within those groups as seperate Containers in the Arquillian Registry.

Currently only supports the Servlet 3.0 Protocol.

General usecase:
- deploy and undeploy to ServerGroups
- start and stop Servers
## Domain Container
- support operations start/stop
- default container mode: suite
- configuration
  - containerNameMap: used to rename the container names seen by Arquillian
    - main-server-group=crm-system
  - containerModeMap: used to change the container mode used by Arquillian
    - host:server-one=manual
## ServerGroup Containers
- support operations start/stop/deploy/undeploy
- default container mode: suite
- default container name: the server group name withing the domain

All operations on a group will be reflected onto the Server instances.

A ServerGroup is always registered as Started, which means it needs to be Stopped before Arquillian allow
the 'underlying' group to be started.
## Server Containers
- support operations start/stop
- attempts to deploy/undeploy on a Server Container results in UnSupportedOpperation
- default container mode: custom
- default container name: 'host-name:server-name'

A Server is registered based on it's current state within the Domain, either Started or Stopped. The ContainerController API support cc.isStarted(name)
