### PR TITLE
AS7-4706 Use Infinispan externalizers to reduce serialized size of replicated data

### DIFF
--- a/build/src/main/resources/configuration/subsystems/infinispan.xml
+++ b/build/src/main/resources/configuration/subsystems/infinispan.xml
@@ -33,7 +33,7 @@
                     <locking isolation="REPEATABLE_READ"/>
                 </replicated-cache>
             </cache-container>
-            <cache-container name="web" aliases="standard-session-cache" default-cache="repl">
+            <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.jboss.as.clustering.web.infinispan">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="repl" mode="ASYNC" batching="true">
                     <file-store/>
@@ -43,7 +43,7 @@
                     <file-store/>
                 </distributed-cache>
             </cache-container>
-            <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl">
+            <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="repl" mode="ASYNC" batching="true">
                     <eviction strategy="LRU" max-entries="10000"/>

--- a/build/src/main/resources/modules/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
@@ -38,6 +38,7 @@
         <module name="org.jboss.as.clustering.infinispan"/>
         <module name="org.jboss.as.clustering.registry"/>
         <module name="org.jboss.as.ejb3"/>
+        <module name="org.jboss.as.network"/>
         <module name="org.jboss.ejb-client"/>
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>

--- a/build/src/main/resources/modules/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/clustering/infinispan/main/module.xml
@@ -38,6 +38,7 @@
         <module name="org.infinispan"/>
         <module name="org.infinispan.cachestore.jdbc"/>
         <module name="org.infinispan.cachestore.remote" />
+        <module name="org.jboss.as.clustering.api"/>
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.clustering.impl"/>
         <module name="org.jboss.as.clustering.jgroups" optional="true"/>

--- a/clustering/api/src/main/java/org/jboss/as/clustering/HashableMarshalledValue.java
+++ b/clustering/api/src/main/java/org/jboss/as/clustering/HashableMarshalledValue.java
@@ -23,6 +23,8 @@
 package org.jboss.as.clustering;
 
 import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * Like {@link SimpleMarshalledValue}, but also serializes the underlying object's hash code,
@@ -32,7 +34,7 @@ import java.io.IOException;
 public class HashableMarshalledValue<T> extends SimpleMarshalledValue<T> {
     private static final long serialVersionUID = -7576022002375288323L;
 
-    private final int hashCode;
+    private transient int hashCode;
 
     /**
      * @param object
@@ -42,6 +44,10 @@ public class HashableMarshalledValue<T> extends SimpleMarshalledValue<T> {
     public HashableMarshalledValue(T object, MarshallingContext context) throws IOException {
         super(object, context);
         this.hashCode = (object != null ) ? object.hashCode() : 0;
+    }
+
+    public HashableMarshalledValue() {
+        // Required for externalization
     }
 
     @Override
@@ -56,5 +62,17 @@ public class HashableMarshalledValue<T> extends SimpleMarshalledValue<T> {
             return (this.hashCode == value.hashCode()) && super.equals(object);
         }
         return super.equals(object);
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        super.writeExternal(out);
+        out.writeInt(this.hashCode);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException {
+        super.readExternal(in);
+        this.hashCode = in.readInt();
     }
 }

--- a/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/ClientMappingExternalizer.java
+++ b/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/ClientMappingExternalizer.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.ejb3.cache.backing.infinispan;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.net.InetAddress;
+
+import org.jboss.as.clustering.infinispan.io.AbstractSimpleExternalizer;
+import org.jboss.as.network.ClientMapping;
+
+/**
+ * @author Paul Ferraro
+ */
+@SuppressWarnings("serial")
+public class ClientMappingExternalizer extends AbstractSimpleExternalizer<ClientMapping> {
+
+    public ClientMappingExternalizer() {
+        super(ClientMapping.class);
+    }
+
+    @Override
+    public void writeObject(ObjectOutput output, ClientMapping mapping) throws IOException {
+        byte[] address = mapping.getSourceNetworkAddress().getAddress();
+        output.writeInt(address.length);
+        output.write(address);
+        output.writeInt(mapping.getSourceNetworkMaskBits());
+        output.writeUTF(mapping.getDestinationAddress());
+        output.writeInt(mapping.getDestinationPort());
+    }
+
+    @Override
+    public ClientMapping readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        byte[] sourceAddress = new byte[input.readInt()];
+        input.read(sourceAddress);
+        int sourcePort = input.readInt();
+        String destAddress = input.readUTF();
+        int destPort = input.readInt();
+        return new ClientMapping(InetAddress.getByAddress(sourceAddress), sourcePort, destAddress, destPort);
+    }
+}

--- a/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/SessionIDExternalizer.java
+++ b/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/SessionIDExternalizer.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.ejb3.cache.backing.infinispan;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.clustering.infinispan.io.AbstractSimpleExternalizer;
+import org.jboss.ejb.client.BasicSessionID;
+import org.jboss.ejb.client.SessionID;
+import org.jboss.ejb.client.UnknownSessionID;
+
+/**
+ * @author Paul Ferraro
+ */
+@SuppressWarnings("serial")
+public class SessionIDExternalizer extends AbstractSimpleExternalizer<SessionID> {
+
+    public SessionIDExternalizer() {
+        super(SessionID.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Set<Class<? extends SessionID>> getTypeClasses() {
+        return new HashSet<Class<? extends SessionID>>(Arrays.asList(BasicSessionID.class, UnknownSessionID.class));
+    }
+
+    @Override
+    public void writeObject(ObjectOutput output, SessionID id) throws IOException {
+        byte[] encoded = id.getEncodedForm();
+        output.writeInt(encoded.length);
+        output.write(encoded);
+    }
+
+    @Override
+    public SessionID readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        byte[] encoded = new byte[input.readInt()];
+        input.read(encoded);
+        return SessionID.createSessionID(encoded);
+    }
+}

--- a/clustering/ejb3-infinispan/src/main/resources/META-INF/services/org.jboss.as.clustering.infinispan.io.SimpleExternalizer
+++ b/clustering/ejb3-infinispan/src/main/resources/META-INF/services/org.jboss.as.clustering.infinispan.io.SimpleExternalizer
@@ -1,0 +1,4 @@
+org.jboss.as.clustering.infinispan.io.SimpleMarshalledValueExternalizer
+org.jboss.as.clustering.infinispan.io.UUIDExternalizer
+org.jboss.as.clustering.ejb3.cache.backing.infinispan.SessionIDExternalizer
+org.jboss.as.clustering.ejb3.cache.backing.infinispan.ClientMappingExternalizer

--- a/clustering/ejb3-infinispan/src/test/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/SimpleExternalizerTestCase.java
+++ b/clustering/ejb3-infinispan/src/test/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/SimpleExternalizerTestCase.java
@@ -1,0 +1,28 @@
+package org.jboss.as.clustering.ejb3.cache.backing.infinispan;
+
+import java.util.HashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+import org.jboss.as.clustering.SimpleMarshalledValue;
+import org.jboss.as.clustering.infinispan.io.SimpleExternalizer;
+import org.jboss.as.network.ClientMapping;
+import org.jboss.ejb.client.SessionID;
+import org.junit.Test;
+
+public class SimpleExternalizerTestCase {
+    @Test
+    public void load() {
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        for (SimpleExternalizer<?> externalizer: ServiceLoader.load(SimpleExternalizer.class)) {
+            classes.add(externalizer.getTargetClass());
+        }
+        assertTrue(classes.contains(UUID.class));
+        assertTrue(classes.contains(ClientMapping.class));
+        assertTrue(classes.contains(SessionID.class));
+        assertTrue(classes.contains(SimpleMarshalledValue.class));
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/AbstractSimpleExternalizer.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/AbstractSimpleExternalizer.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.infinispan.io;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Abstract implementation of an externalizer for a single class.
+ * @author Paul Ferraro
+ */
+@SuppressWarnings("serial")
+// N.B. unlike JBoss Marshalling externalizers, Infinispan AdvancedExternalizers are never serialized
+// While AdvancedExternalizer currently extends Serializable, this will be dropped in a future release
+public abstract class AbstractSimpleExternalizer<T> implements SimpleExternalizer<T> {
+    private final Class<T> targetClass;
+
+    protected AbstractSimpleExternalizer(Class<T> targetClass) {
+        this.targetClass = targetClass;
+    }
+
+    @Override
+    public Class<T> getTargetClass() {
+        return this.targetClass;
+    }
+
+    @Override
+    public Set<Class<? extends T>> getTypeClasses() {
+        return Collections.<Class<? extends T>>singleton(this.targetClass);
+    }
+
+    @Override
+    public Integer getId() {
+        // The externalizer ID will be auto-assigned during registration with cache manager
+        return null;
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/ExternalizableExternalizer.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/ExternalizableExternalizer.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.infinispan.io;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.jboss.marshalling.Creator;
+import org.jboss.marshalling.reflect.ReflectiveCreator;
+
+/**
+ * Externalizer for Externalizable objects.
+ * @author Paul Ferraro
+ */
+@SuppressWarnings("serial")
+public class ExternalizableExternalizer<T extends Externalizable> extends AbstractSimpleExternalizer<T> {
+    private static final Creator creator = new ReflectiveCreator();
+
+    public ExternalizableExternalizer(Class<T> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    public void writeObject(ObjectOutput output, T object) throws IOException {
+        object.writeExternal(output);
+    }
+
+    @Override
+    public T readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        T object = creator.create(this.getTargetClass());
+        object.readExternal(input);
+        return object;
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/HashableMarshalledValueExternalizer.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/HashableMarshalledValueExternalizer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,14 +19,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.as.clustering.infinispan.io;
 
-package org.jboss.as.clustering.web.infinispan;
+import org.jboss.as.clustering.HashableMarshalledValue;
 
 /**
  * @author Paul Ferraro
  */
-public interface SessionKeyFactory<K extends SessionKey> {
-    K createKey(String sessionId);
-
-    boolean ours(K key);
+@SuppressWarnings({ "rawtypes", "serial" })
+public class HashableMarshalledValueExternalizer extends ExternalizableExternalizer<HashableMarshalledValue> {
+    public HashableMarshalledValueExternalizer() {
+        super(HashableMarshalledValue.class);
+    }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/SimpleExternalizer.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/SimpleExternalizer.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.infinispan.io;
+
+import org.infinispan.marshall.AdvancedExternalizer;
+
+/**
+ * This is mostly a marker interface for dynamic loading of externalizers via ServiceLoader.
+ * @author Paul Ferraro
+ */
+public interface SimpleExternalizer<T> extends AdvancedExternalizer<T> {
+    Class<T> getTargetClass();
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/SimpleMarshalledValueExternalizer.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/SimpleMarshalledValueExternalizer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,14 +19,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.as.clustering.infinispan.io;
 
-package org.jboss.as.clustering.web.infinispan;
-
-import java.io.Serializable;
+import org.jboss.as.clustering.SimpleMarshalledValue;
 
 /**
  * @author Paul Ferraro
  */
-public interface SessionKey extends Serializable {
-    String getSessionId();
+@SuppressWarnings({ "rawtypes", "serial" })
+public class SimpleMarshalledValueExternalizer extends ExternalizableExternalizer<SimpleMarshalledValue> {
+    public SimpleMarshalledValueExternalizer() {
+        super(SimpleMarshalledValue.class);
+    }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/UUIDExternalizer.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/io/UUIDExternalizer.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.infinispan.io;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.UUID;
+
+/**
+ * @author Paul Ferraro
+ */
+@SuppressWarnings("serial")
+public class UUIDExternalizer extends AbstractSimpleExternalizer<UUID> {
+    public UUIDExternalizer() {
+        super(UUID.class);
+    }
+
+    @Override
+    public void writeObject(ObjectOutput output, UUID uuid) throws IOException {
+        output.writeLong(uuid.getMostSignificantBits());
+        output.writeLong(uuid.getLeastSignificantBits());
+    }
+
+    @Override
+    public UUID readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        return new UUID(input.readLong(), input.readLong());
+    }
+}

--- a/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/DistributableSessionMetadataExternalizer.java
+++ b/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/DistributableSessionMetadataExternalizer.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.web.infinispan;
+
+import org.jboss.as.clustering.infinispan.io.ExternalizableExternalizer;
+import org.jboss.as.clustering.web.DistributableSessionMetadata;
+
+/**
+ * @author Paul Ferraro
+ */
+@SuppressWarnings("serial")
+public class DistributableSessionMetadataExternalizer extends ExternalizableExternalizer<DistributableSessionMetadata> {
+    public DistributableSessionMetadataExternalizer() {
+        super(DistributableSessionMetadata.class);
+    }
+}

--- a/clustering/web-infinispan/src/main/resources/META-INF/services/org.jboss.as.clustering.infinispan.io.SimpleExternalizer
+++ b/clustering/web-infinispan/src/main/resources/META-INF/services/org.jboss.as.clustering.infinispan.io.SimpleExternalizer
@@ -1,0 +1,2 @@
+org.jboss.as.clustering.infinispan.io.SimpleMarshalledValueExternalizer
+org.jboss.as.clustering.web.infinispan.DistributableSessionMetadataExternalizer

--- a/clustering/web-infinispan/src/test/java/org/jboss/as/clustering/web/infinispan/SimpleExternalizerTestCase.java
+++ b/clustering/web-infinispan/src/test/java/org/jboss/as/clustering/web/infinispan/SimpleExternalizerTestCase.java
@@ -1,0 +1,25 @@
+package org.jboss.as.clustering.web.infinispan;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import org.jboss.as.clustering.SimpleMarshalledValue;
+import org.jboss.as.clustering.infinispan.io.SimpleExternalizer;
+import org.jboss.as.clustering.web.DistributableSessionMetadata;
+import org.junit.Test;
+
+public class SimpleExternalizerTestCase {
+    @Test
+    public void load() {
+        Set<Class<?>> classes = new HashSet<Class<?>>();
+        for (SimpleExternalizer<?> externalizer: ServiceLoader.load(SimpleExternalizer.class)) {
+            classes.add(externalizer.getTargetClass());
+        }
+        assertTrue(classes.contains(DistributableSessionMetadata.class));
+        assertTrue(classes.contains(SimpleMarshalledValue.class));
+    }
+
+}

--- a/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/DistributableSessionMetadata.java
+++ b/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/DistributableSessionMetadata.java
@@ -21,14 +21,17 @@
  */
 package org.jboss.as.clustering.web;
 
-import java.io.Serializable;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
 /**
  * Encapsulates the replicated metadata for a session. The wrapped data can be mutated, allowing the same object to always be
  * stored in JBoss Cache. Always storing the same object avoids an earlier, no longer accurate, object being reverted into the
  * cache during a transaction rollback.
  */
-public class DistributableSessionMetadata implements Serializable {
+public class DistributableSessionMetadata implements Externalizable {
     /** The serialVersionUID */
     private static final long serialVersionUID = -6845914023373746866L;
 
@@ -76,5 +79,23 @@ public class DistributableSessionMetadata implements Serializable {
 
     public void setValid(boolean isValid) {
         this.isValid = isValid;
+    }
+
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+        out.writeUTF(this.id);
+        out.writeLong(this.creationTime);
+        out.writeInt(this.maxInactiveInterval);
+        out.writeBoolean(this.isNew);
+        out.writeBoolean(this.isValid);
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException {
+        this.id = in.readUTF();
+        this.creationTime = in.readLong();
+        this.maxInactiveInterval = in.readInt();
+        this.isNew = in.readBoolean();
+        this.isValid = in.readBoolean();
     }
 }

--- a/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/impl/SessionAttributeMarshallerFactoryImpl.java
+++ b/clustering/web-spi/src/main/java/org/jboss/as/clustering/web/impl/SessionAttributeMarshallerFactoryImpl.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.clustering.web.impl;
 
+import java.io.Externalizable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.IdentityHashMap;
@@ -28,9 +29,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.jboss.as.clustering.MarshallingContext;
-import org.jboss.as.clustering.SimpleMarshalledValue;
 import org.jboss.as.clustering.VersionedMarshallingConfiguration;
-import org.jboss.as.clustering.web.DistributableSessionMetadata;
 import org.jboss.as.clustering.web.LocalDistributableSessionManager;
 import org.jboss.as.clustering.web.SessionAttributeMarshaller;
 import org.jboss.as.clustering.web.SessionAttributeMarshallerFactory;
@@ -91,10 +90,10 @@ public class SessionAttributeMarshallerFactoryImpl implements SessionAttributeMa
         return config;
     }
 
+    // List session attribute classes for optimization
     private static final Class<?>[] classes = new Class<?>[] {
-        DistributableSessionMetadata.class,
-        SimpleMarshalledValue.class,
         Serializable.class,
+        Externalizable.class,
     };
 
     private static final Map<Class<?>, Writer> writers = createWriters();


### PR DESCRIPTION
Clustering performance optimizations.
N.B. These are optimizations for the actual Infinispan cache entries - not the contents of the marshalled values, which contain the actual web session attributes or SFSBs
