### PR TITLE
[AS7-4537] document deprecated messaging attributes

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_2.xsd
@@ -236,10 +236,34 @@
                   <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
                </xs:sequence>
                <xs:sequence>
-                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address" />
-                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-port" />
-                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address" />
-                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port" />
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
            </xs:choice>
            <xs:element maxOccurs="1" minOccurs="0" ref="broadcast-period" />
@@ -255,9 +279,27 @@
                   <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
                </xs:sequence>
                <xs:sequence>
-                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address" />
-                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address" />
-                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port" />
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
             </xs:choice>
             <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int" />


### PR DESCRIPTION
- add documentation to the local/group address/port attributes for
  broadcast-group & discovery groups that they are deprecated and
  socket-bindings should be used instead
