### PR TITLE
Remove copy-namespaces and inherit-namespaces XSLT params, to fix JBPAPP-9057

### DIFF
--- a/testsuite/integration/src/test/xslt/enableTrace.xsl
+++ b/testsuite/integration/src/test/xslt/enableTrace.xsl
@@ -41,7 +41,7 @@
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:copy copy-namespaces="false" inherit-namespaces="false">
+                <xsl:copy>
                     <xsl:attribute name="name">
                         <xsl:value-of select="'CONSOLE'"/>
                     </xsl:attribute>
@@ -60,7 +60,7 @@
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:copy copy-namespaces="false" inherit-namespaces="false">
+                <xsl:copy>
                     <xsl:attribute name="name">
                         <xsl:value-of select="'FILE'"/>
                     </xsl:attribute>


### PR DESCRIPTION
Some time ago, Stuart Douglas has added enableTrace.xsl.

IBM JDK's XSLT engine doesn't support 

```
 <xsl:copy copy-namespaces="false" inherit-namespaces="false">
```

and fails the build.
I've tried to run

```
 mvn clean process-test-resources -rf testsuite/ -Dtrace=org.jboss.as
```

with and without these attribs, and the resulting standalone*.xml's are identical.
So I assume these attribs values are the default and can be removed.
