### PR TITLE
Add testcase for new Natural Id API added to Hibernate(JBQA-6160)

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/Hibernate4NativeAPINaturalIdTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/Hibernate4NativeAPINaturalIdTestCase.java
@@ -1,0 +1,166 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.hibernate.naturalid;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.naming.InitialContext;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that naturalId API used with Hibernate sessionfactory can be inititated from hibernate.cfg.xml and properties added to
+ * Hibernate Configuration in AS7 container
+ * 
+ * @author Madhumita Sadhukhan
+ */
+@RunWith(Arquillian.class)
+public class Hibernate4NativeAPINaturalIdTestCase {
+
+    private static final String ARCHIVE_NAME = "hibernate4naturalid_test";
+
+    public static final String hibernate_cfg = "<?xml version='1.0' encoding='utf-8'?>"
+            + "<!DOCTYPE hibernate-configuration PUBLIC " + "\"//Hibernate/Hibernate Configuration DTD 3.0//EN\" "
+            + "\"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd\">"
+            + "<hibernate-configuration><session-factory>" + "<property name=\"show_sql\">true</property>"
+            + "<property name=\"current_session_context_class\">thread</property>"
+            + "<mapping resource=\"testmapping.hbm.xml\"/>" + "</session-factory></hibernate-configuration>";
+
+    public static final String testmapping = "<?xml version=\"1.0\"?>"
+            + "<!DOCTYPE hibernate-mapping PUBLIC "
+            + "\"-//Hibernate/Hibernate Mapping DTD 3.0//EN\" "
+            + "\"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">"
+            + "<hibernate-mapping package=\"org.jboss.as.test.integration.hibernate.naturalid\">"
+            + "<class name=\"org.jboss.as.test.integration.hibernate.naturalid.Person\" table=\"PERSON\">"
+            + "<id name=\"personId\" column=\"person_id\">"
+            + "<generator class=\"native\"/>"
+            + "</id>"
+            + "<natural-id><property name=\"personVoterId\" column=\"personVoter_id\"/><property name=\"firstName\" column=\"first_name\"/></natural-id>"
+            + "<property name=\"lastName\" column=\"last_name\"/>" + "<property name=\"address\"/>"
+            // + "<set name=\"courses\" table=\"student_courses\">"
+            // + "<key column=\"student_id\"/>"
+            // + "<many-to-many column=\"course_id\" class=\"org.jboss.as.test.integration.nonjpa.hibernate.Course\"/>"
+            // + "</set>" +
+            + "</class></hibernate-mapping>";
+
+    @ArquillianResource
+    private static InitialContext iniCtx;
+
+    @BeforeClass
+    public static void beforeClass() throws NamingException {
+        iniCtx = new InitialContext();
+    }
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
+        // add required jars as manifest dependencies
+        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate \n"), "MANIFEST.MF");
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
+        lib.addClasses(SFSBHibernateSFNaturalId.class);
+        ear.addAsModule(lib);
+
+        lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
+        lib.addClasses(Person.class);
+        lib.addAsResource(new StringAsset(testmapping), "testmapping.hbm.xml");
+        lib.addAsResource(new StringAsset(hibernate_cfg), "hibernate.cfg.xml");
+        ear.addAsLibraries(lib);
+
+        final WebArchive main = ShrinkWrap.create(WebArchive.class, "main.war");
+        main.addClasses(Hibernate4NativeAPINaturalIdTestCase.class);
+        ear.addAsModule(main);
+
+        // add application dependency on H2 JDBC driver, so that the Hibernate classloader (same as app classloader)
+        // will see the H2 JDBC driver.
+        // equivalent hack for use of shared Hiberante module, would be to add the H2 dependency directly to the
+        // shared Hibernate module.
+        // also add dependency on org.slf4j
+        ear.addAsManifestResource(new StringAsset("<jboss-deployment-structure>" + " <deployment>" + " <dependencies>"
+                + " <module name=\"com.h2database.h2\" />" + " <module name=\"org.slf4j\"/>" + " </dependencies>"
+                + " </deployment>" + "</jboss-deployment-structure>"), "jboss-deployment-structure.xml");
+
+        return ear;
+    }
+
+    protected static <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        try {
+            return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + "beans/" + beanName + "!"
+                    + interfaceType.getName()));
+        } catch (NamingException e) {
+            dumpJndi("");
+            throw e;
+        }
+    }
+
+    // TODO: move this logic to a common base class (might be helpful for writing new tests)
+    private static void dumpJndi(String s) {
+        try {
+            dumpTreeEntry(iniCtx.list(s), s);
+        } catch (NamingException ignore) {
+        }
+    }
+
+    private static void dumpTreeEntry(NamingEnumeration<NameClassPair> list, String s) throws NamingException {
+        System.out.println("\ndump " + s);
+        while (list.hasMore()) {
+            NameClassPair ncp = list.next();
+            System.out.println(ncp.toString());
+            if (s.length() == 0) {
+                dumpJndi(ncp.getName());
+            } else {
+                dumpJndi(s + "/" + ncp.getName());
+            }
+        }
+    }
+
+    @Ignore
+    @Test
+    public void testNaturalIdload() throws Exception {
+        SFSBHibernateSFNaturalId sfsb = lookup("SFSBHibernateSFNaturalId", SFSBHibernateSFNaturalId.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        Person s1 = sfsb.createPerson("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 123, 1);
+        Person s2 = sfsb.createPerson("REDHAT", "LINUX", "Worldwide", 435, 3);
+        Person p1 = sfsb.getPersonReference("REDHAT", 435);
+        Person p2 = sfsb.loadPerson("MADHUMITA", 123);
+
+        assertEquals(p2.getAddress(), "99 Purkynova REDHAT BRNO CZ");
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/Person.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/Person.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.hibernate.naturalid;
+
+/**
+ * Represents a Person object.
+ * 
+ * @author Madhumita Sadhukhan
+ */
+public class Person {
+    // unique person id
+    private int personId;
+
+    // unique voterid
+    private int personVoterId;
+    // first name of the person
+    private String firstName;
+    // last name of the person
+    private String lastName;
+    // address of the person
+    private String address;
+
+    /**
+     * Default constructor
+     */
+    public Person() {
+    }
+
+    /**
+     * Creates a new instance of Person.
+     * 
+     * @param firstName first name.
+     * @param lastName last name.
+     * @param address address.
+     */
+    public Person(String firstName, String lastName, String address) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.address = address;
+    }
+
+    /**
+     * Gets the person id for this student.
+     * 
+     * @return person id.
+     */
+    public int getPersonId() {
+        return personId;
+    }
+
+    /**
+     * Sets the person id for this Person.
+     * 
+     * @return person id.
+     */
+    public void setPersonId(int personId) {
+        this.personId = personId;
+    }
+
+    /**
+     * Gets the first name for this person.
+     * 
+     * @return first name.
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Sets the first name for this person.
+     * 
+     * @param first name.
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * Gets the last name for this person.
+     * 
+     * @return last name.
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Sets the last name for this person.
+     * 
+     * @param last name.
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * Gets the address for this student.
+     * 
+     * @return address.
+     */
+    public String getAddress() {
+        return address;
+    }
+
+    /**
+     * Sets the address for this student.
+     * 
+     * @param address.
+     */
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getPersonVoterId() {
+        return personVoterId;
+    }
+
+    public void setPersonVoterId(int personVoterId) {
+        this.personVoterId = personVoterId;
+    }
+
+    /**
+     * Method used by the UI to clear information on the screen.
+     * 
+     * @return String used in the navigation rules.
+     */
+    public String clear() {
+        firstName = "";
+        lastName = "";
+        address = "";
+        return "clear";
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/SFSBHibernateSFNaturalId.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/SFSBHibernateSFNaturalId.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.hibernate.naturalid;
+
+import java.util.Properties;
+
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+import org.hibernate.service.BootstrapServiceRegistryBuilder;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.ServiceRegistryBuilder;
+
+/**
+ * Test that naturalId API used with Hibernate sessionfactory can be inititated from hibernate.cfg.xml and properties added to
+ * Hibernate Configuration in AS7 container
+ * 
+ * @author Madhumita Sadhukhan
+ */
+@Stateful
+@TransactionManagement(TransactionManagementType.BEAN)
+public class SFSBHibernateSFNaturalId {
+
+    private static SessionFactory sessionFactory;
+    private static ServiceRegistryBuilder builder;
+    private static ServiceRegistry serviceRegistry;
+
+    protected static final Class[] NO_CLASSES = new Class[0];
+    protected static final String NO_MAPPINGS = new String();
+
+    public void setupConfig() {
+        // static {
+        try {
+
+            // prepare the configuration
+            Configuration configuration = new Configuration().setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS,
+                    "true");
+            configuration.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
+            configuration.setProperty(Environment.DATASOURCE, "java:jboss/datasources/ExampleDS");
+
+            // configuration.configure("hibernate.cfg.xml");
+
+            // fetch the properties
+            Properties properties = new Properties();
+            properties.putAll(configuration.getProperties());
+
+            Environment.verifyProperties(properties);
+            ConfigurationHelper.resolvePlaceHolders(properties);
+
+            // build the serviceregistry
+            final BootstrapServiceRegistryBuilder bootstrapbuilder = new BootstrapServiceRegistryBuilder();
+            builder = new ServiceRegistryBuilder(bootstrapbuilder.build()).applySettings(properties);
+            serviceRegistry = builder.buildServiceRegistry();
+
+            // Create the SessionFactory from Configuration
+            sessionFactory = configuration.configure("hibernate.cfg.xml").buildSessionFactory(serviceRegistry);
+
+        } catch (Throwable ex) { // Make sure you log the exception, as it might be swallowed
+            System.err.println("Initial SessionFactory creation failed." + ex);
+            // ex.printStackTrace();
+            throw new ExceptionInInitializerError(ex);
+        }
+
+    }
+
+    // create person
+    public Person createPerson(String firstName, String lastName, String address, int voterId, int id) {
+
+        Person per = new Person();
+        per.setPersonId(id);
+        per.setAddress(address);
+        per.setPersonVoterId(voterId);
+        per.setFirstName(firstName);
+        per.setLastName(lastName);
+
+        try {
+            // We are not explicitly initializing a Transaction as Hibernate is expected to invoke the JTA TransactionManager
+            // implicitly
+            Session session = sessionFactory.openSession();
+            session.save(per);
+            session.flush();
+            session.close();
+        } catch (Exception e) {
+
+            e.printStackTrace();
+            throw new RuntimeException("transactional failure while persisting student entity", e);
+
+        }
+
+        return per;
+    }
+
+    // fetch person reference
+    public Person getPersonReference(String name, int voterid) {
+        Person emp = (Person) sessionFactory.openSession().byNaturalId(Person.class).using("firstName", name)
+                .using("personVoterId", voterid).getReference();
+        return emp;
+    }
+
+    // load person
+    public Person loadPerson(String name, int voterid) {
+        Person emp = (Person) sessionFactory.openSession().byNaturalId(Person.class).using("firstName", name)
+                .using("personVoterId", voterid).load();
+        return emp;
+    }
+
+}


### PR DESCRIPTION
Currently this testcase has been marked with @Ignore to skip it as it is failing with current version of Hibernate in AS7.
This bug is due to JBPAPP-8729(HHH-7253) which is a regression added in Hibernate 4.1.2 when upgraded from 4.1.1.Final.

However the fix is being backported to EAP ER6 hence basic idea is to have this testcase available as part of EAP ER6 which can be easily enabled for verification.
Also this can be enabled for verification once the Hibernate version is in AS7.
