### PR TITLE
AS7-4516 Enable AS7 managed container to be started in admin-only mode

### DIFF
--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -58,6 +58,8 @@ public class ManagedContainerConfiguration extends CommonContainerConfiguration 
 
     private boolean enableAssertions = true;
 
+    private boolean adminOnly = false;
+
     private Integer[] waitForPorts;
 
     private Integer waitForPortsTimeoutInSeconds;
@@ -220,4 +222,13 @@ public class ManagedContainerConfiguration extends CommonContainerConfiguration 
     public void setWaitForPortsTimeoutInSeconds(final Integer waitForPortsTimeoutInSeconds) {
         this.waitForPortsTimeoutInSeconds = waitForPortsTimeoutInSeconds;
     }
+
+    public boolean isAdminOnly() {
+        return adminOnly;
+    }
+
+    public void setAdminOnly(boolean adminOnly) {
+        this.adminOnly = adminOnly;
+    }
+
 }

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -128,6 +128,8 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             cmd.add("org.jboss.as.standalone");
             cmd.add("-server-config");
             cmd.add(config.getServerConfig());
+            if (config.isAdminOnly())
+               cmd.add("--admin-only");
 
             // Wait on ports before launching; AS7-4070
             this.waitOnPorts();


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-4516

This makes tests that install extensions, and hence require app server reloading, much faster cos there's less to work first time server is started. This might also reduce the chance of 'channel closed' exceptions in Arquillian.
