### PR TITLE
AS7-3556 Add CLI tests for OSGi management functionality

### DIFF
--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/SubsystemState.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/SubsystemState.java
@@ -22,9 +22,17 @@
 
 package org.jboss.as.osgi.parser;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Observable;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.osgi.service.FrameworkBootstrapService;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
@@ -34,15 +42,6 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Observable;
 
 /**
  * The OSGi subsystem state.
@@ -124,13 +123,12 @@ public class SubsystemState  extends Observable implements Serializable, Service
     }
 
     public OSGiCapability removeCapability(String id) {
-        ModuleIdentifier identifier = ModuleIdentifier.fromString(id);
         synchronized (capabilities) {
             for (Iterator<OSGiCapability> it = capabilities.iterator(); it.hasNext(); ) {
                 OSGiCapability module = it.next();
-                if (module.getIdentifier().equals(identifier)) {
+                if (module.getIdentifier().equals(id)) {
                     it.remove();
-                    notifyObservers(new ChangeEvent(ChangeType.CAPABILITY, true, identifier.toString()));
+                    notifyObservers(new ChangeEvent(ChangeType.CAPABILITY, true, id));
                     return module;
                 }
             }

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivateOperationTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivateOperationTestCase.java
@@ -28,16 +28,13 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.osgi.framework.Services;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 /**
  * @author David Bosschaert
  */
-//@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class ActivateOperationTestCase {
-
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void testActivateOperation() throws Exception {

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivationWriteHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/ActivationWriteHandlerTestCase.java
@@ -28,14 +28,12 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.osgi.parser.SubsystemState.Activation;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 /**
  * @author David Bosschaert
  */
-//@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class ActivationWriteHandlerTestCase {
 
     @Test

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/BundleRuntimeHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/BundleRuntimeHandlerTestCase.java
@@ -35,7 +35,6 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.osgi.framework.Services;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
@@ -48,7 +47,6 @@ import org.osgi.service.startlevel.StartLevel;
 /**
  * @author David Bosschaert
  */
-//@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class BundleRuntimeHandlerTestCase {
     private BundleContext bundleContext;
     private ModelNode contextResult;
@@ -133,7 +131,7 @@ public class BundleRuntimeHandlerTestCase {
     }
 
     @Test
-    public void testTypeAttributeFragmen() throws Exception {
+    public void testTypeAttributeFragment() throws Exception {
         mockEnvironment();
         ModelNode readOp = getReadOperation("1", ModelConstants.TYPE);
 

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiCapabilityAddRemoveTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiCapabilityAddRemoveTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.osgi.parser;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 
 import junit.framework.Assert;
 
@@ -33,15 +32,12 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.osgi.parser.SubsystemState.OSGiCapability;
 import org.jboss.dmr.ModelNode;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * @author David Bosschaert
  * @author Thomas.Diesler@jboss.com
  */
-@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class OSGiCapabilityAddRemoveTestCase extends ResourceAddRemoveTestBase {
     @Test
     public void testOSGiCapabilityAddRemove() throws Exception {

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiFrameworkPropertyAddRemoveTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiFrameworkPropertyAddRemoveTestCase.java
@@ -31,14 +31,12 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author David Bosschaert
  * @author Thomas.Diesler@jboss.com
  */
-//@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class OSGiFrameworkPropertyAddRemoveTestCase extends ResourceAddRemoveTestBase {
 
     @Test

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/ResourceAddRemoveTestBase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/ResourceAddRemoveTestBase.java
@@ -35,7 +35,6 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistry;
-import org.junit.Ignore;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -43,7 +42,6 @@ import org.mockito.stubbing.Answer;
 /**
  * @author David Bosschaert
  */
-//@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 class ResourceAddRemoveTestBase {
 
     private final AtomicReference<ModelNode> operationHolder = new AtomicReference<ModelNode>();

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/StartLevelHandlerTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/StartLevelHandlerTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.osgi.framework.Services;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.osgi.service.startlevel.StartLevel;
@@ -37,7 +36,6 @@ import org.osgi.service.startlevel.StartLevel;
 /**
  * @author David Bosschaert
  */
-//@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class StartLevelHandlerTestCase {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/SubsystemStateTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/SubsystemStateTestCase.java
@@ -21,10 +21,6 @@
  */
 package org.jboss.as.osgi.parser;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
@@ -35,10 +31,12 @@ import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 /**
  * @author David Bosschaert
  */
-@Ignore("[AS7-3556] Replace mocked subsystem model tests with functional tests")
 public class SubsystemStateTestCase {
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/management/OSGiManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/management/OSGiManagementTestCase.java
@@ -27,11 +27,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -180,18 +178,11 @@ public class OSGiManagementTestCase extends AbstractCliTestBase {
         List<?> propertyNames = (List<?>) cliresult1.getResult();
         assertTrue(propertyNames.contains(propName));
 
-        // check the standalone.xml file to see that the value appeared in there
-        String contents = readTextFile(getStandaloneFullFile());
-        assertTrue("Configuration file should contain the property", contents.contains("testing123testing"));
-
         callCLI("/subsystem=osgi/property=" + propName + ":remove");
 
         CLIOpResult cliresult2 = callCLI("/subsystem=osgi:read-children-names(child-type=property)");
         List<?> propertyNames2 = (List<?>) cliresult2.getResult();
         assertFalse(propertyNames2.contains(propName));
-
-        String contents2 = readTextFile(getStandaloneFullFile());
-        assertFalse("Property should be removed from configuration file", contents2.contains("testing123testing"));
     }
 
     @Test
@@ -220,18 +211,11 @@ public class OSGiManagementTestCase extends AbstractCliTestBase {
         Map<?, ?> resultMap = (Map<?, ?>) cliresult2.getResult();
         assertEquals("ACTIVE", resultMap.get("state"));
 
-        // Check the xml configuration file
-        String contents = readTextFile(getStandaloneFullFile());
-        assertTrue("Configuration file should contain the capability", contents.contains(capabilityName));
-
         callCLI("/subsystem=osgi/capability=" + capabilityName + ":remove");
 
         CLIOpResult cliresult3 = callCLI("/subsystem=osgi:read-children-names(child-type=capability)");
         List<?> capNames2 = (List<?>) cliresult3.getResult();
         assertFalse(capNames2.contains(capabilityName));
-
-        String contents2 = readTextFile(getStandaloneFullFile());
-        assertFalse("Configuration file should contain the capability", contents2.contains(capabilityName));
 
         // clean up
         bundleFile.delete();
@@ -245,26 +229,11 @@ public class OSGiManagementTestCase extends AbstractCliTestBase {
         try {
             callCLI("/subsystem=osgi:write-attribute(name=activation,value=eager)");
 
-            // Check the xml configuration file
-            String contents = readTextFile(getStandaloneFullFile());
-            assertTrue("Configuration file should contain the eager setting", contents.contains("activation=\"eager\""));
+            CLIOpResult cliresult2 = callCLI("/subsystem=osgi:read-attribute(name=activation)");
+            assertEquals("eager", cliresult2.getResult());
         } finally {
             callCLI("/subsystem=osgi:write-attribute(name=activation,value=lazy)");
-
-            String contents = readTextFile(getStandaloneFullFile());
-            assertTrue("Configuration file should contain the lazy setting", contents.contains("activation=\"lazy\""));
         }
-    }
-
-    private File getStandaloneFullFile() {
-        String baseDir = System.getProperty("jboss.inst");
-        String xmlFile = baseDir + "/standalone/configuration/standalone-full.xml";
-        return new File(xmlFile);
-    }
-
-    private String readTextFile(File file) throws FileNotFoundException {
-        // The following reads the file into a string
-        return new Scanner(file).useDelimiter("\\A").next();
     }
 
     @SuppressWarnings("unchecked")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/management/OSGiManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/management/OSGiManagementTestCase.java
@@ -22,24 +22,36 @@
 
 package org.jboss.as.test.integration.osgi.management;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.osgi.spi.OSGiManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Test OSGi management operations
  *
  * @author thomas.diesler@jboss.com
+ * @author David Bosschaert
  * @since 06-Mar-2012
  */
 @RunWith(Arquillian.class)
@@ -58,61 +70,272 @@ public class OSGiManagementTestCase extends AbstractCliTestBase {
 
     @Test
     public void testFrameworkActivation() throws Exception {
-
-        // Get the current startlevel
-        String startLevel = getFrameworkStartLevel();
-        
-        // If the startlevel is not defined the subsystem is down
-        // [TODO] define a more explicit runtime atttribute
-        if ("undefined".equals(startLevel)) {
-            cli.sendLine("/subsystem=osgi:activate");
-            CLIOpResult cliresult = cli.readAllAsOpResult(WAIT_TIMEOUT, WAIT_LINETIMEOUT);
-            assertTrue(cliresult.isIsOutcomeSuccess());
-            assertEquals("1", getFrameworkStartLevel());
-        } else if ("1".equals(startLevel)) {
-            // Nothing to do            
-        } else {
-            fail("Unexpected startlevel: " + startLevel);
+        boolean active = isFrameworkActive();
+        if (!active) {
+            callCLI("/subsystem=osgi:activate");
+            assertTrue(isFrameworkActive());
         }
     }
 
     @Test
-    @Ignore
+    public void testStartLevel() throws Exception {
+        ensureFrameworkActive();
+
+        String initial = getFrameworkStartLevel();
+        try {
+            assertEquals("1", initial);
+
+            CLIOpResult b1Result = callCLI("/subsystem=osgi/bundle=1:read-resource(include-runtime=true)");
+            Map<?, ?> resultMap = (Map<?, ?>) b1Result.getResult();
+            assertEquals("ACTIVE", resultMap.get("state"));
+
+            callCLI("/subsystem=osgi:write-attribute(name=startlevel,value=0");
+            assertEquals("0", getFrameworkStartLevel());
+
+            CLIOpResult b1Result2 = callCLI("/subsystem=osgi/bundle=1:read-resource(include-runtime=true)");
+            Map<?, ?> resultMap2 = (Map<?, ?>) b1Result2.getResult();
+            assertEquals("RESOLVED", resultMap2.get("state"));
+        } finally {
+            callCLI("/subsystem=osgi:write-attribute(name=startlevel,value=" + initial);
+        }
+    }
+
+    @Test
+    public void testBundleRuntimeOperations() throws Exception {
+        // No need to ensure the framework is active. If it isn't deploying a bundle
+        // should trigger it into active mode.
+
+        // Create and deploy a test bundle
+        File testBundle = File.createTempFile("testbundle", ".jar");
+        JavaArchive bundleArchive = createTestBundle("test-bundle");
+        bundleArchive.as(ZipExporter.class).exportTo(testBundle, true);
+
+        cli.sendLine("deploy " + testBundle.getAbsolutePath());
+        long testBundleId = findBundleId("test-bundle");
+        assertTrue(testBundleId > 0);
+
+        // Read the bundle information and check that it is correct
+        String readCommand = "/subsystem=osgi/bundle=" + testBundleId + ":read-resource(include-runtime=true)";
+        CLIOpResult cliresult = callCLI(readCommand);
+        Map<?, ?> resultMap = (Map<?, ?>) cliresult.getResult();
+
+        assertEquals(testBundleId + "L", resultMap.get("id"));
+        assertEquals("ACTIVE", resultMap.get("state"));
+        assertEquals("1", resultMap.get("startlevel"));
+        assertEquals("bundle", resultMap.get("type"));
+        assertEquals("test-bundle", resultMap.get("symbolic-name"));
+        assertEquals("1.0.1", resultMap.get("version"));
+
+        // Stop the bundle and start it again
+        callCLI("/subsystem=osgi/bundle=" + testBundleId + ":stop");
+        CLIOpResult cliresult2 = callCLI(readCommand);
+        Map<?, ?> resultMap2 = (Map<?, ?>) cliresult2.getResult();
+        assertEquals("RESOLVED", resultMap2.get("state"));
+
+        callCLI("/subsystem=osgi/bundle=" + testBundleId + ":start");
+        CLIOpResult cliresult3 = callCLI(readCommand);
+        Map<?, ?> resultMap3 = (Map<?, ?>) cliresult3.getResult();
+        assertEquals("ACTIVE", resultMap3.get("state"));
+
+        // Create and deploy a test fragment
+        File testFragment = File.createTempFile("testfragment", ".jar");
+        JavaArchive fragmentArchive = createTestFragment();
+        fragmentArchive.as(ZipExporter.class).exportTo(testFragment, true);
+
+        cli.sendLine("deploy " + testFragment.getAbsolutePath());
+        long testFragId = findBundleId("test-fragment");
+        assertTrue(testFragId > 0);
+
+        // Read the fragment information and check that it is correct
+        CLIOpResult cliresult4 = callCLI("/subsystem=osgi/bundle=" + testFragId + ":read-resource(include-runtime=true)");
+        Map<?, ?> resultMap4 = (Map<?, ?>) cliresult4.getResult();
+        assertEquals(testFragId + "L", resultMap4.get("id"));
+        assertEquals("fragment", resultMap4.get("type"));
+        assertEquals("test-fragment", resultMap4.get("symbolic-name"));
+
+        // Undeploy both the fragment and bundle and check that they're gone
+        cli.sendLine("undeploy " + testFragment.getName());
+        cli.sendLine("undeploy " + testBundle.getName());
+
+        CLIOpResult cliresult5 = callCLI("/subsystem=osgi:read-children-names(child-type=bundle)");
+        List<?> bundleIDs = (List<?>) cliresult5.getResult();
+        assertFalse("The test bundle should have been removed, as it was undeployed",
+                bundleIDs.contains("" + testBundleId));
+        assertFalse("The test fragment should have been removed, as it was undeployed",
+                bundleIDs.contains("" + testFragId));
+
+        assertTrue("Unable to delete test bundle. Are all streams properly closed?", testBundle.delete());
+        assertTrue("Unable to delete test fragment. Are all streams properly closed?", testFragment.delete());
+    }
+
+    @Test
     public void testFrameworkProperties() throws Exception {
-        // [TODO] testFrameworkProperties
+        String propName = "testProp" + System.currentTimeMillis();
+        callCLI("/subsystem=osgi/property=" + propName + ":add(value=testing123testing)");
+
+        CLIOpResult cliresult = callCLI("/subsystem=osgi/property=" + propName + ":read-resource");
+        assertEquals("testing123testing", ((Map<?,?>)cliresult.getResult()).get("value"));
+
+        CLIOpResult cliresult1 = callCLI("/subsystem=osgi:read-children-names(child-type=property)");
+        List<?> propertyNames = (List<?>) cliresult1.getResult();
+        assertTrue(propertyNames.contains(propName));
+
+        // check the standalone.xml file to see that the value appeared in there
+        String contents = readTextFile(getStandaloneFullFile());
+        assertTrue("Configuration file should contain the property", contents.contains("testing123testing"));
+
+        callCLI("/subsystem=osgi/property=" + propName + ":remove");
+
+        CLIOpResult cliresult2 = callCLI("/subsystem=osgi:read-children-names(child-type=property)");
+        List<?> propertyNames2 = (List<?>) cliresult2.getResult();
+        assertFalse(propertyNames2.contains(propName));
+
+        String contents2 = readTextFile(getStandaloneFullFile());
+        assertFalse("Property should be removed from configuration file", contents2.contains("testing123testing"));
     }
 
     @Test
-    @Ignore
     public void testAddRemoveCapabilities() throws Exception {
-        // [TODO] testAddRemoveCapabilities
+        ensureFrameworkActive();
+
+        String capabilityName = "org.jboss.test.testcap" + System.currentTimeMillis();
+        String basedir = System.getProperty("jboss.dist");
+        File targetdir = new File(basedir + "/bundles/" + capabilityName.replace(".", "/") + "/main");
+        targetdir.mkdirs();
+
+        File bundleFile = new File(targetdir, "testcapabilitybundle.jar");
+        JavaArchive capabilityBundle = createTestBundle("capability-bundle");
+        capabilityBundle.as(ZipExporter.class).exportTo(bundleFile);
+
+        callCLI("/subsystem=osgi/capability=" + capabilityName + ":add(startlevel=1)");
+
+        CLIOpResult cliresult1 = callCLI("/subsystem=osgi:read-children-names(child-type=capability)");
+        List<?> capNames = (List<?>) cliresult1.getResult();
+        assertTrue(capNames.contains(capabilityName));
+
+        long capBundleId = findBundleId("capability-bundle");
+        assertTrue(capBundleId > 0);
+
+        CLIOpResult cliresult2 = callCLI("/subsystem=osgi/bundle=" + capBundleId + ":read-resource(include-runtime=true)");
+        Map<?, ?> resultMap = (Map<?, ?>) cliresult2.getResult();
+        assertEquals("ACTIVE", resultMap.get("state"));
+
+        // Check the xml configuration file
+        String contents = readTextFile(getStandaloneFullFile());
+        assertTrue("Configuration file should contain the capability", contents.contains(capabilityName));
+
+        callCLI("/subsystem=osgi/capability=" + capabilityName + ":remove");
+
+        CLIOpResult cliresult3 = callCLI("/subsystem=osgi:read-children-names(child-type=capability)");
+        List<?> capNames2 = (List<?>) cliresult3.getResult();
+        assertFalse(capNames2.contains(capabilityName));
+
+        String contents2 = readTextFile(getStandaloneFullFile());
+        assertFalse("Configuration file should contain the capability", contents2.contains(capabilityName));
+
+        // clean up
+        bundleFile.delete();
     }
 
     @Test
-    @Ignore
-    public void testChangeCapabilityStartlevel() throws Exception {
-        // [TODO] testChangeCapabilityStartlevel
+    public void testActivationMode() throws Exception {
+        CLIOpResult cliresult = callCLI("/subsystem=osgi:read-attribute(name=activation)");
+        assertEquals("lazy", cliresult.getResult());
+
+        try {
+            callCLI("/subsystem=osgi:write-attribute(name=activation,value=eager)");
+
+            // Check the xml configuration file
+            String contents = readTextFile(getStandaloneFullFile());
+            assertTrue("Configuration file should contain the eager setting", contents.contains("activation=\"eager\""));
+        } finally {
+            callCLI("/subsystem=osgi:write-attribute(name=activation,value=lazy)");
+
+            String contents = readTextFile(getStandaloneFullFile());
+            assertTrue("Configuration file should contain the lazy setting", contents.contains("activation=\"lazy\""));
+        }
     }
 
-    @Test
-    @Ignore
-    public void testConfigAdminOperations() throws Exception {
-        // [TODO] testConfigAdminOperations
+    private File getStandaloneFullFile() {
+        String baseDir = System.getProperty("jboss.inst");
+        String xmlFile = baseDir + "/standalone/configuration/standalone-full.xml";
+        return new File(xmlFile);
     }
 
-    @Test
-    @Ignore
-    public void testRuntimeOperations() throws Exception {
-        // [TODO] testRuntimeOperations
+    private String readTextFile(File file) throws FileNotFoundException {
+        // The following reads the file into a string
+        return new Scanner(file).useDelimiter("\\A").next();
     }
 
-    // [TODO] any other management operations that need testing?
+    @SuppressWarnings("unchecked")
+    private long findBundleId(String bsn) throws Exception {
+        CLIOpResult cliresult = callCLI("/subsystem=osgi:read-children-resources(recursive=true,include-runtime=true,child-type=bundle)");
+        long bundleId = -1;
+        Map<String, Map<String, Object>> resultMap = (Map<String, Map<String, Object>>) cliresult.getResult();
+        for (Map<String, Object> map : resultMap.values()) {
+            if (bsn.equals(map.get("symbolic-name"))) {
+                String id = ((String) map.get("id")).trim();
+                if (id.endsWith("L"))
+                    id = id.substring(0, id.length() - 1);
+                bundleId = Long.parseLong(id);
+                break;
+            }
+        }
+        return bundleId;
+    }
+
+    private boolean isFrameworkActive() throws Exception {
+        CLIOpResult cliresult = callCLI("/subsystem=osgi:read-children-names(child-type=bundle)");
+        return ((List<?>) cliresult.getResult()).size() > 0;
+    }
+
+    private void ensureFrameworkActive() throws Exception {
+        boolean active = isFrameworkActive();
+        if (!active) {
+            callCLI("/subsystem=osgi:activate");
+            assertTrue(isFrameworkActive());
+        }
+    }
 
     private String getFrameworkStartLevel() throws Exception {
-        cli.sendLine("/subsystem=osgi:read-attribute(name=startlevel)");
-        CLIOpResult cliresult = cli.readAllAsOpResult(WAIT_TIMEOUT, WAIT_LINETIMEOUT);
+        CLIOpResult cliresult = callCLI("/subsystem=osgi:read-attribute(name=startlevel)");
 
         assertTrue(cliresult.isIsOutcomeSuccess());
         return (String)cliresult.getResult();
+    }
+
+    private CLIOpResult callCLI(String line) throws Exception {
+        cli.sendLine(line);
+        CLIOpResult cliresult = cli.readAllAsOpResult(WAIT_TIMEOUT, WAIT_LINETIMEOUT);
+        assertTrue(cliresult.isIsOutcomeSuccess());
+        return cliresult;
+    }
+
+    private static JavaArchive createTestBundle(String bsn) {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, bsn);
+        archive.setManifest(new Asset() {
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addBundleVersion("1.0.1");
+                builder.addBundleManifestVersion(2);
+                return builder.openStream();
+            }
+        });
+        return archive;
+    }
+
+    private static JavaArchive createTestFragment() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "test-fragment");
+        archive.setManifest(new Asset() {
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addFragmentHost("test-bundle");
+                builder.addBundleManifestVersion(2);
+                return builder.openStream();
+            }
+        });
+        return archive;
     }
 }


### PR DESCRIPTION
Added CLI-based system tests for OSGi management operations.
Re-enabled (and fixed) the unit tests that were previously disabled.
This commit doesn't include ConfigurationAdmin tests yet, these will be done separately in the context of AS7-3904.
