### PR TITLE
AS7-3950 and AS7-2965 Add long/short option support for add-user command-line  

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -515,8 +515,8 @@ public interface DomainManagementMessages {
     /**
      * Message to inform user that the user has been updated to the file identified.
      *
-     * @param username - The new username.
-     * @param fileName - The file the user has been added to.
+     * @param userName - The new username.
+     * @param canonicalPath - The file the user has been added to.
      *
      * @return a {@link String} for the message.
      */
@@ -526,10 +526,10 @@ public interface DomainManagementMessages {
 
 
     /**
-    * The error message if updating user to the file fails.
-    *
-    * @param file - The name of the file the add failed for.
-    * @param error - The failure message.
+     * The error message if updating user to the file fails.
+     *
+     * @param absolutePath - The name of the file the add failed for.
+     * @param message - The failure message.
      *
      * @return a {@link String} for the message.
      */
@@ -612,6 +612,76 @@ public interface DomainManagementMessages {
      */
     @Message(id = 15263, value = "Unable to initialise plug-in %s due to error %s")
     IllegalStateException unableToInitialisePlugIn(final String name, final String message);
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#USAGE} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Usage: ./add-user.sh [args...]%nwhere args include:")
+    String argUsage();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#APPLICATION_USERS} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "If set add an application user instead of a management user")
+    String argApplicationUsers();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#DOMAIN_CONFIG_DIR_USERS} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Define the system property to use for the domain config directory (default is \"jboss.domain.config.dir\")")
+    String argDomainConfigDirUsers();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#SERVER_CONFIG_DIR_USERS} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Define the system property to use for the server config directory (default is \"jboss.server.config.dir\")")
+    String argServerConfigDirUsers();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#PASSWORD} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Password of the user. Should not be same as the username")
+    String argPassword();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#USER} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Name of the user")
+    String argUser();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#REALM} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Name of the realm used to secure the management interfaces (default is \"ManagementRealm\")")
+    String argRealm();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#SILENT} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Activate the silent mode (no output to the console)")
+    String argSilent();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#ROLE} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Comma-separated list of roles for the user (only for application users, see -a)")
+    String argRole();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.AddPropertiesUser.CommandLineArgument#HELP} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Display this message and exit")
+    String argHelp();
 
     /*
      * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementLogger also contains messages in

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
@@ -24,9 +24,10 @@ package org.jboss.as.domain.management.security;
 
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
 
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Properties;
 
 import org.jboss.as.domain.management.security.state.PropertyFileFinder;
@@ -38,6 +39,7 @@ import org.jboss.as.domain.management.security.state.StateValues;
  * A command line utility to add new users to the mgmt-users.properties files.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author <a href="mailto:g.grossetie@gmail.com">Guillaume Grossetie</a>
  */
 public class AddPropertiesUser {
 
@@ -55,25 +57,8 @@ public class AddPropertiesUser {
     public static final String MGMT_USERS_PROPERTIES = "mgmt-users.properties";
     public static final String APPLICATION_USERS_PROPERTIES = "application-users.properties";
     public static final String APPLICATION_ROLES_PROPERTIES = "application-roles.properties";
-    public static final String APPLICATION_USERS_OPTION = "-a";
-    public static final String DOMAIN_CONFIG_DIR_USERS_OPTION = "-dc";
-    public static final String SERVER_CONFIG_DIR_USERS_OPTION = "-sc";
 
-    public static final CommandLineOption PASSWORD_OPTION = new CommandLineOption("-p", "--password");
-    public static final CommandLineOption USER_OPTION = new CommandLineOption("-u", "--user");
-    public static final CommandLineOption REALM_OPTION = new CommandLineOption("-r", "--realm");
-    public static final CommandLineOption SILENT_OPTION = new CommandLineOption("-s", "--silent");
-    public static final CommandLineOption ROLE_OPTION = new CommandLineOption("-ro", "--role");
-
-    // List the available command-line options
-    public static final CommandLineOption[] COMMAND_LINE_OPTIONS = new CommandLineOption[]{
-            PASSWORD_OPTION,
-            USER_OPTION,
-            REALM_OPTION,
-            SILENT_OPTION,
-            ROLE_OPTION};
-
-    public static final String NEW_LINE = "\n";
+    public static final String NEW_LINE = String.format("%n");
     public static final String SPACE = " ";
     private static final Properties argsCliProps = new Properties();
 
@@ -81,8 +66,8 @@ public class AddPropertiesUser {
 
     protected State nextState;
 
-    protected AddPropertiesUser() {
-        theConsole = new JavaConsole();
+    protected AddPropertiesUser(ConsoleWrapper console) {
+        theConsole = console;
         StateValues stateValues = new StateValues();
         stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
 
@@ -92,19 +77,12 @@ public class AddPropertiesUser {
         nextState = new PropertyFilePrompt(theConsole, stateValues);
     }
 
-    protected AddPropertiesUser(ConsoleWrapper console) {
-        this.theConsole = console;
-        StateValues stateValues = new StateValues();
-        stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
-        nextState = new PropertyFilePrompt(theConsole, stateValues);
-    }
-
-    private AddPropertiesUser(final boolean management, final String user, final char[] password, final String realm) {
+    private AddPropertiesUser(ConsoleWrapper console, final boolean management, final String user, final char[] password, final String realm) {
         StateValues stateValues = new StateValues();
         stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
 
         final Interactiveness howInteractive;
-        boolean silent = Boolean.valueOf(argsCliProps.getProperty(SILENT_OPTION.key()));
+        boolean silent = Boolean.valueOf(argsCliProps.getProperty(CommandLineArgument.SILENT.key()));
         if (silent) {
             howInteractive = Interactiveness.SILENT;
         } else {
@@ -113,7 +91,7 @@ public class AddPropertiesUser {
         stateValues.setHowInteractive(howInteractive);
 
         // Silent modes still need to be able to output an error on failure.
-        theConsole = new JavaConsole();
+        theConsole = console;
         if (theConsole.getConsole() == null) {
             throw MESSAGES.noConsoleAvailable();
         }
@@ -121,13 +99,13 @@ public class AddPropertiesUser {
         stateValues.setPassword(password);
         stateValues.setRealm(realm);
         stateValues.setManagement(management);
-        stateValues.setRoles(argsCliProps.getProperty(ROLE_OPTION.key()));
+        stateValues.setRoles(argsCliProps.getProperty(CommandLineArgument.ROLE.key()));
 
         nextState = new PropertyFileFinder(theConsole, stateValues);
     }
 
-    private AddPropertiesUser(boolean management, final String user, final char[] password) {
-        this(management, user, password, management ? DEFAULT_MANAGEMENT_REALM : DEFAULT_APPLICATION_REALM);
+    private AddPropertiesUser(ConsoleWrapper consoleWrapper, boolean management, final String user, final char[] password) {
+        this(consoleWrapper, management, user, password, management ? DEFAULT_MANAGEMENT_REALM : DEFAULT_APPLICATION_REALM);
     }
 
     protected void run() {
@@ -141,6 +119,7 @@ public class AddPropertiesUser {
     public static void main(String[] args) {
 
         boolean management = true;
+        JavaConsole javaConsole = new JavaConsole();
 
         if (args.length >= 1) {
 
@@ -148,52 +127,69 @@ public class AddPropertiesUser {
             String temp;
             while (it.hasNext()) {
                 temp = it.next();
-                if (DOMAIN_CONFIG_DIR_USERS_OPTION.equals(temp)) {
+                if (CommandLineArgument.HELP.match(temp)) {
+                    usage(javaConsole);
+                    return;
+                }
+                if (CommandLineArgument.DOMAIN_CONFIG_DIR_USERS.match(temp)) {
                     System.setProperty(DOMAIN_CONFIG_DIR, it.next());
-                } else if (SERVER_CONFIG_DIR_USERS_OPTION.equals(temp)) {
+                } else if (CommandLineArgument.SERVER_CONFIG_DIR_USERS.match(temp)) {
                     System.setProperty(SERVER_CONFIG_DIR, it.next());
-                } else if (APPLICATION_USERS_OPTION.equals(temp)) {
+                } else if (CommandLineArgument.APPLICATION_USERS.match(temp)) {
                     management = false;
                 } else {
                     // Find the command-line option
-                    CommandLineOption commandLineOption = findCommandLineOption(temp);
-                    if (commandLineOption != null) {
+                    CommandLineArgument commandLineArgument = findCommandLineOption(temp);
+                    if (commandLineArgument != null) {
                         final String value;
-                        if (SILENT_OPTION.equals(commandLineOption)) {
+                        if (CommandLineArgument.SILENT.equals(commandLineArgument)) {
                             value = Boolean.TRUE.toString();
                         } else {
-                            value = it.next();
+                            value = it.hasNext() ? it.next() : null;
                         }
-                        argsCliProps.setProperty(commandLineOption.key(), value);
+                        if (value != null) {
+                            argsCliProps.setProperty(commandLineArgument.key(), value);
+                        }
                     } else {
                         // By default, the first arg without option is the username,
-                        if (!argsCliProps.containsKey(USER_OPTION.key())) {
-                            argsCliProps.setProperty(USER_OPTION.key(), temp);
+                        final String userKey = CommandLineArgument.USER.key();
+                        if (!argsCliProps.containsKey(userKey)) {
+                            argsCliProps.setProperty(userKey, temp);
                         }
                         // the second arg is the password and,
-                        else if (!argsCliProps.containsKey(PASSWORD_OPTION.key())) {
-                            argsCliProps.setProperty(PASSWORD_OPTION.key(), temp);
-                        }
-                        // the third one is the realm.
-                        else if (!argsCliProps.containsKey(REALM_OPTION.key())) {
-                            argsCliProps.setProperty(REALM_OPTION.key(), temp);
+                        else {
+                            final String passwordKey = CommandLineArgument.PASSWORD.key();
+                            if (!argsCliProps.containsKey(passwordKey)) {
+                                argsCliProps.setProperty(passwordKey, temp);
+                            }
+                            // the third one is the realm.
+                            else {
+                                final String realmKey = CommandLineArgument.REALM.key();
+                                if (!argsCliProps.containsKey(realmKey)) {
+                                    argsCliProps.setProperty(realmKey, temp);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
 
-        if (argsCliProps.containsKey(PASSWORD_OPTION.key()) && argsCliProps.containsKey(USER_OPTION.key())) {
-            char[] password = argsCliProps.getProperty(PASSWORD_OPTION.key()).toCharArray();
-            String user = argsCliProps.getProperty(USER_OPTION.key());
-            if (argsCliProps.contains(REALM_OPTION.key())) {
-                new AddPropertiesUser(management, user, password, argsCliProps.getProperty(REALM_OPTION.key())).run();
+        if (argsCliProps.containsKey(CommandLineArgument.PASSWORD.key()) && argsCliProps.containsKey(CommandLineArgument.USER.key())) {
+            char[] password = argsCliProps.getProperty(CommandLineArgument.PASSWORD.key()).toCharArray();
+            String user = argsCliProps.getProperty(CommandLineArgument.USER.key());
+            if (argsCliProps.contains(CommandLineArgument.REALM.key())) {
+                new AddPropertiesUser(javaConsole, management, user, password, argsCliProps.getProperty(CommandLineArgument.REALM.key())).run();
             } else {
-                new AddPropertiesUser(management, user, password).run();
+                new AddPropertiesUser(javaConsole, management, user, password).run();
             }
         } else {
-            new AddPropertiesUser().run();
+            new AddPropertiesUser(javaConsole).run();
         }
+    }
+
+    private static void usage(ConsoleWrapper consoleWrapper) {
+        CommandLineArgument.printUsage(consoleWrapper);
     }
 
     public enum Interactiveness {
@@ -201,35 +197,194 @@ public class AddPropertiesUser {
     }
 
     /**
-     * Find the command-line option corresponding to the parameter {@code option}.
+     * Find the command-line arg corresponding to the parameter {@code arg}.
      *
-     * @param option
-     * @return The corresponding option or null.
+     * @param arg
+     * @return The corresponding arg or null.
      */
-    private static CommandLineOption findCommandLineOption(String option) {
-        for (CommandLineOption commandLineOption : COMMAND_LINE_OPTIONS) {
-            if (commandLineOption.match(option)) {
-                return commandLineOption;
+    private static CommandLineArgument findCommandLineOption(String arg) {
+        for (CommandLineArgument commandLineArgument : CommandLineArgument.values()) {
+            if (commandLineArgument.match(arg)) {
+                return commandLineArgument;
             }
         }
         return null;
     }
 
-    protected static class CommandLineOption {
-        private String shortOption;
-        private String longOption;
+    protected enum CommandLineArgument {
 
-        private CommandLineOption(String shortOption, String longOption) {
-            this.shortOption = shortOption;
-            this.longOption = longOption;
+        APPLICATION_USERS("-a") {
+            @Override
+            public String instructions() {
+                return MESSAGES.argApplicationUsers();
+            }
+        },
+        DOMAIN_CONFIG_DIR_USERS("-dc") {
+            @Override
+            public String argumentExample() {
+                return super.argumentExample().concat(" <value>");
+            }
+
+            @Override
+            public String instructions() {
+                return MESSAGES.argDomainConfigDirUsers();
+            }
+        },
+        SERVER_CONFIG_DIR_USERS("-sc") {
+            @Override
+            public String argumentExample() {
+                return super.argumentExample().concat(" <value>");
+            }
+
+            @Override
+            public String instructions() {
+                return MESSAGES.argServerConfigDirUsers();
+            }
+        },
+        PASSWORD("-p", "--password") {
+            @Override
+            public String argumentExample() {
+                return super.argumentExample().concat(" <value>");
+            }
+
+            @Override
+            public String instructions() {
+                return MESSAGES.argPassword();
+            }
+        },
+        USER("-u", "--user") {
+            @Override
+            public String argumentExample() {
+                return super.argumentExample().concat(" <value>");
+            }
+
+            @Override
+            public String instructions() {
+                return MESSAGES.argUser();
+            }
+        },
+        REALM("-r", "--realm") {
+            @Override
+            public String argumentExample() {
+                return super.argumentExample().concat(" <value>");
+            }
+
+            @Override
+            public String instructions() {
+                return MESSAGES.argRealm();
+            }
+        },
+        SILENT("-s", "--silent") {
+            @Override
+            public String instructions() {
+                return MESSAGES.argSilent();
+            }
+        },
+        ROLE("-ro", "--role") {
+            @Override
+            public String argumentExample() {
+                return super.argumentExample().concat(" <value>");
+            }
+
+            @Override
+            public String instructions() {
+                return MESSAGES.argRole();
+            }
+        },
+        HELP("-h", "--help") {
+            @Override
+            public String instructions() {
+                return MESSAGES.argHelp();
+            }
+        };
+
+        private static String USAGE;
+        private String shortArg;
+        private String longArg;
+
+        private CommandLineArgument(String option) {
+            this.shortArg = option;
+        }
+
+        private CommandLineArgument(String shortArg, String longArg) {
+            this.shortArg = shortArg;
+            this.longArg = longArg;
         }
 
         public String key() {
-            return longOption.substring(2);
+            return longArg != null ? longArg.substring(2) : shortArg.substring(1);
         }
 
         public boolean match(String option) {
-            return shortOption.equals(option) || longOption.equals(option);
+            return option.equals(shortArg) || option.equals(longArg);
+        }
+
+        public String getShortArg() {
+            return shortArg;
+        }
+
+        public String getLongArg() {
+            return longArg;
+        }
+
+        /**
+         * An example of how the argument is used.
+         *
+         * @return the example.
+         */
+        public String argumentExample() {
+            return (null != getShortArg() ? getShortArg() : "").concat(null != getLongArg() ? ", " + getLongArg() : "");
+        }
+
+        /**
+         * The argument instructions.
+         *
+         * @return the instructions.
+         */
+        public abstract String instructions();
+
+        @Override
+        public String toString() {
+            final List<String> instructions = new ArrayList<String>();
+            segmentInstructions(instructions(), instructions);
+            StringBuilder sb = new StringBuilder(String.format("    %-35s %s", argumentExample(), instructions.get(0)));
+            for (int i = 1; i < instructions.size(); i++) {
+                sb.append(NEW_LINE);
+                sb.append(String.format("%-40s%s", " ", instructions.get(i)));
+            }
+            sb.append(NEW_LINE);
+            return sb.toString();
+        }
+
+        private static void segmentInstructions(String instructions, List<String> segments) {
+            if (instructions.length() <= 40) {
+                segments.add(instructions);
+            } else {
+                String testFragment = instructions.substring(0, 40);
+                int lastSpace = testFragment.lastIndexOf(' ');
+                if (lastSpace < 0) {
+                    // degenerate case; we just have to chop not at a space
+                    lastSpace = 39;
+                }
+                segments.add(instructions.substring(0, lastSpace + 1));
+                segmentInstructions(instructions.substring(lastSpace + 1), segments);
+            }
+        }
+
+        public static void printUsage(ConsoleWrapper consoleWrapper) {
+            consoleWrapper.printf(usage());
+        }
+
+        public static String usage() {
+            if (USAGE == null) {
+                final StringBuilder sb = new StringBuilder();
+                sb.append(MESSAGES.argUsage()).append(NEW_LINE);
+                for (CommandLineArgument arg : CommandLineArgument.values()) {
+                    sb.append(arg.toString()).append(NEW_LINE);
+                }
+                USAGE = sb.toString();
+            }
+            return USAGE;
         }
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
@@ -65,6 +65,7 @@ public class AddPropertiesUser {
     public static final CommandLineOption SILENT_OPTION = new CommandLineOption("-s", "--silent");
     public static final CommandLineOption ROLE_OPTION = new CommandLineOption("-ro", "--role");
 
+    // List the available command-line options
     public static final CommandLineOption[] COMMAND_LINE_OPTIONS = new CommandLineOption[]{
             PASSWORD_OPTION,
             USER_OPTION,
@@ -95,7 +96,7 @@ public class AddPropertiesUser {
         this.theConsole = console;
         StateValues stateValues = new StateValues();
         stateValues.setJbossHome(System.getenv("JBOSS_HOME"));
-        nextState = new PropertyFilePrompt(theConsole,stateValues);
+        nextState = new PropertyFilePrompt(theConsole, stateValues);
     }
 
     private AddPropertiesUser(final boolean management, final String user, final char[] password, final String realm) {
@@ -154,6 +155,7 @@ public class AddPropertiesUser {
                 } else if (APPLICATION_USERS_OPTION.equals(temp)) {
                     management = false;
                 } else {
+                    // Find the command-line option
                     CommandLineOption commandLineOption = findCommandLineOption(temp);
                     if (commandLineOption != null) {
                         final String value;
@@ -163,6 +165,19 @@ public class AddPropertiesUser {
                             value = it.next();
                         }
                         argsCliProps.setProperty(commandLineOption.key(), value);
+                    } else {
+                        // By default, the first arg without option is the username,
+                        if (!argsCliProps.containsKey(USER_OPTION.key())) {
+                            argsCliProps.setProperty(USER_OPTION.key(), temp);
+                        }
+                        // the second arg is the password and,
+                        else if (!argsCliProps.containsKey(PASSWORD_OPTION.key())) {
+                            argsCliProps.setProperty(PASSWORD_OPTION.key(), temp);
+                        }
+                        // the third one is the realm.
+                        else if (!argsCliProps.containsKey(REALM_OPTION.key())) {
+                            argsCliProps.setProperty(REALM_OPTION.key(), temp);
+                        }
                     }
                 }
             }
@@ -185,6 +200,12 @@ public class AddPropertiesUser {
         SILENT, NON_INTERACTIVE, INTERACTIVE
     }
 
+    /**
+     * Find the command-line option corresponding to the parameter {@code option}.
+     *
+     * @param option
+     * @return The corresponding option or null.
+     */
     private static CommandLineOption findCommandLineOption(String option) {
         for (CommandLineOption commandLineOption : COMMAND_LINE_OPTIONS) {
             if (commandLineOption.match(option)) {
@@ -201,14 +222,6 @@ public class AddPropertiesUser {
         private CommandLineOption(String shortOption, String longOption) {
             this.shortOption = shortOption;
             this.longOption = longOption;
-        }
-
-        public String getShortOption() {
-            return shortOption;
-        }
-
-        public String getLongOption() {
-            return longOption;
         }
 
         public String key() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ErrorState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ErrorState.java
@@ -63,10 +63,13 @@ public class ErrorState implements State {
         theConsole.printf(MESSAGES.errorHeader());
         theConsole.printf(" * ");
         theConsole.printf(NEW_LINE);
-
         theConsole.printf(errorMessage);
         theConsole.printf(NEW_LINE);
         theConsole.printf(NEW_LINE);
+        // Throw an exception if the mode is non-interactive and there's no next state.
+        if ((stateValues != null && !stateValues.isInteractive()) && nextState == null) {
+            throw new RuntimeException(errorMessage);
+        }
         return nextState;
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFileFinder.java
@@ -53,7 +53,7 @@ public class PropertyFileFinder implements State {
     private ConsoleWrapper theConsole;
     private final StateValues stateValues;
 
-    public PropertyFileFinder(ConsoleWrapper theConsole,final StateValues stateValues) {
+    public PropertyFileFinder(ConsoleWrapper theConsole, final StateValues stateValues) {
         this.theConsole = theConsole;
         this.stateValues = stateValues;
         if ((stateValues != null && stateValues.isSilent() == false) && theConsole.getConsole() == null) {
@@ -99,14 +99,10 @@ public class PropertyFileFinder implements State {
         }
         stateValues.setKnownUsers(foundUsers);
 
-        if (stateValues == null) {
-            return new PromptNewUserState(theConsole);
-        } else {
-            return new PromptNewUserState(theConsole, stateValues);
-        }
+        return new PromptNewUserState(theConsole, stateValues);
     }
 
-    private Map<String,String> loadAllRoles(List<File> foundRoleFiles) throws StartException, IOException {
+    private Map<String, String> loadAllRoles(List<File> foundRoleFiles) throws StartException, IOException {
         Map<String, String> loadedRoles = new HashMap<String, String>();
         for (File file : foundRoleFiles) {
             PropertiesFileLoader propertiesLoad = null;
@@ -114,8 +110,8 @@ public class PropertyFileFinder implements State {
                 propertiesLoad = new UserPropertiesFileHandler(file.getCanonicalPath());
                 propertiesLoad.start(null);
                 loadedRoles.putAll((Map) propertiesLoad.getProperties());
-            }  finally {
-                if (propertiesLoad!=null) {
+            } finally {
+                if (propertiesLoad != null) {
                     propertiesLoad.stop(null);
                 }
             }
@@ -128,15 +124,12 @@ public class PropertyFileFinder implements State {
         if (standaloneProps.exists()) {
             foundFiles.add(standaloneProps);
         }
-        File domainProps = buildFilePath(jbossHome, DOMAIN_CONFIG_USER_DIR,DOMAIN_CONFIG_DIR, DOMAIN_BASE_DIR, "domain", fileName);
+        File domainProps = buildFilePath(jbossHome, DOMAIN_CONFIG_USER_DIR, DOMAIN_CONFIG_DIR, DOMAIN_BASE_DIR, "domain", fileName);
         if (domainProps.exists()) {
             foundFiles.add(domainProps);
         }
 
-        if (foundFiles.size() == 0) {
-            return false;
-        }
-        return true;
+        return !foundFiles.isEmpty();
     }
 
     private File buildFilePath(final String jbossHome, final String serverCofigUserDirPropertyName, final String serverConfigDirPropertyName,
@@ -145,8 +138,8 @@ public class PropertyFileFinder implements State {
         String configUserDirConfiguredPath = System.getProperty(serverCofigUserDirPropertyName);
         String configDirConfiguredPath = configUserDirConfiguredPath != null ? configUserDirConfiguredPath : System.getProperty(serverConfigDirPropertyName);
 
-        File configDir =  configDirConfiguredPath != null ? new File(configDirConfiguredPath) : null;
-        if(configDir == null) {
+        File configDir = configDirConfiguredPath != null ? new File(configDirConfiguredPath) : null;
+        if (configDir == null) {
             String baseDirConfiguredPath = System.getProperty(serverBaseDirPropertyName);
             File baseDir = baseDirConfiguredPath != null ? new File(baseDirConfiguredPath) : new File(jbossHome, defaultBaseDir);
             configDir = new File(baseDir, "configuration");

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFilePrompt.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PropertyFilePrompt.java
@@ -59,35 +59,33 @@ public class PropertyFilePrompt implements State {
         theConsole.printf(MESSAGES.filePrompt());
         theConsole.printf(AddPropertiesUser.NEW_LINE);
 
-        while (true) {
-            String temp = theConsole.readLine("(a): ");
-            if (temp == null) {
-                /*
-                 * This will return user to the command prompt so add a new line to ensure the command prompt is on the next
-                 * line.
-                 */
-                theConsole.printf(AddPropertiesUser.NEW_LINE);
-                return null;
-            }
+        String temp = theConsole.readLine("(a): ");
+        if (temp == null) {
+            /*
+             * This will return user to the command prompt so add a new line to ensure the command prompt is on the next
+             * line.
+             */
+            theConsole.printf(AddPropertiesUser.NEW_LINE);
+            return null;
+        }
 
-            if (temp.length() > 0) {
-                switch (convertResponse(temp)) {
-                    case MANAGEMENT:
-                        stateValues.setManagement(true);
-                        stateValues.setRealm(DEFAULT_MANAGEMENT_REALM);
-                        return new PropertyFileFinder(theConsole, stateValues);
-                    case APPLICATION:
-                        stateValues.setManagement(false);
-                        stateValues.setRealm(DEFAULT_APPLICATION_REALM);
-                        return new PropertyFileFinder(theConsole, stateValues);
-                    default:
-                        return new ErrorState(theConsole, MESSAGES.invalidChoiceResponse(), this);
-                }
-            } else {
-                stateValues.setManagement(true);
-                stateValues.setRealm(DEFAULT_MANAGEMENT_REALM);
-                return new PropertyFileFinder(theConsole, stateValues);
+        if (temp.length() > 0) {
+            switch (convertResponse(temp)) {
+                case MANAGEMENT:
+                    stateValues.setManagement(true);
+                    stateValues.setRealm(DEFAULT_MANAGEMENT_REALM);
+                    return new PropertyFileFinder(theConsole, stateValues);
+                case APPLICATION:
+                    stateValues.setManagement(false);
+                    stateValues.setRealm(DEFAULT_APPLICATION_REALM);
+                    return new PropertyFileFinder(theConsole, stateValues);
+                default:
+                    return new ErrorState(theConsole, MESSAGES.invalidChoiceResponse(), this);
             }
+        } else {
+            stateValues.setManagement(true);
+            stateValues.setRealm(DEFAULT_MANAGEMENT_REALM);
+            return new PropertyFileFinder(theConsole, stateValues);
         }
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/WeakCheckState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/WeakCheckState.java
@@ -60,12 +60,12 @@ public class WeakCheckState implements State {
         State retryState = stateValues.isSilentOrNonInteractive() ? null : new PromptNewUserState(theConsole, stateValues);
 
         if (Arrays.equals(stateValues.getUserName().toCharArray(), stateValues.getPassword())) {
-            return new ErrorState(theConsole, MESSAGES.usernamePasswordMatch(), retryState);
+            return new ErrorState(theConsole, MESSAGES.usernamePasswordMatch(), retryState, stateValues);
         }
 
         for (char currentChar : stateValues.getUserName().toCharArray()) {
             if ((!isValidPunctuation(currentChar)) && (Character.isLetter(currentChar) || Character.isDigit(currentChar)) == false) {
-                return new ErrorState(theConsole, MESSAGES.usernameNotAlphaNumeric(), retryState);
+                return new ErrorState(theConsole, MESSAGES.usernameNotAlphaNumeric(), retryState, stateValues);
             }
         }
 


### PR DESCRIPTION
The command-line now supports :

``` sh
./add-user.sh --user ggrossetie -p abcd --realm kingdom -a --role role1,role2 --silent
```

You can also use it as before without option : 

``` sh
./add-user.sh ggrossetie abcd kingdom
```

I also fixed a bug (the "-sc" option was ignored) and added/corrected some french translations. If I have some more time I will add the --help option.
