### PR TITLE
[AS7-4834] Don't register the connection provider as 'remote' is already registered in the EndpointService.

### DIFF
--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -22,6 +22,10 @@
 
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.RemotingMessages.MESSAGES;
+import static org.xnio.Options.SASL_POLICY_NOANONYMOUS;
+import static org.xnio.Options.SASL_POLICY_NOPLAINTEXT;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
@@ -36,20 +40,13 @@ import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
-import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
 import org.xnio.IoFuture;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Sequence;
-
-import static org.jboss.as.remoting.RemotingMessages.MESSAGES;
-import static org.xnio.Options.SASL_POLICY_NOANONYMOUS;
-import static org.xnio.Options.SASL_POLICY_NOPLAINTEXT;
 
 /**
  * A {@link RemoteOutboundConnectionService} manages a remoting connection created out of a remote:// URI scheme.
@@ -72,25 +69,6 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
     public RemoteOutboundConnectionService(final String connectionName, final OptionMap connectionCreationOptions, final String username) {
         super(connectionName, connectionCreationOptions);
         this.username = username;
-    }
-
-    @Override
-    public void start(StartContext context) throws StartException {
-
-        super.start(context);
-        // setup the connection provider factory for remote:// scheme, for the endpoint
-        final Endpoint endpoint = this.endpointInjectedValue.getValue();
-        // first check if the URI scheme is already registered. If it is, then *don't* re-register
-        // Note: The isValidUriScheme method name is a bit misleading. All it does is a check for already
-        // registered connection providers for that URI scheme
-        if (!endpoint.isValidUriScheme(REMOTE_URI_SCHEME)) {
-            try {
-                // TODO: Allow a way to pass the options
-                endpoint.addConnectionProvider(REMOTE_URI_SCHEME, new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
-            } catch (IOException ioe) {
-                throw MESSAGES.couldNotRegisterConnectionProvider(REMOTE_URI_SCHEME, ioe);
-            }
-        }
     }
 
     @Override

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingMessages.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingMessages.java
@@ -91,9 +91,6 @@ public interface RemotingMessages {
     @Message(id = 17123, value = "Unable to create auth dir %s.")
     StartException unableToCreateAuthDir(String dir);
 
-    @Message(id = 17124, value = "Could not register a connection provider factory for %s uri scheme")
-    StartException couldNotRegisterConnectionProvider(String remoteUriScheme, @Cause IOException ioe);
-
     @Message(id = 17125, value = "Could not connect")
     RuntimeException couldNotConnect(@Cause URISyntaxException e);
 


### PR DESCRIPTION
The reported race condition related to multiple remote-outbound-connection services registering a connection provider for 'remote://' simultaneously - however this was a bad registration and 'remote' is already registered by the EndpointService.

This class uses a URI to connect and EndpointImpl calls getScheme on the URI which returns 'remote' not 'remote://' so the registration code is safe to completely remove.
