### PR TITLE
AS7-4941 Fixed JACC permission creation for EAR deployments. 

### DIFF
--- a/security/src/main/java/org/jboss/as/security/deployment/AbstractSecurityDeployer.java
+++ b/security/src/main/java/org/jboss/as/security/deployment/AbstractSecurityDeployer.java
@@ -42,6 +42,9 @@ public abstract class AbstractSecurityDeployer<T> {
         if (deploymentUnit.getParent() == null) {
             standalone = Boolean.TRUE;
         }
+        else {
+            contextId = deploymentUnit.getParent().getName() + "!" + contextId;
+        }
         return createService(contextId, metaData, standalone);
     }
 

--- a/security/src/main/java/org/jboss/as/security/service/JaccService.java
+++ b/security/src/main/java/org/jboss/as/security/service/JaccService.java
@@ -81,12 +81,10 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
             PolicyConfigurationFactory pcf = PolicyConfigurationFactory.getPolicyConfigurationFactory();
             synchronized (pcf) { // synchronize on the factory
                 policyConfiguration = pcf.getPolicyConfiguration(contextId, false);
-                if (standalone) {
-                    if (metaData != null) {
-                        createPermissions(metaData, policyConfiguration);
-                    } else {
-                        log.debugf("Cannot create permissions with 'null' metaData for id=" + contextId);
-                    }
+                if (metaData != null) {
+                    createPermissions(metaData, policyConfiguration);
+                } else {
+                    log.debugf("Cannot create permissions with 'null' metaData for id=" + contextId);
                 }
                 if (!standalone) {
                     PolicyConfiguration parent = parentPolicy.getValue();

--- a/web/src/main/java/org/jboss/as/web/security/SecurityContextAssociationValve.java
+++ b/web/src/main/java/org/jboss/as/web/security/SecurityContextAssociationValve.java
@@ -147,7 +147,10 @@ public class SecurityContextAssociationValve extends ValveBase {
                 WebLogger.WEB_SECURITY_LOGGER.debug("Failed to determine servlet", e);
             }
             // set JACC contextID
-            PolicyContext.setContextID(deploymentUnit.getName());
+            String contextId = deploymentUnit.getName();
+            if (deploymentUnit.getParent() != null)
+                contextId = deploymentUnit.getParent().getName() + "!" + contextId;
+            PolicyContext.setContextID(contextId);
 
             // Perform the request
             getNext().invoke(request, response);


### PR DESCRIPTION
Also, the EAR name is now considered when building the contextId so that wars/jars with the same name that are included in different ears don't override each others permissions.
