### PR TITLE
[JBPAPP-8824] Fix NPE whilst viewing transactions via the cli

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreProbeHandler.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreProbeHandler.java
@@ -106,8 +106,8 @@ public class LogStoreProbeHandler implements OperationStepHandler {
                     LogStoreConstants.PARTICIPANT_JMX_NAMES);
             String pAddress = pAttributes.get(JNDI_PROPNAME);
 
-            if (pAddress.length() == 0) {
-                pAttributes.put(JNDI_PROPNAME, String.valueOf(i));
+            if (pAddress == null || pAddress.length() == 0) {
+                pAttributes.put(JNDI_PROPNAME, String.valueOf(i++));
                 pAddress = pAttributes.get(JNDI_PROPNAME);
             }
 


### PR DESCRIPTION
This error occurs in JTS transaction mode whilst using the CLI to browser XA participants.
