### PR TITLE
Fix the exception returned for non existent view on EJB

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -480,7 +480,7 @@ public interface EjbLogger extends BasicLogger {
     void failedToCreateOptionForProperty(String propertyName, String reason);
 
     @Message(id = 14151, value = "Could not find view %s for EJB %s")
-    RuntimeException viewNotFound(String viewClass, String ejbName);
+    IllegalStateException viewNotFound(String viewClass, String ejbName);
 
     @Message(id = 14152, value = "Cannot perform asynchronous local invocation for component that is not a session bean")
     RuntimeException asyncInvocationOnlyApplicableForSessionBeans();


### PR DESCRIPTION
The commit fixes a regression in TCK where an incorrect exception type was being returned for a non-existent view on EJB.
