### PR TITLE
Remove directory match.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingConfigurationProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingConfigurationProcessor.java
@@ -153,9 +153,7 @@ public class LoggingConfigurationProcessor implements DeploymentUnitProcessor {
      * Preference is for {@literal logging.properties} or {@literal jboss-logging.properties}.
      *
      * @param resourceRoot the resource to check.
-     *
      * @return the configuration file if found, otherwise {@code null}.
-     *
      * @throws DeploymentUnitProcessingException
      *          if an error occurs.
      */
@@ -203,7 +201,7 @@ public class LoggingConfigurationProcessor implements DeploymentUnitProcessor {
 
         @Override
         public boolean accepts(final VirtualFile file) {
-            return file.isDirectory() || configFiles.contains(file.getName());
+            return configFiles.contains(file.getName());
         }
     }
 }


### PR DESCRIPTION
This filter also picks up directories, where we only want actual logging config files.
Recursion is already in the VFS code, when you use VirtualFile::getChildrenRecursively.
