### PR TITLE
AS7-4685 module schemas are missing from documentation

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -104,6 +104,13 @@
             </patternset>
             <mapper type="flatten"/>
         </unzip>
+        <!-- Copy the JBoss Modules specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <unzip src="${org.jboss.modules:jboss-modules:jar}" dest="${output.dir}/docs/schema/">
+            <patternset>
+                <include name="schema/*.xsd"/>
+            </patternset>
+            <mapper type="flatten"/>
+        </unzip>
 
     </target>
 


### PR DESCRIPTION
The schemas for the jboss module system are missing from the docs/schemas folder. I just copied them over from the jboss-modules project.

https://issues.jboss.org/browse/AS7-4685
