### PR TITLE
Domain server results as7 4491

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
@@ -35,7 +35,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.domain.controller.DomainControllerMessages.MESSAGES;
@@ -227,10 +226,7 @@ public class DomainFinalResultHandler implements OperationStepHandler {
                 serverGroupSuccess = true;
             }
             for (HostServer hostServer : groupToServerMap.get(groupName)) {
-                final ModelNode serverNode = new ModelNode();
-                serverNode.get(HOST).set(hostServer.hostName);
-                serverNode.get(RESPONSE).set(hostServer.result);
-                groupNode.get(hostServer.serverName).set(serverNode);
+                groupNode.get(HOST, hostServer.hostName, hostServer.serverName, RESPONSE).set(hostServer.result);
             }
             context.getServerResults().get(groupName).set(groupNode);
         }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementReadsTestCase.java
@@ -434,22 +434,19 @@ public class ManagementReadsTestCase {
 
     private static void validateResolveExpressionOnMaster(final ModelNode result) {
         System.out.println(result);
-        ModelNode serverResult = result.get("server-groups", "main-server-group", "main-one");
+        ModelNode serverResult = result.get("server-groups", "main-server-group", "host", "master", "main-one");
         Assert.assertTrue(serverResult.isDefined());
-        Assert.assertEquals("master", serverResult.get("host").asString());
         validateResolveExpressionOnServer(serverResult);
     }
 
     private static void validateResolveExpressionOnSlave(final ModelNode result) {
         System.out.println(result);
-        ModelNode serverResult = result.get("server-groups", "main-server-group", "main-three");
+        ModelNode serverResult = result.get("server-groups", "main-server-group", "host", "slave", "main-three");
         Assert.assertTrue(serverResult.isDefined());
-        Assert.assertEquals("slave", serverResult.get("host").asString());
         validateResolveExpressionOnServer(serverResult);
 
-        serverResult = result.get("server-groups", "other-server-group", "other-two");
+        serverResult = result.get("server-groups", "other-server-group", "host", "slave", "other-two");
         Assert.assertTrue(serverResult.isDefined());
-        Assert.assertEquals("slave", serverResult.get("host").asString());
         validateResolveExpressionOnServer(serverResult);
     }
 


### PR DESCRIPTION
Reorganize the server group results by host:

OLD:
[domain@localhost:9999 /] /system-property=xxxs12345:add(value=123)
{
    "outcome" => "success",
    "result" => undefined,
    "server-groups" => {"main-server-group" => {
        "server-one" => {
            "host" => "master",
            "response" => {"outcome" => "success"}
        },
        "server-two" => {
            "host" => "master",
            "response" => {"outcome" => "success"}
        }
    }}
}
NEW:

[domain@localhost:9999 /] /system-property=xxxs12345:add(value=123)
{
    "outcome" => "success",
    "result" => undefined,
    "server-groups" => {"main-server-group" => {"host" => {"master" => {
        "server-one" => {"response" => {"outcome" => "success"}},
        "server-two" => {"response" => {"outcome" => "success"}}
    }}}}
}
