### PR TITLE
[AS7-4439] Moving to XMLSchema 2.0.2 to include fix for XMLSCHEMA-22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.org.apache.santuario>1.5.1</version.org.apache.santuario>
         <version.org.apache.velocity>1.6.3</version.org.apache.velocity>
         <version.org.apache.ws.security>1.6.5</version.org.apache.ws.security>
-        <version.org.apache.ws.xmlschema>2.0</version.org.apache.ws.xmlschema>
+        <version.org.apache.ws.xmlschema>2.0.2</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-1</version.org.apache.xalan>
         <version.org.apache.xerces>2.9.1-jbossas-1</version.org.apache.xerces>
         <version.org.codehaus.jackson>1.9.2</version.org.codehaus.jackson>


### PR DESCRIPTION
This is basically for the issue with enum parsing that was locale specific in xmlschema
