### PR TITLE
[master branch] Fix AS7-4905

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/remove/BaseSFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/remove/BaseSFSB.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -23,30 +23,24 @@
 package org.jboss.as.test.integration.ejb.stateful.remove;
 
 import javax.ejb.Remove;
-import javax.ejb.Stateful;
 
 /**
- * User: jpai
+ * @author Jaikiran Pai
  */
-@Stateful
-public class SFSBWithRemoveMethods extends BaseSFSB {
-
-    @Remove
-    public void remove() {
-        // do nothing
-    }
+public class BaseSFSB {
 
     @Remove(retainIfException = true)
-    public void retainIfAppException() {
+    public void baseRetainIfAppException() {
         throw new SimpleAppException();
     }
 
     @Remove
-    public void removeEvenIfAppException() {
+    public void baseRemoveEvenIfAppException() {
         throw new SimpleAppException();
     }
 
-    public void doNothing() {
-
+    @Remove
+    public void baseJustRemove() {
+        // do nothing
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/remove/RemoveMethodOnSFSBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/remove/RemoveMethodOnSFSBTestCase.java
@@ -42,7 +42,6 @@ import org.junit.runner.RunWith;
  * User: Jaikiran Pai
  */
 @RunWith(Arquillian.class)
-@Ignore("[AS7-734] Migrate to ARQ Beta1")
 public class RemoveMethodOnSFSBTestCase {
 
     private static final Logger log = Logger.getLogger(RemoveMethodOnSFSBTestCase.class.getName());
@@ -56,7 +55,7 @@ public class RemoveMethodOnSFSBTestCase {
         return jar;
     }
 
-    @EJB
+    @EJB (mappedName = "java:module/SFSBWithRemoveMethods!org.jboss.as.test.integration.ejb.stateful.remove.SFSBWithRemoveMethods")
     private SFSBWithRemoveMethods sfsbWithRemoveMethods;
 
     /**
@@ -135,5 +134,70 @@ public class RemoveMethodOnSFSBTestCase {
         sfsbWithRemoveMethods.doNothing();
         sfsbWithRemoveMethods.doNothing();
         sfsbWithRemoveMethods.doNothing();
+    }
+
+    /**
+     * Tests that a invocation on SFSB base class method annotated with @Remove (and without the retainIfException set to true) results in
+     * removal of the bean even in case of application exception.
+     */
+    @Test
+    public void testRemoveEvenIfAppExceptionOnSFSBBaseClass() {
+        // invoke the remove method which throws a app exception
+        try {
+            sfsbWithRemoveMethods.baseRemoveEvenIfAppException();
+            Assert.fail("Did not get the expected app exception");
+        } catch (SimpleAppException sae) {
+            // expected
+        }
+
+        // invoke again and it *must* throw NoSuchEJBException
+        try {
+            sfsbWithRemoveMethods.doNothing();
+            Assert.fail("Did not get the expected NoSuchEJBException on second invocation on SFSB");
+        } catch (NoSuchEJBException nsee) {
+            // expected
+            log.info("Got the expected NoSuchEJBException on second invocation on SFSB");
+        }
+    }
+
+    /**
+     * Tests that a invocation on a SFSB base class method annotated with @Remove results in the removal of the bean instance
+     */
+    @Test
+    public void testSimpleRemoveOnSFSBBaseClass() {
+        // remove the SFSB
+        sfsbWithRemoveMethods.baseJustRemove();
+        // try invoking again. we should expect a NoSuchEJBException
+        try {
+            sfsbWithRemoveMethods.doNothing();
+            Assert.fail("SFSB was expected to be removed after a call to the @Remove method");
+        } catch (NoSuchEJBException nsee) {
+            // expected
+            log.info("Got the expected NoSuchEJBException after invoking remove on the SFSB");
+        }
+    }
+
+    /**
+     * Tests that a invocation on SFSB base class method annotated with @Remove and with "retainIfException = true" *doesn't* result
+     * in removal of the bean when a application exception is thrown.
+     */
+    @Test
+    public void testRemoveWithRetainIfExceptionOnSFSBBaseClass() {
+        // invoke the remove method which throws a app exception
+        try {
+            sfsbWithRemoveMethods.baseRetainIfAppException();
+            Assert.fail("Did not get the expected app exception");
+        } catch (SimpleAppException sae) {
+            // expected
+        }
+
+        // invoke again and it should *not* throw NoSuchEJBException
+        try {
+            sfsbWithRemoveMethods.baseRetainIfAppException();
+            Assert.fail("Did not get the expected app exception on second invocation on SFSB");
+        } catch (SimpleAppException sae) {
+            // expected
+        }
+
     }
 }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4905 which relates to the @Remove annotation not being taken into account for the base class of the bean. This commit includes the testcases too.
