### PR TITLE
AS7-4669 Upgrade PicketBox to version 4.0.9.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>3.0.9.Final</version.org.jgroups>
         <version.org.mockito>1.8.5</version.org.mockito>
-        <version.org.picketbox>4.0.8.Final</version.org.picketbox>
+        <version.org.picketbox>4.0.9.Final</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.1.0.Final</version.org.picketlink>
         <version.org.powermock>1.4.11</version.org.powermock>


### PR DESCRIPTION
Version 4.0.9.Final fixes the way JASPI auth modules are loaded. It now checks if a jboss module has been configured and avoid using the TCCL when loading the modules classes.
