### PR TITLE
Fix the i18n logger category for EJB3 subsystem

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -87,12 +87,12 @@ public interface EjbLogger extends BasicLogger {
      */
     EjbLogger ROOT_LOGGER = Logger.getMessageLogger(EjbLogger.class, EjbLogger.class.getPackage().getName());
 
-    EjbLogger EJB3_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.ejb3");
+    EjbLogger EJB3_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3");
 
     /**
      * logger use to log EJB invocation errors
      */
-    EjbLogger EJB3_INVOCATION_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.ejb3.invocation");
+    EjbLogger EJB3_INVOCATION_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.invocation");
 
     /**
      * Logs an error message indicating an exception occurred while removing the an inactive bean.


### PR DESCRIPTION
This commit fixes the incorrect i18n logger category that was used in EJB3 subsytem. Discussion about this is here http://lists.jboss.org/pipermail/jboss-as7-dev/2012-May/005924.html
