### PR TITLE
Add easy trace logging facility to the test suite

### DIFF
--- a/testsuite/integration/src/test/xslt/enableTrace.xsl
+++ b/testsuite/integration/src/test/xslt/enableTrace.xsl
@@ -1,0 +1,83 @@
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:d="urn:jboss:domain:1.3"
+                xmlns:l="urn:jboss:domain:logging:1.1"
+                exclude-result-prefixes="l d xmlns"
+        >
+
+    <!--
+      An XSLT style sheet which will enable trace logging for the test suite.
+      This can be enabled via -Dtrace=org.jboss.as.category1,org.jboss.as.category2
+    -->
+    <xsl:param name="trace" />
+
+    <xsl:template name="output-loggers">
+        <xsl:param name="list" />
+        <xsl:variable name="first" select="substring-before(concat($list,','), ',')" />
+        <xsl:variable name="remaining" select="substring-after($list, ',')" />
+        <xsl:element name="logger" namespace="urn:jboss:domain:logging:1.1">
+            <xsl:attribute name="category" >
+                <xsl:value-of select="$first"></xsl:value-of>
+            </xsl:attribute>
+            <xsl:element name="level" namespace="urn:jboss:domain:logging:1.1" >
+                <xsl:attribute name="name" >
+                    <xsl:value-of select="'TRACE'"/>
+                </xsl:attribute>
+            </xsl:element>
+        </xsl:element>
+        <xsl:if test="string-length($remaining) > 0">
+            <xsl:call-template name="output-loggers">
+                <xsl:with-param name="list" select="$remaining" />
+            </xsl:call-template>
+        </xsl:if>
+    </xsl:template>
+
+
+    <xsl:template match="//l:subsystem/l:console-handler">
+        <xsl:choose>
+            <xsl:when test="$trace='none'">
+                <xsl:copy>
+                    <xsl:apply-templates select="node()|@*"/>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy copy-namespaces="false" inherit-namespaces="false">
+                    <xsl:attribute name="name">
+                        <xsl:value-of select="'CONSOLE'"/>
+                    </xsl:attribute>
+                    <level name="TRACE"/>
+                    <xsl:apply-templates select="//l:subsystem/l:console-handler/l:formatter"/>
+                </xsl:copy>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="//l:subsystem/l:periodic-rotating-file-handler" use-when="$trace">
+        <xsl:choose>
+            <xsl:when test="$trace='none'">
+                <xsl:copy>
+                    <xsl:apply-templates select="node()|@*"/>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:copy copy-namespaces="false" inherit-namespaces="false">
+                    <xsl:attribute name="name">
+                        <xsl:value-of select="'FILE'"/>
+                    </xsl:attribute>
+                    <level name="TRACE"/>
+                    <xsl:apply-templates select="node()|@*"/>
+                </xsl:copy>
+                <xsl:call-template name="output-loggers">
+                    <xsl:with-param name="list" select="$trace" />
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -83,8 +83,8 @@
         <jbossas.ts.dir>${basedir}</jbossas.ts.dir>
         <!-- This project's root dir. -->
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
-        
-        
+
+
         <!-- Used to provide an absolute location for the distribution under test. -->
         <!-- This value is overridden in modules with the correct relative pathname. -->
         <jboss.dist>${project.basedir}/../build/target/jboss-as-${jboss.as.release.version}</jboss.dist>
@@ -111,8 +111,8 @@
         <jvm.args.securityPolicy></jvm.args.securityPolicy>
         <jvm.args.securityManagerOther></jvm.args.securityManagerOther>
         <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy} ${jvm.args.securityManagerOther}</jvm.args.security>
-        
-        
+
+
         <!-- JaCoCo - Code coverage (-Dcoverage). -->
         <jvm.args.jacoco></jvm.args.jacoco>
 
@@ -146,6 +146,9 @@
 
         <!-- Don't try to deploy the testsuite modules because they don't build jars -->
         <maven.deploy.skip>true</maven.deploy.skip>
+
+        <!-- used to enable trace logging for test suite runs -->
+        <trace>none</trace>
 
     </properties>
 
@@ -358,11 +361,33 @@
                                     <parameters>
                                         <parameter><name>managementIPAddress</name>    <value>${node0}</value></parameter>
                                         <parameter><name>publicIPAddress</name>        <value>${node0}</value></parameter>
-                                        
+
                                         <parameter><name>udpMcastAddress</name>        <value>${mcast}</value></parameter>
                                         <parameter><name>diagnosticsMcastAddress</name><value>${mcast.jgroupsDiag}</value></parameter>
                                         <parameter><name>mpingMcastAddress</name>      <value>${mcast}</value></parameter>
                                         <parameter><name>modclusterMcastAddress</name> <value>${mcast.modcluster}</value></parameter>
+                                    </parameters>
+                                </transformationSet>
+                            </transformationSets>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ts.config-as.trace-logging</id>
+                        <phase>process-test-resources</phase>
+                        <goals><goal>transform</goal></goals>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <transformationSets>
+                                <!-- IPs. -->
+                                <transformationSet>
+                                    <dir>${basedir}/target/jbossas/standalone/configuration</dir>
+                                    <outputDir>${basedir}/target/jbossas/standalone/configuration</outputDir>
+                                    <stylesheet>${xslt.scripts.dir}/enableTrace.xsl</stylesheet>
+                                    <includes>
+                                        <include>standalone*.xml</include>
+                                    </includes>
+                                    <parameters>
+                                        <parameter><name>trace</name>    <value>${trace}</value></parameter>
                                     </parameters>
                                 </transformationSet>
                             </transformationSets>
@@ -634,7 +659,7 @@
             <activation><property><name>mcast.modcluster</name></property></activation>
             <properties> <mcast.modcluster >${mcast.modcluster}</mcast.modcluster> </properties>
         </profile>
-        
+
 
 
         <!-- Security policy.  ARQ-690, AS7-2823, AS7-2826. -->
@@ -965,7 +990,7 @@
                                                     </fileset>
                                                 </classfiles>
                                                 <sourcefiles encoding="UTF-8">
-                                                    <!-- 
+                                                    <!--
                                                          for i in $(find . -path './*/src/main/java'); do
                                                              DIR=`echo $i | sed 's|./||'`;
                                                              echo "<fileset dir=\"../$DIR\"><include name=\"**/*.java\"/></fileset>";
@@ -1050,7 +1075,7 @@
                                             <html destdir ="${basedir}/target/coverage-report/html"/>
                                             <xml  destfile="${basedir}/target/coverage-report/coverage-report.xml"/>
                                             <csv  destfile="${basedir}/target/coverage-report/coverage-report.csv"/>
-                                        </report>                                        
+                                        </report>
                                     </target>
                                 </configuration>
                             </execution>
@@ -1066,7 +1091,7 @@
                 </plugins>
             </build>
         </profile>
-        
+
 
 
     </profiles>


### PR DESCRIPTION
This PR allows you to easily add trace logging to test runs

simply adding -Dtrace to the maven build will add trace logging as part of the server build process, e.g.

-Dtrace=org.jboss.as.ejb3,org.jboss.as.security
