### PR TITLE
AS7-4743/JBPAPP-7577: Disable storeAsBinary

### DIFF
--- a/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanBackingCacheEntryStoreSource.java
+++ b/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanBackingCacheEntryStoreSource.java
@@ -130,6 +130,7 @@ public class InfinispanBackingCacheEntryStoreSource<K extends Serializable, V ex
         Configuration groupCacheConfiguration = groupCache.getCacheConfiguration();
         EmbeddedCacheManager container = groupCache.getCacheManager();
         ConfigurationBuilder builder = new ConfigurationBuilder().read(groupCacheConfiguration);
+        builder.storeAsBinary().enable().storeKeysAsBinary(true).storeValuesAsBinary(false);
         if (this.maxSize > 0) {
             if (!groupCacheConfiguration.eviction().strategy().isEnabled()) {
                 builder.eviction().strategy(EvictionStrategy.LRU);

--- a/clustering/infinispan/src/main/resources/infinispan-defaults.xml
+++ b/clustering/infinispan/src/main/resources/infinispan-defaults.xml
@@ -36,41 +36,35 @@
             <stateTransfer timeout="60000" fetchInMemoryState="true"/>
             <sync replTimeout="17500"/>
         </clustering>
-        <storeAsBinary enabled="true"/>
     </namedCache>
     <namedCache name="REPL_ASYNC">
         <clustering mode="replication">
             <stateTransfer timeout="60000" fetchInMemoryState="true"/>
             <async/>
         </clustering>
-        <storeAsBinary enabled="true"/>
     </namedCache>
     <namedCache name="DIST_SYNC">
         <clustering mode="distribution">
             <stateTransfer timeout="60000" fetchInMemoryState="true"/>
             <sync replTimeout="17500"/>
         </clustering>
-        <storeAsBinary enabled="true"/>
     </namedCache>
     <namedCache name="DIST_ASYNC">
         <clustering mode="distribution">
             <stateTransfer timeout="60000" fetchInMemoryState="true"/>
             <async/>
         </clustering>
-        <storeAsBinary enabled="true"/>
     </namedCache>
     <namedCache name="INVALIDATION_SYNC">
         <clustering mode="invalidation">
             <stateTransfer fetchInMemoryState="false"/>
             <sync replTimeout="17500"/>
         </clustering>
-        <storeAsBinary enabled="true" storeValuesAsBinary="false"/>
     </namedCache>
     <namedCache name="INVALIDATION_ASYNC">
         <clustering mode="invalidation">
             <stateTransfer fetchInMemoryState="false"/>
             <async/>
         </clustering>
-        <storeAsBinary enabled="true" storeValuesAsBinary="false"/>
     </namedCache>
 </infinispan>

--- a/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/WebSessionCacheConfigurationService.java
+++ b/clustering/web-infinispan/src/main/java/org/jboss/as/clustering/web/infinispan/WebSessionCacheConfigurationService.java
@@ -44,7 +44,6 @@ public class WebSessionCacheConfigurationService extends AbstractCacheConfigurat
     @Override
     protected ConfigurationBuilder getConfigurationBuilder() {
         ConfigurationBuilder builder = new ConfigurationBuilder().read(this.configuration.getValue());
-        builder.storeAsBinary().enable().storeKeysAsBinary(false).storeValuesAsBinary(true);
         builder.transaction().syncCommitPhase(false);
         return builder;
     }


### PR DESCRIPTION
We no longer need this for classloader isolation.  It negates the performance advantages of atomic maps and greatly hinders performance of ATTRIBUTE granularity web session replication in particular.
