### PR TITLE
Referer is spelled "Referer" by the HTTP specification:

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/LogoutHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/LogoutHandler.java
@@ -52,7 +52,7 @@ class LogoutHandler implements ManagementHttpHandler {
         boolean opera = userAgent != null && userAgent.contains("Opera");
         boolean win = !opera && userAgent != null && userAgent.contains("MSIE");
 
-        String referrer = responseHeaders.getFirst("Referrer");
+        String referrer = responseHeaders.getFirst("Referer");
 
         // Calculate location URL
         String protocol = "http";


### PR DESCRIPTION
http://en.wikipedia.org/wiki/HTTP_referer

Pulling the header from "Referrer" means that the code to parse the referer header will never be triggered by a real browser.
