### PR TITLE
AS7-4560 Use KeyAffinityService to generate session IDs for web sessions and SFSBs

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/affinity/KeyAffinityServiceFactory.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/affinity/KeyAffinityServiceFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2007, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2011, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,27 +19,23 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.ejb3.cache;
 
-import java.io.Serializable;
+package org.jboss.as.clustering.infinispan.affinity;
 
-import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
+import org.infinispan.Cache;
+import org.infinispan.affinity.KeyAffinityService;
+import org.infinispan.affinity.KeyGenerator;
 
 /**
- * Defines the contract for an EJB3 Stateful Cache Factory
- *
- * @author <a href="mailto:andrew.rubinger@redhat.com">ALR</a>
- * @author Brian Stansberry
+ * Factory for creating a key affinity service.
+ * @author Paul Ferraro
  */
-public interface CacheFactory<K extends Serializable, T extends Identifiable<K>> {
+public interface KeyAffinityServiceFactory {
     /**
-     * Creates a cache for a container.
-     *
-     * @param factory factory for creating objects managed by the cache
-     * @param passivationManager manager for invoking pre and post passivation and replication callbacks on the cached objects
-     * @param timeout the stateful timeout
-     *
-     * @return the cache
+     * Creates a key affinity service for use with the specified cache, that generates key using the specified generator.
+     * @param cache
+     * @param generator
+     * @return a key affinity service
      */
-    Cache<K, T> createCache(String beanName, IdentifierFactory<K> identifierFactory, StatefulObjectFactory<T> factory, PassivationManager<K, T> passivationManager, StatefulTimeoutInfo timeout);
+    <K> KeyAffinityService<K> createService(Cache<K, ?> cache, KeyGenerator<K> generator);
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/affinity/LocalKeyAffinityServiceFactory.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/affinity/LocalKeyAffinityServiceFactory.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.affinity;
+
+import java.util.Collections;
+import java.util.concurrent.Executor;
+
+import org.infinispan.Cache;
+import org.infinispan.affinity.KeyAffinityService;
+import org.infinispan.affinity.KeyAffinityServiceImpl;
+import org.infinispan.affinity.KeyGenerator;
+import org.infinispan.remoting.transport.Address;
+
+/**
+ * Key affinity service that only generates keys for use by the local node.
+ * Returns a trivial implementation if the specified cache is not distributed.
+ * @author Paul Ferraro
+ */
+public class LocalKeyAffinityServiceFactory implements KeyAffinityServiceFactory {
+    private final Executor executor;
+    private final int bufferSize;
+
+    public LocalKeyAffinityServiceFactory(Executor executor, int bufferSize) {
+        this.executor = executor;
+        this.bufferSize = bufferSize;
+    }
+
+    @Override
+    public <K> KeyAffinityService<K> createService(Cache<K, ?> cache, KeyGenerator<K> generator) {
+        boolean distributed = cache.getCacheConfiguration().clustering().cacheMode().isDistributed();
+        return distributed ? new KeyAffinityServiceImpl<K>(this.executor, cache, generator, this.bufferSize, Collections.singleton(cache.getCacheManager().getAddress()), false) : new SimpleKeyAffinityService<K>(generator);
+    }
+
+    private static class SimpleKeyAffinityService<K> implements KeyAffinityService<K> {
+        private final KeyGenerator<K> generator;
+        private volatile boolean started = false;
+
+        SimpleKeyAffinityService(KeyGenerator<K> generator) {
+            this.generator = generator;
+        }
+
+        @Override
+        public void start() {
+            this.started = true;
+        }
+
+        @Override
+        public void stop() {
+            this.started = false;
+        }
+
+        @Override
+        public K getKeyForAddress(Address address) {
+            return this.generator.getKey();
+        }
+
+        @Override
+        public K getCollocatedKey(K otherKey) {
+            return this.generator.getKey();
+        }
+
+        @Override
+        public boolean isStarted() {
+            return this.started;
+        }
+    }
+}

--- a/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/DistributedCacheManagerFactory.java
+++ b/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/DistributedCacheManagerFactory.java
@@ -26,6 +26,7 @@ import static org.jboss.as.clustering.web.infinispan.InfinispanWebMessages.MESSA
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.Executors;
 
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
@@ -33,6 +34,8 @@ import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.CacheContainer;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.jboss.as.clustering.infinispan.affinity.KeyAffinityServiceFactory;
+import org.jboss.as.clustering.infinispan.affinity.LocalKeyAffinityServiceFactory;
 import org.jboss.as.clustering.infinispan.atomic.AtomicMapCache;
 import org.jboss.as.clustering.infinispan.invoker.CacheInvoker;
 import org.jboss.as.clustering.infinispan.invoker.RetryingCacheInvoker;
@@ -73,6 +76,7 @@ public class DistributedCacheManagerFactory implements org.jboss.as.clustering.w
     private SessionAttributeStorageFactory storageFactory = new SessionAttributeStorageFactoryImpl();
     private CacheInvoker invoker = new RetryingCacheInvoker(10, 100);
     private SessionAttributeMarshallerFactory marshallerFactory = new SessionAttributeMarshallerFactoryImpl();
+    private KeyAffinityServiceFactory affinityFactory = new LocalKeyAffinityServiceFactory(Executors.newSingleThreadExecutor(), 10);
     @SuppressWarnings("rawtypes")
     private final InjectedValue<Registry> registry = new InjectedValue<Registry>();
     private final InjectedValue<EmbeddedCacheManager> container = new InjectedValue<EmbeddedCacheManager>();
@@ -100,7 +104,7 @@ public class DistributedCacheManagerFactory implements org.jboss.as.clustering.w
         BatchingManager batchingManager = new TransactionBatchingManager(sessionCache.getTransactionManager());
         SessionAttributeStorage<T> storage = this.storageFactory.createStorage(manager.getReplicationConfig().getReplicationGranularity(), this.marshallerFactory.createMarshaller(manager));
 
-        return new DistributedCacheManager<T>(manager, new AtomicMapCache<String, Object, Object>(sessionCache), jvmRouteRegistry, this.lockManager.getOptionalValue(), storage, batchingManager, this.invoker);
+        return new DistributedCacheManager<T>(manager, new AtomicMapCache<String, Object, Object>(sessionCache), jvmRouteRegistry, this.lockManager.getOptionalValue(), storage, batchingManager, this.invoker, this.affinityFactory);
     }
 
     @Override

--- a/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/DistributedCacheManager.java
+++ b/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/DistributedCacheManager.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * SPI implemented by the distributed caching layer.
  * @author Brian Stansberry
  */
-public interface DistributedCacheManager<T extends OutgoingDistributableSessionData> {
+public interface DistributedCacheManager<T extends OutgoingDistributableSessionData> extends SessionIdFactory {
     /**
      * Starts the distributed caching layer.
      */

--- a/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/LocalDistributableSessionManager.java
+++ b/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/LocalDistributableSessionManager.java
@@ -28,7 +28,7 @@ import org.jboss.metadata.web.jboss.ReplicationConfig;
  * Callback interface to allow the distributed caching layer to invoke upon the local session manager.
  * @author Brian Stansberry
  */
-public interface LocalDistributableSessionManager {
+public interface LocalDistributableSessionManager extends SessionIdFactory {
     /**
      * Gets whether the webapp is configured for passivation.
      * @return <code>true</code> if passivation is enabled

--- a/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/SessionIdFactory.java
+++ b/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/SessionIdFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2007, Red Hat Middleware LLC, and individual contributors
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,27 +19,15 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.ejb3.cache;
-
-import java.io.Serializable;
-
-import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
+package org.jboss.as.clustering.web;
 
 /**
- * Defines the contract for an EJB3 Stateful Cache Factory
- *
- * @author <a href="mailto:andrew.rubinger@redhat.com">ALR</a>
- * @author Brian Stansberry
+ * @author Paul Ferraro
  */
-public interface CacheFactory<K extends Serializable, T extends Identifiable<K>> {
+public interface SessionIdFactory {
     /**
-     * Creates a cache for a container.
-     *
-     * @param factory factory for creating objects managed by the cache
-     * @param passivationManager manager for invoking pre and post passivation and replication callbacks on the cached objects
-     * @param timeout the stateful timeout
-     *
-     * @return the cache
+     * Generates a new web session identifier.
+     * @return a session id
      */
-    Cache<K, T> createCache(String beanName, IdentifierFactory<K> identifierFactory, StatefulObjectFactory<T> factory, PassivationManager<K, T> passivationManager, StatefulTimeoutInfo timeout);
+    String createSessionId();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
@@ -30,7 +30,7 @@ import java.io.Serializable;
  * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
  * @version $Revision: $
  */
-public interface Cache<K extends Serializable, V extends Identifiable<K>> extends Removable<K>, AffinitySupport<K> {
+public interface Cache<K extends Serializable, V extends Identifiable<K>> extends Removable<K>, AffinitySupport<K>, IdentifierFactory<K> {
     /**
      * Creates and caches a new instance of <code>T</code>.
      *

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/IdentifierFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/IdentifierFactory.java
@@ -3,7 +3,7 @@
  * Copyright 2007, Red Hat Middleware LLC, and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
- *
+  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation; either version 2.1 of
@@ -21,25 +21,9 @@
  */
 package org.jboss.as.ejb3.cache;
 
-import java.io.Serializable;
-
-import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
-
 /**
- * Defines the contract for an EJB3 Stateful Cache Factory
- *
- * @author <a href="mailto:andrew.rubinger@redhat.com">ALR</a>
- * @author Brian Stansberry
+ * @author Paul Ferraro
  */
-public interface CacheFactory<K extends Serializable, T extends Identifiable<K>> {
-    /**
-     * Creates a cache for a container.
-     *
-     * @param factory factory for creating objects managed by the cache
-     * @param passivationManager manager for invoking pre and post passivation and replication callbacks on the cached objects
-     * @param timeout the stateful timeout
-     *
-     * @return the cache
-     */
-    Cache<K, T> createCache(String beanName, IdentifierFactory<K> identifierFactory, StatefulObjectFactory<T> factory, PassivationManager<K, T> passivationManager, StatefulTimeoutInfo timeout);
+public interface IdentifierFactory<K> {
+    K createIdentifier();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/NonPassivatingBackingCacheImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/NonPassivatingBackingCacheImpl.java
@@ -34,6 +34,7 @@ import javax.ejb.NoSuchEJBException;
 import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.cache.Cacheable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.StatefulObjectFactory;
 import org.jboss.as.ejb3.cache.spi.BackingCache;
 import org.jboss.as.ejb3.cache.spi.BackingCacheEntryFactory;
@@ -61,20 +62,28 @@ public class NonPassivatingBackingCacheImpl<K extends Serializable, V extends Ca
     private final ThreadFactory threadFactory;
     private final Map<K, Future<?>> expirationFutures = new ConcurrentHashMap<K, Future<?>>();
     private final ServerEnvironment environment;
+    private final IdentifierFactory<K> identifierFactory;
 
-    public NonPassivatingBackingCacheImpl(StatefulObjectFactory<V> factory, ThreadFactory threadFactory, StatefulTimeoutInfo timeout, ServerEnvironment environment) {
+    public NonPassivatingBackingCacheImpl(IdentifierFactory<K> identifierFactory, StatefulObjectFactory<V> factory, ThreadFactory threadFactory, StatefulTimeoutInfo timeout, ServerEnvironment environment) {
+        this.identifierFactory = identifierFactory;
         this.factory = factory;
         this.timeout = timeout;
         this.threadFactory = threadFactory;
         this.environment = environment;
     }
 
-    public NonPassivatingBackingCacheImpl(StatefulObjectFactory<V> factory, ScheduledExecutorService executor, StatefulTimeoutInfo timeout, ServerEnvironment environment) {
+    public NonPassivatingBackingCacheImpl(IdentifierFactory<K> identifierFactory, StatefulObjectFactory<V> factory, ScheduledExecutorService executor, StatefulTimeoutInfo timeout, ServerEnvironment environment) {
+        this.identifierFactory = identifierFactory;
         this.factory = factory;
         this.timeout = timeout;
         this.executor = executor;
         this.threadFactory = null;
         this.environment = environment;
+    }
+
+    @Override
+    public K createIdentifier() {
+        return this.identifierFactory.createIdentifier();
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/PassivatingBackingCacheImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/PassivatingBackingCacheImpl.java
@@ -92,6 +92,11 @@ public class PassivatingBackingCacheImpl<K extends Serializable, V extends Cache
     }
 
     @Override
+    public K createIdentifier() {
+        return this.store.createIdentifier();
+    }
+
+    @Override
     public boolean isClustered() {
         return store.isClustered();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupContainer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupContainer.java
@@ -103,12 +103,7 @@ public class SerializationGroupContainer<K extends Serializable, V extends Cache
 
     @Override
     public SerializationGroup<K, V, UUID> createEntry(Cacheable<UUID> item) {
-        UUID key = null;
-        do {
-            key = UUID.randomUUID();
-        } while (!this.groupCache.hasAffinity(key));
-
-        SerializationGroupImpl<K, V> group = new SerializationGroupImpl<K, V>(key);
+        SerializationGroupImpl<K, V> group = new SerializationGroupImpl<K, V>(this.groupCache.createIdentifier());
         group.setClustered(clustered);
         group.setGroupCache(groupCache);
         return group;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupMemberContainer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupMemberContainer.java
@@ -79,6 +79,11 @@ public class SerializationGroupMemberContainer<K extends Serializable, V extends
     }
 
     @Override
+    public K createIdentifier() {
+        return this.store.createIdentifier();
+    }
+
+    @Override
     public Affinity getStrictAffinity() {
         return this.store.getStrictAffinity();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SimpleBackingCacheEntryStore.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SimpleBackingCacheEntryStore.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.cache.Cacheable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.spi.BackingCacheEntry;
 import org.jboss.as.ejb3.cache.spi.BackingCacheEntryStore;
 import org.jboss.as.ejb3.cache.spi.BackingCacheEntryStoreConfig;
@@ -53,9 +54,9 @@ import org.jboss.ejb.client.NodeAffinity;
  * @author Paul Ferraro
  */
 public class SimpleBackingCacheEntryStore<K extends Serializable, V extends Cacheable<K>, E extends BackingCacheEntry<K, V>> extends AbstractBackingCacheEntryStore<K, V, E> {
+    private final IdentifierFactory<K> identifierFactory;
     private final PersistentObjectStore<K, E> store;
     private final Map<K, EntryHolder> cache = new ConcurrentHashMap<K, EntryHolder>();
-
 
     /**
      * SORTED SETS COMPARE FOR EQUALITY USING Comparable
@@ -70,10 +71,16 @@ public class SimpleBackingCacheEntryStore<K extends Serializable, V extends Cach
     /**
      * Create a new SimpleIntegratedObjectStore.
      */
-    public SimpleBackingCacheEntryStore(PersistentObjectStore<K, E> store, ServerEnvironment environment, StatefulTimeoutInfo timeout, BackingCacheEntryStoreConfig config) {
+    public SimpleBackingCacheEntryStore(IdentifierFactory<K> identifierFactory, PersistentObjectStore<K, E> store, ServerEnvironment environment, StatefulTimeoutInfo timeout, BackingCacheEntryStoreConfig config) {
         super(timeout, config);
+        this.identifierFactory = identifierFactory;
         this.store = store;
         this.environment = environment;
+    }
+
+    @Override
+    public K createIdentifier() {
+        return this.identifierFactory.createIdentifier();
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/factory/NonClusteredBackingCacheEntryStoreSource.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/factory/NonClusteredBackingCacheEntryStoreSource.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.ejb3.cache.Cacheable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.PassivationManager;
 import org.jboss.as.ejb3.cache.impl.backing.SimpleBackingCacheEntryStore;
 import org.jboss.as.ejb3.cache.spi.BackingCacheEntryStore;
@@ -72,19 +73,19 @@ public class NonClusteredBackingCacheEntryStoreSource<K extends Serializable, V 
     private volatile PathManager.Callback.Handle callbackHandle;
 
     @Override
-    public <E extends SerializationGroup<K, V, G>> BackingCacheEntryStore<G, Cacheable<G>, E> createGroupIntegratedObjectStore(PassivationManager<G, E> passivationManager, StatefulTimeoutInfo timeout) {
+    public <E extends SerializationGroup<K, V, G>> BackingCacheEntryStore<G, Cacheable<G>, E> createGroupIntegratedObjectStore(IdentifierFactory<G> identifierFactory, PassivationManager<G, E> passivationManager, StatefulTimeoutInfo timeout) {
         FilePersistentObjectStore<G, E> objectStore = new FilePersistentObjectStore<G, E>(passivationManager.getMarshallingConfiguration(), this.getStoragePath(null, this.groupDirectoryName), subdirectoryCount);
 
-        SimpleBackingCacheEntryStore<G, Cacheable<G>, E> store = new SimpleBackingCacheEntryStore<G, Cacheable<G>, E>(objectStore, this.environment.getValue(), timeout, this);
+        SimpleBackingCacheEntryStore<G, Cacheable<G>, E> store = new SimpleBackingCacheEntryStore<G, Cacheable<G>, E>(identifierFactory, objectStore, this.environment.getValue(), timeout, this);
 
         return store;
     }
 
     @Override
-    public <E extends SerializationGroupMember<K, V, G>> BackingCacheEntryStore<K, V, E> createIntegratedObjectStore(String beanName, PassivationManager<K, E> passivationManager, StatefulTimeoutInfo timeout) {
+    public <E extends SerializationGroupMember<K, V, G>> BackingCacheEntryStore<K, V, E> createIntegratedObjectStore(String beanName, IdentifierFactory<K> identifierFactory, PassivationManager<K, E> passivationManager, StatefulTimeoutInfo timeout) {
         FilePersistentObjectStore<K, E> objectStore = new FilePersistentObjectStore<K, E>(passivationManager.getMarshallingConfiguration(), this.getStoragePath(beanName, this.sessionDirectoryName), subdirectoryCount);
 
-        SimpleBackingCacheEntryStore<K, V, E> store = new SimpleBackingCacheEntryStore<K, V, E>(objectStore, this.environment.getValue(), timeout, this);
+        SimpleBackingCacheEntryStore<K, V, E> store = new SimpleBackingCacheEntryStore<K, V, E>(identifierFactory, objectStore, this.environment.getValue(), timeout, this);
 
         return store;
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/factory/NonPassivatingCacheFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/factory/NonPassivatingCacheFactory.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import org.jboss.as.ejb3.cache.Cache;
 import org.jboss.as.ejb3.cache.CacheFactory;
 import org.jboss.as.ejb3.cache.Cacheable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.PassivationManager;
 import org.jboss.as.ejb3.cache.StatefulObjectFactory;
 import org.jboss.as.ejb3.cache.impl.SimpleCache;
@@ -54,8 +55,8 @@ public class NonPassivatingCacheFactory<K extends Serializable, V extends Cachea
     }
 
     @Override
-    public Cache<K, V> createCache(String beanName, StatefulObjectFactory<V> factory, PassivationManager<K, V> passivationManager, StatefulTimeoutInfo timeout) {
-        NonPassivatingBackingCacheImpl<K, V> backingCache = new NonPassivatingBackingCacheImpl<K, V>(factory, Executors.defaultThreadFactory(), timeout, this.environment);
+    public Cache<K, V> createCache(String beanName, IdentifierFactory<K> identifierFactory, StatefulObjectFactory<V> factory, PassivationManager<K, V> passivationManager, StatefulTimeoutInfo timeout) {
+        NonPassivatingBackingCacheImpl<K, V> backingCache = new NonPassivatingBackingCacheImpl<K, V>(identifierFactory, factory, Executors.defaultThreadFactory(), timeout, this.environment);
         return new SimpleCache<K, V, NonPassivatingBackingCacheEntry<K, V>>(backingCache, false);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCache.java
@@ -29,6 +29,7 @@ import javax.ejb.NoSuchEJBException;
 import org.jboss.as.ejb3.cache.AffinitySupport;
 import org.jboss.as.ejb3.cache.Cache;
 import org.jboss.as.ejb3.cache.Cacheable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.Removable;
 
 /**
@@ -51,7 +52,7 @@ import org.jboss.as.ejb3.cache.Removable;
  * @author Brian Stansberry
  * @author Paul Ferraro
  */
-public interface BackingCache<K extends Serializable, V extends Cacheable<K>, E extends BackingCacheEntry<K, V>> extends Removable<K>, AffinitySupport<K> {
+public interface BackingCache<K extends Serializable, V extends Cacheable<K>, E extends BackingCacheEntry<K, V>> extends Removable<K>, AffinitySupport<K>, IdentifierFactory<K> {
     /**
      * Creates and caches a new instance of <code>C</code>, wrapped by a new <code>T</code>. The new <code>T</code> *is*
      * returned, but is not regarded as being "in use". Callers *must not* attempt to use the underlying <code>C</code> without

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCacheEntryStore.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCacheEntryStore.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.jboss.as.ejb3.cache.AffinitySupport;
 import org.jboss.as.ejb3.cache.Cacheable;
 import org.jboss.as.ejb3.cache.Identifiable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
 
 /**
@@ -41,7 +42,7 @@ import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
  * @author Paul Ferraro
  */
 public interface BackingCacheEntryStore<K extends Serializable, V extends Cacheable<K>, E extends BackingCacheEntry<K, V>>
-    extends GroupCompatibilityChecker, AffinitySupport<K> {
+    extends GroupCompatibilityChecker, AffinitySupport<K>, IdentifierFactory<K> {
     /**
      * Put a new entry into the store. This operation should only be performed once per entry.
      *

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCacheEntryStoreSource.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCacheEntryStoreSource.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 
 import org.jboss.as.ejb3.cache.CacheFactory;
 import org.jboss.as.ejb3.cache.Cacheable;
+import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.PassivationManager;
 import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
 import org.jboss.msc.service.ServiceBuilder;
@@ -44,14 +45,14 @@ public interface BackingCacheEntryStoreSource<K extends Serializable, V extends 
      *
      * @return the store
      */
-    <E extends SerializationGroup<K, V, G>> BackingCacheEntryStore<G, Cacheable<G>, E> createGroupIntegratedObjectStore(PassivationManager<G, E> passivationManager, StatefulTimeoutInfo timeout);
+    <E extends SerializationGroup<K, V, G>> BackingCacheEntryStore<G, Cacheable<G>, E> createGroupIntegratedObjectStore(IdentifierFactory<G> identifierFactory, PassivationManager<G, E> passivationManager, StatefulTimeoutInfo timeout);
 
     /**
      * Provide a {@link BackingCacheEntryStore} for storage of serialization group members.
      *
      * @return the store
      */
-    <E extends SerializationGroupMember<K, V, G>> BackingCacheEntryStore<K, V, E> createIntegratedObjectStore(String beanName, PassivationManager<K, E> passivationManager, StatefulTimeoutInfo timeout);
+    <E extends SerializationGroupMember<K, V, G>> BackingCacheEntryStore<K, V, E> createIntegratedObjectStore(String beanName, IdentifierFactory<K> identifierFactory, PassivationManager<K, E> passivationManager, StatefulTimeoutInfo timeout);
 
     void addDependencies(ServiceTarget target, ServiceBuilder<?> builder);
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/impl/AbstractCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/impl/AbstractCache.java
@@ -44,6 +44,11 @@ public abstract class AbstractCache<K extends Serializable, V extends Cacheable<
     }
 
     @Override
+    public K createIdentifier() {
+        return this.backingCache.createIdentifier();
+    }
+
+    @Override
     public V create() {
         return this.backingCache.create().getUnderlyingItem();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentInstance.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentInstance.java
@@ -67,19 +67,7 @@ public class StatefulSessionComponentInstance extends SessionBeanComponentInstan
         super(component, instanceReference, preDestroyInterceptor, methodInterceptors);
 
         final SessionID existingSession = (SessionID) factoryContext.getContextData().get(SessionID.class);
-        if (existingSession != null) {
-            this.id = existingSession;
-        } else {
-            SessionID id = null;
-            do {
-                final UUID uuid = UUID.randomUUID();
-                ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-                bb.putLong(uuid.getMostSignificantBits());
-                bb.putLong(uuid.getLeastSignificantBits());
-                id = SessionID.createSessionID(bb.array());
-            } while (!component.getCache().hasAffinity(id));
-            this.id = id;
-        }
+        this.id = (existingSession != null) ? existingSession : component.getCache().createIdentifier();
         this.afterBegin = component.createInterceptor(component.getAfterBegin(), factoryContext);
         this.afterCompletion = component.createInterceptor(component.getAfterCompletion(), factoryContext);
         this.beforeCompletion = component.createInterceptor(component.getBeforeCompletion(), factoryContext);

--- a/web/src/main/java/org/jboss/as/web/session/DistributableSessionManager.java
+++ b/web/src/main/java/org/jboss/as/web/session/DistributableSessionManager.java
@@ -635,6 +635,11 @@ public class DistributableSessionManager<O extends OutgoingDistributableSessionD
     }
 
     @Override
+    protected String generateSessionId(Random random) {
+        return this.distributedCacheManager.createSessionId();
+    }
+
+    @Override
     protected boolean appendJVMRoute() {
         return this.getUseJK();
     }
@@ -808,6 +813,11 @@ public class DistributableSessionManager<O extends OutgoingDistributableSessionD
     @Override
     public String locate(String sessionId) {
         return this.distributedCacheManager.locate(sessionId);
+    }
+
+    @Override
+    public String createSessionId() {
+        return super.generateSessionId(this.getEngine().getService().getRandom());
     }
 
     @Override

--- a/web/src/test/java/org/jboss/as/web/session/mocks/MockDistributedCacheManager.java
+++ b/web/src/test/java/org/jboss/as/web/session/mocks/MockDistributedCacheManager.java
@@ -152,6 +152,11 @@ public class MockDistributedCacheManager implements DistributedCacheManager<Outg
         return null;
     }
 
+    @Override
+    public String createSessionId() {
+        return null;
+    }
+
     private static class MockBatchingManager implements BatchingManager {
         private static final MockBatchingManager INSTANCE = new MockBatchingManager();
 


### PR DESCRIPTION
Fixes lousy DIST performance.  Generated keys should hash to primary lock owner, not just any data owner.
