### PR TITLE
AS7-4070 Arquillian should wait until a port is free after AS JVM process ends to prevent "port in use".

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -21,6 +21,9 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
 
 /**
  * JBossAS7 server configuration

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -17,6 +17,10 @@
  */
 package org.jboss.as.arquillian.container.managed;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.deployment.Validate;
 import org.jboss.as.arquillian.container.CommonContainerConfiguration;
@@ -28,6 +32,11 @@ import org.jboss.as.arquillian.container.CommonContainerConfiguration;
  * @author Thomas.Diesler@jboss.com
  */
 public class ManagedContainerConfiguration extends CommonContainerConfiguration {
+
+    /**
+     * Default timeout value waiting on ports is 10 seconds
+     */
+    private static final Integer DEFAULT_VALUE_WAIT_FOR_PORTS_TIMEOUT_SECONDS = 10;
 
     private String jbossHome = System.getenv("JBOSS_HOME");
 
@@ -48,6 +57,10 @@ public class ManagedContainerConfiguration extends CommonContainerConfiguration 
     private boolean allowConnectingToRunningServer = false;
 
     private boolean enableAssertions = true;
+
+    private Integer[] waitForPorts;
+
+    private Integer waitForPortsTimeoutInSeconds;
 
     public ManagedContainerConfiguration() {
         // if no javaHome is set use java.home of already running jvm
@@ -184,5 +197,27 @@ public class ManagedContainerConfiguration extends CommonContainerConfiguration 
 
     public void setEnableAssertions(final boolean enableAssertions) {
         this.enableAssertions = enableAssertions;
+    }
+
+    public Integer[] getWaitForPorts() {
+        return waitForPorts;
+    }
+
+    public void setWaitForPorts(String waitForPorts) {
+        final Scanner scanner = new Scanner(waitForPorts);
+        final List<Integer> list = new ArrayList<Integer>();
+        while (scanner.hasNextInt()) {
+            list.add(scanner.nextInt());
+        }
+        this.waitForPorts = list.toArray(new Integer[] {});
+    }
+
+    public Integer getWaitForPortsTimeoutInSeconds() {
+        return waitForPortsTimeoutInSeconds != null ? waitForPortsTimeoutInSeconds
+            : DEFAULT_VALUE_WAIT_FOR_PORTS_TIMEOUT_SECONDS;
+    }
+
+    public void setWaitForPortsTimeoutInSeconds(final Integer waitForPortsTimeoutInSeconds) {
+        this.waitForPortsTimeoutInSeconds = waitForPortsTimeoutInSeconds;
     }
 }

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/PortAcquisitionTimeoutException.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/PortAcquisitionTimeoutException.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+
+/**
+ * Denotes that a port could not be obtained within a designated timeout period.
+ *
+ * @author <a href="mailto:alr@jboss.org">ALR</a>
+ * @see https://issues.jboss.org/browse/AS7-4070
+ */
+public class PortAcquisitionTimeoutException extends LifecycleException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new instance noting the port that could not be acquired in the designated amount of time
+     *
+     * @param ports
+     * @param timeoutSeconds
+     */
+    public PortAcquisitionTimeoutException(final int port, final int timeoutSeconds) {
+        super("Could not acquire requested port " + port + " in " + timeoutSeconds + " seconds");
+    }
+}

--- a/arquillian/container-managed/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed/src/test/resources/arquillian.xml
@@ -10,6 +10,15 @@
 			     sure that they have not left a stale server running when merging pull requests
                         -->
                         <property name="allowConnectingToRunningServer">false</property>
+
+			<!--
+			
+			Space-delimited list of ports on which to wait 
+			<property name="waitForPorts">2222</property>
+			
+			Time, in seconds, to wait on the above ports
+			<property name="waitForPortsTimeoutInSeconds">20</property>
+			 -->
 		</configuration>
 	</container>
 </arquillian>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -12,6 +12,10 @@
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9999}</property>
+
+            <!-- AS7-4070 -->
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -13,6 +13,10 @@
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9999}</property>
+
+            <!-- AS7-4070 -->
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 
@@ -23,6 +27,10 @@
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9999}</property>
+
+            <!-- AS7-4070 -->
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
 
@@ -36,6 +44,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9999}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
 
@@ -46,6 +58,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
         

--- a/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
@@ -12,6 +12,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9999}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
 
@@ -23,6 +27,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
     </group>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -12,6 +12,10 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9999}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
 
@@ -23,6 +27,10 @@
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
     </group>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -13,6 +13,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9999}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
 
@@ -24,6 +28,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10099</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
     </group>

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -10,6 +10,10 @@
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9999}</property>
+
+            <!-- AS7-4070 -->
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
     


### PR DESCRIPTION
Solves the problem of ports being held for some period even after JVM was reportedly killed;
On slower machines, this caused testsuite failures.

https://issues.jboss.org/browse/AS7-4070
