### PR TITLE
JDR: [JBPAPP-8225] fixing windows checksum generation

### DIFF
--- a/jdr/jboss-as-sos/src/main/resources/sos/policies/__init__.py
+++ b/jdr/jboss-as-sos/src/main/resources/sos/policies/__init__.py
@@ -217,7 +217,7 @@ No changes will be made to your system.
         if not final_filename:
             return False
 
-        archive_fp = open(final_filename, 'r')
+        archive_fp = open(final_filename, 'rb')
         digest = hashlib.new(get_hash_name())
         digest.update(archive_fp.read())
         archive_fp.close()


### PR DESCRIPTION
Open files in binary mode when doing checksum calculation to ensure that checksums are the same across platforms.
