### PR TITLE
AS7-4895 flushCache missing principal argument

### DIFF
--- a/security/src/main/java/org/jboss/as/security/SecuritySubsystemDescriptions.java
+++ b/security/src/main/java/org/jboss/as/security/SecuritySubsystemDescriptions.java
@@ -1020,6 +1020,11 @@ class SecuritySubsystemDescriptions {
             op.get(OPERATION_NAME).set(Constants.FLUSH_CACHE);
             op.get(DESCRIPTION).set(bundle.getString("flush-cache"));
 
+            op.get(REQUEST_PROPERTIES, Constants.PRINCIPAL_ARGUMENT, DESCRIPTION).set(bundle.getString("principal"));
+            op.get(REQUEST_PROPERTIES, Constants.PRINCIPAL_ARGUMENT, TYPE).set(ModelType.STRING);
+            op.get(REQUEST_PROPERTIES, Constants.PRINCIPAL_ARGUMENT, REQUIRED).set(false);
+
+
             return op;
         }
 

--- a/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
+++ b/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
@@ -107,6 +107,7 @@ jsse.additional-properties=Additional properties that may be necessary to config
 
 list-cached-principals=Lists the principals stored in the authentication cache for this security domain.
 flush-cache=Remove entries stored in the authentication cache for this security domain. A single entry can be flushed by using the principal argument with the username as the value. If no argument is passed to the operation, all entries are flushed.
+principal=Username of the principal to remove from the authentication cache.
 vault=Security Vault for attributes.
 vault.add=Adds a security vault configuration
 vault.remove=Removes a security vault configuration


### PR DESCRIPTION
The flushCache operation on a security domain takes an optional
principal name argument. If this argument is present only the principal
with this username is removed from the cache, otherwise all items are
removed from the cache. However in the description of this operation the
principal name argument is missing.
- add optional principal argument to fushCache operation

https://issues.jboss.org/browse/AS7-4895
