### PR TITLE
AS7-4912 AnonLoginModule not mapped in ModulesMap

### DIFF
--- a/security/src/main/java/org/jboss/as/security/ModulesMap.java
+++ b/security/src/main/java/org/jboss/as/security/ModulesMap.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import org.jboss.as.security.remoting.RemotingLoginModule;
 import org.jboss.security.ClientLoginModule;
+import org.jboss.security.auth.spi.AnonLoginModule;
 import org.jboss.security.auth.spi.BaseCertLoginModule;
 import org.jboss.security.auth.spi.CertRolesLoginModule;
 import org.jboss.security.auth.spi.DatabaseCertLoginModule;
@@ -88,6 +89,7 @@ public interface ModulesMap {
             put("RealmUsersRoles", RealmUsersRolesLoginModule.class.getName());
             put("RealmDirect", RealmDirectLoginModule.class.getName());
             put("Disabled", DisabledLoginModule.class.getName());
+            put("Anon", AnonLoginModule.class.getName());
             // Authentication only modules
             put("PropertiesUsers", PropertiesUsersLoginModule.class.getName());
             put("SimpleUsers", SimpleUsersLoginModule.class.getName());

--- a/security/src/test/resources/org/jboss/as/security/test/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/test/securitysubsystemv12.xml
@@ -5,6 +5,7 @@
                 <login-module code="Remoting" flag="optional">
                   <module-option name="password-stacking" value="useFirstPass"/>
                 </login-module>
+                <login-module code="Anon" flag="optional"/>
                 <login-module code="RealmUsersRoles" flag="required">
                   <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
                   <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>


### PR DESCRIPTION
org.jboss.as.security.ModulesMap maps short names of login modules to
fully qualified class names. Several login modules are listed there but
org.jboss.security.auth.spi.AnonLoginModule is missing.
- map org.jboss.security.auth.spi.AnonLoginModule to "Anon"

https://issues.jboss.org/browse/AS7-4912
