### PR TITLE
AS7-4584 modulePath should pass to -mp and not -Djboss.modules.dir

### DIFF
--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -178,7 +178,6 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
         cmd.add("-Djboss.home.dir=" + jbossHomeDir);
         cmd.add("-Dorg.jboss.boot.log.file=" + jbossHomeDir + "/domain/log/host-controller.log");
         cmd.add("-Dlogging.configuration=file:" + jbossHomeDir + CONFIG_PATH + "logging.properties");
-        cmd.add("-Djboss.modules.dir=" + modulesDir.getCanonicalPath());
         cmd.add("-Djboss.bundles.dir=" + bundlesDir.getCanonicalPath());
         cmd.add("-Djboss.domain.default.config=" + config.getDomainConfig());
         cmd.add("-Djboss.host.default.config=" + config.getHostConfig());

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -117,7 +117,6 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             cmd.add("-Djboss.home.dir=" + jbossHome);
             cmd.add("-Dorg.jboss.boot.log.file=" + jbossHome + "/standalone/log/boot.log");
             cmd.add("-Dlogging.configuration=file:" + jbossHome + CONFIG_PATH + "logging.properties");
-            cmd.add("-Djboss.modules.dir=" + modulesPath);
             cmd.add("-Djboss.bundles.dir=" + bundlesPath);
             cmd.add("-jar");
             cmd.add(modulesJar.getAbsolutePath());


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-4584

That is because -Djboss.modules.dir does not support multiple directories any more. This is responsability of JBoss Modules.
