### PR TITLE
[JBQA-5855] Adding passivation test of object with inheritance

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChild.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChild.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
+
+import javax.ejb.Stateful;
+
+import org.jboss.as.test.clustering.NodeNameGetter;
+import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.logging.Logger;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+@Clustered
+@Stateful
+public class StatefulBeanChild extends StatefulBeanParent implements StatefulBeanChildRemote {
+    private static final Logger log = Logger.getLogger(StatefulBeanChild.class);
+    
+    private TestingDTO dto = new TestingDTO();
+    private transient TestingDTO transientDto = new TestingDTO();
+       
+    public int getInt() {
+        return intNumber;
+    }
+    public void setInt(int parentInt) {
+        this.intNumber = parentInt;
+    }
+    
+    public String getNodeName() {
+        String nodeName = NodeNameGetter.getNodeName();
+        log.info(this.getClass().getSimpleName() + " called on node " + nodeName);
+        return nodeName;
+    }
+    
+    // ---- Methods for manipulation with dto data ----
+    public void setDTOStringData(String str) {
+        dto.setData(str);
+    }
+    
+    public String getDTOStringData() {
+        return dto.getData();
+    }
+    
+    public void setDTONumberData(int number) {
+        dto.setNumber(number);
+    }
+    
+    public int getDTONumberData() {
+        return dto.getNumber();
+    }
+    
+    public void setTransientDTOStringData(String str) {
+        transientDto.setData(str);
+    }
+    
+    public String getTransientDTOStringData() {
+        return transientDto.getData();
+    }
+    
+    public void setTransientDTONumberData(int number) {
+        transientDto.setNumber(number);
+    }
+    
+    public int getTransientDTONumberData() {
+        return transientDto.getNumber();
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChildRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChildRemote.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
+
+import javax.ejb.Remote;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+@Remote
+public interface StatefulBeanChildRemote {
+    int getInt();
+    void setInt(int parentInt);
+    
+    String getNodeName();
+    
+    // standard dto
+    void setDTOStringData(String str);
+    String getDTOStringData();
+    void setDTONumberData(int number);
+    int getDTONumberData();
+    
+    // dto defined as transient
+    void setTransientDTOStringData(String str);
+    String getTransientDTOStringData();   
+    void setTransientDTONumberData(int number);
+    int getTransientDTONumberData();    
+
+    // dto defined in parent class
+    void setParentDTOStringData(String str);
+    String getParentDTOStringData();
+    void setParentDTOTransientStringData(String str);
+    String getParentDTOTransientStringData();
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanParent.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanParent.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public class StatefulBeanParent {
+    private TestingDTOParent dtoParent = new TestingDTOParent();
+    protected int intNumber;
+
+
+    public void setParentDTOStringData(String str) {
+        dtoParent.setData(str);
+    }
+    
+    public String getParentDTOStringData() {
+        return dtoParent.getData();
+    }
+    
+    public void setParentDTOTransientStringData(String str) {
+        dtoParent.setTransientData(str);
+    }
+    
+    public String getParentDTOTransientStringData() {
+        return dtoParent.getTransientData();
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTO.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTO.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public class TestingDTO extends TestingDTOParent {
+    private static final long serialVersionUID = 1L;
+    
+    private transient int transientNumber;
+    private int number;
+        
+    public int getTransientInt() {
+        return transientNumber;
+    }
+    public void setTransientNumber(int num) {
+        this.transientNumber = num;
+    }
+    public int getNumber() {
+        return number;
+    }
+    public void setNumber(int num) {
+        this.number = num;
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTOParent.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTOParent.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
+
+import java.io.Serializable;
+
+/**
+ * @author Ondrej Chaloupka
+ */
+public class TestingDTOParent implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
+    private String data;
+    private transient String transientData;
+       
+    public String getData() {
+        return data;
+    }
+    public void setData(String data) {
+        this.data = data;
+    }
+    public String getTransientData() {
+        return transientData;
+    }
+    public void setTransientData(String transientData) {
+        this.transientData = transientData;
+    }
+    
+}


### PR DESCRIPTION
Passivation of a dto object (with inheritance) defined in clustered SFSB. 
It's part of the migration of clustering tests. This is from AS6 testsuite and cluster/ejb3/clusteredsession/unit/PassivationUnit.
