### PR TITLE
[AS7-4594] fix messaging socket-binding resolution

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -133,11 +133,20 @@ class HornetQService implements Service<HornetQServer> {
                                 throw MESSAGES.failedToFindConnectorSocketBinding(tc.getName());
                             }
                             InetSocketAddress sa = socketBinding.getSocketAddress();
-                            host = sa.getAddress().getHostName();
                             port = sa.getPort();
+                            // resolve the host name of the address only if a loopback adress has been set
+                            if (sa.getAddress().isLoopbackAddress()) {
+                                host = sa.getAddress().getHostName();
+                            } else {
+                                host = sa.getAddress().getHostAddress();
+                            }
                         } else {
-                            host = binding.getDestinationAddress().getHostName();
                             port = binding.getDestinationPort();
+                            if (binding.getDestinationAddress().isLoopbackAddress()) {
+                                host = binding.getDestinationAddress().getHostName();
+                            } else {
+                                host = binding.getDestinationAddress().getHostAddress();
+                            }
                         }
                         tc.getParams().put(HOST, host);
                         tc.getParams().put(PORT, String.valueOf(port));


### PR DESCRIPTION
- do not resolve the hostname associated to the addresses passed
  to HornetQ transport configuration _unless_ the address is a loopback.
  these adresses will be serialized and send to the clients "as is" so
  that he can connect to HornetQ with the same value written in the
  configuration.
