### PR TITLE
Fix for AS7-4755

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
@@ -158,7 +158,7 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
      * consisting of just the {@link LocalEjbReceiver}. i.e. this client configuration cannot be used
      * for setting up connections to remote servers
      */
-    private class LocalOnlyEjbClientConfiguration implements EJBClientConfiguration {
+    class LocalOnlyEjbClientConfiguration implements EJBClientConfiguration {
 
         private final DeploymentNodeSelector localPreferringDeploymentNodeSelector = new LocalEJBReceiverPreferringDeploymentNodeSelector();
 


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4755. 

The issue was that when the local EJB receiver received a cluster topology, it passed on that info to the EJB client contexts that were available on that local server so that those contexts can make use of that information for connecting to cluster nodes. The default server level EJB client context which can only manage the local EJB receiver, due to its inherent inability to know about connection configurations of remote nodes, should be skipped while trying to make use of the cluster topology so that it doesn't try to connect and fail with cannot connect errors. The commit here ensures that we skip that EJB client context.
