### PR TITLE
Add missing attributes to jacorb and security subsystems.

### DIFF
--- a/build/src/main/resources/configuration/subsystems/jacorb.xml
+++ b/build/src/main/resources/configuration/subsystems/jacorb.xml
@@ -2,8 +2,8 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.jacorb</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jacorb:1.1">
-       <orb>
+   <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+       <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
            <initializers transactions="spec" security="on"/>
        </orb>
    </subsystem>

--- a/build/src/main/resources/configuration/subsystems/security.xml
+++ b/build/src/main/resources/configuration/subsystems/security.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.security</extension-module>
-   <subsystem xmlns="urn:jboss:domain:security:1.1">
+   <subsystem xmlns="urn:jboss:domain:security:1.2">
        <security-domains>
            <security-domain name="other" cache-type="default">
                <authentication>

--- a/build/src/main/resources/docs/schema/jboss-as-jacorb_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jacorb_1_2.xsd
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:jacorb:1.2"
+           xmlns="urn:jboss:domain:jacorb:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.2">
+
+    <!-- The jacorb subsystem root element -->
+    <xs:element name="subsystem" type="jacorbSubsystemType"/>
+
+    <xs:complexType name="jacorbSubsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The jacorbSubsystemType specifies the elements that can be used to configure the various aspects of the
+                jacorb subsystem.
+
+                - orb: holds the attributes used to configure the Object Request Broken (ORB).
+                - poa: holds the attributes used to configure the Portable Object Adapters (POA).
+                - naming: holds the attributes used to configured the CORBA Naming Service.
+                - interop: holds the attributes that control the ORB interoperability features.
+                - security: holds the attributes that control the ORB security features.
+                - properties: allows for the specification of generic name/value properties.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="orb" minOccurs="0" maxOccurs="1" type="orbConfigType"/>
+            <xs:element name="poa" minOccurs="0" maxOccurs="1" type="poaConfigType"/>
+            <xs:element name="naming" minOccurs="0" maxOccurs="1" type="namingConfigType"/>
+            <xs:element name="interop" minOccurs="0" maxOccurs="1" type="interopConfigType"/>
+            <xs:element name="security" minOccurs="0" maxOccurs="1" type="securityConfigType"/>
+            <xs:element name="properties" minOccurs="0" maxOccurs="1" type="genericPropertiesType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="orbConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                the orbConfigType specifies the elements and attributes that can be used to configure the behavior of the
+                Object Request Broker (ORB).
+
+                - connection: this element allows for the configuration of the connection properties.
+                - naming: this element allows for the configuration of the naming initial reference.
+
+                * name: the name of the running ORB.
+                * print-version: indicates whether the version number should be printed during ORB startup (on) or not (off).
+                * use-imr: indicates whether the implementation repository should be used (on) or not (off).
+                * use-bom: indicates whether GIOP 1.2 byte order markers should be used (on) or not (off).
+                * cache-typecodes: indicates whether typecodes should be cached (on) or not (off).
+                * cache-poa-names: indicates whether POA names should be cached (on) or not (off).
+                * giop-minor-version: the GIOP minor version to be used.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="connection" minOccurs="0" maxOccurs="1" type="orbConnectionConfigType"/>
+            <xs:element name="initializers" minOccurs="0" maxOccurs="1" type="orbInitializersConfigType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="optional" default="JBoss"/>
+        <xs:attribute name="print-version" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="use-imr" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="use-bom" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="cache-typecodes" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="cache-poa-names" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="giop-minor-version" type="xs:integer" use="optional" default="2"/>
+        <xs:attribute name="socket-binding" type="xs:string" use="optional" default="jacorb"/>
+        <xs:attribute name="ssl-socket-binding" type="xs:string" use="optional" default="jacorb-ssl"/>
+    </xs:complexType>
+
+    <xs:complexType name="orbConnectionConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The orbConnectionConfigType specifies the attributes used to configure the ORB connections.
+
+                * retries: the number of retries if connections cannot be promptly established.
+                * retry-interval: the interval in milliseconds between retries.
+                * client-timeout: the client-side connection timeout value in milliseconds. A value of zero indicates that
+                                  the connection never times out.
+                * server-timeout: the server-side connection timeout value in milliseconds. A value of zero indicates that
+                                  the connection never times out.
+                * max-server-connections: the maximum number of connections accepted by the server.
+                * max-managed-buf-size: the log2 of maximum size managed by the internal buffer manager.
+                * outbuf-size: the size of the network buffers for outgoing messages.
+                * outbuf-cache-timeout: the buffer cache timeout in milliseconds.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="retries" type="xs:integer" use="optional" default="5"/>
+        <xs:attribute name="retry-interval" type="xs:integer" use="optional" default="500"/>
+        <xs:attribute name="client-timeout" type="xs:integer" use="optional" default="0"/>
+        <xs:attribute name="server-timeout" type="xs:integer" use="optional" default="0"/>
+        <xs:attribute name="max-server-connections" type="xs:integer" use="optional"/>
+        <xs:attribute name="max-managed-buf-size" type="xs:integer" use="optional" default="24"/>
+        <xs:attribute name="outbuf-size" type="xs:integer" use="optional" default="2048"/>
+        <xs:attribute name="outbuf-cache-timeout" type="xs:integer" use="optional" default="-1"/>
+    </xs:complexType>
+
+    <xs:complexType name="orbInitializersConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The orbInitializersConfigType specifies the attributes used to configure the ORB initializers.
+
+                * security: indicates whether the security (SAS and CSIv2) initializers should be installed (on) or not (off).
+                * transactions: indicates which transaction initializers should be installed. There are three possibilities:
+                    on   - This requires JTS to be enabled in the transactions subsystem config, and will enable full transaction
+                           interaoprability with other JBoss AS instances.
+                    spec - This does not require JTS to be enabled, but will install the minimum set of transaction interceptors
+                           required for EJB spec compliance. These interceptors detect an incoming transaction and throw an
+                           exception if the invocation should be run in the incoming transaction context.
+                    off  - No transaction initalizers will be installed.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="security" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="transactions" type="transactionEnabledType" use="optional" default="off"/>
+    </xs:complexType>
+
+    <xs:complexType name="poaConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The poaConfigType specifies the elements and attributes used to configure the Portable Object Adapterss (POA).
+
+                - request-processors: element that allows for the configuration of the POA request processors.
+
+                * monitoring: indicates whether the monitoring GUI should be displayed (on) or not (off).
+                * queue-wait: indicates whether requests that exceed the maximum queue size should wait (on) or not (off).
+                              When disabled, a TRANSIENT exception is thrown if the queue is full.
+                * queue-min: the size of the queue for notifying waiting requests. In other words, blocked requests are
+                             only notified when the queue has no more than queue-min requests.
+                * queue-max: the maximum number of requests that can be queued. If new requests arrive and queue-wait is
+                             on, the exceeding requests will be blocked until the queue reaches its minimum value.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="request-processors" minOccurs="0" maxOccurs="1" type="poaRequestProcessorsConfigType"/>
+        </xs:sequence>
+        <xs:attribute name="monitoring" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="queue-wait" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="queue-min" type="xs:integer" use="optional" default="10"/>
+        <xs:attribute name="queue-max" type="xs:integer" use="optional" default="100"/>
+    </xs:complexType>
+
+    <xs:complexType name="poaRequestProcessorsConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The poaRequestProcessorsConfigType specifies the attributes used to configure the POA request processors.
+
+                * pool-size: the size of the request processors thread-pool. Threads that finish processing a request are
+                             placed back in the pool if the pool is not full and discarded otherwise.
+                * max-threads: the maximum number of active request processor threads. Threads are first obtained from
+                               the pool and once the pool is exhausted new threads are created until the number of threads
+                               reaches this limit. New requests will wait until an active thread finishes its job.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pool-size" type="xs:integer" use="optional" default="5"/>
+        <xs:attribute name="max-threads" type="xs:integer" use="optional" default="32"/>
+    </xs:complexType>
+
+    <xs:complexType name="namingConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The namingConfigType specifies the attributes used to configure the naming service.
+
+                * root-context: the naming service root context.
+                * export-corbaloc: indicates whether the root context should be exported as corbaloc::address:port/NameService
+                                   (on) or not (off).
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="root-context" type="xs:string" use="optional" default="JBoss/Naming/root"/>
+        <xs:attribute name="export-corbaloc" type="onOffType" use="optional" default="on"/>
+    </xs:complexType>
+
+    <xs:complexType name="interopConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The interopConfigType specifies the attributes used to configure the ORB interoperability features.
+
+                * sun: indicates whether interoperability with Sun's ORB is enabled (on) or not (off).
+                * comet: indicates whether interoperability with Comet's ORB is enabled (on) or not (off).
+                * iona: indicates whether interoperability with IONA's ASP is enabled (on) or not (off).
+                * chunk-custom-rmi-valuetypes: indicates whether custom RMI valuetypes should be encoded as chunks (on)
+                                               or not (off).
+                * lax-boolean-encoding: indicates whether any non-zero CDR encoded boolean value should be interpreted as
+                                        true (on) or not (off).
+                * indirection-encoding-disabled: indicates whether indirection encoding for repeated typecodes should be
+                                                 disabled (on) or not (off).
+                * strict-check-on-tc-creation: indicates whether the method create_abstract_interface_tc should perform
+                                               a validation check on the name parameter (on) or not (off).
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="sun" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="comet" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="iona" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="chunk-custom-rmi-valuetypes" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="lax-boolean-encoding" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="indirection-encoding-disable" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="strict-check-on-tc-creation" type="onOffType" use="optional" default="off"/>
+    </xs:complexType>
+
+    <xs:complexType name="securityConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The securityConfigType specifies the attributes used to configure the ORB security features.
+
+                * support-ssl: indicates whether SSL is to be supported (on) or not (off).
+                * security-domain: the name of the security domain that holds the key and trust stores that will be used
+                                   to establish SSL connections.
+                * add-component-via-interceptor: indicates whether SSL components should be added by an IOR interceptor
+                                                 (on) or not (off).
+                * client-supports: value that indicates the client SSL supported parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * client-requires: value that indicates the client SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * server-supports: value that indicates the server SSL supported parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * server-requires: value that indicates the server SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="support-ssl" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="security-domain" type="xs:string" use="optional"/>
+        <xs:attribute name="add-component-via-interceptor" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="client-supports" type="sslConfigType" use="optional" default="MutualAuth"/>
+        <xs:attribute name="client-requires" type="sslConfigType" use="optional" default="None"/>
+        <xs:attribute name="server-supports" type="sslConfigType" use="optional" default="MutualAuth"/>
+        <xs:attribute name="server-requires" type="sslConfigType" use="optional" default="None"/>
+    </xs:complexType>
+
+    <xs:complexType name="genericPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+               Enclosing element for a list of generic properties.
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded" type="genericPropertyType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="genericPropertyType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+               The property element allows for the specification of generic name/value properties. It is useful to specify
+               configuration attributes that have not been covered in this schema.
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="onOffType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Enumeration of allowed values for the standard JacORB attributes.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transactionEnabledType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the transaction interceptor config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+            <xs:enumeration value="spec"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sslConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the SSL config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="None"/>
+            <xs:enumeration value="ServerAuth"/>
+            <xs:enumeration value="ClientAuth"/>
+            <xs:enumeration value="MutualAuth"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/build/src/main/resources/docs/schema/jboss-as-security_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-security_1_2.xsd
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:security:1.2"
+           xmlns="urn:jboss:domain:security:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.2">
+
+   <!-- The security subsystem root element -->
+   <xs:element name="subsystem" type="security-containerType" />
+
+   <!-- The security container configuration -->
+   <xs:complexType name="security-containerType">
+      <xs:annotation>
+         <xs:documentation>
+                <![CDATA[
+                    The security subsystem, used to configure authentication and authorization.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element name="security-management" type="securityManagementType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="security-domains" type="securityDomainsType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+      </xs:all>
+   </xs:complexType>
+
+   <!-- The security management element -->
+   <xs:complexType name="securityManagementType">
+      <xs:annotation>
+         <xs:documentation>
+                <![CDATA[
+                    The optional "deep-copy-subject-mode" attribute sets the copy mode of subjects done by the security
+                    managers to be deep copies that makes copies of the subject principals and credentials if they are
+                    cloneable. It should be set to true if subject include mutable content that can be corrupted when
+                    multiple threads have the same identity and cache flushes/logout clearing the subject in one thread
+                    results in subject references affecting other threads. Default value is "false".
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:attribute name="deep-copy-subject-mode" type="xs:boolean" use="optional"/>
+   </xs:complexType>
+
+   <!-- Configuration for security domains -->
+   <xs:complexType name="securityDomainsType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Configures security domains for applications.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="security-domain" type="securityDomainType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="securityDomainType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Definition of a security domain.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:choice>
+            <xs:element name="authentication" type="authenticationType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="authentication-jaspi" type="authenticationJaspiType" minOccurs="0" maxOccurs="1"/>
+         </xs:choice>
+         <xs:element name="authorization" type="authorizationType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="acl" type="aclType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="mapping" type="mappingType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="audit" type="auditType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="identity-trust" type="identityTrustType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="jsse" type="jsseType" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+      <xs:attribute name="cache-type" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="authenticationType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authentication configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="login-module" type="loginModuleType" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="authenticationJaspiType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    JASPI authentication configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="login-module-stack" type="loginModuleStackType" maxOccurs="unbounded"/>
+         <xs:element name="auth-module" type="authModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="authorizationType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authorization configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="policy-module" type="policyModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="aclType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    ACL configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="acl-module" type="aclModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="mappingType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Mapping configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="mapping-module" type="mappingModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="auditType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Audit configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="provider-module" type="providerModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="identityTrustType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Identity trust configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="trust-module" type="trustModuleType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:simpleType name="module-option-flag">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    The flag attribute controls how a login module
+                    participates in the overall procedure.
+                    Required - The LoginModule is required to succeed. If it
+                    succeeds or fails, authentication still continues to proceed
+                    down the LoginModule list.
+
+                    Requisite - The LoginModule is required to succeed. If it succeeds,
+                    authentication continues down the LoginModule list. If it fails,
+                    control immediately returns to the application (authentication does not proceed
+                    down the LoginModule list).
+
+                    Sufficient - The LoginModule is  not required to succeed. If it does
+                    succeed, control immediately returns to the application (authentication
+                    does not proceed down the LoginModule list). If it fails,
+                    authentication continues down the LoginModule list.
+
+                    Optional - The LoginModule is not required to succeed. If it succeeds or
+                    fails, authentication still continues to proceed down the
+                    LoginModule list.
+
+                    The overall authentication succeeds only if
+                    all required and requisite LoginModules succeed. If a
+                    sufficient LoginModule is configured and succeeds, then only
+                    the required and requisite LoginModules prior to that
+                    sufficient LoginModule need to have succeeded for the overall
+                    authentication to succeed. If no required or requisite
+                    LoginModules are configured for an application, then at least
+                    one sufficient or optional LoginModule must succeed.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="required"/>
+         <xs:enumeration value="requisite"/>
+         <xs:enumeration value="sufficient"/>
+         <xs:enumeration value="optional"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="loginModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Login module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="propertyType">
+      <xs:attribute name="name" type="xs:string" use="required"/>
+      <xs:attribute name="value" type="xs:string" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="loginModuleStackType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Login module configuration for JASPI.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="login-module" type="loginModuleType" minOccurs="1" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+   </xs:complexType>
+
+   <xs:complexType name="authModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authentication module configuration for JASPI.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="optional"/>
+      <xs:attribute name="login-module-stack-ref" type="xs:string" use="optional"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="policyModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Authorization module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="aclModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    ACL module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="mappingModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Mapping module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="type" type="xs:string" use="optional"/>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="providerModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Audit module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="trustModuleType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Identity trust module configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="required"/>
+      <xs:attribute name="flag" type="module-option-flag" use="required"/>
+      <xs:attribute name="module" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="jsseType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    JSSE configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+        <xs:element name="additional-properties" type="properties" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute name="keystore-password" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-type" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-url" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="keystore-provider-argument" type="xs:string" use="optional"/>
+      <xs:attribute name="key-manager-factory-algorithm" type="xs:string" use="optional"/>
+      <xs:attribute name="key-manager-factory-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-password" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-type" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-url" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="truststore-provider-argument" type="xs:string" use="optional"/>
+      <xs:attribute name="trust-manager-factory-algorithm" type="xs:string" use="optional"/>
+      <xs:attribute name="trust-manager-factory-provider" type="xs:string" use="optional"/>
+      <xs:attribute name="client-alias" type="xs:string" use="optional"/>
+      <xs:attribute name="server-alias" type="xs:string" use="optional"/>
+      <xs:attribute name="service-auth-token" type="xs:string" use="optional"/>
+      <xs:attribute name="client-auth" type="xs:boolean" use="optional"/>
+      <xs:attribute name="cipher-suites" type="xs:string" use="optional"/>
+      <xs:attribute name="protocols" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+   <xs:complexType name="properties">
+      <xs:sequence>
+         <xs:element name="property" type="propertyType" maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="vaultType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Vault Configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="vault-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="optional"/>
+   </xs:complexType>
+</xs:schema>

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBExtension.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBExtension.java
@@ -65,5 +65,6 @@ public class JacORBExtension implements Extension {
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, JacORBSubsystemParser.Namespace.JacORB_1_0.getUriString(), PARSER);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, JacORBSubsystemParser.Namespace.JacORB_1_1.getUriString(), PARSER);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, JacORBSubsystemParser.Namespace.JacORB_1_2.getUriString(), PARSER);
     }
 }

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemAdd.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemAdd.java
@@ -73,10 +73,6 @@ import org.omg.PortableServer.POA;
  */
 public class JacORBSubsystemAdd extends AbstractAddStepHandler {
 
-    private static final String JACORB_SOCKET_BINDING = "jacorb";
-
-    private static final String JACORB_SSL_SOCKET_BINDING = "jacorb-ssl";
-
     static final JacORBSubsystemAdd INSTANCE = new JacORBSubsystemAdd();
 
     private static final ServiceName SECURITY_DOMAIN_SERVICE_NAME = ServiceName.JBOSS.append("security").append("security-domain");
@@ -151,9 +147,11 @@ public class JacORBSubsystemAdd extends AbstractAddStepHandler {
             builder.addDependency(SECURITY_DOMAIN_SERVICE_NAME.append(securityDomain));
 
         // inject the socket bindings that specify the JacORB IIOP and IIOP/SSL ports.
-        builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(JACORB_SOCKET_BINDING), SocketBinding.class,
+        String socketBinding = props.getProperty(JacORBSubsystemConstants.ORB_SOCKET_BINDING);
+        builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(socketBinding), SocketBinding.class,
                 orbService.getJacORBSocketBindingInjector());
-        builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(JACORB_SSL_SOCKET_BINDING), SocketBinding.class,
+        String sslSocketBinding = props.getProperty(JacORBSubsystemConstants.ORB_SSL_SOCKET_BINDING);
+        builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(sslSocketBinding), SocketBinding.class,
                 orbService.getJacORBSSLSocketBindingInjector());
         builder.addListener(verificationHandler);
         // set the initial mode and install the service.

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemConstants.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemConstants.java
@@ -57,6 +57,8 @@ public final class JacORBSubsystemConstants {
     public static final String ORB_CONN_MAX_MANAGED_BUF_SIZE = "max-managed-buf-size";
     public static final String ORB_CONN_OUTBUF_SIZE = "outbuf-size";
     public static final String ORB_CONN_OUTBUF_CACHE_TIMEOUT = "outbuf-cache-timeout";
+    public static final String ORB_SOCKET_BINDING = "socket-binding";
+    public static final String ORB_SSL_SOCKET_BINDING = "ssl-socket-binding";
     public static final String ORB_INIT = "initializers";
     public static final String ORB_INIT_SECURITY = "security";
     public static final String ORB_INIT_TRANSACTIONS = "transactions";

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemDefinitions.java
@@ -116,6 +116,18 @@ class JacORBSubsystemDefinitions {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
+    public static final SimpleAttributeDefinition ORB_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(
+            JacORBSubsystemConstants.ORB_SOCKET_BINDING, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode().set("jacorb"))
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .build();
+
+    public static final SimpleAttributeDefinition ORB_SSL_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(
+            JacORBSubsystemConstants.ORB_SSL_SOCKET_BINDING, ModelType.STRING, true)
+            .setDefaultValue(new ModelNode().set("jacorb-ssl"))
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .build();
+
     // connection attribute definitions.
     public static final SimpleAttributeDefinition ORB_CONN_RETRIES = new SimpleAttributeDefinitionBuilder(
             JacORBSubsystemConstants.ORB_CONN_RETRIES, ModelType.INT, true)
@@ -351,7 +363,8 @@ class JacORBSubsystemDefinitions {
 
     // list that contains the orb attribute definitions.
     static final List<SimpleAttributeDefinition> ORB_ATTRIBUTES = Arrays.asList(ORB_NAME, ORB_PRINT_VERSION,
-            ORB_USE_IMR, ORB_USE_BOM, ORB_CACHE_TYPECODES, ORB_CACHE_POA_NAMES, ORB_GIOP_MINOR_VERSION);
+            ORB_USE_IMR, ORB_USE_BOM, ORB_CACHE_TYPECODES, ORB_CACHE_POA_NAMES, ORB_GIOP_MINOR_VERSION,
+            ORB_SOCKET_BINDING, ORB_SSL_SOCKET_BINDING);
 
     // list that contains the orb connection attribute definitions.
     static final List<SimpleAttributeDefinition> ORB_CONN_ATTRIBUTES = Arrays.asList(ORB_CONN_RETRIES,

--- a/jacorb/src/main/resources/org/jboss/as/jacorb/LocalDescriptions.properties
+++ b/jacorb/src/main/resources/org/jboss/as/jacorb/LocalDescriptions.properties
@@ -10,6 +10,8 @@ jacorb.use-bom=Indicates whether GIOP 1.2 byte order markers should be used (on)
 jacorb.cache-typecodes=Indicates whether typecodes should be cached (on) or not (off).
 jacorb.cache-poa-names=Indicates whether POA names should be cached (on) or not (off).
 jacorb.giop-minor-version=The GIOP minor version to be used.
+jacorb.socket-binding=The name of the socket binding configuration that specifies the ORB port.
+jacorb.ssl-socket-binding=The name of the socket binding configuration that specifies the ORB SSL port.
 
 # orb connection configuration properties.
 jacorb.retries=The number of retries if connections cannot be promptly established.

--- a/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
+++ b/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
@@ -60,9 +60,9 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
     protected String getSubsystemXml() throws IOException {
         // for the standard subsystem test we use a complete configuration XML.
         return
-        "<subsystem xmlns=\"urn:jboss:domain:jacorb:1.1\">" +
+        "<subsystem xmlns=\"urn:jboss:domain:jacorb:1.2\">" +
         "    <orb name=\"JBoss\" print-version=\"off\" use-imr=\"off\" use-bom=\"off\"  cache-typecodes=\"off\" " +
-        "        cache-poa-names=\"off\" giop-minor-version =\"2\">" +
+        "        cache-poa-names=\"off\" giop-minor-version =\"2\" socket-binding=\"jacorb\" ssl-socket-binding=\"jacorb-ssl\">" +
         "        <connection retries=\"5\" retry-interval=\"500\" client-timeout=\"0\" server-timeout=\"0\" " +
         "            max-server-connections=\"500\" max-managed-buf-size=\"24\" outbuf-size=\"2048\" " +
         "            outbuf-cache-timeout=\"-1\"/>" +
@@ -238,9 +238,8 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testParseSubsystemWithBadInitializer_1_0() throws Exception {
-        // try parsing a XML with an invalid element.
         String subsystemXml =
-                "<subsystem xmlns=\"" + JacORBSubsystemParser.Namespace.CURRENT.getUriString() + "\">" +
+                "<subsystem xmlns=\"" + JacORBSubsystemParser.Namespace.JacORB_1_0.getUriString() + "\">" +
                 "   <initializers>invalid</initializers>" +
                 "</subsystem>";
         try {

--- a/security/src/main/java/org/jboss/as/security/JASPIAuthenticationModulesAttributeDefinition.java
+++ b/security/src/main/java/org/jboss/as/security/JASPIAuthenticationModulesAttributeDefinition.java
@@ -33,6 +33,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.ParametersOfValidator;
@@ -54,6 +55,8 @@ public class JASPIAuthenticationModulesAttributeDefinition extends ListAttribute
     static {
         final ParametersValidator delegate = new ParametersValidator();
         delegate.registerValidator(CODE, new StringLengthValidator(1));
+        delegate.registerValidator(Constants.FLAG, new EnumValidator<ModuleFlag>(ModuleFlag.class, true, false));
+        delegate.registerValidator(Constants.MODULE, new StringLengthValidator(1,true));
         delegate.registerValidator(Constants.MODULE_OPTIONS, new ModelTypeValidator(ModelType.OBJECT, true));
         delegate.registerValidator(Constants.LOGIN_MODULE_STACK_REF, new StringLengthValidator(1, true));
 
@@ -76,6 +79,8 @@ public class JASPIAuthenticationModulesAttributeDefinition extends ListAttribute
     protected void addAttributeValueTypeDescription(ModelNode node, ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
         final ModelNode valueType = getNoTextValueTypeDescription(node);
         valueType.get(CODE, DESCRIPTION).set(resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, CODE));
+        valueType.get(Constants.FLAG, DESCRIPTION).set(resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, Constants.FLAG));
+        valueType.get(Constants.MODULE, DESCRIPTION).set(resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, Constants.MODULE));
         valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, Constants.MODULE_OPTIONS));
         valueType.get(Constants.LOGIN_MODULE_STACK_REF, DESCRIPTION).set(resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, Constants.LOGIN_MODULE_STACK_REF));
     }
@@ -84,6 +89,8 @@ public class JASPIAuthenticationModulesAttributeDefinition extends ListAttribute
     protected void addOperationParameterValueTypeDescription(ModelNode node, String operationName, ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
         final ModelNode valueType = getNoTextValueTypeDescription(node);
         valueType.get(CODE, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, CODE));
+        valueType.get(Constants.FLAG, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.FLAG));
+        valueType.get(Constants.MODULE, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.MODULE));
         valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.MODULE_OPTIONS));
         valueType.get(Constants.LOGIN_MODULE_STACK_REF, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.LOGIN_MODULE_STACK_REF));
     }
@@ -95,6 +102,15 @@ public class JASPIAuthenticationModulesAttributeDefinition extends ListAttribute
             for (ModelNode module : modules.asList()) {
                 writer.writeStartElement(getXmlName());
                 writer.writeAttribute(Attribute.CODE.getLocalName(), module.get(CODE).asString());
+
+                if (module.hasDefined(Constants.FLAG)) {
+                    writer.writeAttribute(Attribute.FLAG.getLocalName(), module.get(Constants.FLAG).asString().toLowerCase(Locale.ENGLISH));
+                }
+
+                if (module.hasDefined(Constants.MODULE)){
+                    writer.writeAttribute(Attribute.MODULE.getLocalName(), module.get(Constants.MODULE).asString());
+                }
+
                 if (module.hasDefined(Constants.LOGIN_MODULE_STACK_REF)) {
                     writer.writeAttribute(Attribute.LOGIN_MODULE_STACK_REF.getLocalName(), module.get(Constants.LOGIN_MODULE_STACK_REF).asString());
                 }
@@ -136,6 +152,17 @@ public class JASPIAuthenticationModulesAttributeDefinition extends ListAttribute
         code.get(TYPE).set(ModelType.STRING);
         code.get(NILLABLE).set(false);
         code.get(MIN_LENGTH).set(1);
+
+        final ModelNode flag = valueType.get(Constants.FLAG);
+        flag.get(DESCRIPTION);  // placeholder
+        flag.get(TYPE).set(ModelType.STRING);
+        flag.get(NILLABLE).set(true);
+        for (ModuleFlag value : ModuleFlag.values())
+            flag.get(ALLOWED).add(value.toString());
+
+        final ModelNode module = valueType.get(Constants.MODULE);
+        module.get(TYPE).set(ModelType.STRING);
+        module.get(NILLABLE).set(true);
 
         final ModelNode moduleOptions = valueType.get(Constants.MODULE_OPTIONS);
         moduleOptions.get(DESCRIPTION);  // placeholder

--- a/security/src/main/java/org/jboss/as/security/Namespace.java
+++ b/security/src/main/java/org/jboss/as/security/Namespace.java
@@ -35,12 +35,13 @@ public enum Namespace {
     UNKNOWN(null),
 
     SECURITY_1_0("urn:jboss:domain:security:1.0"),
-    SECURITY_1_1("urn:jboss:domain:security:1.1");
+    SECURITY_1_1("urn:jboss:domain:security:1.1"),
+    SECURITY_1_2("urn:jboss:domain:security:1.2");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = SECURITY_1_1;
+    public static final Namespace CURRENT = SECURITY_1_2;
 
     private final String name;
 

--- a/security/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
+++ b/security/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
@@ -382,6 +382,9 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
                 loginStackRef = authModule.get(LOGIN_MODULE_STACK_REF).asString();
             Map<String, Object> options = extractOptions(authModule) ;
             AuthModuleEntry entry = new AuthModuleEntry(code, options, loginStackRef);
+            if (authModule.hasDefined(FLAG)) {
+                entry.setControlFlag(ControlFlag.valueOf(authModule.get(FLAG).asString()));
+            }
             if (loginStackRef != null) {
                 if (!holders.containsKey(loginStackRef)) {
                     throw SecurityMessages.MESSAGES.loginModuleStackIllegalArgument(loginStackRef);
@@ -389,6 +392,11 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
                 entry.setLoginModuleStackHolder(holders.get(loginStackRef));
             }
             authenticationInfo.add(entry);
+
+            String moduleName = authModule.get(MODULE).asString();
+            if(authModule.hasDefined(MODULE) && moduleName != null &&  moduleName.length() > 0 ) {
+                authenticationInfo.setJBossModuleName(moduleName);
+            }
         }
         applicationPolicy.setAuthenticationInfo(authenticationInfo);
         return true;

--- a/security/src/main/java/org/jboss/as/security/SecurityExtension.java
+++ b/security/src/main/java/org/jboss/as/security/SecurityExtension.java
@@ -22,12 +22,11 @@
 
 package org.jboss.as.security;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.SubsystemRegistration;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
-
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
@@ -84,5 +83,6 @@ public class SecurityExtension implements Extension {
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.SECURITY_1_0.getUriString(), PARSER);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.SECURITY_1_1.getUriString(), PARSER);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.SECURITY_1_2.getUriString(), PARSER);
     }
 }

--- a/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
+++ b/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
@@ -70,6 +70,7 @@ authentication.jaspi.add=Adds a JASPI authentication configuration
 authentication.jaspi.remove=Removes a JASPI authentication configuration
 authentication.jaspi.auth-modules=List of authentication modules to be used.
 authentication.jaspi.auth-modules.code=Class name of the module to be instantiated.
+authentication.jaspi.auth-modules.flag=The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.
 authentication.jaspi.auth-modules.module=Name of JBoss Module where the auth module code is located.
 authentication.jaspi.auth-modules.module-options=List of module options containing a name/value pair.
 authentication.jaspi.auth-modules.login-module-stack-ref=Reference to a login module stack name previously configured in the same security domain.

--- a/security/src/test/java/org/jboss/as/security/test/SecurityDomainModelv11UnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/test/SecurityDomainModelv11UnitTestCase.java
@@ -21,16 +21,14 @@
  */
 package org.jboss.as.security.test;
 
-import java.io.IOException;
-
 import org.jboss.as.security.SecurityExtension;
-import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 
-public class SecurityDomainModelv11UnitTestCase extends AbstractSubsystemBaseTest {
+public class SecurityDomainModelv11UnitTestCase extends AbstractSubsystemTest {
 
     public SecurityDomainModelv11UnitTestCase() {
         super(SecurityExtension.SUBSYSTEM_NAME, new SecurityExtension());
@@ -59,9 +57,33 @@ public class SecurityDomainModelv11UnitTestCase extends AbstractSubsystemBaseTes
         assertRemoveSubsystemResources(servicesA);
     }
 
-    @Override
-    protected String getSubsystemXml() throws IOException {
-        return readResource("securitysubsystemv11.xml");
+
+    @Test
+    public void testParseAndMarshalModelWithJASPI() throws Exception {
+        //Parse the subsystem xml and install into the first controller
+        String subsystemXml = readResource("securitysubsystemJASPIv11.xml");
+
+        KernelServices servicesA = super.installInController(AdditionalInitialization.MANAGEMENT, subsystemXml);
+        //Get the model and the persisted xml from the first controller
+        ModelNode modelA = servicesA.readWholeModel();
+        String marshalled = servicesA.getPersistedSubsystemXml();
+        servicesA.shutdown();
+
+        System.out.println(marshalled);
+
+        //Install the persisted xml from the first controller into a second controller
+        KernelServices servicesB = super.installInController(AdditionalInitialization.MANAGEMENT, marshalled);
+        ModelNode modelB = servicesB.readWholeModel();
+
+        //Make sure the models from the two controllers are identical
+        super.compare(modelA, modelB);
+
+        assertRemoveSubsystemResources(servicesA);
+    }
+
+//    @Override
+//    protected String getSubsystemXml() throws IOException {
+//        return readResource("securitysubsystemv11.xml");
         /*return "<subsystem xmlns=\"urn:jboss:domain:security:1.1\">" +
                 " <security-domains> " +
                   " <security-domain name=\"other\" cache-type=\"default\">" +
@@ -98,5 +120,5 @@ public class SecurityDomainModelv11UnitTestCase extends AbstractSubsystemBaseTes
                 "</security-domain>" +
             "</security-domains>" +
         "</subsystem>";*/
-    }
+//    }
 }

--- a/security/src/test/java/org/jboss/as/security/test/SecurityDomainModelv12UnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/test/SecurityDomainModelv12UnitTestCase.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.security.test;
+
+import java.io.IOException;
+
+import org.jboss.as.security.SecurityExtension;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ * <p>
+ * Security subsystem tests for the version 1.2 of the subsystem schema.
+ * </p>
+ */
+public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTest {
+
+    public SecurityDomainModelv12UnitTestCase() {
+        super(SecurityExtension.SUBSYSTEM_NAME, new SecurityExtension());
+    }
+
+    @Test
+    public void testParseAndMarshalModel() throws Exception {
+        //Parse the subsystem xml and install into the first controller
+        String subsystemXml = readResource("securitysubsystemv12.xml");
+
+        KernelServices servicesA = super.installInController(AdditionalInitialization.MANAGEMENT, subsystemXml);
+        //Get the model and the persisted xml from the first controller
+        ModelNode modelA = servicesA.readWholeModel();
+        String marshalled = servicesA.getPersistedSubsystemXml();
+        servicesA.shutdown();
+
+        System.out.println(marshalled);
+
+        //Install the persisted xml from the first controller into a second controller
+        KernelServices servicesB = super.installInController(AdditionalInitialization.MANAGEMENT, marshalled);
+        ModelNode modelB = servicesB.readWholeModel();
+
+        //Make sure the models from the two controllers are identical
+        super.compare(modelA, modelB);
+
+        assertRemoveSubsystemResources(servicesA);
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("securitysubsystemv12.xml");
+    }
+}

--- a/security/src/test/resources/org/jboss/as/security/test/securitysubsystemJASPIv11.xml
+++ b/security/src/test/resources/org/jboss/as/security/test/securitysubsystemJASPIv11.xml
@@ -1,0 +1,51 @@
+<subsystem xmlns="urn:jboss:domain:security:1.1">
+	<security-domains>
+		<security-domain name="other" cache-type="default">
+             <authentication>
+                <login-module code="Remoting" flag="optional">
+                  <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmUsersRoles" flag="required">
+                  <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                  <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                  <module-option name="realm" value="ApplicationRealm"/>
+                  <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+              </authentication>
+			<authorization>
+			   <policy-module code="DenyAll" flag="required">
+                 <module-option name="a" value="c"/>
+               </policy-module>
+			</authorization>
+			<mapping>
+			  <mapping-module code="SimpleRoles" type="role">
+                 <module-option name="d" value="e"/>
+              </mapping-module>
+            </mapping>
+            <audit>
+                 <provider-module code="customModule">
+                   <module-option name="d" value="r"/>
+                 </provider-module>
+            </audit> 
+			<jsse truststore-url="../standalone/configuration/keystores/tomcat.keystore"
+                  truststore-password="rmi+ssl"
+                  keystore-url="../standalone/configuration/keystores/clientcert.jks"
+                  keystore-password="changeit"/> 
+		</security-domain>
+		<security-domain name="jaspi-test" cache-type="default">
+             <authentication-jaspi>
+                 <login-module-stack name="lm-stack">
+                     <login-module code="UsersRoles" flag="required">
+                         <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                         <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                     </login-module>
+                  </login-module-stack>
+                  <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"/>
+              </authentication-jaspi>
+        </security-domain>
+	</security-domains>
+	<vault code="somevault">
+	  <vault-option name="xyz" value="zxc"/>
+	  <vault-option name="abc" value="def"/>
+    </vault>
+</subsystem>

--- a/security/src/test/resources/org/jboss/as/security/test/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/test/securitysubsystemv12.xml
@@ -1,0 +1,52 @@
+<subsystem xmlns="urn:jboss:domain:security:1.2">
+	<security-domains>
+		<security-domain name="other" cache-type="default">
+             <authentication>
+                <login-module code="Remoting" flag="optional">
+                  <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+                <login-module code="RealmUsersRoles" flag="required">
+                  <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                  <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                  <module-option name="realm" value="ApplicationRealm"/>
+                  <module-option name="password-stacking" value="useFirstPass"/>
+                </login-module>
+              </authentication>
+			<authorization>
+			   <policy-module code="DenyAll" flag="required">
+                 <module-option name="a" value="c"/>
+               </policy-module>
+			</authorization>
+			<mapping>
+			  <mapping-module code="SimpleRoles" type="role">
+                 <module-option name="d" value="e"/>
+              </mapping-module>
+            </mapping>
+            <audit>
+                 <provider-module code="customModule">
+                   <module-option name="d" value="r"/>
+                 </provider-module>
+            </audit> 
+			<jsse truststore-url="../standalone/configuration/keystores/tomcat.keystore"
+                  truststore-password="rmi+ssl"
+                  keystore-url="../standalone/configuration/keystores/clientcert.jks"
+                  keystore-password="changeit"/> 
+		</security-domain>
+        <security-domain name="jaspi-test" cache-type="default">
+            <authentication-jaspi>
+                <login-module-stack name="lm-stack">
+                    <login-module code="UsersRoles" flag="required">
+                        <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
+                        <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                    </login-module>
+                </login-module-stack>
+                <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
+                        flag="optional"/>
+            </authentication-jaspi>
+        </security-domain>
+	</security-domains>
+	<vault code="somevault">
+	  <vault-option name="xyz" value="zxc"/>
+	  <vault-option name="abc" value="def"/>
+    </vault>
+</subsystem>

--- a/testsuite/integration/src/test/xslt/enableJTS.xsl
+++ b/testsuite/integration/src/test/xslt/enableJTS.xsl
@@ -1,7 +1,7 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:t="urn:jboss:domain:transactions:1.2"
-                xmlns:j="urn:jboss:domain:jacorb:1.1">
+                xmlns:j="urn:jboss:domain:jacorb:1.2">
 
     <!--
         An XSLT style sheet which will enable JTS,


### PR DESCRIPTION
jacorb [AS7-3997]: allow the jacorb socket bindings to be configured via attributes in the subsystem.
security [AS7-4598]: add missing control flag attribute to JASPI auth-modules.
