### PR TITLE
Fix for AS7-4497

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_3.xsd
@@ -51,7 +51,8 @@
             <xs:element name="remote" type="remoteType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="thread-pools" type="threadPoolsType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="iiop" type="iiopType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="in-vm-remote-interface-invocation" type="in-vm-remote-interface-invocationType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="in-vm-remote-interface-invocation" type="in-vm-remote-interface-invocationType"
+                        minOccurs="0" maxOccurs="1"/>
             <xs:element name="default-distinct-name" type="default-distinct-nameType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="statistics" type="statisticsType" minOccurs="0" maxOccurs="1"/>
         </xs:all>
@@ -67,7 +68,7 @@
     <xs:complexType name="entityType">
         <xs:all>
             <xs:element name="bean-instance-pool-ref" type="bean-instance-pool-refType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="optimistic-locking" type="optimistic-lockingType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="optimistic-locking" type="optimistic-lockingType" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
 
@@ -77,7 +78,8 @@
 
     <xs:complexType name="remoteType">
         <xs:all>
-            <xs:element name="channel-creation-options" type="channel-creation-optionsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="channel-creation-options" type="channel-creation-optionsType" minOccurs="0"
+                        maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="connector-ref" type="xs:string" use="required"/>
         <xs:attribute name="thread-pool-name" type="xs:token" use="required"/>
@@ -234,7 +236,7 @@
     <xs:complexType name="threadPoolType">
         <xs:annotation>
             <xs:documentation>
-            <![CDATA[
+                <![CDATA[
                 A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no
                 upper bound.  When a task is submitted, if the number of running threads is less than the core size,
                 a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be
@@ -293,14 +295,35 @@
     </xs:complexType>
 
     <xs:complexType name="channel-creation-optionsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The options that will be used while creating the channel for EJB remote invocation communication
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
         <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="option" type="optionType"/>
         </xs:choice>
     </xs:complexType>
 
     <xs:complexType name="optionType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The "name" attribute specifies the name of the option being configured.
+
+                The "value" attribute is the value that's going to be set for the option.
+
+                The "type" attribute value can either be "xnio" or "remoting". If it's "xnio", then the option
+                being configured will be looked up against the org.xnio.Options class. If it's "remoting" then
+                the option will be looked up against the org.xnio.Option.RemotingOptions class.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="value" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string" use="required"/>
     </xs:complexType>
 
 </xs:schema>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -2054,6 +2054,9 @@ public interface EjbMessages {
     @Message(id = 14573, value = "Could not obtain lock on %s to passivate %s")
     IllegalStateException couldNotObtainLockForGroup(String groupId, String groupMember);
 
+    @Message(id = 14574, value = "Unknown channel creation option type %s")
+    IllegalArgumentException unknownChannelCreationOptionType(String optionType);
+
 
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -94,6 +94,7 @@ public interface EJB3SubsystemModel {
 
     String CHANNEL_CREATION_OPTIONS = "channel-creation-options";
     String VALUE = "value";
+    String TYPE = "type";
 
     PathElement REMOTE_SERVICE_PATH = PathElement.pathElement(SERVICE, REMOTE);
     PathElement ASYNC_SERVICE_PATH = PathElement.pathElement(SERVICE, ASYNC);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
@@ -74,6 +74,7 @@ public enum EJB3SubsystemXMLAttribute {
     SUBDIRECTORY_COUNT("subdirectory-count"),
 
     THREAD_POOL_NAME("thread-pool-name"),
+    TYPE("type"),
 
     USE_QUALIFIED_NAME("use-qualified-name"),
 

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -158,6 +158,7 @@ remote.client-mappings-cache-container-ref=The name of the clustered cache conta
 remote.client-mappings-cache-ref=The name of the clustered cache which will be used to store/access the client-mappings of the EJB remoting connector's socket-binding on each node, in the cluster
 channel-creation-options=The options that will be used during the EJB remote channel creation
 channel-creation-options.value=The value for the EJB remote channel creation option
+channel-creation-options.type=The type of the channel creation option
 channel-creation-options.add=Adds a EJB remote channel creation option
 channel-creation-options.remove=Removes a EJB remote channel creation option
 

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
@@ -2,8 +2,8 @@
 
     <remote connector-ref="remoting-connector" thread-pool-name="default">
         <channel-creation-options>
-            <option name="org.xnio.Options.READ_TIMEOUT" value="20"/>
-            <option name="org.jboss.remoting3.RemotingOptions.MAX_OUTBOUND_MESSAGES" value="1234"/>
+            <option name="READ_TIMEOUT" value="20" type="xnio"/>
+            <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
         </channel-creation-options>
     </remote>
 


### PR DESCRIPTION
The commit in this branch fixes https://issues.jboss.org/browse/AS7-4497. The EJB3 subsystem xsd (was recently) updated to allow channel creation options for the EJB remote channel. This introduced a bug where we allowed references to classnames in the xml. The commit here fixes the issue by no longer allowing references to those classnames. The referenced JIRA has the details on how this can be configured now.
