### PR TITLE
SingleSignOn test case

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/EJBServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/EJBServlet.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Date;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.rmi.PortableRemoteObject;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.test.integration.web.sso.interfaces.StatelessSession;
+import org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionHome;
+import org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionLocal;
+import org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionLocalHome;
+
+/**
+ * A servlet that accesses an EJB and tests whether the call argument is
+ * serialized.
+ * 
+ * @author Scott.Stark@jboss.org
+ * @author
+ */
+public class EJBServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 2070931818661985879L;
+
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException,
+            IOException {
+        try {
+            InitialContext ctx = new InitialContext();
+            Context enc = (Context) ctx.lookup("java:comp/env");
+            StatelessSessionHome home = (StatelessSessionHome) enc.lookup("ejb/OptimizedEJB");
+            StatelessSession bean = home.create();
+            bean.noop();
+
+            Object homeRef = enc.lookup("ejb/OptimizedEJB");
+            home = (StatelessSessionHome) PortableRemoteObject.narrow(homeRef, StatelessSessionHome.class);
+            bean = home.create();
+            bean.noop();
+            bean.getData();
+
+            StatelessSessionLocalHome localHome = (StatelessSessionLocalHome) enc.lookup("ejb/local/OptimizedEJB");
+            StatelessSessionLocal localBean = localHome.create();
+            localBean.noop();
+        } catch (Exception e) {
+            throw new ServletException("Failed to call OptimizedEJB through remote and local interfaces", e);
+        }
+        response.setContentType("text/html");
+        PrintWriter out = response.getWriter();
+        out.println("<html>");
+        out.println("<head><title>EJBServlet</title></head>");
+        out.println("<body>Tests passed<br>Time:" + new Date().toString() + "</body>");
+        out.println("</html>");
+        out.close();
+    }
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/LogoutServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/LogoutServlet.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/**
+ * A servlet that logs out a user by invalidating any current session and then
+ * redirects the user to the welcome page.
+ * 
+ * @author Brian Stansberry
+ */
+public class LogoutServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 2133162198049851268L;
+
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException,
+            IOException {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        response.sendRedirect(request.getContextPath() + "/index.html");
+    }
+
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        processRequest(request, response);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/SingleSignOnUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/SingleSignOnUnitTestCase.java
@@ -1,0 +1,218 @@
+/*
+ * JBoss, a division of Red Hat
+ * Copyright 2006, Red Hat Middleware, LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.test.integration.web.SSOBaseCase;
+import org.jboss.as.test.integration.web.sso.interfaces.StatelessSession;
+import org.jboss.as.test.shared.RetryTaskExecutor;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests of web app single sign-on
+ * 
+ * @author Scott.Stark@jboss.org
+ * @author lbarreiro@redhat.com
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(SingleSignOnUnitTestCase.SingleSignOnUnitTestCaseSetup.class)
+@Ignore(value="ARQ-791 Arquillian is unable to reconnect to JMX server if the connection is lost")
+public class SingleSignOnUnitTestCase {
+
+    private static Logger log = Logger.getLogger(SingleSignOnUnitTestCase.class);
+
+    static class SingleSignOnUnitTestCaseSetup implements ServerSetupTask {
+
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            SingleSignOnUnitTestCase.addSso(managementClient.getControllerClient());
+            restartServer(managementClient.getControllerClient());
+        }
+
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            SingleSignOnUnitTestCase.removeSso(managementClient.getControllerClient());
+        }
+    }
+
+    public static void addSso(ModelControllerClient client) throws Exception {
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+
+        // SSO element name must be 'configuration'
+        updates.add(createOpNode("subsystem=web/virtual-server=default-host/sso=configuration", ADD));
+
+        applyUpdates(updates, client);
+    }
+
+    public static void removeSso(final ModelControllerClient client) throws Exception {
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+
+        updates.add(createOpNode("subsystem=web/virtual-server=default-host/sso=configuration", REMOVE));
+
+        applyUpdates(updates, client);
+    }
+
+    public static void applyUpdates(final List<ModelNode> updates, final ModelControllerClient client) throws Exception {
+        for (ModelNode update : updates) {
+            log.info("+++ Update on " + client + ":\n" + update.toString());
+            ModelNode result = client.execute(new OperationBuilder(update).build());
+            if (result.hasDefined("outcome") && "success".equals(result.get("outcome").asString())) {
+                if (result.hasDefined("result"))
+                    log.info(result.get("result"));
+            } else if (result.hasDefined("failure-description")) {
+                throw new RuntimeException(result.get("failure-description").toString());
+            } else {
+                throw new RuntimeException("Operation not successful; outcome = " + result.get("outcome"));
+            }
+        }
+    }
+
+    // Reload operation is not handled well by Arquillian
+    // See ARQ-791: JMX: Arquillian is unable to reconnect to JMX server if the connection is lost
+    private static void restartServer(final ModelControllerClient client) {
+        try {
+            applyUpdates(Arrays.asList(createOpNode(null, "reload")), client);
+        } catch (Exception e) {
+            throw new RuntimeException("Restart operation not successful. " + e.getMessage());
+        }
+        try {
+            RetryTaskExecutor<Boolean> rte = new RetryTaskExecutor<Boolean>();
+            rte.retryTask(new Callable<Boolean>() {
+                public Boolean call() throws Exception {
+                    ModelNode result = client.execute(new OperationBuilder(createOpNode(null, READ_RESOURCE_OPERATION)).build());
+                    if (result.hasDefined("outcome") && "success".equals(result.get("outcome").asString())) {
+                        if (result.hasDefined("result"))
+                            log.info(result.get("result"));
+                        return true;
+                    } else {
+                        log.info("Server is down.");
+                        throw new Exception("Connector not available.");
+                    }
+                }
+            });
+        } catch (TimeoutException e) {
+            throw new RuntimeException("Timeout on restart operation. " + e.getMessage());
+        }
+        log.info("Server is up.");
+    }
+
+    /**
+     * One time setup for all SingleSignOnUnitTestCase unit tests
+     */
+    @Deployment(name = "web-sso.ear", testable = false)
+    public static EnterpriseArchive deployment() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        String resourcesLocation = "org/jboss/as/test/integration/web/sso/resources/";
+
+        WebArchive war1 = SingleSignOnUnitTestCase.createSsoWar("sso-form-auth1.war");
+        WebArchive war2 = SingleSignOnUnitTestCase.createSsoWar("sso-form-auth2.war");
+        WebArchive war3 = SingleSignOnUnitTestCase.createSsoWar("sso-with-no-auth.war");
+
+        // Remove jboss-web.xml so the war will not have an authenticator
+        war3.delete(war3.get("WEB-INF/jboss-web.xml").getPath());
+
+        JavaArchive webEjbs = ShrinkWrap.create(JavaArchive.class, "jbosstest-web-ejbs.jar");
+        webEjbs.addAsManifestResource(tccl.getResource(resourcesLocation + "ejb-jar.xml"), "ejb-jar.xml");
+        webEjbs.addAsManifestResource(tccl.getResource(resourcesLocation + "jboss.xml"), "jboss.xml");
+        webEjbs.addPackage(StatelessSession.class.getPackage());
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "web-sso.ear");
+        ear.setApplicationXML(tccl.getResource(resourcesLocation + "application.xml"));
+
+        ear.addAsModule(war1);
+        ear.addAsModule(war2);
+        ear.addAsModule(war3);
+        ear.addAsModule(webEjbs);
+
+        log.info(war1.toString(true));
+        log.info(war2.toString(true));
+        log.info(war3.toString(true));
+        log.info(webEjbs.toString(true));
+        log.info(ear.toString(true));
+        return ear;
+    }
+
+    private static WebArchive createSsoWar(String warName) {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        String resourcesLocation = "org/jboss/as/test/integration/web/sso/resources/";
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, warName);
+        war.setWebXML(tccl.getResource(resourcesLocation + "web-form-auth.xml"));
+        war.addAsWebInfResource(tccl.getResource(resourcesLocation + "jboss-web.xml"), "jboss-web.xml");
+
+        war.addAsWebResource(tccl.getResource(resourcesLocation + "error.html"), "error.html");
+        war.addAsWebResource(tccl.getResource(resourcesLocation + "index.html"), "index.html");
+        war.addAsWebResource(tccl.getResource(resourcesLocation + "index.jsp"), "index.jsp");
+        war.addAsWebResource(tccl.getResource(resourcesLocation + "login.html"), "login.html");
+
+        war.addClass(EJBServlet.class);
+        war.addClass(LogoutServlet.class);
+
+        return war;
+    }
+
+    /**
+     * Test single sign-on across two web apps using form based auth
+     */
+    @Test
+    public void testFormAuthSingleSignOn(@ArquillianResource URL baseURLNoAuth) throws Exception {
+        log.info("+++ testFormAuthSingleSignOn");
+        SSOBaseCase.executeFormAuthSingleSignOnTest(baseURLNoAuth, baseURLNoAuth, log);
+    }
+
+    /**
+     * Test single sign-on across two web apps using form based auth
+     */
+    @Test
+    public void testNoAuthSingleSignOn(@ArquillianResource URL baseURLNoAuth) throws Exception {
+        log.info("+++ testNoAuthSingleSignOn");
+        SSOBaseCase.executeNoAuthSingleSignOnTest(baseURLNoAuth, baseURLNoAuth, log);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/ReturnData.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/ReturnData.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso.interfaces;
+
+import java.io.Serializable;
+
+/**
+ * A class that is placed into the WEB-INF/classes directory that accesses a
+ * class loaded from a jar jbosstest-web.ear/lib due to a reference from the
+ * jbosstest-web-ejbs.jar manifest ClassPath.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public class ReturnData implements Serializable {
+
+    private static final long serialVersionUID = -6620950977249481726L;
+
+    public String data;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSession.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSession.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso.interfaces;
+
+import javax.ejb.EJBObject;
+import java.rmi.RemoteException;
+
+/**
+ * A trivial SessionBean interface.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public interface StatelessSession extends EJBObject {
+
+    /** A method that returns its arg */
+    public String echo(String arg) throws RemoteException;
+    
+    /**
+     * A method that does nothing. It is used to test call optimization.
+     */
+    public void noop() throws RemoteException;
+
+    /** Return a data object */
+    public ReturnData getData() throws RemoteException;
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionBean.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso.interfaces;
+
+import java.security.Principal;
+
+import javax.ejb.CreateException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+
+import org.jboss.logging.Logger;
+
+
+/**
+ * A simple session bean for testing declarative security.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public class StatelessSessionBean implements SessionBean {
+    
+    private static final long serialVersionUID = -4565135285688543978L;
+
+    static Logger log = Logger.getLogger(StatelessSessionBean.class);
+
+    private SessionContext sessionContext;
+
+    public void ejbCreate() throws CreateException {
+        log.debug("ejbCreate() called");
+    }
+
+    public void ejbActivate() {
+        log.debug("ejbActivate() called");
+    }
+
+    public void ejbPassivate() {
+        log.debug("ejbPassivate() called");
+    }
+
+    public void ejbRemove() {
+        log.debug("ejbRemove() called");
+    }
+
+    public void setSessionContext(SessionContext context) {
+        log.debug("setSessionContext() called");
+        sessionContext = context;
+    }
+    
+    public String echo(String arg) {
+        log.debug("echo, arg=" + arg);
+        Principal p = sessionContext.getCallerPrincipal();
+        log.debug("echo, callerPrincipal=" + p);
+        return p.getName();
+    }
+    
+    public void noop() {
+        log.debug("noop");
+    }
+    
+    public ReturnData getData() {
+        ReturnData data = new ReturnData();
+        data.data = "TheReturnData";
+        return data;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionHome.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso.interfaces;
+
+import javax.ejb.*;
+import java.rmi.*;
+
+public interface StatelessSessionHome extends EJBHome {
+    public StatelessSession create() throws RemoteException, CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionLocal.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionLocal.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso.interfaces;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBLocalObject;
+
+/**
+ * A trivial SessionBean local interface.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public interface StatelessSessionLocal extends EJBLocalObject {
+
+    /** A method that returns its arg */
+    public String echo(String arg) throws RemoteException;
+    
+    /** A method that does nothing. It is used to test call optimization. */
+    public void noop();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionLocalHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/interfaces/StatelessSessionLocalHome.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.sso.interfaces;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBLocalHome;
+
+/**
+ * A trivial local SessionBean home interface.
+ * 
+ * @author Scott.Stark@jboss.org
+ */
+public interface StatelessSessionLocalHome extends EJBLocalHome {
+    public StatelessSessionLocal create() throws CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/application.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/application.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN" "http://java.sun.com/dtd/application_1_3.dtd">
+<application>
+    <display-name>JBossTest Web Single SignOn Tests</display-name>
+    <module>
+        <web>
+            <web-uri>sso-form-auth1.war</web-uri>
+            <context-root>/war1</context-root>
+        </web>
+    </module>
+    <module>
+        <web>
+            <web-uri>sso-form-auth2.war</web-uri>
+            <context-root>/war2</context-root>
+        </web>
+    </module>
+    <module>
+        <web>
+            <web-uri>sso-with-no-auth.war</web-uri>
+            <context-root>/war6</context-root>
+        </web>
+    </module>
+    <module>
+        <ejb>jbosstest-web-ejbs.jar</ejb>
+    </module>
+</application>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/ejb-jar.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<ejb-jar>
+    <description>WebApp Integration Tests</description>
+    <enterprise-beans>
+        <session>
+            <description>A secured EJB</description>
+            <ejb-name>SecuredEJB</ejb-name>
+            <home>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionHome</home>
+            <remote>org.jboss.as.test.integration.web.sso.interfaces.StatelessSession</remote>
+            <local-home>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionLocalHome</local-home>
+            <local>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionLocal</local>
+            <ejb-class>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionBean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Container</transaction-type>
+        </session>
+    </enterprise-beans>
+    <assembly-descriptor>
+        <!-- Security constraints for the SecuredEJB -->
+        <security-role>
+            <description>An anonymous unauthenticated user</description>
+            <role-name>Anonymous</role-name>
+        </security-role>
+        <security-role>
+            <description>An authenticated user</description>
+            <role-name>AuthorizedUser</role-name>
+        </security-role>
+        <security-role>
+            <description>A role that no user should have</description>
+            <role-name>InternalUser</role-name>
+        </security-role>
+        <!-- The methods an Anonymous user can access -->
+        <method-permission>
+            <role-name>Anonymous</role-name>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-name>create</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-name>echo</method-name>
+            </method>
+        </method-permission>
+        <!-- The methods an AuthorizedUser user can access -->
+        <method-permission>
+            <role-name>AuthorizedUser</role-name>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-intf>Home</method-intf>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-intf>LocalHome</method-intf>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-name>echo</method-name>
+                <method-params>
+                    <method-param>java.lang.String</method-param>
+                </method-params>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-name>noop</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-intf>Local</method-intf>
+                <method-name>unchecked</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-intf>Remote</method-intf>
+                <method-name>getData</method-name>
+            </method>
+            <method>
+                <ejb-name>EntityFacade</ejb-name>
+                <method-name>*</method-name>
+            </method>
+        </method-permission>
+        <!-- The methods an InternalUser user can access -->
+        <method-permission>
+            <role-name>InternalUser</role-name>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-intf>LocalHome</method-intf>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-name>checkRunAs</method-name>
+            </method>
+            <method>
+                <ejb-name>UnsecureRunAsServletWithPrincipalNameTarget</ejb-name>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>UnsecureRunAsServletWithPrincipalNameAndRolesTarget</ejb-name>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>EntityFacade</ejb-name>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>InternalEntity</ejb-name>
+                <method-name>*</method-name>
+            </method>
+        </method-permission>
+        <!-- The methods a user without any permission may access -->
+        <method-permission>
+            <unchecked />
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-intf>LocalHome</method-intf>
+                <method-name>*</method-name>
+            </method>
+            <method>
+                <ejb-name>SecuredEJB</ejb-name>
+                <method-name>unchecked</method-name>
+            </method>
+        </method-permission>
+    </assembly-descriptor>
+</ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/error.html
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/error.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>Error Page For Examples</title>
+</head>
+<body bgcolor="white">Invalid username and/or password, please try again
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/index.html
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/index.html
@@ -1,0 +1,9 @@
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+<title>A Secure Web App</title>
+</head>
+<body>
+    <h1>A Secure Web App</h1>
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/index.jsp
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/index.jsp
@@ -1,0 +1,14 @@
+
+<%
+    // Give the session a quick timeout so the timeout test can be short
+    session.setMaxInactiveInterval(5);
+%>
+<!doctype html public "-//w3c//dtd html 4.0 transitional//en">
+<html>
+<head>
+<title>A Secure Web App</title>
+</head>
+<body>
+    <h1>A Secure Web App</h1>
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/jboss-web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 5.0//EN" "http://www.jboss.org/j2ee/dtd/jboss-web_5_0.dtd">
+<jboss-web>
+    <!-- Specify the security domain for authentication/authorization and require that the domain's cache be flushed when the session invalidates. -->
+    <security-domain flushOnSessionInvalidation="true">other</security-domain>
+</jboss-web>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/jboss.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/jboss.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE jboss PUBLIC "-//JBoss//DTD JBOSS 4.0//EN" "http://www.jboss.org/j2ee/dtd/jboss_4_0.dtd">
+<jboss>
+    <enterprise-beans>
+        <session>
+            <ejb-name>SecuredEJB</ejb-name>
+            <jndi-name>jbosstest/ejbs/SecuredEJB</jndi-name>
+            <local-jndi-name>jbosstest/ejbs/local/SecuredEJB</local-jndi-name>
+            <configuration-name>Secure Stateless SessionBean</configuration-name>
+        </session>
+        <session>
+            <ejb-name>UnsecuredEJB</ejb-name>
+            <jndi-name>jbosstest/ejbs/UnsecuredEJB</jndi-name>
+            <ejb-ref>
+                <ejb-ref-name>ejb/Session</ejb-ref-name>
+                <jndi-name>jbosstest/ejbs/SecuredEJB</jndi-name>
+            </ejb-ref>
+        </session>
+    </enterprise-beans>
+    <container-configurations>
+        <container-configuration extends="Standard Stateless SessionBean">
+            <container-name>Secure Stateless SessionBean</container-name>
+            <security-domain>java:/jaas/jbosstest-web</security-domain>
+        </container-configuration>
+    </container-configurations>
+</jboss>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/login.html
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/login.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+<title>Login Page for Examples</title>
+</head>
+<body bgcolor="white">
+    <form method="POST" action="j_security_check">
+        <table border="0" cellspacing="5">
+            <tr>
+                <th align="right">Username:</th>
+                <td align="left"><input type="text" name="j_username">
+                </td>
+            </tr>
+            <tr>
+                <th align="right">Password:</th>
+                <td align="left"><input type="password" name="j_password">
+                </td>
+            </tr>
+            <tr>
+                <td align="right"><input type="submit" value="Log In">
+                </td>
+                <td align="left"><input type="reset">
+                </td>
+            </tr>
+        </table>
+    </form>
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/web-form-auth.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/sso/resources/web-form-auth.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
+<web-app>
+    <description>WebApp Integration Tests</description>
+    <servlet>
+        <servlet-name>LogoutServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.web.sso.LogoutServlet</servlet-class>
+    </servlet>
+    <servlet>
+        <servlet-name>EJBServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.web.sso.EJBServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>LogoutServlet</servlet-name>
+        <url-pattern>/Logout</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>EJBServlet</servlet-name>
+        <url-pattern>/EJBServlet</url-pattern>
+    </servlet-mapping>
+    <session-config>
+        <session-timeout>1</session-timeout>
+    </session-config>
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Restricted</web-resource-name>
+            <description>Single SignOn Tests</description>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <description>Only authenticated users can access secure content</description>
+            <role-name>Users</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <login-config>
+        <auth-method>FORM</auth-method>
+        <form-login-config>
+            <form-login-page>/login.html</form-login-page>
+            <form-error-page>/error.html</form-error-page>
+        </form-login-config>
+    </login-config>
+    <security-role>
+        <role-name>Users</role-name>
+    </security-role>
+    <ejb-ref>
+        <ejb-ref-name>ejb/OptimizedEJB</ejb-ref-name>
+        <ejb-ref-type>Session</ejb-ref-type>
+        <home>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionHome</home>
+        <remote>org.jboss.as.test.integration.web.sso.interfaces.StatelessSession</remote>
+        <ejb-link>jbosstest-web-ejbs.jar#SecuredEJB</ejb-link>
+    </ejb-ref>
+    <ejb-local-ref>
+        <ejb-ref-name>ejb/local/OptimizedEJB</ejb-ref-name>
+        <ejb-ref-type>Session</ejb-ref-type>
+        <local-home>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionLocalHome</local-home>
+        <local>org.jboss.as.test.integration.web.sso.interfaces.StatelessSessionLocal</local>
+        <ejb-link>jbosstest-web-ejbs.jar#SecuredEJB</ejb-link>
+    </ejb-local-ref>
+</web-app>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/SSOBaseCase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/SSOBaseCase.java
@@ -1,0 +1,279 @@
+/*
+ * JBoss, a division of Red Hat
+ * Copyright 2006, Red Hat Middleware, LLC, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.util.EntityUtils;
+import org.jboss.logging.Logger;
+
+/**
+ * Base class for tests of web app single sign-on
+ * 
+ * @author Brian Stansberry
+ * @author lbarreiro@redhat.com
+ */
+public abstract class SSOBaseCase {
+
+    /**
+     * Test single sign-on across two web apps using form based auth
+     * 
+     * @throws Exception
+     */
+    public static void executeFormAuthSingleSignOnTest(URL serverA, URL serverB, Logger log) throws Exception {
+        URL warA1 = new URL(serverA, "/war1/");
+        URL warB2 = new URL(serverB, "/war2/");
+
+        // Start by accessing the secured index.html of war1
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+
+        checkAccessDenied(httpclient, warA1 + "index.html");
+
+        CookieStore store = httpclient.getCookieStore();
+
+        log.debug("Saw JSESSIONID=" + getSessionIdValueFromState(store));
+
+        // Submit the login form
+        executeFormLogin(httpclient, warA1);
+
+        String ssoID = processSSOCookie(store, serverA.toString(), serverB.toString());
+        log.debug("Saw JSESSIONIDSSO=" + ssoID);
+
+        // Pause a moment before switching wars to better simulate real life
+        // use cases. Otherwise, the test case can "outrun" the async
+        // replication in the TreeCache used by the clustered SSO
+        // 500 ms is a long time, but this isn't a test of replication speed
+        // and we don't want spurious failures.
+        if (!serverA.equals(serverB)) {
+            Thread.sleep(500);
+        }
+
+        // Now try getting the war2 index using the JSESSIONIDSSO cookie
+        log.debug("Prepare /war2/index.html get");
+        checkAccessAllowed(httpclient, warB2 + "index.html");
+
+        // Access a secured servlet that calls a secured ejb in war2 to test
+        // propagation of the SSO identity to the ejb container.
+        checkAccessAllowed(httpclient, warB2 + "EJBServlet");
+
+        // Now try logging out of war2
+        executeLogout(httpclient, warB2);
+
+        // Again, pause before switching wars
+        if (!serverA.equals(serverB)) {
+            Thread.sleep(500);
+        }
+
+        // Reset Http client
+        httpclient = new DefaultHttpClient();
+
+        // Try accessing war1 again
+        checkAccessDenied(httpclient, warA1 + "index.html");
+
+        // Try accessing war2 again
+        checkAccessDenied(httpclient, warB2 + "index.html");
+
+    }
+
+    public static void executeNoAuthSingleSignOnTest(URL serverA, URL serverB, Logger log) throws Exception {
+        URL warA1 = new URL(serverA, "/war1/");
+        URL warB2 = new URL(serverB + "/war2/");
+        URL warB6 = new URL(serverB + "/war6/");
+
+        // Start by accessing the secured index.html of war1
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+
+        checkAccessDenied(httpclient, warA1 + "index.html");
+
+        CookieStore store = httpclient.getCookieStore();
+
+        log.debug("Saw JSESSIONID=" + getSessionIdValueFromState(store));
+
+        // Submit the login form
+        executeFormLogin(httpclient, warA1);
+
+        String ssoID = processSSOCookie(store, serverA.toString(), serverB.toString());
+        log.debug("Saw JSESSIONIDSSO=" + ssoID);
+
+        // Pause a moment before switching wars to better simulate real life
+        // use cases. Otherwise, the test case can "outrun" the async
+        // replication in the TreeCache used by the clustered SSO
+        // 500 ms is a long time, but this isn't a test of replication speed
+        // and we don't want spurious failures.
+        if (!serverA.equals(serverB)) {
+            Thread.sleep(500);
+        }
+
+        // Now try getting the war2 index using the JSESSIONIDSSO cookie
+        log.debug("Prepare /war2/index.html get");
+        checkAccessAllowed(httpclient, warB2 + "index.html");
+
+        // Access a secured servlet that calls a secured ejb in war2 to test
+        // propagation of the SSO identity to the ejb container.
+        checkAccessAllowed(httpclient, warB2 + "EJBServlet");
+
+        // Do the same test on war6 to test SSO auth replication with no auth
+        // configured war
+        checkAccessAllowed(httpclient, warB6 + "index.html");
+
+        checkAccessAllowed(httpclient, warB2 + "EJBServlet");
+
+    }
+
+    public static void executeLogout(HttpClient httpConn, URL warURL) throws IOException {
+        HttpGet logout = new HttpGet(warURL + "Logout");
+        logout.setParams(new BasicHttpParams().setParameter("http.protocol.handle-redirects", false));
+        HttpResponse response = httpConn.execute(logout);
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        assertTrue("Logout: Didn't saw HTTP_MOVED_TEMP(" + statusCode + ")", statusCode == HttpURLConnection.HTTP_MOVED_TEMP);
+
+        Header location = response.getFirstHeader("Location");
+        assertTrue("Get of " + warURL + "Logout not redirected to login page", location.getValue().indexOf("index.html") >= 0);
+    }
+
+    public static void checkAccessAllowed(HttpClient httpConn, String url) throws IOException {
+        HttpGet getMethod = new HttpGet(url);
+        HttpResponse response = httpConn.execute(getMethod);
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        assertTrue("Expected code == OK but got " + statusCode + " for request=" + url, statusCode == HttpURLConnection.HTTP_OK);
+
+        String body = EntityUtils.toString(response.getEntity());
+        assertTrue("Get of " + url + " redirected to login page", body.indexOf("j_security_check") < 0);
+    }
+
+    public static void executeFormLogin(HttpClient httpConn, URL warURL) throws IOException {
+        // Submit the login form
+        HttpPost formPost = new HttpPost(warURL + "j_security_check");
+        formPost.addHeader("Referer", warURL + "login.html");
+
+        List<NameValuePair> formparams = new ArrayList<NameValuePair>();
+        formparams.add(new BasicNameValuePair("j_username", "user1"));
+        formparams.add(new BasicNameValuePair("j_password", "password1"));
+        formPost.setEntity(new UrlEncodedFormEntity(formparams, "UTF-8"));
+
+        HttpResponse postResponse = httpConn.execute(formPost);
+
+        int statusCode = postResponse.getStatusLine().getStatusCode();
+        Header[] errorHeaders = postResponse.getHeaders("X-NoJException");
+        assertTrue("Should see HTTP_MOVED_TEMP. Got " + statusCode, statusCode == HttpURLConnection.HTTP_MOVED_TEMP);
+        assertTrue("X-NoJException(" + Arrays.toString(errorHeaders) + ") is null", errorHeaders.length == 0);
+        EntityUtils.consume(postResponse.getEntity());
+
+        // Follow the redirect to the index.html page
+        String indexURL = postResponse.getFirstHeader("Location").getValue();
+        HttpGet rediretGet = new HttpGet(indexURL.toString());
+        HttpResponse redirectResponse = httpConn.execute(rediretGet);
+
+        statusCode = redirectResponse.getStatusLine().getStatusCode();
+        errorHeaders = redirectResponse.getHeaders("X-NoJException");
+        assertTrue("Wrong response code: " + statusCode, statusCode == HttpURLConnection.HTTP_OK);
+        assertTrue("X-NoJException(" + Arrays.toString(errorHeaders) + ") is null", errorHeaders.length == 0);
+
+        String body = EntityUtils.toString(redirectResponse.getEntity());
+        assertTrue("Get of " + indexURL + " redirected to login page", body.indexOf("j_security_check") < 0);
+    }
+
+    public static void checkAccessDenied(HttpClient httpConn, String url) throws IOException {
+        HttpGet getMethod = new HttpGet(url);
+        HttpResponse response = httpConn.execute(getMethod);
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        assertTrue("Expected code == OK but got " + statusCode + " for request=" + url, statusCode == HttpURLConnection.HTTP_OK);
+
+        String body = EntityUtils.toString(response.getEntity());
+        assertTrue("Redirected to login page for request=" + url + ", body[" + body + "]", body.indexOf("j_security_check") > 0);
+    }
+
+    public static String processSSOCookie(CookieStore cookieStore, String serverA, String serverB) {
+        String ssoID = null;
+        for (Cookie cookie : cookieStore.getCookies()) {
+            if ("JSESSIONIDSSO".equalsIgnoreCase(cookie.getName())) {
+                ssoID = cookie.getValue();
+                if (serverA.equals(serverB) == false) {
+                    // Make an sso cookie to send to serverB
+                    Cookie copy = copyCookie(cookie, serverB);
+                    cookieStore.addCookie(copy);
+                }
+            }
+        }
+        assertTrue("Didn't saw JSESSIONIDSSO", ssoID != null);
+        return ssoID;
+    }
+
+    public static Cookie copyCookie(Cookie toCopy, String targetServer) {
+        // Parse the target server down to a domain name
+        int index = targetServer.indexOf("://");
+        if (index > -1) {
+            targetServer = targetServer.substring(index + 3);
+        }
+        // JBAS-8540
+        // need to be able to parse IPv6 URLs which have enclosing brackets
+        // HttpClient 3.1 creates cookies which include the square brackets
+        // index = targetServer.indexOf(":");
+        index = targetServer.lastIndexOf(":");
+        if (index > -1) {
+            targetServer = targetServer.substring(0, index);
+        }
+        index = targetServer.indexOf("/");
+        if (index > -1) {
+            targetServer = targetServer.substring(0, index);
+        }
+
+        // Cookie copy = new Cookie(targetServer, toCopy.getName(),
+        // toCopy.getValue(), "/", null, false);
+        return new BasicClientCookie(toCopy.getName(), toCopy.getValue());
+    }
+
+    public static String getSessionIdValueFromState(CookieStore cookieStore) {
+        String sessionID = null;
+        for (Cookie cookie : cookieStore.getCookies()) {
+            if ("JSESSIONID".equalsIgnoreCase(cookie.getName())) {
+                sessionID = cookie.getValue();
+                break;
+            }
+        }
+        return sessionID;
+    }
+
+}


### PR DESCRIPTION
The test case passes but for now has to be skipped because it requires a server restart, and due to ARQ-791 subsequent tests in the testsuite will fail.

It has to be upstream so that work on the clustered version of the test can begin.
