### PR TITLE
AS7-582 Aggregated JBoss AS Javadoc - update

### DIFF
--- a/build/javadoc/README.txt
+++ b/build/javadoc/README.txt
@@ -1,0 +1,30 @@
+
+
+How to create Public JBoss AS API aggregated JavaDoc
+====================================================
+
+1) run ./extractPublicApiArtifactsList.sh
+This will print out a list of artifacts in this format:
+
+<include>com.h2database:h2</include>
+<include>commons-configuration:commons-configuration</include>
+<include>dom4j:dom4j</include>
+<include>javax.activation:activation</include>
+...
+
+2) Put these includes into build/pom.xml to the "javadocDist" profile.
+
+3) cd build; mvn clean javadoc:aggregate -PjavadocDist;
+This will fail because of AS7-4557 - Javadoc tool fails on certain AS dependencies' sources.
+
+4) Workaround: Find which artifacts cause this issue and remove them from the set of <include>'s.
+
+5) When done, aggregated JavaDoc will be created in:
+  target/apidocs
+  target/jboss-as-build-7.1.2.Final-SNAPSHOT-javadoc.jar
+  
+6) Check that the final result contains all packages it should.
+  
+  
+  
+  

--- a/build/javadoc/convertModuleNameToGroupID.xsl
+++ b/build/javadoc/convertModuleNameToGroupID.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:output method="text" indent="no"/>
+
+    <xsl:param name="moduleName"></xsl:param>
+
+    <!-- Print the groupId. -->
+    <xsl:template match="//module-def[@name]">
+        <!-- This needs to go inside since we don't have XSLT 2.0. -->
+        <xsl:if test="@name = $moduleName">
+            <xsl:apply-templates select="maven-resource"/>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template match="//maven-resource">
+        <xsl:value-of select="@group"/>:<xsl:value-of select="@artifact"/>
+        <xsl:text>
+</xsl:text>
+    </xsl:template>
+    
+    
+    <!-- Skip everything else. -->
+    <xsl:template match="@*|node()">
+        <xsl:apply-templates select="@*|node()"/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/build/javadoc/extractPublicApiArtifactsList.sh
+++ b/build/javadoc/extractPublicApiArtifactsList.sh
@@ -1,0 +1,69 @@
+
+###  
+###  Creates a list of Maven artifacts to be included in Public JBoss AS 7 API aggregated JavaDoc.
+###  
+
+
+PROGNAME=`basename $0`
+DIRNAME=`dirname $0`
+
+TARGET=$DIRNAME/target
+PROJECT_ROOT_DIR="$DIRNAME/../..";
+
+if [ ! `which xsltproc` ]; then 
+  echo "xsltproc not found. This script needs it. Please install it.";
+  exit 2;
+fi
+
+mkdir $TARGET;
+
+
+#####  With exported dependencies, converted from module names to groupIDs:
+
+echo '' > $TARGET/packages.tmp.txt
+for i in `find $PROJECT_ROOT_DIR/build/src/main/resources/modules/ -name module.xml` ;  do
+  FILE=`grep 'value="private"' --files-without-match  $i`;
+  if [ "$FILE" == "" ] ; then continue; fi;
+  echo "  Public module: $i"
+
+  ##  Extract module name.
+  PKG=`grep '<module .* name="' $FILE | head -1 | sed 's#<module .* name="\([^"]*\).*"#\1#' | sed 's#/\?>##'`;
+  echo "    == $PKG"
+  echo $PKG >> $TARGET/packages.tmp.txt
+
+  ##  Exported dependencies.
+  #grep '<module name="' $FILE | grep 'export="true"' | sed 's#<module name="\([^"]*\).*"#\1#' | sed 's#/\?>##' | sed 's#\s*\(.*\)\s*#\1#' | sed 's#.*#    Exported dep: \0#'
+  #grep '<module name="' $FILE | grep 'export="true"' | sed 's#<module name="\([^"]*\).*"#\1#' | sed 's#/\?>##' | sed 's#\s*\(.*\)\s*#\1#' >> $TARGET/packages.tmp.txt
+  grep '<module name="' $FILE | grep 'export="true"' | sed 's#<module name="\([^"]*\).*"#\1#' | sed 's#/\?>##' | sed 's#\s*\(.*\)\s*#\1#' | tee --append $TARGET/packages.tmp.txt | sed 's#.*#    Exported dep: \0#'
+done
+sort $TARGET/packages.tmp.txt | uniq > $TARGET/modules.tmp2.txt
+#cat $TARGET/packages.tmp2.txt | sed 's#.*#<include>\0:*</include>#'
+
+
+
+###  Now we have a list of public API modules, e.g. javax.management.j2ee.api
+###  Let's convert it into a list of groupIDs.
+echo > $TARGET/groupIDs.tmp.txt
+while read -r MODULE ; do
+  echo "Artefacts for module: $MODULE"
+  GROUP_ID=`xsltproc --stringparam moduleName "$MODULE"  $DIRNAME/convertModuleNameToGroupID.xsl $PROJECT_ROOT_DIR/build/build.xml`
+  echo "  GroupID: $GROUP_ID"
+  echo $GROUP_ID >> $TARGET/groupIDs.tmp.txt
+done < $TARGET/modules.tmp2.txt
+cat $TARGET/groupIDs.tmp.txt | sort | uniq > $TARGET/groupIDs.tmp-sorted.txt
+
+###  Wrap it as includes for pom.xml.
+cat $TARGET/groupIDs.tmp-sorted.txt | sed 's#.*#<include>\0</include>#'
+
+
+
+
+
+###  Not used;  this uses Xalan instead of xsltproc which might not be available.
+function doXSLT(){
+  AS_DIR=`ls -1d build/target/jboss-as-*`
+  CP=$AS_DIR/modules/org/apache/xalan/main/xalan-2.7.1.jbossorg-1.jar
+  echo java -cp $CP org.apache.xalan.xslt.Process -IN $1 -XSL $2 -OUT $3
+  java -cp $CP org.apache.xalan.xslt.Process -IN $1 -XSL $2 -OUT $3
+}
+

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1782,11 +1782,112 @@
                                 </goals>
                                 <phase>validate</phase>
                                 <configuration>
-                                   <includeDependencySources>true</includeDependencySources>
-                                   <dependencySourceIncludes>
-                                       <include>org.jboss.spec.javax.servlet:*</include>
-                                       <include>org.jboss.spec.javax.ejb:*</include>
-                                   </dependencySourceIncludes>
+                                    <debug>true</debug>
+                                    <verbose>true</verbose>
+                                    <maxmemory>1024m</maxmemory>
+                                    
+                                    <includeDependencySources>true</includeDependencySources>
+                                    <dependencySourceIncludes>
+                                        <include>com.h2database:*</include>
+                                        <include>commons-configuration:commons-configuration</include>
+                                        <include>dom4j:dom4j</include>
+                                        <include>javax.activation:activation</include>
+                                        <include>javax.enterprise:cdi-api</include>
+                                        <include>javax.faces:jsf-api</include>
+                                        <include>javax.inject:javax.inject</include>
+                                        <include>javax.jws:jsr181-api</include>
+                                        <include>javax.mail:mail</include>
+                                        <include>javax.validation:validation-api</include>
+                                        <include>joda-time:joda-time</include>
+                                        
+                                        <include>org.apache.juddi:juddi-client</include>
+                                        <include>org.apache.juddi.scout:scout</include>
+                                        <include>org.apache.juddi:uddi-ws</include>
+                                        <include>org.hibernate.common:hibernate-commons-annotations</include>
+                                        <include>org.hibernate:hibernate-core</include>
+                                        <include>org.hibernate:hibernate-entitymanager</include>
+                                        <include>org.hibernate:hibernate-envers</include>
+                                        <include>org.hibernate:hibernate-infinispan</include>
+                                        <include>org.hibernate:hibernate-validator</include>
+                                        <include>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</include>
+                                        <include>org.hornetq:hornetq-core</include>
+                                        <include>org.hornetq:hornetq-jms</include>
+                                        <!-- Causes [ERROR] java.lang.ClassCastException: com.sun.tools.javadoc.ClassDocImpl cannot be cast to com.sun.javadoc.AnnotationTypeDoc
+                                        <include>org.infinispan:infinispan-core</include>
+                                        <include>org.jboss.as:jboss-as-controller-client</include>
+                                        -->
+                                        <include>org.jboss.com.sun.httpserver:httpserver</include>
+                                        <include>org.jboss.invocation:jboss-invocation</include>
+                                        <!-- Causes [ERROR] java.lang.ClassCastException: com.sun.tools.javadoc.ClassDocImpl cannot be cast to com.sun.javadoc.AnnotationTypeDoc
+                                        <include>org.jboss:jboss-dmr</include>
+                                        -->
+
+                                        <include>org.jboss:jboss-ejb-client</include>
+                                        <include>org.jboss:jboss-remote-naming</include>
+                                        <include>org.jboss.jbossts:jbosstxbridge</include>
+                                        <include>org.jboss.jbossts:jbossxts</include>
+                                        <include>org.jboss.jbossts:jbossxts-api</include>
+                                        <include>org.jboss:jboss-vfs</include>
+                                        <include>org.jboss.logging:jboss-logging</include>
+                                        <include>org.jboss.logging:jul-to-slf4j-stub</include>
+                                        <include>org.jboss.logmanager:jboss-logmanager</include>
+                                        <include>org.jboss.marshalling:jboss-marshalling</include>
+                                        <include>org.jboss.msc:jboss-msc</include>
+                                        <include>org.jboss.remotingjmx:remoting-jmx</include>
+                                        <include>org.jboss.remoting3:jboss-remoting</include>
+                                        <include>org.jboss.sasl:jboss-sasl</include>
+                                        
+                                        <include>org.jboss.spec.javax.annotation:jboss-annotations-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec</include>
+                                        <include>org.jboss.spec.javax.el:jboss-el-api_2.2_spec</include>
+                                        <include>org.jboss.spec.javax.enterprise.deploy:jboss-jad-api_1.2_spec</include>
+                                        <include>org.jboss.spec.javax.faces:jboss-jsf-api_2.1_spec</include>
+                                        <include>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.management.j2ee:jboss-j2eemgmt-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.resource:jboss-connector-api_1.6_spec</include>
+                                        <include>org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec</include>
+                                        <include>org.jboss.spec.javax.security.auth.message:jboss-jaspi-api_1.0_spec</include>
+                                        <include>org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.4_spec</include>
+                                        <include>org.jboss.spec.javax.servlet:jboss-servlet-api_3.0_spec</include>
+                                        <include>org.jboss.spec.javax.servlet.jsp:jboss-jsp-api_2.2_spec</include>
+                                        <include>org.jboss.spec.javax.servlet.jstl:jboss-jstl-api_1.2_spec</include>
+                                        <include>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.2_spec</include>
+                                        <include>org.jboss.spec.javax.xml.registry:jboss-jaxr-api_1.0_spec</include>
+                                        <include>org.jboss.spec.javax.xml.rpc:jboss-jaxrpc-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.xml.soap:jboss-saaj-api_1.3_spec</include>
+                                        <include>org.jboss.spec.javax.xml.ws:jboss-jaxws-api_2.2_spec</include>
+
+                                        <include>org.jboss.threads:jboss-threads</include>
+                                        <include>org.jboss.weld:weld-api</include>
+                                        <include>org.jboss.ws:jbossws-api</include>
+                                        <include>org.jboss.xnio:xnio-api</include>
+                                        <include>org.jdom:jdom</include>
+                                        <include>org.jgroups:jgroups</include>
+                                        <include>org.osgi:org.osgi.core</include>
+                                        <include>org.picketbox:picketbox</include>
+                                        <!-- 
+                                        <include>org.picketbox:picketbox-commons</include>
+                                        -->
+                                        <include>org.picketbox:picketbox-infinispan</include>
+                                        <include>org.picketlink:picketlink-bindings</include>
+                                        <include>org.picketlink:picketlink-bindings-jboss</include>
+                                        <include>org.picketlink:picketlink-fed</include>
+                                        <include>org.slf4j:jcl-over-slf4j</include>
+                                        <include>org.slf4j:slf4j-api</include>
+                                        <include>org.slf4j:slf4j-ext</include>
+                                        <include>wsdl4j:wsdl4j</include>
+                                        <!--
+                                            [ERROR] 1) org.jboss.as:jboss-as-build:pom:7.1.0.CR1-SNAPSHOT
+                                            [ERROR] 2) xalan:xalan:jar:sources:2.7.1.jbossorg-1
+                                            [ERROR] 3) xalan:serializer:jar:2.7.1-jbossorg-1
+                                        <include>xalan:serializer</include>
+                                        -->
+                                        <include>xalan:xalan</include>
+                                        <include>xerces:xercesImpl</include>
+                                    </dependencySourceIncludes>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1794,6 +1895,8 @@
                 </plugins>
             </build>
         </profile>
+        
+        
     </profiles>
 
 </project>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1776,102 +1776,24 @@
                         <version>2.8.1</version>
                         <executions>
                             <execution>
-                                <id>javadocDist</id>
+                                <id>javadocs-dist</id>
+                                <goals>
+                                    <goal>aggregate-jar</goal>
+                                </goals>
                                 <phase>validate</phase>
-                                <goals><goal>aggregate-jar</goal></goals>
                                 <configuration>
-                                    <includeDependencySources>true</includeDependencySources>
-                                    <dependencySourceIncludes>
-                                        <include>com.h2database.h2:*</include>
-                                        <include>javaee.api:*</include>
-                                        <include>javax.activation.api:*</include>
-                                        <include>javax.annotation.api:*</include>
-                                        <include>javax.api:*</include>
-                                        <include>javax.ejb.api:*</include>
-                                        <include>javax.el.api:*</include>
-                                        <include>javax.enterprise.api:*</include>
-                                        <include>javax.enterprise.deploy.api:*</include>
-                                        <include>javax.faces.api:*</include>
-                                        <include>javax.faces.api:*</include>
-                                        <include>javax.inject.api:*</include>
-                                        <include>javax.interceptor.api:*</include>
-                                        <include>javax.jms.api:*</include>
-                                        <include>javax.jws.api:*</include>
-                                        <include>javax.mail.api:*</include>
-                                        <include>javax.management.j2ee.api:*</include>
-                                        <include>javax.persistence.api:*</include>
-                                        <include>javax.resource.api:*</include>
-                                        <include>javax.rmi.api:*</include>
-                                        <include>javax.security.auth.message.api:*</include>
-                                        <include>javax.security.jacc.api:*</include>
-                                        <include>javax.servlet.api:*</include>
-                                        <include>javax.servlet.jsp.api:*</include>
-                                        <include>javax.servlet.jstl.api:*</include>
-                                        <include>javax.transaction.api:*</include>
-                                        <include>javax.validation.api:*</include>
-                                        <include>javax.wsdl4j.api:*</include>
-                                        <include>javax.ws.rs.api:*</include>
-                                        <include>javax.xml.bind.api:*</include>
-                                        <include>javax.xml.jaxp-provider:*</include>
-                                        <include>javax.xml.registry.api:*</include>
-                                        <include>javax.xml.rpc.api:*</include>
-                                        <include>javax.xml.soap.api:*</include>
-                                        <include>javax.xml.stream.api:*</include>
-                                        <include>javax.xml.ws.api:*</include>
-                                        <include>org.apache.commons.configuration:*</include>
-                                        <include>org.apache.juddi.juddi-client:*</include>
-                                        <include>org.apache.juddi.scout:*</include>
-                                        <include>org.apache.juddi.uddi-ws:*</include>
-                                        <include>org.apache.xalan:*</include>
-                                        <include>org.apache.xerces:*</include>
-                                        <include>org.dom4j:*</include>
-                                        <include>org.hibernate.envers:*</include>
-                                        <include>org.hibernate:*</include>
-                                        <include>org.hibernate.validator:*</include>
-                                        <include>org.hornetq:*</include>
-                                        <include>org.infinispan:*</include>
-                                        <include>org.jboss.as.controller-client:*</include>
-                                        <include>org.jboss.com.sun.httpserver:*</include>
-                                        <include>org.jboss.dmr:*</include>
-                                        <include>org.jboss.ejb-client:*</include>
-                                        <include>org.jboss.invocation:*</include>
-                                        <include>org.jboss.logging:*</include>
-                                        <include>org.jboss.logging.jul-to-slf4j-stub:*</include>
-                                        <include>org.jboss.logmanager:*</include>
-                                        <include>org.jboss.marshalling:*</include>
-                                        <include>org.jboss.modules:*</include>
-                                        <include>org.jboss.msc:*</include>
-                                        <include>org.jboss.remote-naming:*</include>
-                                        <include>org.jboss.remoting3:*</include>
-                                        <include>org.jboss.remoting3.remoting-jmx:*</include>
-                                        <include>org.jboss.sasl:*</include>
-                                        <include>org.jboss.threads:*</include>
-                                        <include>org.jboss.vfs:*</include>
-                                        <include>org.jboss.weld.api:*</include>
-                                        <include>org.jboss.ws.api:*</include>
-                                        <include>org.jboss.xnio:*</include>
-                                        <include>org.jboss.xts:*</include>
-                                        <include>org.jdom:*</include>
-                                        <include>org.jgroups:*</include>
-                                        <include>org.joda.time:*</include>
-                                        <include>org.omg.api:*</include>
-                                        <include>org.osgi.core:*</include>
-                                        <include>org.picketbox:*</include>
-                                        <include>org.picketlink:*</include>
-                                        <include>org.slf4j.ext:*</include>
-                                        <include>org.slf4j:*</include>
-                                        <include>org.slf4j.jcl-over-slf4j:*</include>
-                                        <include>sun.jdk:*</include>
-                                    </dependencySourceIncludes>
+                                   <includeDependencySources>true</includeDependencySources>
+                                   <dependencySourceIncludes>
+                                       <include>org.jboss.spec.javax.servlet:*</include>
+                                       <include>org.jboss.spec.javax.ejb:*</include>
+                                   </dependencySourceIncludes>
                                 </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
-
             </build>
         </profile>
-
     </profiles>
 
 </project>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1825,9 +1825,13 @@
                                         <include>org.jboss:jboss-ejb-client</include>
                                         <include>org.jboss:jboss-remote-naming</include>
                                         <include>org.jboss.jbossts:jbosstxbridge</include>
+
+                                        <!--                                        
                                         <include>org.jboss.jbossts:jbossxts</include>
                                         <include>org.jboss.jbossts:jbossxts-api</include>
+                                        -->
                                         <include>org.jboss:jboss-vfs</include>
+
                                         <include>org.jboss.logging:jboss-logging</include>
                                         <include>org.jboss.logging:jul-to-slf4j-stub</include>
                                         <include>org.jboss.logmanager:jboss-logmanager</include>
@@ -1887,6 +1891,7 @@
                                         -->
                                         <include>xalan:xalan</include>
                                         <include>xerces:xercesImpl</include>
+
                                     </dependencySourceIncludes>
                                 </configuration>
                             </execution>
@@ -1900,4 +1905,3 @@
     </profiles>
 
 </project>
-


### PR DESCRIPTION
This adds build/javadoc directory with a script 
which extracts the list of public modules and their exported dependencies.

For details, see https://issues.jboss.org/browse/AS7-582
