### PR TITLE
AS7-4664: Upgrade to PicketLink v2.1.0.Final

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1139,9 +1139,8 @@
         </module-def>
 
         <module-def name="org.picketlink">
-            <maven-resource group="org.picketlink" artifact="picketlink-fed" jandex="true"/>
-            <maven-resource group="org.picketlink" artifact="picketlink-bindings" jandex="true"/>
-            <maven-resource group="org.picketlink" artifact="picketlink-bindings-jboss"/>
+            <maven-resource group="org.picketlink" artifact="picketlink-core" jandex="true"/>
+            <maven-resource group="org.picketlink.distribution" artifact="picketlink-jbas7" jandex="true"/>
         </module-def>
 
         <module-def name="org.picketbox">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1616,17 +1616,12 @@
 
                 <dependency>
                     <groupId>org.picketlink</groupId>
-                    <artifactId>picketlink-fed</artifactId>
+                    <artifactId>picketlink-core</artifactId>
                 </dependency>
 
                 <dependency>
-                    <groupId>org.picketlink</groupId>
-                    <artifactId>picketlink-bindings</artifactId>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.picketlink</groupId>
-                    <artifactId>picketlink-bindings-jboss</artifactId>
+                    <groupId>org.picketlink.distribution</groupId>
+                    <artifactId>picketlink-jbas7</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1871,9 +1866,8 @@
                                         <include>org.picketbox:picketbox-commons</include>
                                         -->
                                         <include>org.picketbox:picketbox-infinispan</include>
-                                        <include>org.picketlink:picketlink-bindings</include>
-                                        <include>org.picketlink:picketlink-bindings-jboss</include>
-                                        <include>org.picketlink:picketlink-fed</include>
+                                        <include>org.picketlink.distribution:picketlink-jbas7</include>
+                                        <include>org.picketlink:picketlink-core</include>
                                         <include>org.slf4j:jcl-over-slf4j</include>
                                         <include>org.slf4j:slf4j-api</include>
                                         <include>org.slf4j:slf4j-ext</include>

--- a/build/src/main/resources/modules/org/picketlink/main/module.xml
+++ b/build/src/main/resources/modules/org/picketlink/main/module.xml
@@ -28,7 +28,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="javax.security.auth.message.api"/>
         <module name="javax.security.jacc.api"/>
         <module name="javax.transaction.api"/>
@@ -43,5 +42,6 @@
         <module name="javax.xml.ws.api"/>
         <module name="org.apache.log4j"/>
         <module name="org.apache.santuario.xmlsec"/>
+        <module name="javax.api"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <version.org.mockito>1.8.5</version.org.mockito>
         <version.org.picketbox>4.0.8.Final</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
-        <version.org.picketlink>2.0.2.Final</version.org.picketlink>
+        <version.org.picketlink>2.1.0.Final</version.org.picketlink>
         <version.org.powermock>1.4.11</version.org.powermock>
         <version.org.projectodd.stilts>0.1.26</version.org.projectodd.stilts>
         <version.org.python.jython.standalone>2.5.2</version.org.python.jython.standalone>
@@ -5680,60 +5680,20 @@
 
             <dependency>
                 <groupId>org.picketlink</groupId>
-                <artifactId>picketlink-fed</artifactId>
-                <version>${version.org.picketlink}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.picketlink</groupId>
-                <artifactId>picketlink-bindings</artifactId>
+                <artifactId>picketlink-core</artifactId>
                 <version>${version.org.picketlink}</version>
                 <exclusions>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketlink</groupId>
-                        <artifactId>picketlink-fed-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketlink</groupId>
-                        <artifactId>picketlink-fed-model</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketlink</groupId>
-                        <artifactId>picketlink-web</artifactId>
-                    </exclusion>
+                  <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging-api</artifactId>
+                  </exclusion>
                 </exclusions>
             </dependency>
 
             <dependency>
-                <groupId>org.picketlink</groupId>
-                <artifactId>picketlink-bindings-jboss</artifactId>
+                <groupId>org.picketlink.distribution</groupId>
+                <artifactId>picketlink-jbas7</artifactId>
                 <version>${version.org.picketlink}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.jboss.security</groupId>
-                        <artifactId>jboss-security-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.security</groupId>
-                        <artifactId>jbosssx</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketlink</groupId>
-                        <artifactId>picketlink-fed-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketlink</groupId>
-                        <artifactId>picketlink-fed-model</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.picketlink</groupId>
-                        <artifactId>picketlink-web</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The jars have been reduced to now 2.
