### PR TITLE
AS7-4518 Fix a NPE while processing @RunAs/run-as information

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/RunAsMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/RunAsMergingProcessor.java
@@ -99,7 +99,7 @@ public class RunAsMergingProcessor extends AbstractMergingProcessor<EJBComponent
             String principal = null;
             String globalRunAsPrincipal = null;
             EjbJarMetaData jbossMetaData = deploymentUnit.getAttachment(EjbDeploymentAttachmentKeys.EJB_JAR_METADATA);
-            if (jbossMetaData != null) {
+            if (jbossMetaData != null && jbossMetaData.getAssemblyDescriptor() != null) {
                 List<EJBBoundSecurityMetaData> securityMetaDatas = jbossMetaData.getAssemblyDescriptor().getAny(EJBBoundSecurityMetaData.class);
                 if (securityMetaDatas != null) {
                     for (EJBBoundSecurityMetaData securityMetaData : securityMetaDatas) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsTestCaseEJBMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/RunAsTestCaseEJBMDB.java
@@ -120,6 +120,7 @@ public class RunAsTestCaseEJBMDB {
                         HowdyBean.class,
                         HelloMDB.class);
         jar.addAsManifestResource(new StringAsset("Dependencies: deployment.runasmdbejb-ejb2.jar  \n"), "MANIFEST.MF");
+        jar.addAsManifestResource(RunAsTestCaseEJBMDB.class.getPackage(), "ejb-jar-ejb3.xml", "ejb-jar.xml");
         log.info(jar.toString(true));
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/ejb-jar-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/ejb2mdb/ejb-jar-ejb3.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                            http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd"
+         version="3.0">
+
+</ejb-jar>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4518 which relates to a NPE while processing run-as information in the absence of assembly-descriptor configuration.
