### PR TITLE
Ordered child resources as7 4682

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import javax.management.MBeanServer;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -38,6 +37,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+
+import javax.management.MBeanServer;
 
 import org.jboss.as.clustering.jgroups.ChannelFactory;
 import org.jboss.as.clustering.jgroups.JGroupsMessages;

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTest.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTest.java
@@ -28,10 +28,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import junit.framework.Assert;
+
 import org.jboss.as.clustering.subsystem.ClusteringSubsystemTest;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.ModelDescriptionValidator.ValidationConfiguration;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
 
 /**
  *
@@ -66,5 +71,23 @@ public class JGroupsSubsystemTest extends ClusteringSubsystemTest {
             addresses.add(ignoredChild);
         }
         return new HashSet<PathAddress>(addresses);
+    }
+
+    @Test
+    public void testProtocolOrdering() throws Exception {
+        String xml = getSubsystemXml();
+        KernelServices kernel = super.installInController(xml);
+
+        ModelNode model = kernel.readWholeModel().require("subsystem").require("jgroups").require("stack").require("maximal");
+        List<ModelNode> protocols = model.require("protocols").asList();
+        Set<String> keys = model.get("protocol").keys();
+
+        Assert.assertEquals(protocols.size(), keys.size());
+        int i = 0;
+        for (String key : keys) {
+            String name = protocols.get(i).asString();
+            Assert.assertEquals(key, name);
+            i++;
+        }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -50,8 +50,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -139,7 +140,7 @@ public class GlobalOperationHandlers {
             // Non-AccessType.METRIC attributes with a special read handler registered
             final Map<String, ModelNode> otherAttributes = new HashMap<String, ModelNode>();
             // Child resources recursively read
-            final Map<PathElement, ModelNode> childResources = recursive ? new HashMap<PathElement, ModelNode>() : Collections.<PathElement, ModelNode>emptyMap();
+            final Map<PathElement, ModelNode> childResources = recursive ? new LinkedHashMap<PathElement, ModelNode>() : Collections.<PathElement, ModelNode>emptyMap();
 
             // We're going to add a bunch of steps that should immediately follow this one. We are going to add them
             // in reverse order of how they should execute, as that is the way adding a Stage.IMMEDIATE step works
@@ -1168,7 +1169,7 @@ public class GlobalOperationHandlers {
             }
             Set<String> set = result.get(childType);
             if (set == null) {
-                set = new HashSet<String>();
+                set = new LinkedHashSet<String>();
                 result.put(childType, set);
                 if (resource.hasChildren(childType)) {
                     set.addAll(resource.getChildrenNames(childType));

--- a/controller/src/test/java/org/jboss/as/controller/services/path/PathsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/services/path/PathsTestCase.java
@@ -24,15 +24,11 @@ package org.jboss.as.controller.services.path;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_OCCURS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
@@ -46,7 +42,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
@@ -77,7 +72,6 @@ import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.State;
 import org.jboss.msc.service.ServiceController.Transition;
-import org.jboss.msc.service.ServiceListener;
 import org.jboss.msc.service.ServiceName;
 import org.junit.Test;
 
@@ -793,36 +787,6 @@ public class PathsTestCase extends AbstractControllerTestBase {
         operation.get(RECURSIVE).set(true);
 
         return executeForResult(operation);
-    }
-
-    protected ModelNode createOperation(String operationName, String...address) {
-        ModelNode operation = new ModelNode();
-        operation.get(OP).set(operationName);
-        if (address.length > 0) {
-            for (String addr : address) {
-                operation.get(OP_ADDR).add(addr);
-            }
-        } else {
-            operation.get(OP_ADDR).setEmptyList();
-        }
-
-        return operation;
-    }
-
-    public ModelNode executeForResult(ModelNode operation) throws OperationFailedException {
-        ModelNode rsp = getController().execute(operation, null, null, null);
-        if (FAILED.equals(rsp.get(OUTCOME).asString())) {
-            throw new OperationFailedException(rsp.get(FAILURE_DESCRIPTION));
-        }
-        return rsp.get(RESULT);
-    }
-
-    public void executeForFailure(ModelNode operation) throws OperationFailedException {
-        try {
-            executeForResult(operation);
-            Assert.fail("Should have given error");
-        } catch (OperationFailedException expected) {
-        }
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
@@ -1,0 +1,117 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.controller.test;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+
+import java.util.EnumSet;
+import java.util.Locale;
+
+import junit.framework.Assert;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.common.CommonProviders;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class ReadResourceChildOrderingTestCase extends AbstractControllerTestBase {
+
+    private String[] str = new String[] {"g", "e", "l", "d", "h", "h", "k", "f", "a", "b", "j", "g", "c", "i"};
+
+    ModelNode model;
+    public ReadResourceChildOrderingTestCase() {
+        model = new ModelNode();
+        for (int i = 0 ; i < str.length ; i++) {
+            model.get("test", str[i], "prop").set(str[i].toUpperCase(Locale.ENGLISH));
+        }
+    }
+
+
+    @Test
+    public void testOrdering() throws Exception {
+        ModelNode op = createOperation(READ_RESOURCE_OPERATION);
+        op.get(RECURSIVE).set(true);
+
+        ModelNode result = executeForResult(op);
+        Assert.assertEquals(model, result);
+    }
+
+    @Override
+    protected DescriptionProvider getRootDescriptionProvider() {
+        return new DescriptionProvider() {
+
+            @Override
+            public ModelNode getModelDescription(Locale locale) {
+                return new ModelNode();
+            }
+        };
+    }
+
+    @Override
+    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
+        registration.registerOperationHandler(READ_RESOURCE_OPERATION, GlobalOperationHandlers.READ_RESOURCE, CommonProviders.READ_RESOURCE_PROVIDER, true, EnumSet.of(Flag.RUNTIME_ONLY));
+        registration.registerOperationHandler("setup", new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                    createModel(context, model);
+                    context.completeStep();
+                }
+            }, new DescriptionProvider() {
+            @Override
+            public ModelNode getModelDescription(Locale locale) {
+                return new ModelNode();
+            }
+        }, false, OperationEntry.EntryType.PRIVATE);
+        ManagementResourceRegistration reg = registration.registerSubModel(PathElement.pathElement("test"), new DescriptionProvider() {
+
+            @Override
+            public ModelNode getModelDescription(Locale locale) {
+                ModelNode node = new ModelNode();
+                node.get(DESCRIPTION).set("a test node");
+                node.get(ATTRIBUTES, "prop", TYPE).set(ModelType.STRING);
+                node.get(ATTRIBUTES, "prop", DESCRIPTION).set("A test property");
+                return node;
+            }
+        });
+        rootResource.getModel().set(model);
+        System.out.println(model);
+    }
+
+}

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -36,6 +36,7 @@ import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.MountType;
@@ -44,8 +45,6 @@ import org.jboss.as.server.services.security.VaultReaderException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.invocation.proxy.MethodIdentifier;
 import org.jboss.logging.Cause;
-import org.jboss.logging.LogMessage;
-import org.jboss.logging.Logger;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageBundle;
 import org.jboss.logging.Messages;
@@ -602,4 +601,7 @@ public interface ServerMessages {
 
     @Message(id = 18769, value = "Validation for %s is not implemented")
     UnsupportedOperationException attributeValidationUnimplemented(String attribute);
+
+    @Message(id = 18770, value = "Cannot add more than one socket binding group. Add of '%s' attempted, but '%s' already exists")
+    OperationFailedException cannotAddMoreThanOneSocketBindingGroupForServer(PathAddress wanted, PathAddress existing);
 }


### PR DESCRIPTION
Make read-resouce handler read child resources of the same type in the order they were added to the model as described in: http://issues.jboss.org/browse/AS7-4682
This fixes the jgroups protocol ordering: http://issues.jboss.org/browse/AS7-3863
