### PR TITLE
AS7-4401 Users authenticatior, as defined in standalone.xml, appears not to be registered correctly

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/XmlAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/XmlAuthenticationResourceDefinition.java
@@ -38,7 +38,7 @@ import org.jboss.as.controller.registry.OperationEntry;
 public class XmlAuthenticationResourceDefinition extends SimpleResourceDefinition {
 
     public XmlAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.USER),
+        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.USERS),
                 ManagementDescription.getResourceDescriptionResolver("core.management.security-realm.authentication.xml"),
                 new SecurityRealmChildAddHandler(true), new SecurityRealmChildRemoveHandler(true),
                 OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);


### PR DESCRIPTION
Fix a problem with resource definition for xml authentication resource was registered with ModelDescriptionConstants.USER and should be ModelDescriptionConstants.USERS
