### PR TITLE
AS7-3857 Coordinate AttributeDefinition validation with allowNull and allowExpression configs

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-web_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-web_1_1.xsd
@@ -308,14 +308,14 @@
       <xs:annotation>
          <xs:documentation>
             <![CDATA[
-                The "relative-to" references a global path configuration in the domain model, with the default
-                to the JBoss Application data directory (jboss.server.data.dir).
-                The "path" the directory based on the referenced path.
+                The "relative-to" references a global path configuration in the domain model.
+                The "path" is the directory based on the referenced path. If "path" is not
+                set, the name of the virtual-server is used.
             ]]>
          </xs:documentation>
       </xs:annotation>
-      <xs:attribute name="path" type="xs:string" default="tx-object-store" />
-      <xs:attribute name="relative-to" type="xs:string" use="optional" />
+      <xs:attribute name="path" type="xs:string" use="optional" />
+      <xs:attribute name="relative-to" type="xs:string" use="optional" default="jboss.server.log.dir" />
    </xs:complexType>
 
    <xs:complexType name="mime-mappingType">

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheAdd.java
@@ -26,7 +26,7 @@ public abstract class ClusteredCacheAdd extends CacheAdd {
                     .setXmlName(Attribute.MODE.getLocalName())
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<Mode>(Mode.class, true, false))
+                    .setValidator(new EnumValidator<Mode>(Mode.class, false, true))
                     .build();
 
     ClusteredCacheAdd(CacheMode mode) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CommonAttributes.java
@@ -259,7 +259,7 @@ public interface CommonAttributes {
                     .setXmlName(Attribute.MODE.getLocalName())
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new EnumValidator<TransactionMode>(TransactionMode.class, true, false))
+                    .setValidator(new EnumValidator<TransactionMode>(TransactionMode.class, true, true))
                     .setDefaultValue(new ModelNode().set(TransactionMode.NONE.name()))
                     .build();
     SimpleAttributeDefinition MODIFICATION_QUEUE_SIZE =

--- a/connector/src/main/java/org/jboss/as/connector/pool/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/pool/Constants.java
@@ -66,7 +66,7 @@ public class Constants {
 
     public static final SimpleAttributeDefinition IDLETIMEOUTMINUTES = new SimpleAttributeDefinition(IDLETIMEOUTMINUTES_NAME, TimeOut.Tag.IDLE_TIMEOUT_MINUTES.getLocalName(),  new ModelNode(), ModelType.LONG, true, true, MeasurementUnit.MINUTES);
 
-    public static final SimpleAttributeDefinition BACKGROUNDVALIDATIONMILLIS = new SimpleAttributeDefinition(BACKGROUNDVALIDATIONMILLIS_NAME, Validation.Tag.BACKGROUND_VALIDATION_MILLIS.getLocalName(),  new ModelNode(), ModelType.LONG, true, true, MeasurementUnit.MILLISECONDS, new IntRangeValidator(1, true));
+    public static final SimpleAttributeDefinition BACKGROUNDVALIDATIONMILLIS = new SimpleAttributeDefinition(BACKGROUNDVALIDATIONMILLIS_NAME, Validation.Tag.BACKGROUND_VALIDATION_MILLIS.getLocalName(),  new ModelNode(), ModelType.LONG, true, true, MeasurementUnit.MILLISECONDS, new IntRangeValidator(1, true, true));
 
     public static final SimpleAttributeDefinition BACKGROUNDVALIDATION = new SimpleAttributeDefinition(BACKGROUNDVALIDATION_NAME, Validation.Tag.BACKGROUND_VALIDATION.getLocalName(), new ModelNode().set(Defaults.BACKGROUND_VALIDATION), ModelType.BOOLEAN, true, true, MeasurementUnit.NONE);
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -210,8 +210,7 @@ class Constants {
 
         @Override
         public void validateResolvedParameter(String parameterName, ModelNode value) throws OperationFailedException {
-            //TODO implement validateResolvedParameter
-            throw new UnsupportedOperationException();
+            validateParameter(parameterName,  value.resolve());
         }
     });
 

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
 import org.jboss.as.controller.operations.validation.MinMaxValidator;
+import org.jboss.as.controller.operations.validation.NillableOrExpressionParameterValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -76,13 +77,14 @@ public abstract class AttributeDefinition {
                                final ParameterValidator validator, final String[] alternatives, final String[] requires,
                                final AttributeAccess.Flag... flags) {
         this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
-                null, validator, alternatives, requires, flags);
+                null, validator, true, alternatives, requires, flags);
     }
 
     protected AttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
-            final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
-            final ParameterCorrector valueCorrector, final ParameterValidator validator,
-            final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
+                                  final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
+                                  final ParameterCorrector valueCorrector, final ParameterValidator validator,
+                                  boolean validateNull, final String[] alternatives, final String[] requires,
+                                  final AttributeAccess.Flag... flags) {
 
         this.name = name;
         this.xmlName = xmlName;
@@ -98,7 +100,12 @@ public abstract class AttributeDefinition {
         this.alternatives = alternatives;
         this.requires = requires;
         this.valueCorrector = valueCorrector;
-        this.validator = validator;
+        if (validator == null) {
+            this.validator = null;
+        } else {
+            Boolean nullCheck = validateNull ? allowNull : null;
+            this.validator = new NillableOrExpressionParameterValidator(validator, nullCheck, allowExpression);
+        }
         if (flags == null || flags.length == 0) {
             this.flags = EnumSet.noneOf(AttributeAccess.Flag.class);
         } else if (flags.length == 0) {

--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -701,16 +701,16 @@ public interface ControllerMessages {
     UnsupportedOperationException immutableResource();
 
     /**
-     * A message indicating the type is invalid.
+     * An exception indicating the type is invalid.
      *
      * @param name        the name the invalid type was found for.
      * @param validTypes  a collection of valid types.
      * @param invalidType the invalid type.
      *
-     * @return the message.
+     * @return the exception.
      */
     @Message(id = 14688, value = "Wrong type for %s. Expected %s but was %s")
-    String incorrectType(String name, Collection<ModelType> validTypes, ModelType invalidType);
+    OperationFailedException incorrectType(String name, Collection<ModelType> validTypes, ModelType invalidType);
 
     /**
      * A message indicating interrupted while waiting for request.
@@ -1379,14 +1379,14 @@ public interface ControllerMessages {
     IllegalStateException nullAsynchronousExecutor();
 
     /**
-     * A message indicating the {@code name} may not be {@code null}.
+     * An exception indicating the {@code name} may not be {@code null}.
      *
      * @param name the name that cannot be {@code null}.
      *
-     * @return the message.
+     * @return the exception.
      */
     @Message(id = 14746, value = "%s may not be null")
-    String nullNotAllowed(String name);
+    OperationFailedException nullNotAllowed(String name);
 
     /**
      * Creates an exception indicating the variable, represented by the {@code name} parameter, was {@code null}.
@@ -2458,5 +2458,15 @@ public interface ControllerMessages {
 
     @Message(id = 14854, value="Path '%s' is read-only; it cannot be modified")
     OperationFailedException cannotModifyReadOnlyPath(String pathName);
+
+    /**
+     * An exception indicating the {@code name} may not be {@link ModelType#EXPRESSION}.
+     *
+     * @param name the name of the attribute or parameter value that cannot be an expression
+     *
+     * @return the exception.
+     */
+    @Message(id = 14855, value = "%s may not be ModelType.EXPRESSION")
+    OperationFailedException expressionNotAllowed(String name);
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
@@ -56,7 +56,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
      * Constructor which enables validation via ObjectTypeValidator.
      */
     private ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull, final ParameterCorrector corrector, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
-        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, new ObjectTypeValidator(allowNull, valueTypes), alternatives, requires, flags);
+        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, new ObjectTypeValidator(allowNull, valueTypes), false, alternatives, requires, flags);
         this.valueTypes = valueTypes;
         if (suffix == null) {
             this.suffix = "";
@@ -69,7 +69,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
      * Constructor which allows specifying a custom ParameterValidator. Disabled by default.
      */
     private ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull, final ParameterValidator validator, final ParameterCorrector corrector, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
-        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, validator, alternatives, requires, flags);
+        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, validator, false, alternatives, requires, flags);
         this.valueTypes = valueTypes;
         if (suffix == null) {
             this.suffix = "";

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
@@ -100,16 +100,16 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
     public SimpleAttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
                                      final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
                                      final ParameterValidator validator, String[] alternatives, String[] requires, AttributeAccess.Flag... flags) {
-        super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
-                createParameterValidator(validator, type, allowNull, allowExpression), alternatives, requires, flags);
+        this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit, null,
+                createParameterValidator(validator, type, allowNull, allowExpression), true, alternatives, requires, flags);
     }
 
     public SimpleAttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
-            final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
-            final ParameterCorrector corrector, final ParameterValidator validator,
-            String[] alternatives, String[] requires, AttributeAccess.Flag... flags) {
+                                     final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
+                                     final ParameterCorrector corrector, final ParameterValidator validator,
+                                     boolean validateNull, String[] alternatives, String[] requires, AttributeAccess.Flag... flags) {
         super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
-                corrector, createParameterValidator(validator, type, allowNull, allowExpression), alternatives, requires, flags);
+                corrector, createParameterValidator(validator, type, allowNull, allowExpression), validateNull, alternatives, requires, flags);
     }
 
     public SimpleAttributeDefinition(final String name, final ModelNode defaultValue, final ModelType type, final boolean allowNull, final String[] alternatives) {
@@ -117,7 +117,7 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
     }
 
     public SimpleAttributeDefinition(final String name, final ModelType type, final boolean allowNull, ParameterCorrector corrector, ParameterValidator validator) {
-        this(name, name, null, type, allowNull, false, MeasurementUnit.NONE, corrector, validator, null, null);
+        this(name, name, null, type, allowNull, false, MeasurementUnit.NONE, corrector, validator, true, null, null);
     }
 
     private static ParameterValidator createParameterValidator(final ParameterValidator existing, final ModelType type,final boolean allowNull, final boolean allowExpression) {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
@@ -61,6 +61,8 @@ public class SimpleAttributeDefinitionBuilder {
     private String[] requires;
     private ParameterCorrector corrector;
     private ParameterValidator validator;
+    private boolean validateNull = true;
+
     private AttributeAccess.Flag[] flags;
 
     public SimpleAttributeDefinitionBuilder(final String attributeName, final ModelType type) {
@@ -91,7 +93,7 @@ public class SimpleAttributeDefinitionBuilder {
 
     public SimpleAttributeDefinition build() {
         return new SimpleAttributeDefinition(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
-                                     corrector, validator, alternatives, requires, flags);
+                                     corrector, validator, validateNull, alternatives, requires, flags);
     }
 
     public SimpleAttributeDefinitionBuilder setXmlName(String xmlName) {
@@ -126,6 +128,21 @@ public class SimpleAttributeDefinitionBuilder {
 
     public SimpleAttributeDefinitionBuilder setValidator(ParameterValidator validator) {
         this.validator = validator;
+        return this;
+    }
+
+    /**
+     * Sets whether the attribute definition should check for {@link ModelNode#isDefined() undefined} values if
+     * {@link #setAllowNull(boolean) null is not allowed} in addition to any validation provided by any
+     * {@link #setValidator(ParameterValidator) configured validator}. The default if not set is {@code true}. The use
+     * case for setting this to {@code false} would be to ignore undefined values in the basic validation performed
+     * by the {@link AttributeDefinition} and instead let operation handlers validate using more complex logic
+     * (e.g. checking for {@link #setAlternatives(String...) alternatives}.
+     *
+     * @param validateNull {@code true} if additional validation should be performed; {@false} otherwise
+     */
+    public SimpleAttributeDefinitionBuilder setValidateNull(boolean validateNull) {
+        this.validateNull = validateNull;
         return this;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/common/InterfaceDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/common/InterfaceDescription.java
@@ -166,18 +166,18 @@ public class InterfaceDescription {
             .build();
 
     public static final AttributeDefinition ANY_ADDRESS = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ANY_ADDRESS, ModelType.BOOLEAN)
-            .setAllowExpression(false).setAllowNull(false).setRestartAllServices()
-            .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true, true))
+            .setAllowExpression(false).setAllowNull(true).setRestartAllServices()
+            .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true, false))
             .addAlternatives(OTHERS).addAlternatives(ModelDescriptionConstants.ANY_IPV4_ADDRESS, ModelDescriptionConstants.ANY_IPV6_ADDRESS)
             .build();
     public static final AttributeDefinition ANY_IPV4_ADDRESS = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ANY_IPV4_ADDRESS, ModelType.BOOLEAN)
-            .setAllowExpression(false).setAllowNull(false).setRestartAllServices()
-            .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true, true))
+            .setAllowExpression(false).setAllowNull(true).setRestartAllServices()
+            .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true, false))
             .addAlternatives(OTHERS).addAlternatives(ModelDescriptionConstants.ANY_ADDRESS, ModelDescriptionConstants.ANY_IPV6_ADDRESS)
             .build();
     public static final AttributeDefinition ANY_IPV6_ADDRESS = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ANY_IPV6_ADDRESS, ModelType.BOOLEAN)
-            .setAllowExpression(false).setAllowNull(false).setRestartAllServices()
-            .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true, true))
+            .setAllowExpression(false).setAllowNull(true).setRestartAllServices()
+            .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true, false))
             .addAlternatives(OTHERS).addAlternatives(ModelDescriptionConstants.ANY_ADDRESS, ModelDescriptionConstants.ANY_IPV4_ADDRESS)
             .build();
     public static final AttributeDefinition INET_ADDRESS = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.INET_ADDRESS, ModelType.STRING)

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/ModelTypeValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/ModelTypeValidator.java
@@ -124,7 +124,7 @@ public class ModelTypeValidator implements ParameterValidator {
     public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
         if (!value.isDefined()) {
             if (!nullable)
-                throw new OperationFailedException(new ModelNode().set(MESSAGES.nullNotAllowed(parameterName)));
+                throw MESSAGES.nullNotAllowed(parameterName);
         } else  {
             boolean matched = false;
             if (strictType) {
@@ -138,7 +138,7 @@ public class ModelTypeValidator implements ParameterValidator {
                 }
             }
             if  (!matched)
-                throw new OperationFailedException(new ModelNode().set(MESSAGES.incorrectType(parameterName, validTypes, value.getType())));
+                throw MESSAGES.incorrectType(parameterName, validTypes, value.getType());
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/NillableOrExpressionParameterValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/NillableOrExpressionParameterValidator.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.operations.validation;
+
+import static org.jboss.as.controller.ControllerMessages.MESSAGES;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * {@link ParameterValidator} that validates undefined values and expression types, delegating to a provided
+ * validator for everything else.
+ *
+ * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ */
+public class NillableOrExpressionParameterValidator implements ParameterValidator {
+
+    private final ParameterValidator delegate;
+    private final Boolean allowNull;
+    private final boolean allowExpression;
+
+    /**
+     * Creates a new {@code NillableOrExpressionParameterValidator}.
+     *
+     * @param delegate validator to delegate to once null and expression validation is done
+     * @param allowNull whether undefined values are allowed. If this param is {@code null}, checking for undefined
+     *                  is delegated to the provided {@code delegate}
+     * @param allowExpression  whether expressions are allowed
+     */
+    public NillableOrExpressionParameterValidator(ParameterValidator delegate, Boolean allowNull, boolean allowExpression) {
+        this.delegate = delegate;
+        this.allowNull = allowNull;
+        this.allowExpression = allowExpression;
+    }
+
+
+    @Override
+    public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+        switch (value.getType()) {
+            case EXPRESSION:
+                if (!allowExpression) {
+                    throw MESSAGES.expressionNotAllowed(parameterName);
+                }
+                break;
+            case UNDEFINED:
+                if (allowNull != null) {
+                    if (!allowNull) {
+                        throw MESSAGES.nullNotAllowed(parameterName);
+                    }
+                    break;
+                } // else fall through and let the delegate validate
+            default:
+                delegate.validateParameter(parameterName, value);
+        }
+    }
+
+    @Override
+    public void validateResolvedParameter(String parameterName, ModelNode value) throws OperationFailedException {
+        if (!value.isDefined()) {
+            if (!allowExpression) {
+                throw MESSAGES.nullNotAllowed(parameterName);
+            }
+        } else {
+            delegate.validateResolvedParameter(parameterName, value);
+        }
+    }
+}

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerDefinition.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerDefinition.java
@@ -27,7 +27,7 @@ public class DeploymentScannerDefinition extends SimpleResourceDefinition {
     protected static final SimpleAttributeDefinition NAME =
             new SimpleAttributeDefinitionBuilder(CommonAttributes.NAME, ModelType.STRING, false)
                     .setXmlName(Attribute.NAME.getLocalName())
-                    .setAllowExpression(true)
+                    .setAllowExpression(false)
                     .setValidator(new StringLengthValidator(1))
                     .setDefaultValue(new ModelNode().set(DeploymentScannerExtension.DEFAULT_SCANNER_NAME))
                     .build();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
@@ -40,7 +40,7 @@ public class KeystoreAttributes {
 
     public static final SimpleAttributeDefinition ALIAS = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ALIAS,
             ModelType.STRING, true).setXmlName(ModelDescriptionConstants.ALIAS)
-            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final SimpleAttributeDefinition KEY_PASSWORD = new SimpleAttributeDefinitionBuilder(

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
@@ -65,12 +65,17 @@ public class LdapAuthenticationResourceDefinition extends SimpleResourceDefiniti
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final SimpleAttributeDefinition USERNAME_FILTER = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.USERNAME_ATTRIBUTE, ModelType.STRING, false)
-            .setXmlName("attribute").setAlternatives(ModelDescriptionConstants.ADVANCED_FILTER)
-            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false)).setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
+            .setXmlName("attribute")
+            .setAlternatives(ModelDescriptionConstants.ADVANCED_FILTER)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+            .setValidateNull(false)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final SimpleAttributeDefinition ADVANCED_FILTER = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ADVANCED_FILTER, ModelType.STRING, false)
             .setXmlName("filter")
-            .setAlternatives(ModelDescriptionConstants.USERNAME_ATTRIBUTE).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+            .setAlternatives(ModelDescriptionConstants.USERNAME_ATTRIBUTE)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+            .setValidateNull(false)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -66,7 +66,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                     .setXmlName(EJB3SubsystemXMLAttribute.DEFAULT_ACCESS_TIMEOUT.getLocalName())
                     .setDefaultValue(new ModelNode().set(5000)) // TODO: this should come from component description
                     .setAllowExpression(true) // we allow expression for setting a timeout value
-                    .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, false, false))
+                    .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
                     .build();
 
@@ -75,7 +75,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                     .setXmlName(EJB3SubsystemXMLAttribute.DEFAULT_ACCESS_TIMEOUT.getLocalName())
                     .setDefaultValue(new ModelNode().set(5000)) // TODO: this should come from component description
                     .setAllowExpression(true) // we allow expression for setting a timeout value
-                    .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, false, false))
+                    .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
                     .build();
     public static final SimpleAttributeDefinition DEFAULT_SFSB_CACHE =

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -77,7 +77,7 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition ENCODING = SimpleAttributeDefinitionBuilder.create("encoding", ModelType.STRING, true).build();
 
-    SimpleAttributeDefinition FILE = SimpleAttributeDefinitionBuilder.create("file", ModelType.OBJECT, true).
+    SimpleAttributeDefinition FILE = SimpleAttributeDefinitionBuilder.create("file", ModelType.OBJECT, false).
             setCorrector(FileCorrector.INSTANCE).
             setValidator(new FileValidator()).
             build();
@@ -105,25 +105,25 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition MATCH = SimpleAttributeDefinitionBuilder.create("match", ModelType.STRING, true).build();
 
-    SimpleAttributeDefinition MAX_BACKUP_INDEX = SimpleAttributeDefinitionBuilder.create("max-backup-index", ModelType.INT).
+    SimpleAttributeDefinition MAX_BACKUP_INDEX = SimpleAttributeDefinitionBuilder.create("max-backup-index", ModelType.INT, true).
             setDefaultValue(new ModelNode().set(1)).
             setValidator(new IntRangeValidator(1, true)).
             build();
 
-    SimpleAttributeDefinition MAX_INCLUSIVE = SimpleAttributeDefinitionBuilder.create("max-inclusive", ModelType.BOOLEAN).
+    SimpleAttributeDefinition MAX_INCLUSIVE = SimpleAttributeDefinitionBuilder.create("max-inclusive", ModelType.BOOLEAN, true).
             setDefaultValue(new ModelNode().set(true)).
             build();
 
-    SimpleAttributeDefinition MAX_LEVEL = SimpleAttributeDefinitionBuilder.create("max-level", ModelType.STRING).
+    SimpleAttributeDefinition MAX_LEVEL = SimpleAttributeDefinitionBuilder.create("max-level", ModelType.STRING, true).
             setCorrector(CaseParameterCorrector.TO_UPPER).
             setValidator(new LogLevelValidator(true)).
             build();
 
-    SimpleAttributeDefinition MIN_INCLUSIVE = SimpleAttributeDefinitionBuilder.create("min-inclusive", ModelType.BOOLEAN).
+    SimpleAttributeDefinition MIN_INCLUSIVE = SimpleAttributeDefinitionBuilder.create("min-inclusive", ModelType.BOOLEAN, true).
             setDefaultValue(new ModelNode().set(true)).
             build();
 
-    SimpleAttributeDefinition MIN_LEVEL = SimpleAttributeDefinitionBuilder.create("min-level", ModelType.STRING).
+    SimpleAttributeDefinition MIN_LEVEL = SimpleAttributeDefinitionBuilder.create("min-level", ModelType.STRING, true).
             setCorrector(CaseParameterCorrector.TO_UPPER).
             setValidator(new LogLevelValidator(true)).
             build();
@@ -134,7 +134,7 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition VALUE = SimpleAttributeDefinitionBuilder.create("value", ModelType.STRING).build();
 
-    SimpleAttributeDefinition NEW_LEVEL = SimpleAttributeDefinitionBuilder.create("new-level", ModelType.STRING).
+    SimpleAttributeDefinition NEW_LEVEL = SimpleAttributeDefinitionBuilder.create("new-level", ModelType.STRING, true).
             setCorrector(CaseParameterCorrector.TO_UPPER).
             setValidator(new LogLevelValidator(true)).
             build();
@@ -190,7 +190,7 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition TARGET = SimpleAttributeDefinitionBuilder.create("target", ModelType.STRING, true).
             setDefaultValue(new ModelNode().set(Target.SYSTEM_OUT.toString())).
-            setValidator(EnumValidator.create(Target.class, false, false)).
+            setValidator(EnumValidator.create(Target.class, true, false)).
             build();
 
     SimpleAttributeDefinition USE_PARENT_HANDLERS = SimpleAttributeDefinitionBuilder.create("use-parent-handlers", ModelType.BOOLEAN, true).

--- a/logging/src/main/java/org/jboss/as/logging/ObjectTypeAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/ObjectTypeAttributeDefinition.java
@@ -54,7 +54,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
     private final String suffix;
 
     private ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull, final ParameterCorrector corrector, final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
-        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, new ObjectTypeValidator(allowNull, valueTypes), alternatives, requires, flags);
+        super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, new ObjectTypeValidator(allowNull, valueTypes), false, alternatives, requires, flags);
         this.valueTypes = valueTypes;
         if (suffix == null) {
             this.suffix = "";

--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigResourceDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigResourceDefinition.java
@@ -90,6 +90,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition STOP_CONTEXT_TIMEOUT = SimpleAttributeDefinitionBuilder.create(CommonAttributes.STOP_CONTEXT_TIMEOUT, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(10))
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setValidator(new IntRangeValidator(1, true, true))
@@ -97,6 +98,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition SOCKET_TIMEOUT = SimpleAttributeDefinitionBuilder.create(CommonAttributes.SOCKET_TIMEOUT, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(20))
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setValidator(new IntRangeValidator(1, true, true))
@@ -119,6 +121,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition WORKER_TIMEOUT = SimpleAttributeDefinitionBuilder.create(CommonAttributes.WORKER_TIMEOUT, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setValidator(new IntRangeValidator(-1, true, true))
@@ -127,6 +130,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition MAX_ATTEMPTS = SimpleAttributeDefinitionBuilder.create(CommonAttributes.MAX_ATTEMPTS, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(1))
             .setValidator(new IntRangeValidator(-1, true, true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
@@ -138,6 +142,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition FLUSH_WAIT = SimpleAttributeDefinitionBuilder.create(CommonAttributes.FLUSH_WAIT, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setValidator(new IntRangeValidator(-1, true, true))
@@ -152,6 +157,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition SMAX = SimpleAttributeDefinitionBuilder.create(CommonAttributes.SMAX, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(-1))
             .setValidator(new IntRangeValidator(-1, true, true))
             .setCorrector(ZeroToNegativeOneParameterCorrector.INSTANCE)
@@ -159,6 +165,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition TTL = SimpleAttributeDefinitionBuilder.create(CommonAttributes.TTL, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setValidator(new IntRangeValidator(-1, true, true))
@@ -167,6 +174,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition NODE_TIMEOUT = SimpleAttributeDefinitionBuilder.create(CommonAttributes.NODE_TIMEOUT, ModelType.INT, true)
+            .setAllowExpression(true)
             .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setValidator(new IntRangeValidator(-1, true, true))
@@ -192,6 +200,7 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .setValidator(new IntRangeValidator(1, true, true))
             .build();
+
     // order here controls the order of writing into xml, should follow xsd schema
     static final SimpleAttributeDefinition[] ATTRIBUTES = {
             ADVERTISE_SOCKET,

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
@@ -78,7 +78,7 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     }
 
     private static SimpleAttributeDefinition createIntAttribute(String name, Attribute attribute, int defaultValue) {
-        return SimpleAttributeDefinitionBuilder.create(name, ModelType.INT, true).setDefaultValue(new ModelNode().set(defaultValue)).setXmlName(attribute.getLocalName()).setValidator(new IntRangeValidator(1)).build();
+        return SimpleAttributeDefinitionBuilder.create(name, ModelType.INT, true).setDefaultValue(new ModelNode().set(defaultValue)).setXmlName(attribute.getLocalName()).setValidator(new IntRangeValidator(1, true)).build();
     }
 
     private static class ThreadWriteAttributeHandler extends RestartParentWriteAttributeHandler {

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingAddHandler.java
@@ -153,7 +153,7 @@ public class BindingAddHandler extends SocketBindingAddHandler {
             ModelNode destinationNode = mappingNode.get(DESTINATION_ADDRESS);
             if (! destinationNode.isDefined()) {
                 // Validation prevents this, but just in case
-                throw new OperationFailedException(ControllerMessages.MESSAGES.nullNotAllowed(DESTINATION_ADDRESS));
+                throw ControllerMessages.MESSAGES.nullNotAllowed(DESTINATION_ADDRESS);
             }
             destination = destinationNode.asString();
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
@@ -119,7 +119,7 @@ class LogStoreConstants {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode())
             .setMeasurementUnit(MeasurementUnit.NONE)
-            .setValidator(new EnumValidator(ParticipantStatus.class, false, false))
+            .setValidator(new EnumValidator(ParticipantStatus.class, true, false))
             .build();
 
     static SimpleAttributeDefinition PARTICIPANT_JNDI_NAME = (new SimpleAttributeDefinitionBuilder(JNDI_ATTRIBUTE, ModelType.STRING))

--- a/web/src/main/java/org/jboss/as/web/WebAccessLogDirectoryDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebAccessLogDirectoryDefinition.java
@@ -21,9 +21,9 @@ public class WebAccessLogDirectoryDefinition extends AbstractAliasedResourceDefi
     public static final WebAccessLogDirectoryDefinition INSTANCE = new WebAccessLogDirectoryDefinition();
 
     protected static final SimpleAttributeDefinition RELATIVE_TO =
-            new SimpleAttributeDefinitionBuilder(Constants.RELATIVE_TO, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.RELATIVE_TO, ModelType.STRING)
                     .setXmlName(Constants.RELATIVE_TO)
-                    .setAllowNull(false)
+                    .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, true))
                     .setDefaultValue(new ModelNode("jboss.server.log.dir"))
@@ -31,11 +31,12 @@ public class WebAccessLogDirectoryDefinition extends AbstractAliasedResourceDefi
 
 
     protected static final SimpleAttributeDefinition PATH =
-            new SimpleAttributeDefinitionBuilder(Constants.PATH, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PATH, ModelType.STRING)
                     .setXmlName(Constants.PATH)
+                    .setAllowNull(true)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new StringLengthValidator(1, true))
+                    .setValidator(new StringLengthValidator(1, true, true))
                     .build();
 
 

--- a/web/src/main/java/org/jboss/as/web/WebConnectorDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebConnectorDefinition.java
@@ -20,37 +20,38 @@ public class WebConnectorDefinition extends SimpleResourceDefinition {
 
 
     protected static final SimpleAttributeDefinition NAME =
-            new SimpleAttributeDefinitionBuilder(Constants.NAME, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.NAME, ModelType.STRING)
                     .setXmlName(Constants.NAME)
                     .setAllowNull(true) // todo should be false, but 'add' won't validate then
-                    .setValidator(new StringLengthValidator(1, false))
                     .build();
 
     protected static final SimpleAttributeDefinition PROTOCOL =
-            new SimpleAttributeDefinitionBuilder(Constants.PROTOCOL, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PROTOCOL, ModelType.STRING)
                     .setXmlName(Constants.PROTOCOL)
                     .setAllowNull(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new StringLengthValidator(1, true))
+                    .setValidator(new StringLengthValidator(1))
                     .build();
+
     protected static final SimpleAttributeDefinition SOCKET_BINDING =
-            new SimpleAttributeDefinitionBuilder(Constants.SOCKET_BINDING, ModelType.STRING, false)
+            new SimpleAttributeDefinitionBuilder(Constants.SOCKET_BINDING, ModelType.STRING)
                     .setXmlName(Constants.SOCKET_BINDING)
                     .setAllowNull(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new StringLengthValidator(1, false))
+                    .setValidator(new StringLengthValidator(1))
                     .build();
+
     protected static final SimpleAttributeDefinition SCHEME =
-            new SimpleAttributeDefinitionBuilder(Constants.SCHEME, ModelType.STRING, false)
+            new SimpleAttributeDefinitionBuilder(Constants.SCHEME, ModelType.STRING)
                     .setXmlName(Constants.SCHEME)
                     .setAllowNull(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new StringLengthValidator(1, false))
+                    .setValidator(new StringLengthValidator(1))
                     //.setDefaultValue(new ModelNode("http"))
                     .build();
 
     protected static final SimpleAttributeDefinition EXECUTOR =
-            new SimpleAttributeDefinitionBuilder(Constants.EXECUTOR, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.EXECUTOR, ModelType.STRING)
                     .setXmlName(Constants.EXECUTOR)
                     .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
@@ -59,14 +60,15 @@ public class WebConnectorDefinition extends SimpleResourceDefinition {
 
 
     protected static final SimpleAttributeDefinition ENABLED =
-            new SimpleAttributeDefinitionBuilder(Constants.ENABLED, ModelType.BOOLEAN, true)
+            new SimpleAttributeDefinitionBuilder(Constants.ENABLED, ModelType.BOOLEAN)
                     .setXmlName(Constants.ENABLED)
                     .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(true))
                     .build();
+
     protected static final SimpleAttributeDefinition ENABLE_LOOKUPS =
-            new SimpleAttributeDefinitionBuilder(Constants.ENABLE_LOOKUPS, ModelType.BOOLEAN, true)
+            new SimpleAttributeDefinitionBuilder(Constants.ENABLE_LOOKUPS, ModelType.BOOLEAN)
                     .setXmlName(Constants.ENABLE_LOOKUPS)
                     .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
@@ -74,7 +76,7 @@ public class WebConnectorDefinition extends SimpleResourceDefinition {
                     .build();
 
     protected static final SimpleAttributeDefinition PROXY_NAME =
-            new SimpleAttributeDefinitionBuilder(Constants.PROXY_NAME, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PROXY_NAME, ModelType.STRING)
                     .setXmlName(Constants.PROXY_NAME)
                     .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
@@ -82,7 +84,7 @@ public class WebConnectorDefinition extends SimpleResourceDefinition {
                     .build();
 
     protected static final SimpleAttributeDefinition PROXY_PORT =
-            new SimpleAttributeDefinitionBuilder(Constants.PROXY_PORT, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PROXY_PORT, ModelType.INT)
                     .setXmlName(Constants.PROXY_PORT)
                     .setAllowNull(true)
                     .setValidator(new IntRangeValidator(1, true))
@@ -90,50 +92,57 @@ public class WebConnectorDefinition extends SimpleResourceDefinition {
                     .build();
 
     protected static final SimpleAttributeDefinition MAX_POST_SIZE =
-            new SimpleAttributeDefinitionBuilder(Constants.MAX_POST_SIZE, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.MAX_POST_SIZE, ModelType.INT)
                     .setXmlName(Constants.MAX_POST_SIZE)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(1024, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(2097152))
                     .build();
 
     protected static final SimpleAttributeDefinition MAX_SAVE_POST_SIZE =
-            new SimpleAttributeDefinitionBuilder(Constants.MAX_SAVE_POST_SIZE, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.MAX_SAVE_POST_SIZE, ModelType.INT)
                     .setXmlName(Constants.MAX_SAVE_POST_SIZE)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(0, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(4096))
                     .build();
 
     protected static final SimpleAttributeDefinition SECURE =
-            new SimpleAttributeDefinitionBuilder(Constants.SECURE, ModelType.BOOLEAN, true)
+            new SimpleAttributeDefinitionBuilder(Constants.SECURE, ModelType.BOOLEAN)
                     .setXmlName(Constants.SECURE)
+                    .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(false))
                     .build();
+
     protected static final SimpleAttributeDefinition REDIRECT_PORT =
-            new SimpleAttributeDefinitionBuilder(Constants.REDIRECT_PORT, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.REDIRECT_PORT, ModelType.INT)
                     .setXmlName(Constants.REDIRECT_PORT)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(8433))
                     .build();
 
     protected static final SimpleAttributeDefinition MAX_CONNECTIONS =
-            new SimpleAttributeDefinitionBuilder(Constants.MAX_CONNECTIONS, ModelType.INT, true) //todo why is this string somewhere??
+            new SimpleAttributeDefinitionBuilder(Constants.MAX_CONNECTIONS, ModelType.INT) //todo why is this string somewhere??
                     .setXmlName(Constants.MAX_CONNECTIONS)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                             //.setDefaultValue(new ModelNode(8433))
                     .build();
 
     protected static final SimpleAttributeDefinition VIRTUAL_SERVER =
-            new SimpleAttributeDefinitionBuilder(Constants.VIRTUAL_SERVER, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.VIRTUAL_SERVER, ModelType.STRING)
                     .setXmlName(Constants.VIRTUAL_SERVER)
                     .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, true))
                     .build();
+
     protected static final SimpleAttributeDefinition[] CONNECTOR_ATTRIBUTES = {
             //NAME, // name is read-only
             // IMPORTANT -- keep these in xsd order as this order controls marshalling

--- a/web/src/main/java/org/jboss/as/web/WebJSPDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebJSPDefinition.java
@@ -24,21 +24,21 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.DEVELOPMENT, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.DEVELOPMENT)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
     protected static final SimpleAttributeDefinition DISABLED =
             new SimpleAttributeDefinitionBuilder(Constants.DISABLED, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.DISABLED)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
     protected static final SimpleAttributeDefinition KEEP_GENERATED =
             new SimpleAttributeDefinitionBuilder(Constants.KEEP_GENERATED, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.KEEP_GENERATED)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
 
@@ -46,7 +46,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.TRIM_SPACES, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.TRIM_SPACES)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
@@ -54,7 +54,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.TAG_POOLING, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.TAG_POOLING)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
 
@@ -62,7 +62,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.MAPPED_FILE, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.MAPPED_FILE)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
 
@@ -85,7 +85,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.RECOMPILE_ON_FAIL, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.RECOMPILE_ON_FAIL)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
@@ -93,7 +93,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.SMAP, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.SMAP)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
 
@@ -101,7 +101,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.DUMP_SMAP, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.DUMP_SMAP)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
@@ -109,7 +109,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.GENERATE_STRINGS_AS_CHAR_ARRAYS, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.GENERATE_STRINGS_AS_CHAR_ARRAYS)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
@@ -118,7 +118,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.ERROR_ON_USE_BEAN_INVALID_CLASS_ATTRIBUTE, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.ERROR_ON_USE_BEAN_INVALID_CLASS_ATTRIBUTE)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
@@ -158,7 +158,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.X_POWERED_BY, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.X_POWERED_BY)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
 
@@ -166,7 +166,7 @@ public class WebJSPDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.DISPLAY_SOURCE_FRAGMENT, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.DISPLAY_SOURCE_FRAGMENT)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
     protected static final SimpleAttributeDefinition[] JSP_ATTRIBUTES = {

--- a/web/src/main/java/org/jboss/as/web/WebReWriteConditionDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebReWriteConditionDefinition.java
@@ -18,14 +18,14 @@ public class WebReWriteConditionDefinition extends SimpleResourceDefinition {
     public static final WebReWriteConditionDefinition INSTANCE = new WebReWriteConditionDefinition();
 
     protected static final SimpleAttributeDefinition TEST =
-            new SimpleAttributeDefinitionBuilder(Constants.TEST, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.TEST, ModelType.STRING, false)
                     .setXmlName(Constants.TEST)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false))
                     .build();
 
     protected static final SimpleAttributeDefinition PATTERN =
-            new SimpleAttributeDefinitionBuilder(Constants.PATTERN, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PATTERN, ModelType.STRING, false)
                     .setXmlName(Constants.PATTERN)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false))
@@ -33,7 +33,7 @@ public class WebReWriteConditionDefinition extends SimpleResourceDefinition {
 
 
     protected static final SimpleAttributeDefinition FLAGS =
-            new SimpleAttributeDefinitionBuilder(Constants.FLAGS, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.FLAGS, ModelType.STRING, false)
                     .setXmlName(Constants.FLAGS)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false))

--- a/web/src/main/java/org/jboss/as/web/WebReWriteDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebReWriteDefinition.java
@@ -18,7 +18,7 @@ public class WebReWriteDefinition extends SimpleResourceDefinition {
     public static final WebReWriteDefinition INSTANCE = new WebReWriteDefinition();
 
     protected static final SimpleAttributeDefinition PATTERN =
-            new SimpleAttributeDefinitionBuilder(Constants.PATTERN, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PATTERN, ModelType.STRING, false)
                     .setXmlName(Constants.PATTERN)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false))
@@ -26,13 +26,13 @@ public class WebReWriteDefinition extends SimpleResourceDefinition {
 
 
     protected static final SimpleAttributeDefinition SUBSTITUTION =
-            new SimpleAttributeDefinitionBuilder(Constants.SUBSTITUTION, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.SUBSTITUTION, ModelType.STRING, false)
                     .setXmlName(Constants.SUBSTITUTION)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false))
                     .build();
     protected static final SimpleAttributeDefinition FLAGS =
-            new SimpleAttributeDefinitionBuilder(Constants.FLAGS, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.FLAGS, ModelType.STRING, false)
                     .setXmlName(Constants.FLAGS)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false))

--- a/web/src/main/java/org/jboss/as/web/WebSSLDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebSSLDefinition.java
@@ -12,6 +12,7 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -23,118 +24,136 @@ public class WebSSLDefinition extends AbstractAliasedResourceDefinition {
 
 
     protected static final SimpleAttributeDefinition NAME =
-            new SimpleAttributeDefinitionBuilder(Constants.NAME, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.NAME, ModelType.STRING)
                     .setXmlName(Constants.NAME)
                     .setAllowNull(true)
                     .build();
 
     protected static final SimpleAttributeDefinition KEY_ALIAS =
-            new SimpleAttributeDefinitionBuilder(Constants.KEY_ALIAS, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.KEY_ALIAS, ModelType.STRING)
                     .setXmlName(Constants.KEY_ALIAS)
-                    .setAllowNull(false)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     protected static final SimpleAttributeDefinition PASSWORD =
-            new SimpleAttributeDefinitionBuilder(Constants.PASSWORD, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PASSWORD, ModelType.STRING)
                     .setXmlName(Constants.PASSWORD)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setAllowExpression(true)
                     .build();
 
     protected static final SimpleAttributeDefinition CERTIFICATE_KEY_FILE =
-            new SimpleAttributeDefinitionBuilder(Constants.CERTIFICATE_KEY_FILE, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.CERTIFICATE_KEY_FILE, ModelType.STRING)
                     .setXmlName(Constants.CERTIFICATE_KEY_FILE)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setAllowExpression(true)
                     .build();
 
     protected static final SimpleAttributeDefinition CIPHER_SUITE =
-            new SimpleAttributeDefinitionBuilder(Constants.CIPHER_SUITE, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.CIPHER_SUITE, ModelType.STRING)
                     .setXmlName(Constants.CIPHER_SUITE)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     protected static final SimpleAttributeDefinition PROTOCOL =
-            new SimpleAttributeDefinitionBuilder(Constants.PROTOCOL, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.PROTOCOL, ModelType.STRING)
                     .setXmlName(Constants.PROTOCOL)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     protected static final SimpleAttributeDefinition VERIFY_CLIENT =
-            new SimpleAttributeDefinitionBuilder(Constants.VERIFY_CLIENT, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.VERIFY_CLIENT, ModelType.STRING)
                     .setXmlName(Constants.VERIFY_CLIENT)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     protected static final SimpleAttributeDefinition VERIFY_DEPTH =
-            new SimpleAttributeDefinitionBuilder(Constants.VERIFY_DEPTH, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.VERIFY_DEPTH, ModelType.INT)
                     .setXmlName(Constants.VERIFY_DEPTH)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(0, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
+
     protected static final SimpleAttributeDefinition CERTIFICATE_FILE =
-            new SimpleAttributeDefinitionBuilder(Constants.CERTIFICATE_FILE, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.CERTIFICATE_FILE, ModelType.STRING)
                     .setXmlName(Constants.CERTIFICATE_FILE)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setAllowExpression(true)
                     .build();
 
     protected static final SimpleAttributeDefinition CA_CERTIFICATE_FILE =
-            new SimpleAttributeDefinitionBuilder(Constants.CA_CERTIFICATE_FILE, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.CA_CERTIFICATE_FILE, ModelType.STRING)
                     .setXmlName(Constants.CA_CERTIFICATE_FILE)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setAllowExpression(true)
                     .build();
 
     protected static final SimpleAttributeDefinition CA_CERTIFICATE_PASSWORD =
-            new SimpleAttributeDefinitionBuilder(Constants.CA_CERTIFICATE_PASSWORD, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.CA_CERTIFICATE_PASSWORD, ModelType.STRING)
                     .setXmlName(Constants.CA_CERTIFICATE_PASSWORD)
+                    .setAllowNull(true)
+                    .setAllowExpression(true)
                     .setValidator(new StringLengthValidator(1, true, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setAllowExpression(true)
                     .build();
 
     protected static final SimpleAttributeDefinition CA_REVOCATION_URL =
-            new SimpleAttributeDefinitionBuilder(Constants.CA_REVOCATION_URL, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.CA_REVOCATION_URL, ModelType.STRING)
                     .setXmlName(Constants.CA_REVOCATION_URL)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     protected static final SimpleAttributeDefinition TRUSTSTORE_TYPE =
-            new SimpleAttributeDefinitionBuilder(Constants.TRUSTSTORE_TYPE, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.TRUSTSTORE_TYPE, ModelType.STRING)
                     .setXmlName(Constants.TRUSTSTORE_TYPE)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
+
     protected static final SimpleAttributeDefinition KEYSTORE_TYPE =
-            new SimpleAttributeDefinitionBuilder(Constants.KEYSTORE_TYPE, ModelType.STRING, true)
+            new SimpleAttributeDefinitionBuilder(Constants.KEYSTORE_TYPE, ModelType.STRING)
                     .setXmlName(Constants.KEYSTORE_TYPE)
+                    .setAllowNull(true)
                     .setValidator(new StringLengthValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     protected static final SimpleAttributeDefinition SESSION_CACHE_SIZE =
-            new SimpleAttributeDefinitionBuilder(Constants.SESSION_CACHE_SIZE, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.SESSION_CACHE_SIZE, ModelType.INT)
                     .setXmlName(Constants.SESSION_CACHE_SIZE)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
+
     protected static final SimpleAttributeDefinition SESSION_TIMEOUT =
-            new SimpleAttributeDefinitionBuilder(Constants.SESSION_TIMEOUT, ModelType.INT, true)
+            new SimpleAttributeDefinitionBuilder(Constants.SESSION_TIMEOUT, ModelType.INT)
                     .setXmlName(Constants.SESSION_TIMEOUT)
+                    .setAllowNull(true)
                     .setValidator(new IntRangeValidator(1, true))
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
+
     protected static SimpleAttributeDefinition[] SSL_ATTRIBUTES = {
             // IMPORTANT -- keep these in xsd order as this order controls marshalling
             KEY_ALIAS,

--- a/web/src/main/java/org/jboss/as/web/WebStaticResources.java
+++ b/web/src/main/java/org/jboss/as/web/WebStaticResources.java
@@ -24,7 +24,7 @@ public class WebStaticResources extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.LISTINGS, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.LISTINGS)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
     protected static final SimpleAttributeDefinition SENDFILE =
@@ -45,14 +45,14 @@ public class WebStaticResources extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.READ_ONLY, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.READ_ONLY)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(true))
                     .build();
     protected static final SimpleAttributeDefinition WEBDAV =
             new SimpleAttributeDefinitionBuilder(Constants.WEBDAV, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.WEBDAV)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
@@ -74,7 +74,7 @@ public class WebStaticResources extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.DISABLED, ModelType.BOOLEAN, true)
                     .setXmlName(Constants.DISABLED)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN))
+                    .setValidator(new ModelTypeValidator(ModelType.BOOLEAN, true))
                     .setDefaultValue(new ModelNode(false))
                     .build();
     protected static final SimpleAttributeDefinition[] STATIC_ATTRIBUTES = {

--- a/web/src/main/java/org/jboss/as/web/WebVirtualHostDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebVirtualHostDefinition.java
@@ -39,7 +39,7 @@ public class WebVirtualHostDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_WEB_MODULE, ModelType.STRING, true)
                     .setXmlName(Constants.DEFAULT_WEB_MODULE)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                    .setValidator(new StringLengthValidator(1, true,true))
+                    .setValidator(new StringLengthValidator(1, true, false))
                     .setDefaultValue(new ModelNode("ROOT.war"))
                     .build();
     protected static final SimpleAttributeDefinition ENABLE_WELCOME_ROOT =

--- a/web/src/main/java/org/jboss/as/web/WebVirtualHostService.java
+++ b/web/src/main/java/org/jboss/as/web/WebVirtualHostService.java
@@ -82,7 +82,7 @@ public class WebVirtualHostService implements Service<VirtualHost> {
         }
         if(accessLog != null) {
             host.addValve(createAccessLogValve(host, pathManagerInjector.getValue().resolveRelativePathEntry(accessLogPath, accessLogRelativeTo), accessLog));
-            pathManagerInjector.getValue().registerCallback(accessLogRelativeTo, PathManager.ReloadServerCallback.create(), PathManager.Event.UPDATED, PathManager.Event.REMOVED);
+            callbackHandle = pathManagerInjector.getValue().registerCallback(accessLogRelativeTo, PathManager.ReloadServerCallback.create(), PathManager.Event.UPDATED, PathManager.Event.REMOVED);
         }
         if(rewrite != null) {
             host.addValve(createRewriteValve(host, rewrite));


### PR DESCRIPTION
Use the AttributeDefinition allowNull and allowExpression settings in validation.

Review all AttributeDefinition initializations to check for inconsistencies; fix problems found.
