### PR TITLE
JBPAPP-8726 - Infer the remote view from the home view for EJB2 beans based on deployment descriptors

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -2057,6 +2057,11 @@ public interface EjbMessages {
     @Message(id = 14574, value = "Unknown channel creation option type %s")
     IllegalArgumentException unknownChannelCreationOptionType(String optionType);
 
+    @Message(id = 14575, value = "Could not determine remote interface from home interface %s for bean %s")
+    DeploymentUnitProcessingException couldNotDetermineRemoteInterfaceFromHome(final String homeClass, final String beanName);
+
+    @Message(id = 14576, value = "Could not determine local interface from local home interface %s for bean %s")
+    DeploymentUnitProcessingException couldNotDetermineLocalInterfaceFromLocalHome(final String localHomeClass, final String beanName);
 
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/RemoveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/RemoveTestCase.java
@@ -74,8 +74,7 @@ public class RemoveTestCase {
             SFSB1 sfsb1 = lookup("SFSB1", SFSB1.class);
             sfsb1.done();   // first call is expected to work
             sfsb1.done();   // second call is expected to fail since we are calling a destroyed bean
-            // uncomment the following line after @Remove is implemented
-            // fail("Expecting NoSuchEJBException");
+            Assert.fail("Expecting NoSuchEJBException");
         } catch (NoSuchEJBException expectedException) {
             // good
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21ViewDDBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/Ejb21ViewDDBean.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.EJBException;
+import javax.ejb.EJBHome;
+import javax.ejb.EJBObject;
+import javax.ejb.Handle;
+import javax.ejb.RemoveException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.rmi.RemoteException;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class Ejb21ViewDDBean implements SessionBean {
+
+    @Override
+    public void setSessionContext(SessionContext sessionContext) throws EJBException, RemoteException {
+
+    }
+    public void ejbCreate() {
+    }
+
+    @Override
+    public void ejbRemove() throws EJBException, RemoteException {
+        try {
+            final Context ctx = new InitialContext();
+            final RemoveMethodInvocationTracker removeMethodInvocationTracker = (RemoveMethodInvocationTracker) ctx.lookup("java:app/remove-method-test/" + RemoveMethodInvocationTrackerBean.class.getSimpleName() + "!" + RemoveMethodInvocationTracker.class.getName());
+            removeMethodInvocationTracker.ejbRemoveCallbackInvoked();
+        } catch (NamingException ne) {
+            throw new RuntimeException(ne);
+        }
+
+    }
+
+    @Override
+    public void ejbActivate() throws EJBException, RemoteException {
+    }
+
+    @Override
+    public void ejbPassivate() throws EJBException, RemoteException {
+    }
+
+    public String test() throws RemoteException {
+        return this.getClass().getName();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodInvocationTracker.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodInvocationTracker.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remove.method;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface RemoveMethodInvocationTracker {
+
+    boolean wasEjbRemoveCallbackInvoked();
+
+    void ejbRemoveCallbackInvoked();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodInvocationTrackerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/RemoveMethodInvocationTrackerBean.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.remove.method;
+
+import javax.ejb.Remote;
+import javax.ejb.Singleton;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Singleton
+@Remote (RemoveMethodInvocationTracker.class)
+public class RemoveMethodInvocationTrackerBean implements RemoveMethodInvocationTracker {
+
+    private boolean ejbRemoveCallbackInvoked;
+
+    @Override
+    public boolean wasEjbRemoveCallbackInvoked() {
+        return this.ejbRemoveCallbackInvoked;
+    }
+
+    @Override
+    public void ejbRemoveCallbackInvoked() {
+        this.ejbRemoveCallbackInvoked = true;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remove/method/ejb-jar.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' ?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN"
+        "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<ejb-jar>
+    <enterprise-beans>
+        <session>
+            <ejb-name>Ejb21ViewDDBean</ejb-name>
+            <home>org.jboss.as.test.integration.ejb.remove.method.Ejb21ViewHome</home>
+            <ejb-class> org.jboss.as.test.integration.ejb.remove.method.Ejb21ViewDDBean</ejb-class>
+            <session-type>Stateful</session-type>
+            <transaction-type>Container</transaction-type>
+        </session>
+    </enterprise-beans>
+</ejb-jar>
+
+


### PR DESCRIPTION
The commit here fixes the NPE that's reported in https://issues.jboss.org/browse/JBPAPP-8726. It also adds a test to assert that the ejbRemove() callback is indeed invoked for the bean which is configured via  ejb-jar.xml deployment descriptor.
