### PR TITLE
[AS7-4414] Error with HornetQ connector in domain mode

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
@@ -137,6 +137,9 @@ class TransportConfigOperationHandlers {
         if(node.hasDefined(CommonAttributes.SERVER_ID.getName())) {
             operation.get(CommonAttributes.SERVER_ID.getName()).set(node.get(CommonAttributes.SERVER_ID.getName()));
         }
+        if(node.hasDefined(CommonAttributes.FACTORY_CLASS.getName())) {
+            operation.get(CommonAttributes.FACTORY_CLASS.getName()).set(node.get(CommonAttributes.FACTORY_CLASS.getName()));
+        }
         if(node.hasDefined(CommonAttributes.PARAM)) {
             for(final Property param : node.get(CommonAttributes.PARAM).asPropertyList()) {
                 operation.get(CommonAttributes.PARAM, param.getName()).set(param.getValue().get(ModelDescriptionConstants.VALUE));

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_1.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_1.xml
@@ -20,6 +20,11 @@
             <journal-directory path="test" relative-to="test" />
             <large-messages-directory path="test" relative-to="test" />
             <connectors>
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+               </connector>
                <netty-connector name="netty" socket-binding="messaging" />
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                   <param key="batch-delay" value="50"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_2.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_2.xml
@@ -20,6 +20,11 @@
             <journal-directory path="test" relative-to="test" />
             <large-messages-directory path="test" relative-to="test" />
             <connectors>
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+               </connector>
                <netty-connector name="netty" socket-binding="messaging" />
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                   <param key="batch-delay" value="50"/>


### PR DESCRIPTION
- the <factory-class> attribute was missing when describing the
  operation to add a connector
- add a generic <connector> to the configuration test files
