### PR TITLE
AS7-3995 make add-users.sh/bat script have domain directory location a parameter

### DIFF
--- a/build/src/main/resources/bin/add-user.bat
+++ b/build/src/main/resources/bin/add-user.bat
@@ -69,7 +69,10 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
-"%JAVA%" ^
+# Uncomment to override standalone and domain user location  
+# set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.config.user.dir=../standalone/configuration -Djboss.domain.config.user.dir=../domain/configuration"
+
+"%JAVA%" %JAVA_OPTS% ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.domain-add-user ^

--- a/build/src/main/resources/bin/add-user.sh
+++ b/build/src/main/resources/bin/add-user.sh
@@ -62,6 +62,8 @@ fi
 
 # Sample JPDA settings for remote socket debugging
 #JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y"
+# Uncomment to override standalone and domain user location  
+#JAVA_OPTS="$JAVA_OPTS -Djboss.server.config.user.dir=../standalone/configuration -Djboss.domain.config.user.dir=../domain/configuration"
 
 eval \"$JAVA\" $JAVA_OPTS \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
@@ -47,8 +47,10 @@ public class AddPropertiesUser {
 
     public static final String SERVER_BASE_DIR = "jboss.server.base.dir";
     public static final String SERVER_CONFIG_DIR = "jboss.server.config.dir";
+    public static final String SERVER_CONFIG_USER_DIR = "jboss.server.config.user.dir";
     public static final String DOMAIN_BASE_DIR = "jboss.domain.base.dir";
     public static final String DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
+    public static final String DOMAIN_CONFIG_USER_DIR = "jboss.domain.config.user.dir";
 
     public static final String DEFAULT_MANAGEMENT_REALM = "ManagementRealm";
     public static final String DEFAULT_APPLICATION_REALM = "ApplicationRealm";
@@ -56,7 +58,8 @@ public class AddPropertiesUser {
     public static final String APPLICATION_USERS_PROPERTIES = "application-users.properties";
     public static final String APPLICATION_ROLES_PROPERTIES = "application-roles.properties";
     public static final String APPLICATION_USERS_SWITCH = "-a";
-
+    public static final String DOMAIN_CONFIG_DIR_USERS_SWITCH = "-dc";
+    public static final String SERVER_CONFIG_DIR_USERS_SWITCH = "-sc";
 
     private static final char CARRIAGE_RETURN_CHAR = '\r';
 
@@ -72,21 +75,26 @@ public class AddPropertiesUser {
 
     protected AddPropertiesUser() {
         theConsole = new JavaConsole();
+        StateValues stateValues = new StateValues();
+        stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
+
         if (theConsole.getConsole() == null) {
             throw MESSAGES.noConsoleAvailable();
         }
-        nextState = new PropertyFilePrompt(theConsole);
+        nextState = new PropertyFilePrompt(theConsole, stateValues);
     }
 
     protected AddPropertiesUser(ConsoleWrapper console) {
         this.theConsole = console;
-        nextState = new PropertyFilePrompt(theConsole);
+        StateValues stateValues = new StateValues();
+        stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
+        nextState = new PropertyFilePrompt(theConsole,stateValues);
     }
 
     private AddPropertiesUser(final boolean management, final String user, final char[] password, final String realm) {
         boolean silent = false;
         StateValues stateValues = new StateValues();
-
+        stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
         String valueSilent = argsCliProps.getProperty("silent");
 
         if (valueSilent != null) {
@@ -144,6 +152,10 @@ public class AddPropertiesUser {
                     }
                 } else if (temp.equals(APPLICATION_USERS_SWITCH)) {
                     management = false;
+                } else if (temp.indexOf(DOMAIN_CONFIG_DIR_USERS_SWITCH)>=0) {
+                    System.setProperty(DOMAIN_CONFIG_DIR,temp.substring(3));
+                } else if (temp.indexOf(SERVER_CONFIG_DIR)>=0) {
+                    System.setProperty(SERVER_CONFIG_DIR,temp.substring(3));
                 } else {
                     argsList.add(temp);
                 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFileFinder.java
@@ -45,15 +45,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.MGMT_USERS_PROPERTIES;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.APPLICATION_USERS_PROPERTIES;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.APPLICATION_ROLES_PROPERTIES;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.SERVER_CONFIG_DIR;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.SERVER_BASE_DIR;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.DOMAIN_BASE_DIR;
-import static org.jboss.as.domain.management.security.AddPropertiesUser.DOMAIN_CONFIG_DIR;
 
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
+import static org.jboss.as.domain.management.security.AddPropertiesUser.*;
 
 /**
  * The first state executed, responsible for searching for the relevant properties files.
@@ -74,7 +68,7 @@ public class PropertyFileFinder implements State {
     @Override
     public State execute() {
         stateValues.setKnownRoles(new HashMap<String, String>());
-        String jbossHome = System.getenv("JBOSS_HOME");
+        String jbossHome = stateValues.getJBossHome();
         if (jbossHome == null) {
             return new ErrorState(theConsole, MESSAGES.jbossHomeNotSet(), null, stateValues);
         }
@@ -134,12 +128,11 @@ public class PropertyFileFinder implements State {
     }
 
     private boolean findFiles(final String jbossHome, final List<File> foundFiles, final String fileName) {
-
-        File standaloneProps = buildFilePath(jbossHome, SERVER_CONFIG_DIR, SERVER_BASE_DIR, "standalone", fileName);
+        File standaloneProps = buildFilePath(jbossHome, SERVER_CONFIG_USER_DIR, SERVER_CONFIG_DIR, SERVER_BASE_DIR, "standalone", fileName);
         if (standaloneProps.exists()) {
             foundFiles.add(standaloneProps);
         }
-        File domainProps = buildFilePath(jbossHome, DOMAIN_CONFIG_DIR, DOMAIN_BASE_DIR, "domain", fileName);
+        File domainProps = buildFilePath(jbossHome, DOMAIN_CONFIG_USER_DIR,DOMAIN_CONFIG_DIR, DOMAIN_BASE_DIR, "domain", fileName);
         if (domainProps.exists()) {
             foundFiles.add(domainProps);
         }
@@ -150,10 +143,12 @@ public class PropertyFileFinder implements State {
         return true;
     }
 
-    private File buildFilePath(final String jbossHome, final String serverConfigDirPropertyName,
+    private File buildFilePath(final String jbossHome, final String serverCofigUserDirPropertyName, final String serverConfigDirPropertyName,
                                final String serverBaseDirPropertyName, final String defaultBaseDir, final String fileName) {
 
-        String configDirConfiguredPath = System.getProperty(serverConfigDirPropertyName);
+        String configUserDirConfiguredPath = System.getProperty(serverCofigUserDirPropertyName);
+        String configDirConfiguredPath = configUserDirConfiguredPath != null ? configUserDirConfiguredPath : System.getProperty(serverConfigDirPropertyName);
+
         File configDir =  configDirConfiguredPath != null ? new File(configDirConfiguredPath) : null;
         if(configDir == null) {
             String baseDirConfiguredPath = System.getProperty(serverBaseDirPropertyName);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFilePrompt.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFilePrompt.java
@@ -40,9 +40,11 @@ public class PropertyFilePrompt implements State {
     private static final int INVALID = 2;
 
     private ConsoleWrapper theConsole;
+    private StateValues stateValues;
 
-    public PropertyFilePrompt(ConsoleWrapper theConsole) {
+    public PropertyFilePrompt(ConsoleWrapper theConsole, StateValues stateValues) {
         this.theConsole = theConsole;
+        this.stateValues = stateValues;
         if (theConsole.getConsole() == null) {
             throw MESSAGES.noConsoleAvailable();
         }
@@ -50,7 +52,6 @@ public class PropertyFilePrompt implements State {
 
     @Override
     public State execute() {
-        StateValues stateValues = new StateValues();
 
         theConsole.printf(AddPropertiesUser.NEW_LINE);
         theConsole.printf(MESSAGES.filePrompt());

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/StateValues.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/StateValues.java
@@ -46,6 +46,7 @@ public class StateValues {
     private List<File> roleFiles;
     private Set<String> knownUsers;
     private Map<String,String> knownRoles;
+    private String jbossHome;
 
     public boolean isSilentOrNonInteractive() {
         return (howInteractive == AddPropertiesUser.Interactiveness.NON_INTERACTIVE) || isSilent();
@@ -138,5 +139,13 @@ public class StateValues {
 
     public void setKnownRoles(Map<String, String> knownRoles) {
         this.knownRoles = knownRoles;
+    }
+
+    public String getJBossHome() {
+        return this.jbossHome;
+    }
+
+    public void setJbossHome(String path) {
+        this.jbossHome = path;
     }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/AddUserTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/AddUserTestCase.java
@@ -28,11 +28,8 @@ import org.jboss.msc.service.StartException;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Test the AddUser state
@@ -54,21 +51,11 @@ public class AddUserTestCase extends PropertyTestHelper {
         consoleMock.setResponses(consoleBuilder);
         addUserState.update(values);
 
-        assertRolePropertyFile();
-        assertUserPropertyFile();
+        assertRolePropertyFile(USER_NAME);
+        assertUserPropertyFile(USER_NAME);
 
         consoleBuilder.validate();
     }
 
-    private void assertUserPropertyFile() throws StartException, IOException {
-        Properties properties = loadProperties(values.getPropertiesFiles().get(0).getAbsolutePath());
-        String password = (String) properties.get(USER_NAME);
-        assertNotNull(password);
-    }
 
-    private void assertRolePropertyFile() throws StartException, IOException {
-        Properties properties = loadProperties(values.getRoleFiles().get(0).getAbsolutePath());
-        String roles = (String) properties.get(USER_NAME);
-        assertEquals(ROLES,roles);
-    }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyFileFinderTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyFileFinderTestCase.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.security.state;
+
+import org.jboss.as.domain.management.security.AddPropertiesUser;
+import org.jboss.as.domain.management.security.AssertConsoleBuilder;
+import org.jboss.msc.service.StartException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.Properties;
+
+import static java.lang.System.getProperty;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test the property file finder.
+ *
+ * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ */
+public class PropertyFileFinderTestCase extends PropertyTestHelper {
+
+
+    @Before
+    public void setup() throws IOException {
+        values.setManagement(true);
+        values.setJbossHome(getProperty("java.io.tmpdir"));
+    }
+
+    private File createPropertyFile(String filename, String mode) throws IOException {
+
+        File domainDir = new File(getProperty("java.io.tmpdir")+File.separator+mode);
+        domainDir.mkdir();
+        domainDir.deleteOnExit();
+        File propertyUserFile = new File(domainDir, filename);
+        propertyUserFile.createNewFile();
+        propertyUserFile.deleteOnExit();
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(propertyUserFile),"UTF8"));
+        try {
+          Properties domainPropeties = new Properties();
+          domainPropeties.setProperty(USER_NAME,"mypassword");
+          domainPropeties.store(bw,"");
+        } finally {
+           bw.close();
+        }
+        return propertyUserFile;
+    }
+
+    @Test
+    public void overridePropertyfileLocationRead() throws IOException {
+        File domainMgmtUserFile = createPropertyFile("mgmt-users.properties", "domain");
+        File standaloneMgmtUserFile = createPropertyFile("mgmt-users.properties", "standalone");
+
+        System.setProperty("jboss.server.config.user.dir", standaloneMgmtUserFile.getParent());
+        System.setProperty("jboss.domain.config.user.dir", domainMgmtUserFile.getParent());
+        State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
+        State nextState = propertyFileFinder.execute();
+        assertTrue(nextState instanceof PromptNewUserState);
+        assertTrue("Expected to find the "+USER_NAME+" in the list of known users",values.getKnownUsers().contains(USER_NAME));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile.getCanonicalPath(),values.getPropertiesFiles().contains(standaloneMgmtUserFile.getCanonicalFile()));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile.getCanonicalPath(),values.getPropertiesFiles().contains(domainMgmtUserFile.getCanonicalFile()));
+    }
+
+    @Test
+    public void overridePropertyfileLocationWrite() throws IOException, StartException {
+        File domainUserFile = createPropertyFile("application-users.properties", "domain");
+        File standaloneUserFile = createPropertyFile("application-users.properties", "standalone");
+        File domainRolesFile = createPropertyFile("application-roles.properties", "domain");
+        File standaloneRolesFile = createPropertyFile("application-roles.properties", "standalone");
+
+        String newUserName = "Hugh.Jackman";
+        values.setRoles(null);
+        values.setUserName(newUserName);
+        values.setManagement(false);
+        System.setProperty("jboss.server.config.user.dir", domainUserFile.getParent());
+        System.setProperty("jboss.domain.config.user.dir", standaloneUserFile.getParent());
+        State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
+        State nextState = propertyFileFinder.execute();
+        assertTrue(nextState instanceof PromptNewUserState);
+
+        File locatedDomainPropertyFile = values.getPropertiesFiles().get(values.getPropertiesFiles().indexOf(domainUserFile));
+        File locatedStandalonePropertyFile = values.getPropertiesFiles().get(values.getPropertiesFiles().indexOf(standaloneUserFile));
+        UpdateUser updateUserState = new UpdateUser(consoleMock, values);
+
+        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
+                expectedDisplayText(updateUserState.consoleUserMessage(locatedDomainPropertyFile.getCanonicalPath())).
+                expectedDisplayText(AddPropertiesUser.NEW_LINE).
+                expectedDisplayText(updateUserState.consoleUserMessage(locatedStandalonePropertyFile.getCanonicalPath())).
+                expectedDisplayText(AddPropertiesUser.NEW_LINE);
+        consoleMock.setResponses(consoleBuilder);
+        updateUserState.update(values);
+
+        assertUserPropertyFile(newUserName);
+        consoleBuilder.validate();
+    }
+
+
+}

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyFileFinderTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyFileFinderTestCase.java
@@ -82,8 +82,8 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
         State nextState = propertyFileFinder.execute();
         assertTrue(nextState instanceof PromptNewUserState);
         assertTrue("Expected to find the "+USER_NAME+" in the list of known users",values.getKnownUsers().contains(USER_NAME));
-        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile.getCanonicalPath(),values.getPropertiesFiles().contains(standaloneMgmtUserFile.getCanonicalFile()));
-        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile.getCanonicalPath(),values.getPropertiesFiles().contains(domainMgmtUserFile.getCanonicalFile()));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile,values.getPropertiesFiles().contains(standaloneMgmtUserFile));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile,values.getPropertiesFiles().contains(domainMgmtUserFile));
     }
 
     @Test

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyTestHelper.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyTestHelper.java
@@ -31,6 +31,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Properties;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 /**
  * Helper for setting up a test case with ConsoleMock, StateValues and
  * property files for user and roles
@@ -73,5 +76,17 @@ public class PropertyTestHelper {
         Properties properties = (Properties) propertiesLoad.getProperties().clone();
         propertiesLoad.stop(null);
         return properties;
+    }
+
+    protected void assertUserPropertyFile(String userName) throws StartException, IOException {
+        Properties properties = loadProperties(values.getPropertiesFiles().get(0).getAbsolutePath());
+        String password = (String) properties.get(userName);
+        assertNotNull(password);
+    }
+
+    protected void assertRolePropertyFile(String userName) throws StartException, IOException {
+        Properties properties = loadProperties(values.getRoleFiles().get(0).getAbsolutePath());
+        String roles = (String) properties.get(userName);
+        assertEquals(ROLES,roles);
     }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/UpdateUserTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/UpdateUserTestCase.java
@@ -28,10 +28,6 @@ import org.jboss.msc.service.StartException;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Properties;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * Test update user
@@ -51,7 +47,7 @@ public class UpdateUserTestCase extends PropertyTestHelper {
         consoleMock.setResponses(consoleBuilder);
         updateUserState.update(values);
 
-        assertUserPropertyFile();
+        assertUserPropertyFile(USER_NAME);
 
         consoleBuilder.validate();
     }
@@ -68,22 +64,10 @@ public class UpdateUserTestCase extends PropertyTestHelper {
         consoleMock.setResponses(consoleBuilder);
         updateUserState.update(values);
 
-        assertUserPropertyFile();
-        assertRolePropertyFile();
+        assertUserPropertyFile(USER_NAME);
+        assertRolePropertyFile(USER_NAME);
 
         consoleBuilder.validate();
-    }
-
-    private void assertUserPropertyFile() throws StartException, IOException {
-        Properties properties = loadProperties(values.getPropertiesFiles().get(0).getAbsolutePath());
-        String password = (String) properties.get(USER_NAME);
-        assertNotNull(password);
-    }
-
-    private void assertRolePropertyFile() throws StartException, IOException {
-        Properties properties = loadProperties(values.getRoleFiles().get(0).getAbsolutePath());
-        String roles = (String) properties.get(USER_NAME);
-        assertEquals(ROLES,roles);
     }
 
 


### PR DESCRIPTION
added support for overriding the user and roles property files for both the standalone and domain server mode.

Specify the system property jboss.server.config.user.dir to overriding the location for standalone user files and
the property jboss.domain.config.user.dir for overiding the location for domain mode
