### PR TITLE
Just use a Final tagged version of mod_cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>1.3.14.GA</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.marshalling.jboss-marshalling-river>1.3.14.GA</version.org.jboss.marshalling.jboss-marshalling-river>
         <version.org.jboss.metadata>7.0.3.Final</version.org.jboss.metadata>
-        <version.org.jboss.mod_cluster>1.2.1.Beta2</version.org.jboss.mod_cluster>
+        <version.org.jboss.mod_cluster>1.2.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.1.2.GA</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.0.2.GA</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.netty>3.2.6.Final</version.org.jboss.netty>


### PR DESCRIPTION
There are no changes in the JAVA part of mod_cluster that just to have a clean tag.
