### PR TITLE
[AS7-4531] split up connection factories parser

### DIFF
--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_2.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_2.xml
@@ -239,9 +239,9 @@
               <pooled-connection-factory name="hornetq-ra">
                  <user>alice</user>
                  <password>alicepassword</password>
+                 <transaction mode="xa"/>
                  <min-pool-size>42</min-pool-size>
                  <max-pool-size>242</max-pool-size>
-                 <transaction mode="xa"/>
                  <connectors>
                     <connector-ref connector-name="in-vm"/>
                  </connectors>


### PR DESCRIPTION
- split up the code reading/writing connection factories into 3
  1. specific to regular CF
  2. specific to pooled CF
  3. common to both types of CF
- this reflects the way they are defined in the XSD schemas
