### PR TITLE
JBPAPP-8921 fix

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/context/SessionContextImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/context/SessionContextImpl.java
@@ -29,6 +29,7 @@ import javax.transaction.UserTransaction;
 import javax.xml.rpc.handler.MessageContext;
 
 import org.jboss.as.ee.component.ComponentView;
+import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
 import org.jboss.as.ejb3.component.allowedmethods.MethodType;
 import org.jboss.as.ejb3.component.interceptors.CancellationFlag;
@@ -101,6 +102,9 @@ public class SessionContextImpl extends EJBContextImpl implements SessionContext
     public boolean wasCancelCalled() throws IllegalStateException {
         final InterceptorContext invocation = CurrentInvocationContext.get();
         final CancellationFlag flag = invocation.getPrivateData(CancellationFlag.class);
+        if (flag == null) {
+            throw EjbMessages.MESSAGES.noAsynchronousInvocationInProgress();
+        }
         return flag.get();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sessioncontext/SFSBImplementingSessionBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sessioncontext/SFSBImplementingSessionBean.java
@@ -34,6 +34,7 @@ import java.rmi.RemoteException;
  */
 @Stateful
 public class SFSBImplementingSessionBean implements SessionBean {
+    private static final long serialVersionUID = 1L;
 
     private SessionContext sessionContext;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sessioncontext/SLSBImplementingSessionBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sessioncontext/SLSBImplementingSessionBean.java
@@ -34,6 +34,7 @@ import java.rmi.RemoteException;
  */
 @Stateless
 public class SLSBImplementingSessionBean implements SessionBean {
+    private static final long serialVersionUID = 1L;
 
     private SessionContext sessionContext;
 
@@ -70,5 +71,9 @@ public class SLSBImplementingSessionBean implements SessionBean {
 
     public boolean wasSessionContextInjected() {
         return this.injectedSessionContext != null;
+    }
+    
+    public void wasCanceledCalled() {
+        sessionContext.wasCancelCalled();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sessioncontext/SetSessionContextMethodInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/sessioncontext/SetSessionContextMethodInvocationTestCase.java
@@ -28,7 +28,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -109,9 +108,8 @@ public class SetSessionContextMethodInvocationTestCase {
     }
 
     /**
-     * Testing whether correct exception is called on SessionContext.wasCanceledCalled is returned. Supposing IllegalStateException.
+     * Testing whether correct exception is called on {@link javax.ejb.SessionContext#wasCancelCalled()} is returned. Supposing IllegalStateException.
      */
-    @Ignore("JBPAPP-8921")
     @Test
     public void testWasCancelledCalled() throws Exception {
         final SLSBImplementingSessionBean slsb = lookup(SLSBImplementingSessionBean.class);


### PR DESCRIPTION
Fixes the NPE that was being thrown for SessionContext.wasCancelCalled() when no async invocation on the bean, was in progress. Related JIRA https://issues.jboss.org/browse/JBPAPP-8921
