### PR TITLE
cli: unmanaged deployment content and preferences

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
@@ -82,16 +82,6 @@ public interface ArgumentValueConverter {
         };
         @Override
         protected ModelNode fromNonDMRString(String value) throws CommandFormatException {
-/*            // strip [] if they are present
-            if(value.length() >= 2 && value.charAt(0) == '[' && value.charAt(value.length() - 1) == ']') {
-                value = value.substring(1, value.length() - 1);
-            }
-            final ModelNode list = new ModelNode();
-            for (String item : value.split(",")) {
-                list.add(new ModelNode().set(item));
-            }
-            return list;
-*/
             final ArgumentValueCallbackHandler handler = new ArgumentValueCallbackHandler();
             StateParser.parse(value, handler, initialState);
             return handler.getResult();
@@ -106,26 +96,6 @@ public interface ArgumentValueConverter {
         };
         @Override
         protected ModelNode fromNonDMRString(String value) throws CommandFormatException {
-            /*
-            // strip [] if they are present
-            if(value.length() >= 2 && value.charAt(0) == '[' && value.charAt(value.length() - 1) == ']') {
-                value = value.substring(1, value.length() - 1);
-            }
-            final String[] props = value.split(",");
-            final ModelNode list = new ModelNode();
-            for (String prop : props) {
-                int equals = prop.indexOf('=');
-                if (equals == -1) {
-                    throw new CommandFormatException("Property '" + prop + "' in '" + value + "' is missing the equals sign.");
-                }
-                String propName = prop.substring(0, equals);
-                if (propName.isEmpty()) {
-                    throw new CommandFormatException("Property name is missing for '" + prop + "' in '" + value + "'");
-                }
-                list.add(propName, prop.substring(equals + 1));
-            }
-            return list;
-*/
             final ArgumentValueCallbackHandler handler = new ArgumentValueCallbackHandler();
             StateParser.parse(value, handler, initialState);
             return handler.getResult();
@@ -134,28 +104,7 @@ public interface ArgumentValueConverter {
 
     ArgumentValueConverter OBJECT = new DMRWithFallbackConverter() {
         @Override
-        protected ModelNode fromNonDMRString(String value)
-                throws CommandFormatException {
-/*            // strip {} if they are present
-            if(value.length() >= 2 && value.charAt(0) == '{' && value.charAt(value.length() - 1) == '}') {
-                value = value.substring(1, value.length() - 1);
-            }
-
-            final String[] props = value.split(",");
-            final ModelNode o = new ModelNode();
-            for (String prop : props) {
-                int equals = prop.indexOf('=');
-                if (equals == -1) {
-                    throw new CommandFormatException("Property '" + prop + "' in '" + value + "' is missing the equals sign.");
-                }
-                String propName = prop.substring(0, equals);
-                if (propName.isEmpty()) {
-                    throw new CommandFormatException("Property name is missing for '" + prop + "' in '" + value + "'");
-                }
-                o.get(propName).set(prop.substring(equals + 1));
-            }
-            return o;
-*/
+        protected ModelNode fromNonDMRString(String value) throws CommandFormatException {
             final ArgumentValueCallbackHandler handler = new ArgumentValueCallbackHandler();
             StateParser.parse(value, handler, ArgumentValueInitialState.INSTANCE);
             return handler.getResult();

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -77,4 +77,13 @@ public interface CliConfig {
      * @return The SSLConfig
      */
     SSLConfig getSslConfig();
+
+    /**
+     * Whether the operation requests should be validated in terms of
+     * addresses, operation names and parameters before they are
+     * sent to the controller for execution.
+     *
+     * @return  true is the operation requests should be validated, false - otherwise.
+     */
+    boolean isValidateOperationRequests();
 }

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -43,6 +43,7 @@ public class Util {
     public static final String ADD = "add";
     public static final String ADDRESS = "address";
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
+    public static final String ARCHIVE = "archive";
     public static final String ATTRIBUTES = "attributes";
     public static final String BYTES = "bytes";
     public static final String CHILDREN = "children";
@@ -79,6 +80,7 @@ public class Util {
     public static final String OPERATION = "operation";
     public static final String OPERATION_HEADERS = "operation-headers";
     public static final String OUTCOME = "outcome";
+    public static final String PATH = "path";
     public static final String PERSISTENT = "persistent";
     public static final String PRODUCT_NAME = "product-name";
     public static final String PRODUCT_VERSION = "product-version";

--- a/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
@@ -69,7 +69,9 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
             throw new CommandFormatException("Parsed request isn't available.");
         }
 
-        validateRequest(ctx, request);
+        if(ctx.getConfig().isValidateOperationRequests()) {
+            validateRequest(ctx, request);
+        }
 
         try {
             final ModelNode result = client.execute(request);

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -59,6 +59,7 @@ class CliConfigImpl implements CliConfig {
     private static final String HOST = "host";
     private static final String MAX_SIZE = "max-size";
     private static final String PORT = "port";
+    private static final String VALIDATE_OPERATION_REQUESTS = "validate-operation-requests";
 
     static CliConfig load(final CommandContext ctx) throws CliInitializationException {
         final String jbossHome = SecurityActions.getEnvironmentVariable("JBOSS_HOME");
@@ -99,6 +100,9 @@ class CliConfigImpl implements CliConfig {
                                 SslConfig sslConfig = new SslConfig();
                                 readSSLElement(reader, sslConfig);
                                 config.sslConfig = sslConfig;
+                            } else if(localName.equals(VALIDATE_OPERATION_REQUESTS)) {
+                                final String resolved = resolveString(reader.getElementText());
+                                config.validateOperationRequests = Boolean.parseBoolean(resolved);
                             } else {
                                 throw new XMLStreamException("Unexpected element: " + localName);
                             }
@@ -215,6 +219,8 @@ class CliConfigImpl implements CliConfig {
     private String historyFileDir;
     private int historyMaxSize;
 
+    private boolean validateOperationRequests = true;
+
     private SSLConfig sslConfig;
 
     @Override
@@ -245,6 +251,11 @@ class CliConfigImpl implements CliConfig {
     @Override
     public int getHistoryMaxSize() {
         return historyMaxSize;
+    }
+
+    @Override
+    public boolean isValidateOperationRequests() {
+        return validateOperationRequests;
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
@@ -53,7 +53,7 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
                     stack = new ArrayDeque<ValueState>();
                 }
                 stack.push(currentState);
-                currentState = new DefaultValueState(currentState instanceof ListValueState);
+                currentState = new DefaultValueState(currentState.isList());
             } else {
                 currentState = new DefaultValueState(false);
             }
@@ -80,13 +80,7 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
         final String stateId = ctx.getState().getId();
         //System.out.println("left " + stateId + " '" + ctx.getCharacter() + "'");
 
-        if(ArgumentValueState.ID.equals(stateId)) {
-            currentState.complete();
-            if(stack != null && stack.peek() != null) {
-                stack.peek().addChild(currentState);
-                currentState = stack.pop();
-            }
-        } else if(ListState.ID.equals(stateId)) {
+        if(ArgumentValueState.ID.equals(stateId) || ListState.ID.equals(stateId)) {
             currentState.complete();
             if(stack != null && stack.peek() != null) {
                 stack.peek().addChild(currentState);
@@ -123,6 +117,8 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
         void character(char ch);
 
         ModelNode getValue();
+
+        boolean isList();
     }
 
     class DefaultValueState implements ValueState {
@@ -227,6 +223,11 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
                 }
             }
         }
+
+        @Override
+        public boolean isList() {
+            return false;
+        }
     }
 
     class ListValueState implements ValueState {
@@ -275,6 +276,11 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
         @Override
         public ModelNode getValue() {
             return list;
+        }
+
+        @Override
+        public boolean isList() {
+            return true;
         }
     }
 

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -1,6 +1,7 @@
 SYNOPSIS
 
-    deploy (file_path [--name=deployment_name] [--runtime_name=deployment_runtime_name] [--force | --disabled] | --name=deployment_name)
+    deploy (file_path [--name=deployment_name] [--runtime_name=deployment_runtime_name] [--force | --disabled] [--unmanaged]
+               | --name=deployment_name)
            [--server-groups=group_name (,group_name)* | --all-server-groups]
            [--headers={operation_header (;operation_header)*}]
 
@@ -30,6 +31,14 @@ ARGUMENTS
                        with the one specified in the command arguments.
 
  --disabled          - indicates that the deployment has to be added to the repository disabled.
+ 
+ --unmanaged         - if this argument is not specified, the deployment content will be
+                       copied (i.e. uploaded) to the server's deployment repository
+                       before it is deployed.
+                       If the argument is present, the deployment content will remain
+                       at and be deployed directly from its original location specified
+                       with the file_path.
+                       NOTE: exploded deployments are supported only as unmanaged.
 
  --server-groups     - comma separated list of server group names the deploy command should apply to.
                        Either server-groups or all-server-groups is required in the domain mode.

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -65,4 +65,9 @@ public class MockCliConfig implements CliConfig {
     public int getHistoryMaxSize() {
         return 500;
     }
+
+    @Override
+    public boolean isValidateOperationRequests() {
+        return true;
+    }
 }


### PR DESCRIPTION
- AS7-4385 Add support for fs-archive and fs-exploded deployments to the CLI deploy command

deploy command has got --unmanaged argument that will indicate whether the deployment content should uploaded or used from its original location
- AS7-3468 cli preferences: validation of operation requests before they are sent to the server controller

Thanks,
Alexey
