### PR TITLE
AS7-4898 list-cached-principals missing reply type

### DIFF
--- a/security/src/main/java/org/jboss/as/security/SecuritySubsystemDescriptions.java
+++ b/security/src/main/java/org/jboss/as/security/SecuritySubsystemDescriptions.java
@@ -1010,6 +1010,9 @@ class SecuritySubsystemDescriptions {
             op.get(OPERATION_NAME).set(Constants.LIST_CACHED_PRINCIPALS);
             op.get(DESCRIPTION).set(bundle.getString("list-cached-principals"));
 
+            op.get(REPLY_PROPERTIES, DESCRIPTION).set("list-cached-principals.return");
+            op.get(REPLY_PROPERTIES, TYPE).set(ModelType.LIST);
+
             return op;
         }
 

--- a/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
+++ b/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
@@ -106,6 +106,7 @@ jsse.protocols=Comma separated list of protocols to enable on SSLSockets.
 jsse.additional-properties=Additional properties that may be necessary to configure JSSE.
 
 list-cached-principals=Lists the principals stored in the authentication cache for this security domain.
+list-cached-principals.return=The usernames of the principals stored in the authentication cache for this security domain.
 flush-cache=Remove entries stored in the authentication cache for this security domain. A single entry can be flushed by using the principal argument with the username as the value. If no argument is passed to the operation, all entries are flushed.
 vault=Security Vault for attributes.
 vault.add=Adds a security vault configuration


### PR DESCRIPTION
The list-cached-principals operation is missing reply a type. As a
result the operation shows up as java.lang.Void in VisualVM when
in fact it returns a list of strings.
- set the reply type on list-cached-principals

https://issues.jboss.org/browse/AS7-4898
