### PR TITLE
Add mime types for wellcome content handling

### DIFF
--- a/web/src/main/java/org/jboss/as/web/WelcomeContextService.java
+++ b/web/src/main/java/org/jboss/as/web/WelcomeContextService.java
@@ -95,6 +95,10 @@ class WelcomeContextService implements Service<Context> {
                 context.addServletMapping("/", "default");
                 context.addMimeMapping("html", "text/html");
                 context.addMimeMapping("jpg", "image/jpeg");
+                context.addMimeMapping("png", "image/png");
+                context.addMimeMapping("gif", "image/gif");
+                context.addMimeMapping("css", "text/css");
+                context.addMimeMapping("js", "text/javascript");
 
                 // Add the WelcomeContextConsoleServlet
                 WelcomeContextConsoleServlet wccs = new WelcomeContextConsoleServlet(httpManagement);


### PR DESCRIPTION
as we don't serve css's with text/css ie9 denies loading of css..

this should go to 7.2 and 7.1.3
