### PR TITLE
[AS7-4765] Add <cluster-password> to messaging HA conf

### DIFF
--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -86,6 +86,7 @@
    <supplement name="ha">
        <replacement placeholder="CLUSTERED">
            <clustered>true</clustered>
+           <cluster-password>${jboss.messaging.cluster.password:CHANGE ME!!}</cluster-password>
        </replacement>
        <replacement placeholder="BROADCAST-GROUPS">
            <broadcast-groups>


### PR DESCRIPTION
- add a <cluster-password> element to messaging HA configuration
  which defaults to the HornetQ default cluster password and can be
  customized using the expression jboss.messaging.cluster.password
