### PR TITLE
[master branch] Fix for AS7-4872

### DIFF
--- a/build/src/main/resources/modules/org/jboss/remote-naming/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/remote-naming/main/module.xml
@@ -28,6 +28,7 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="org.jboss.ejb-client"/>
         <module name="org.jboss.remoting3"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4872 where the remote-naming module was missing a dependency on ejb-client module.
