### PR TITLE
Fix for AS7-3492 

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ForwardingEjbClientConfiguration.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ForwardingEjbClientConfiguration.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 
 import javax.security.auth.callback.CallbackHandler;
 
+import org.jboss.ejb.client.DeploymentNodeSelector;
 import org.jboss.ejb.client.EJBClientConfiguration;
 import org.xnio.OptionMap;
 
@@ -61,5 +62,10 @@ public abstract class ForwardingEjbClientConfiguration implements EJBClientConfi
     @Override
     public long getReconnectTasksTimeout() {
         return delegate.getReconnectTasksTimeout();
+    }
+
+    @Override
+    public DeploymentNodeSelector getDeploymentNodeSelector() {
+        return delegate.getDeploymentNodeSelector();
     }
 }

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_2.xsd
@@ -81,6 +81,16 @@
                 </documentation>
             </annotation>
         </xsd:attribute>
+        <xsd:attribute name="deployment-node-selector" type="xsd:string" use="optional">
+            <annotation xmlns="http://www.w3.org/2001/XMLSchema">
+                <documentation>
+                    The fully qualified classname of the class which implements the
+                    org.jboss.ejb.client.DeploymentNodeSelector
+                    interface. The instance of this class will be used for selecting nodes, from among multiple eligible
+                    nodes within a EJB client context, which can handle a particular deployment
+                </documentation>
+            </annotation>
+        </xsd:attribute>
     </xsd:complexType>
 
     <xsd:complexType name="ejb-receiversType">

--- a/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
@@ -40,6 +40,7 @@ public class EJBClientDescriptorMetaData {
     private boolean excludeLocalReceiver;
     private Boolean localReceiverPassByValue;
     private long invocationTimeout;
+    private String deploymentNodeSelector;
 
     private Map<String, RemotingReceiverConfiguration> remotingReceiverConfigurations = new HashMap<String, RemotingReceiverConfiguration>();
     private Set<ClusterConfig> clusterConfigs = new HashSet<ClusterConfig>();
@@ -125,6 +126,14 @@ public class EJBClientDescriptorMetaData {
 
     public void setInvocationTimeout(final long invocationTimeout) {
         this.invocationTimeout = invocationTimeout;
+    }
+
+    public String getDeploymentNodeSelector() {
+        return this.deploymentNodeSelector;
+    }
+
+    public void setDeploymentNodeSelector(final String selector) {
+        this.deploymentNodeSelector = selector;
     }
 
     public class ClusterConfig extends CommonConnectionConfig {

--- a/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor12Parser.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EJBClientDescriptor12Parser.java
@@ -124,6 +124,7 @@ class EJBClientDescriptor12Parser implements XMLElementReader<EJBClientDescripto
         USERNAME,
         SECURITY_REALM,
         INVOCATION_TIMEOUT,
+        DEPLOYMENT_NODE_SELECTOR,
         // default unknown attribute
         UNKNOWN;
 
@@ -142,6 +143,7 @@ class EJBClientDescriptor12Parser implements XMLElementReader<EJBClientDescripto
             attributesMap.put(new QName("username"), USERNAME);
             attributesMap.put(new QName("security-realm"), SECURITY_REALM);
             attributesMap.put(new QName("invocation-timeout"), INVOCATION_TIMEOUT);
+            attributesMap.put(new QName("deployment-node-selector"), DEPLOYMENT_NODE_SELECTOR);
             attributes = attributesMap;
         }
 
@@ -187,6 +189,9 @@ class EJBClientDescriptor12Parser implements XMLElementReader<EJBClientDescripto
                 case INVOCATION_TIMEOUT:
                     final Long invocationTimeout = Long.parseLong(val.trim());
                     ejbClientDescriptorMetaData.setInvocationTimeout(invocationTimeout);
+                    break;
+                case DEPLOYMENT_NODE_SELECTOR:
+                    ejbClientDescriptorMetaData.setDeploymentNodeSelector(val.trim());
                     break;
                 default:
                     unexpectedContent(reader);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -26,7 +26,6 @@ package org.jboss.as.ejb3;
 
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ResourceInjectionTarget;
-import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.ejb3.component.entity.EntityBeanComponentInstance;
 import org.jboss.as.ejb3.component.stateful.StatefulSessionComponentInstance;
 import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
@@ -48,12 +47,10 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.Message;
 import org.jboss.logging.MessageLogger;
 import org.jboss.logging.Param;
-import org.jboss.metadata.ejb.spec.SessionType;
 import org.jboss.remoting3.Channel;
 
 import javax.ejb.EJBException;
 import javax.ejb.EJBTransactionRequiredException;
-import javax.ejb.EJBTransactionRolledbackException;
 import javax.ejb.NoSuchObjectLocalException;
 import javax.ejb.RemoveException;
 import javax.ejb.Timer;
@@ -63,14 +60,16 @@ import javax.resource.spi.UnavailableException;
 import javax.resource.spi.endpoint.MessageEndpoint;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.transaction.RollbackException;
 import javax.transaction.Transaction;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
 import java.util.Date;
 
-import static org.jboss.logging.Logger.Level.*;
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * This module is using message IDs in the range 14100-14599. This file is using the subset 14100-14149 for
@@ -711,6 +710,14 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 14223, value = "Asynchronous invocations are only supported on session beans. Bean class %s is not a session bean, invocation on method %s will have no asynchronous semantics")
     void asyncMethodSupportedOnlyForSessionBeans(Class beanClass, Method invokedMethod);
+
+    @LogMessage(level = INFO)
+    @Message(id = 14224, value = "Cannot add cluster node %s to cluster %s since none of the client mappings matched for address %s")
+    void cannotAddClusterNodeDueToUnresolvableClientMapping(final String nodeName, final String clusterName, final InetAddress bindAddress);
+
+    @Message(id = 14225, value = "Could not create an instance of deployment node selector %s")
+    RuntimeException failedToCreateDeploymentNodeSelector(@Cause Exception e, String deploymentNodeSelectorClassName);
+
 
     // Don't add message ids greater that 14299!!! If you need more first check what EjbMessages is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -715,9 +715,6 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 14224, value = "Cannot add cluster node %s to cluster %s since none of the client mappings matched for address %s")
     void cannotAddClusterNodeDueToUnresolvableClientMapping(final String nodeName, final String clusterName, final InetAddress bindAddress);
 
-    @Message(id = 14225, value = "Could not create an instance of deployment node selector %s")
-    RuntimeException failedToCreateDeploymentNodeSelector(@Cause Exception e, String deploymentNodeSelectorClassName);
-
 
     // Don't add message ids greater that 14299!!! If you need more first check what EjbMessages is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -2074,4 +2074,13 @@ public interface EjbMessages {
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is
     // all used, go to https://community.jboss.org/docs/DOC-16810 and allocate another block for this subsystem
+
+
+    // *Exception messages* greater >= 14225 start here.
+    @Message(id = 14225, value = "Could not create an instance of deployment node selector %s")
+    DeploymentUnitProcessingException failedToCreateDeploymentNodeSelector(@Cause Exception e, String deploymentNodeSelectorClassName);
+
+    // Don't add exception messages greater that 14299!!! If you need more go to
+    // https://community.jboss.org/docs/DOC-16810 and allocate another block for this subsystem
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.deployment.processors;
 import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
 import org.jboss.as.ee.structure.Attachments;
 import org.jboss.as.ejb3.EjbLogger;
+import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.remote.DescriptorBasedEJBClientContextService;
 import org.jboss.as.ejb3.remote.EJBClientClusterConfig;
@@ -138,7 +139,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
 
     }
 
-    private EJBClientConfiguration createClientConfiguration(final ServiceRegistry serviceRegistry, final ClassLoader classLoader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) {
+    private EJBClientConfiguration createClientConfiguration(final ServiceRegistry serviceRegistry, final ClassLoader classLoader, final EJBClientDescriptorMetaData ejbClientDescriptorMetaData) throws DeploymentUnitProcessingException {
 
         final JBossEJBClientXmlConfiguration ejbClientConfig = new JBossEJBClientXmlConfiguration();
         ejbClientConfig.setInvocationTimeout(ejbClientDescriptorMetaData.getInvocationTimeout());
@@ -149,7 +150,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
                 final Class<?> deploymentNodeSelectorClass = classLoader.loadClass(deploymentNodeSelectorClassName);
                 ejbClientConfig.setDeploymentNodeSelector((DeploymentNodeSelector) deploymentNodeSelectorClass.newInstance());
             } catch (Exception e) {
-                throw EjbLogger.EJB3_LOGGER.failedToCreateDeploymentNodeSelector(e, deploymentNodeSelectorClassName);
+                throw EjbMessages.MESSAGES.failedToCreateDeploymentNodeSelector(e, deploymentNodeSelectorClassName);
             }
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -37,6 +37,7 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.ejb.client.DeploymentNodeSelector;
 import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
@@ -141,6 +142,17 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
 
         final JBossEJBClientXmlConfiguration ejbClientConfig = new JBossEJBClientXmlConfiguration();
         ejbClientConfig.setInvocationTimeout(ejbClientDescriptorMetaData.getInvocationTimeout());
+        // deployment node selector
+        final String deploymentNodeSelectorClassName = ejbClientDescriptorMetaData.getDeploymentNodeSelector();
+        if (deploymentNodeSelectorClassName != null && !deploymentNodeSelectorClassName.trim().isEmpty()) {
+            try {
+                final Class<?> deploymentNodeSelectorClass = classLoader.loadClass(deploymentNodeSelectorClassName);
+                ejbClientConfig.setDeploymentNodeSelector((DeploymentNodeSelector) deploymentNodeSelectorClass.newInstance());
+            } catch (Exception e) {
+                throw EjbLogger.EJB3_LOGGER.failedToCreateDeploymentNodeSelector(e, deploymentNodeSelectorClassName);
+            }
+        }
+
         for (final EJBClientDescriptorMetaData.ClusterConfig clusterMetadata : ejbClientDescriptorMetaData.getClusterConfigs()) {
             final EJBClientClusterConfig clusterConfig = new EJBClientClusterConfig(clusterMetadata, classLoader, serviceRegistry);
             // add it to the client configuration

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AnonymousCallbackHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AnonymousCallbackHandler.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.ejb3.EjbLogger;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+import java.io.IOException;
+
+/**
+* @author Jaikiran Pai
+*/
+class AnonymousCallbackHandler implements CallbackHandler {
+
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        for (Callback current : callbacks) {
+            if (current instanceof NameCallback) {
+                NameCallback ncb = (NameCallback) current;
+                ncb.setName("anonymous");
+            } else if (current instanceof RealmCallback) {
+                RealmCallback rcb = (RealmCallback) current;
+                rcb.setText(rcb.getDefaultText());
+            } else {
+                throw EjbLogger.ROOT_LOGGER.unsupportedCallback(current);
+            }
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
@@ -34,12 +34,7 @@ import org.jboss.msc.service.ServiceRegistry;
 import org.xnio.Option;
 import org.xnio.OptionMap;
 
-import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.sasl.RealmCallback;
-import java.io.IOException;
 import java.util.Properties;
 
 
@@ -134,20 +129,4 @@ class EJBClientCommonConnectionConfig implements EJBClientConfiguration.CommonCo
         }
     }
 
-    private class AnonymousCallbackHandler implements CallbackHandler {
-
-        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-            for (Callback current : callbacks) {
-                if (current instanceof NameCallback) {
-                    NameCallback ncb = (NameCallback) current;
-                    ncb.setName("anonymous");
-                } else if (current instanceof RealmCallback) {
-                    RealmCallback rcb = (RealmCallback) current;
-                    rcb.setText(rcb.getDefaultText());
-                } else {
-                    throw EjbLogger.ROOT_LOGGER.unsupportedCallback(current);
-                }
-            }
-        }
-    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
@@ -28,6 +28,7 @@ import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 import org.jboss.as.ejb3.remote.protocol.versionone.VersionOneProtocolChannelReceiver;
 import org.jboss.as.network.ClientMapping;
+import org.jboss.as.network.SocketBinding;
 import org.jboss.as.remoting.AbstractStreamServerService;
 import org.jboss.as.remoting.InjectedSocketBindingStreamServerService;
 import org.jboss.as.server.ServerEnvironment;
@@ -152,6 +153,13 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
 
     public Injector<TransactionSynchronizationRegistry> getTxSyncRegistryInjector() {
         return this.txSyncRegistry;
+    }
+
+    SocketBinding getEJBRemoteConnectorSocketBinding() {
+        if (this.remotingServer == null) {
+            return null;
+        }
+        return this.remotingServer.getSocketBinding();
     }
 
     private void sendVersionMessage(final ChannelAssociation channelAssociation) throws IOException {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.ejb3.remote;
 
+import org.jboss.ejb.client.DeploymentNodeSelector;
 import org.jboss.ejb.client.EJBClientConfiguration;
 import org.xnio.OptionMap;
 
@@ -38,6 +39,7 @@ public class JBossEJBClientXmlConfiguration implements EJBClientConfiguration {
 
     private final Map<String, ClusterConfiguration> clusterConfigs = new HashMap<String, ClusterConfiguration>();
     private long invocationTimeout;
+    private DeploymentNodeSelector deploymentNodeSelector = new LocalEJBReceiverPreferringDeploymentNodeSelector();
 
     @Override
     public String getEndpointName() {
@@ -91,6 +93,11 @@ public class JBossEJBClientXmlConfiguration implements EJBClientConfiguration {
         return 0;
     }
 
+    @Override
+    public DeploymentNodeSelector getDeploymentNodeSelector() {
+        return this.deploymentNodeSelector;
+    }
+
     public void addClusterConfiguration(final EJBClientClusterConfig clusterConfig) {
         this.clusterConfigs.put(clusterConfig.getClusterName(), clusterConfig);
     }
@@ -99,4 +106,7 @@ public class JBossEJBClientXmlConfiguration implements EJBClientConfiguration {
         this.invocationTimeout = invocationTimeout;
     }
 
+    public void setDeploymentNodeSelector(final DeploymentNodeSelector deploymentNodeSelector) {
+        this.deploymentNodeSelector = deploymentNodeSelector;
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEJBReceiverPreferringDeploymentNodeSelector.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEJBReceiverPreferringDeploymentNodeSelector.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.ejb.client.DeploymentNodeSelector;
+import org.jboss.logging.Logger;
+
+import java.util.Random;
+
+/**
+ * A {@link DeploymentNodeSelector} which selects a local node, if available, from among the
+ * eligible nodes
+ *
+ * @author Jaikiran Pai
+ */
+public class LocalEJBReceiverPreferringDeploymentNodeSelector implements DeploymentNodeSelector {
+
+    private static final Logger logger = Logger.getLogger(LocalEJBReceiverPreferringDeploymentNodeSelector.class);
+
+    private final String localNodeName;
+
+    public LocalEJBReceiverPreferringDeploymentNodeSelector() {
+        this.localNodeName = SecurityActions.getSystemProperty(ServerEnvironment.NODE_NAME);
+    }
+
+    @Override
+    public String selectNode(String[] eligibleNodes, String appName, String moduleName, String distinctName) {
+        // Just a single node available, so just return it
+        if (eligibleNodes.length == 1) {
+            return eligibleNodes[0];
+        }
+        // prefer local node if available
+        for (final String eligibleNode : eligibleNodes) {
+            if (localNodeName.equals(eligibleNode)) {
+                logger.debug("Selected local node " + this.localNodeName + " for [app: " + appName + ", module: "
+                        + moduleName + ",  distinctname: " + distinctName + "]");
+                return eligibleNode;
+            }
+        }
+        // select one randomly
+        final Random random = new Random();
+        final int randomSelection = random.nextInt(eligibleNodes.length);
+        return eligibleNodes[randomSelection];
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingConnectionClusterNodeManager.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingConnectionClusterNodeManager.java
@@ -1,0 +1,167 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.ejb.client.ClusterContext;
+import org.jboss.ejb.client.ClusterNodeManager;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBReceiver;
+import org.jboss.ejb.client.remoting.IoFutureHelper;
+import org.jboss.ejb.client.remoting.NetworkUtil;
+import org.jboss.ejb.client.remoting.ReconnectHandler;
+import org.jboss.ejb.client.remoting.RemotingConnectionEJBReceiver;
+import org.jboss.logging.Logger;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.Endpoint;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+
+import javax.security.auth.callback.CallbackHandler;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Jaikiran Pai
+ */
+class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
+
+    private static final Logger logger = Logger.getLogger(RemotingConnectionClusterNodeManager.class);
+
+    private final String nodeName;
+    private final ClusterContext clusterContext;
+    private final String destinationHost;
+    private final int destinationPort;
+    private final Endpoint endpoint;
+
+
+    RemotingConnectionClusterNodeManager(final ClusterContext clusterContext, final Endpoint endpoint,
+                                         final String nodeName, final String destinationHost,
+                                         final int destinationPort) {
+        this.nodeName = nodeName;
+        this.clusterContext = clusterContext;
+        this.destinationHost = destinationHost;
+        this.destinationPort = destinationPort;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public String getNodeName() {
+        return this.nodeName;
+    }
+
+    @Override
+    public EJBReceiver getEJBReceiver() {
+        Connection connection;
+        final ReconnectHandler reconnectHandler;
+        OptionMap channelCreationOptions = OptionMap.EMPTY;
+        final EJBClientConfiguration ejbClientConfiguration = this.clusterContext.getEJBClientContext().getEJBClientConfiguration();
+        try {
+            // if the client configuration is available create the connection using those configs
+            if (ejbClientConfiguration != null) {
+                final EJBClientConfiguration.ClusterConfiguration clusterConfiguration = ejbClientConfiguration.getClusterConfiguration(clusterContext.getClusterName());
+                if (clusterConfiguration == null) {
+                    // use default configurations
+                    final OptionMap connectionCreationOptions = OptionMap.EMPTY;
+                    final CallbackHandler callbackHandler = ejbClientConfiguration.getCallbackHandler();
+                    final IoFuture<Connection> futureConnection = NetworkUtil.connect(endpoint, destinationHost, destinationPort, null, connectionCreationOptions, callbackHandler, null);
+                    // wait for the connection to be established
+                    connection = IoFutureHelper.get(futureConnection, 5000, TimeUnit.MILLISECONDS);
+                    // create a re-connect handler (which will be used on connection breaking down)
+                    reconnectHandler = new ClusterNodeReconnectHandler(destinationHost, destinationPort, connectionCreationOptions, callbackHandler, channelCreationOptions, 5000);
+
+                } else {
+                    final EJBClientConfiguration.ClusterNodeConfiguration clusterNodeConfiguration = clusterConfiguration.getNodeConfiguration(this.getNodeName());
+                    // use the specified configurations
+                    channelCreationOptions = clusterNodeConfiguration == null ? clusterConfiguration.getChannelCreationOptions() : clusterNodeConfiguration.getChannelCreationOptions();
+                    final OptionMap connectionCreationOptions = clusterNodeConfiguration == null ? clusterConfiguration.getConnectionCreationOptions() : clusterNodeConfiguration.getConnectionCreationOptions();
+                    final CallbackHandler callbackHandler = clusterNodeConfiguration == null ? clusterConfiguration.getCallbackHandler() : clusterNodeConfiguration.getCallbackHandler();
+                    final IoFuture<Connection> futureConnection = NetworkUtil.connect(endpoint, destinationHost, destinationPort, null, connectionCreationOptions, callbackHandler, null);
+                    final long timeout = clusterNodeConfiguration == null ? clusterConfiguration.getConnectionTimeout() : clusterNodeConfiguration.getConnectionTimeout();
+                    // wait for the connection to be established
+                    connection = IoFutureHelper.get(futureConnection, timeout, TimeUnit.MILLISECONDS);
+                    // create a re-connect handler (which will be used on connection breaking down)
+                    reconnectHandler = new ClusterNodeReconnectHandler(destinationHost, destinationPort, connectionCreationOptions, callbackHandler, channelCreationOptions, timeout);
+                }
+
+            } else {
+                // create the connection using defaults
+                final OptionMap connectionCreationOptions = OptionMap.EMPTY;
+                final CallbackHandler callbackHandler = new AnonymousCallbackHandler();
+                final IoFuture<Connection> futureConnection = NetworkUtil.connect(endpoint, destinationHost, destinationPort, null, connectionCreationOptions, callbackHandler, null);
+                // wait for the connection to be established
+                connection = IoFutureHelper.get(futureConnection, 5000, TimeUnit.MILLISECONDS);
+                // create a re-connect handler (which will be used on connection breaking down)
+                reconnectHandler = new ClusterNodeReconnectHandler(destinationHost, destinationPort, connectionCreationOptions, callbackHandler, channelCreationOptions, 5000);
+
+            }
+        } catch (Exception e) {
+            logger.info("Could not create a connection for cluster node " + this.nodeName + " in cluster " + clusterContext.getClusterName(), e);
+            return null;
+        }
+        return new RemotingConnectionEJBReceiver(connection, reconnectHandler, channelCreationOptions);
+    }
+
+
+    private class ClusterNodeReconnectHandler implements ReconnectHandler {
+
+        private final String destinationHost;
+        private final int destinationPort;
+        private final OptionMap connectionCreationOptions;
+        private final OptionMap channelCreationOptions;
+        private final CallbackHandler callbackHandler;
+        private final long connectionTimeout;
+
+        ClusterNodeReconnectHandler(final String host, final int port, final OptionMap connectionCreationOptions, final CallbackHandler callbackHandler, final OptionMap channelCreationOptions, final long connectionTimeoutInMillis) {
+            this.destinationHost = host;
+            this.destinationPort = port;
+            this.connectionCreationOptions = connectionCreationOptions;
+            this.channelCreationOptions = channelCreationOptions;
+            this.callbackHandler = callbackHandler;
+            this.connectionTimeout = connectionTimeoutInMillis;
+        }
+
+        @Override
+        public void reconnect() throws IOException {
+            Connection connection = null;
+            try {
+                final IoFuture<Connection> futureConnection = NetworkUtil.connect(endpoint, destinationHost, destinationPort, null, connectionCreationOptions, callbackHandler, null);
+                connection = IoFutureHelper.get(futureConnection, connectionTimeout, TimeUnit.MILLISECONDS);
+                logger.debug("Successfully reconnected to connection " + connection);
+
+            } catch (Exception e) {
+                logger.debug("Failed to re-connect to " + this.destinationHost + ":" + this.destinationPort, e);
+            }
+            if (connection == null) {
+                return;
+            }
+            try {
+                final EJBReceiver ejbReceiver = new RemotingConnectionEJBReceiver(connection, this, channelCreationOptions);
+                RemotingConnectionClusterNodeManager.this.clusterContext.registerEJBReceiver(ejbReceiver);
+            } finally {
+                // if we successfully re-connected then unregister this ReconnectHandler from the EJBClientContext
+                RemotingConnectionClusterNodeManager.this.clusterContext.getEJBClientContext().unregisterReconnectHandler(this);
+            }
+
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -75,7 +75,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     private final MarshallerFactory marshallerFactory;
     private final ExecutorService executorService;
     private final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector;
-    private final Set<ClusterTopologyUpdateListener> clusterTopologyUpdateListeners = new HashSet<ClusterTopologyUpdateListener>();
+    private final Set<ClusterTopologyUpdateListener> clusterTopologyUpdateListeners = Collections.synchronizedSet(new HashSet<ClusterTopologyUpdateListener>());
 
     public VersionOneProtocolChannelReceiver(final ChannelAssociation channelAssociation, final DeploymentRepository deploymentRepository,
                                              final EJBRemoteTransactionsRepository transactionsRepository, final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector,
@@ -259,12 +259,18 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     }
 
     @Override
-    public void registryAdded(Registry<String, List<ClientMapping>> registry) {
+    public void registryAdded(Registry<String, List<ClientMapping>> cluster) {
         try {
-            logger.debug("Received new cluster formation notification for cluster " + registry.getName());
-            this.sendNewClusterFormedMessage(Collections.singleton(registry));
+            logger.debug("Received new cluster formation notification for cluster " + cluster.getName());
+            this.sendNewClusterFormedMessage(Collections.singleton(cluster));
         } catch (IOException ioe) {
-            EjbLogger.EJB3_LOGGER.failedToSendClusterFormationMessageToClient(ioe, registry.getName(), channelAssociation.getChannel());
+            EjbLogger.EJB3_LOGGER.failedToSendClusterFormationMessageToClient(ioe, cluster.getName(), channelAssociation.getChannel());
+        } finally {
+            // add a listener for receiving node(s) addition/removal from the cluster
+            final ClusterTopologyUpdateListener clusterTopologyUpdateListener = new ClusterTopologyUpdateListener(cluster, this);
+            cluster.addListener(clusterTopologyUpdateListener);
+            // keep track of this update listener so that we cleanup properly
+            this.clusterTopologyUpdateListeners.add(clusterTopologyUpdateListener);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -98,12 +98,14 @@ import org.jboss.as.ejb3.iiop.POARegistry;
 import org.jboss.as.ejb3.iiop.RemoteObjectSubstitutionService;
 import org.jboss.as.ejb3.iiop.stub.DynamicStubFactoryFactory;
 import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
+import org.jboss.as.ejb3.remote.EJBRemoteConnectorService;
 import org.jboss.as.ejb3.remote.LocalEjbReceiver;
 import org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService;
 import org.jboss.as.jacorb.rmi.DelegatingStubFactoryFactory;
 import org.jboss.as.jacorb.service.CorbaPOAService;
 import org.jboss.as.naming.InitialContext;
 import org.jboss.as.network.ClientMapping;
+import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.security.service.SimpleSecurityManagerService;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -119,6 +121,7 @@ import org.jboss.jca.core.spi.rar.ResourceAdapterRepository;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
+import org.jboss.remoting3.Endpoint;
 import org.omg.PortableServer.POA;
 
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL;
@@ -343,6 +346,8 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
             newControllers.add(serviceTarget.addService(LocalEjbReceiver.BY_VALUE_SERVICE_NAME, byValueLocalEjbReceiver)
                     .addDependency(DeploymentRepository.SERVICE_NAME, DeploymentRepository.class, byValueLocalEjbReceiver.getDeploymentRepository())
                     .addDependency(ClusteredBackingCacheEntryStoreSourceService.CLIENT_MAPPING_REGISTRY_COLLECTOR_SERVICE_NAME, RegistryCollector.class, byValueLocalEjbReceiver.getClusterRegistryCollectorInjector())
+                    .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, byValueLocalEjbReceiver.getEndpointInjector())
+                    .addDependency(EJBRemoteConnectorService.SERVICE_NAME, EJBRemoteConnectorService.class, byValueLocalEjbReceiver.getEJBRemoteConnectorServiceInjector())
                     .install());
 
             //the receiver for invocations that allow pass by reference
@@ -350,6 +355,8 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
             newControllers.add(serviceTarget.addService(LocalEjbReceiver.BY_REFERENCE_SERVICE_NAME, byReferenceLocalEjbReceiver)
                     .addDependency(DeploymentRepository.SERVICE_NAME, DeploymentRepository.class, byReferenceLocalEjbReceiver.getDeploymentRepository())
                     .addDependency(ClusteredBackingCacheEntryStoreSourceService.CLIENT_MAPPING_REGISTRY_COLLECTOR_SERVICE_NAME, RegistryCollector.class, byReferenceLocalEjbReceiver.getClusterRegistryCollectorInjector())
+                    .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, byReferenceLocalEjbReceiver.getEndpointInjector())
+                    .addDependency(EJBRemoteConnectorService.SERVICE_NAME, EJBRemoteConnectorService.class, byReferenceLocalEjbReceiver.getEJBRemoteConnectorServiceInjector())
                     .install());
 
             // setup the default local ejb receiver service

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <version.org.jboss.common.jboss-common-beans>1.0.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb-client>1.0.9.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.10.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.0.0</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.1.1.Final</version.org.jboss.invocation>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/DummyDeploymentNodeSelector.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/DummyDeploymentNodeSelector.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.client.descriptor;
+
+import org.jboss.ejb.client.DeploymentNodeSelector;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class DummyDeploymentNodeSelector implements DeploymentNodeSelector {
+    @Override
+    public String selectNode(String[] eligibleNodes, String appName, String moduleName, String distinctName) {
+        return eligibleNodes[0];
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/ClientSFSB.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/ClientSFSB.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+@Remote(ClientSFSBRemote.class)
+public class ClientSFSB implements ClientSFSBRemote {
+
+    private static final Logger logger = Logger.getLogger(ClientSFSB.class);
+
+    private NodeNameRetriever nodeNameRetriever;
+
+    @PostConstruct
+    void onConstruct() throws Exception {
+        this.nodeNameRetriever = InitialContext.doLookup("ejb:/node-name-app/NodeNameSFSB!org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover.NodeNameRetriever?stateful");
+    }
+
+    @Override
+    public String invokeAndFetchNodeNameFromClusteredSFSBRemoteBean() {
+        logger.info(this.getClass().getSimpleName() + " invoked on " + System.getProperty("jboss.node.name"));
+        return this.nodeNameRetriever.getNodeName();
+    }
+
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/ClientSFSBRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/ClientSFSBRemote.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface ClientSFSBRemote {
+    String invokeAndFetchNodeNameFromClusteredSFSBRemoteBean();
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
@@ -1,0 +1,219 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+import junit.framework.Assert;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusteringTestConstants;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.Properties;
+
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+
+/**
+ * Tests that if a local EJB receiver handled an invocation on a clustered EJB app and if that app is
+ * undeployed later, then subsequent invocations on that bean are redirected to a remote node which is part
+ * of that cluster
+ *
+ * @author Jaikiran Pai
+ * @see https://issues.jboss.org/browse/AS7-3492
+ */
+@RunWith(Arquillian.class)
+public class LocalEJBClientFailoverTestCase {
+
+    private static final Logger logger = Logger.getLogger(LocalEJBClientFailoverTestCase.class);
+
+    private static final String CLIENT_APP_MODULE_NAME = "client-app";
+    private static final String NODE_NAME_APP_MODULE_NAME = "node-name-app";
+
+    private static final String CLIENT_ARQ_DEPLOYMENT = "client-arq-deployment";
+    private static final String NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1 = "node-name-arq-deployment-container-1";
+    private static final String NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2 = "node-name-arq-deployment-container-2";
+
+    @ArquillianResource
+    private ContainerController container;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    private Context jndiContext;
+
+    private boolean containerOneStarted;
+    private boolean containerTwoStarted;
+    private boolean clientAppDeployed;
+    private boolean nodeNameAppDeployedOnContainerOne;
+    private boolean nodeNameAppDeployedOnContainerTwo;
+
+    @Deployment(name = CLIENT_ARQ_DEPLOYMENT, testable = false, managed = false)
+    @TargetsContainer(ClusteringTestConstants.CONTAINER_2)
+    public static Archive createClientApplication() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, CLIENT_APP_MODULE_NAME + ".jar");
+        jar.addClasses(ClientSFSB.class, ClientSFSBRemote.class, NodeNameRetriever.class);
+        jar.addAsManifestResource(LocalEJBClientFailoverTestCase.class.getPackage(), "local-ejb-client-failover-jboss-ejb-client.xml", "jboss-ejb-client.xml");
+
+        return jar;
+    }
+
+    @Deployment(name = NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1, testable = false, managed = false)
+    @TargetsContainer(ClusteringTestConstants.CONTAINER_1)
+    public static Archive createNodeNameApplicationForContainer1() {
+        return createNodeNameApplication();
+    }
+
+    @Deployment(name = NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2, testable = false, managed = false)
+    @TargetsContainer(ClusteringTestConstants.CONTAINER_2)
+    public static Archive createNodeNameApplicationForContainer2() {
+        return createNodeNameApplication();
+    }
+
+    private static Archive createNodeNameApplication() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, NODE_NAME_APP_MODULE_NAME + ".jar");
+        jar.addClasses(NodeNameRetriever.class, NodeNameSFSB.class);
+        return jar;
+    }
+
+    @Before
+    public void beforeTest() throws Exception {
+        final Properties props = new Properties();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        jndiContext = new InitialContext(props);
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        if (clientAppDeployed) {
+            try {
+                this.deployer.undeploy(CLIENT_ARQ_DEPLOYMENT);
+            } catch (Exception e) {
+                logger.error("Could not undeploy " + CLIENT_ARQ_DEPLOYMENT, e);
+            }
+        }
+        if (nodeNameAppDeployedOnContainerOne) {
+            try {
+                this.deployer.undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1);
+            } catch (Exception e) {
+                logger.error("Could not undeploy " + NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1, e);
+            }
+        }
+
+        if (nodeNameAppDeployedOnContainerTwo) {
+            try {
+                this.deployer.undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
+            } catch (Exception e) {
+                logger.error("Could not undeploy " + NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2, e);
+            }
+        }
+
+        if (containerOneStarted) {
+            try {
+                this.container.stop(CONTAINER_1);
+            } catch (Exception e) {
+                logger.error("Failed to stop " + CONTAINER_1, e);
+            }
+        }
+
+        if (containerTwoStarted) {
+            try {
+                this.container.stop(CONTAINER_2);
+            } catch (Exception e) {
+                logger.error("Failed to stop " + CONTAINER_2, e);
+            }
+        }
+
+    }
+
+    /**
+     * - 2 instances of server, A and B, forming a cluster
+     * - Instance A contains foo-app and bar-client apps. foo-app contains a clustered SFSB and bar-client
+     * just acts as a client invoking on that clustered SFSB
+     * - Instance B contains (only) foo-app with that clustered SFSB
+     * - bar-client on Instance A invokes on the clustered SFSB when both server are up and when foo-app is deployed
+     * on both servers. It's expected that the call to that clustered SFSB stays local to Instance A, on this occasion
+     * - foo-app on Instance A is undeployed
+     * - bar-client invokes (again) on the same instance of clustered SFSB. It's expected that this call is now routed to
+     * the remote Instance B server
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFailoverWhenLocalTargetApplicationIsUndeployed() throws Exception {
+        // Container is unmanaged, so start it ourselves
+        this.container.start(CONTAINER_1);
+        containerOneStarted = true;
+        // start the other container too
+        this.container.start(CONTAINER_2);
+        containerTwoStarted = true;
+
+        this.deployer.deploy(CLIENT_ARQ_DEPLOYMENT);
+        clientAppDeployed = true;
+        this.deployer.deploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1);
+        nodeNameAppDeployedOnContainerOne = true;
+        this.deployer.deploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
+        nodeNameAppDeployedOnContainerTwo = true;
+
+        final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/local-ejb-sfsb-failover-jboss-ejb-client.properties");
+        try {
+            final ClientSFSBRemote clientSFSB = (ClientSFSBRemote) jndiContext.lookup("ejb:/" + CLIENT_APP_MODULE_NAME + "//" + ClientSFSB.class.getSimpleName() + "!" + ClientSFSBRemote.class.getName() + "?stateful");
+            // invoke on non-clustered SFSB which invokes/delegates to clustered SFSB on same node
+            final String sfsbNodeName = clientSFSB.invokeAndFetchNodeNameFromClusteredSFSBRemoteBean();
+            // the clustered sfsb should be invoked on the same instance as the non-clustered slsb, since the clustered sfsb deployment
+            // is available on that node
+            Assert.assertEquals("Clustered SFSB created on unexpected node", ClusteringTestConstants.NODE_2, sfsbNodeName);
+
+            // now undeploy the clustered sfsb app on the node which has the client application
+            this.deployer.undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
+            nodeNameAppDeployedOnContainerTwo = false;
+
+            // now invoke again on the same non-clustered sfsb
+            final String sfsbNodeNameAfterUndeployment = clientSFSB.invokeAndFetchNodeNameFromClusteredSFSBRemoteBean();
+            // the invocation on the clustered sfsb from within the non-clustered sfsb, should failover to the remote
+            // node since on the local node, the app has been undeployed
+            Assert.assertEquals("Clustered SFSB did not failover to remote node even after the local app was undeployed", ClusteringTestConstants.NODE_1, sfsbNodeNameAfterUndeployment);
+
+        } finally {
+            if (previousSelector != null) {
+                EJBClientContext.setSelector(previousSelector);
+            }
+        }
+
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/NodeNameRetriever.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/NodeNameRetriever.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface NodeNameRetriever {
+
+    String getNodeName();
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/NodeNameSFSB.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/NodeNameSFSB.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.logging.Logger;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+@Clustered
+@Remote(NodeNameRetriever.class)
+public class NodeNameSFSB implements NodeNameRetriever {
+
+    private static final Logger logger = Logger.getLogger(NodeNameSFSB.class);
+
+    @Override
+    public String getNodeName() {
+        final String nodeName = System.getProperty("jboss.node.name");
+        logger.info(this.getClass().getSimpleName() + " invoked on " + System.getProperty("jboss.node.name"));
+        return nodeName;
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/local-ejb-client-failover-jboss-ejb-client.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/local-ejb-client-failover-jboss-ejb-client.xml
@@ -19,17 +19,15 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.2">
-    <!-- A 1 second invocation timeout which will be tested in EJBClientDescriptorTestCase -->
-    <client-context invocation-timeout="1000" deployment-node-selector="org.jboss.as.test.integration.ejb.client.descriptor.DummyDeploymentNodeSelector">
-        <ejb-receivers exclude-local-receiver="true">
-            <remoting-ejb-receiver outbound-connection-ref="ejb-client-descriptor-test-remote-outbound-connection"
-                    connect-timeout="7000">
-                <channel-creation-options>
-                    <property name="org.jboss.remoting3.MAX_OUTBOUND_MESSAGES" value="1234"/>
-                    <property name="org.jboss.remoting3.MAX_INBOUND_MESSAGES" value="343"/>
-                </channel-creation-options>
-            </remoting-ejb-receiver>
-        </ejb-receivers>
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.1">
+    <client-context>
+        <clusters>
+            <cluster name="ejb" connect-timeout="5000" username="user1" security-realm="PasswordRealm">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>
+                </connection-creation-options>
+            </cluster>
+        </clusters>
     </client-context>
 </jboss-ejb-client>

--- a/testsuite/integration/clust/src/test/resources/cluster/ejb3/stateful/failover/local-ejb-sfsb-failover-jboss-ejb-client.properties
+++ b/testsuite/integration/clust/src/test/resources/cluster/ejb3/stateful/failover/local-ejb-sfsb-failover-jboss-ejb-client.properties
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2012, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=${node1:localhost}
+remote.connection.default.port=4547
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+callback.handler.class=org.jboss.as.test.shared.integration.ejb.security.CallbackHandler

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/CustomDeploymentNodeSelector.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/CustomDeploymentNodeSelector.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.ejb.client.cluster;
+
+import org.jboss.ejb.client.DeploymentNodeSelector;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class CustomDeploymentNodeSelector implements DeploymentNodeSelector {
+
+    private volatile String previouslySelectedNode;
+
+    @Override
+    public String selectNode(String[] eligibleNodes, String appName, String moduleName, String distinctName) {
+        if (eligibleNodes.length == 1) {
+            return eligibleNodes[0];
+        }
+        for (String node : eligibleNodes) {
+            if (!node.equals(previouslySelectedNode)) {
+                this.previouslySelectedNode = node;
+                return node;
+            }
+        }
+        return eligibleNodes[0];
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -115,7 +115,7 @@ public class EJBClientClusterConfigurationTestCase {
     @TargetsContainer(JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION)
     public static Archive createContainer2Deployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
-        ejbJar.addClasses(ClusteredStatefulNodeNameEcho.class, NonClusteredStatefulNodeNameEcho.class, NodeNameEcho.class, ApplicationSpecificClusterNodeSelector.class);
+        ejbJar.addClasses(ClusteredStatefulNodeNameEcho.class, CustomDeploymentNodeSelector.class, NonClusteredStatefulNodeNameEcho.class, NodeNameEcho.class, ApplicationSpecificClusterNodeSelector.class);
         ejbJar.addAsManifestResource(NonClusteredStatefulNodeNameEcho.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return ejbJar;
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
@@ -19,8 +19,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.1">
-    <client-context>
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.2">
+    <client-context deployment-node-selector="org.jboss.as.test.manualmode.ejb.client.cluster.CustomDeploymentNodeSelector">
         <ejb-receivers exclude-local-receiver="true">
             <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
         </ejb-receivers>


### PR DESCRIPTION
The commit here fixes the issue reported in AS7-3492 and allows for failover of clustered beans when the application on the local node which handled a previous invocation, is undeployed. The commit also includes a testcase for the same.
