### PR TITLE
[AS7-4628] JMS bridge

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -2501,7 +2501,7 @@
                                         </group>
                                         <group>
                                             <title>Module org.jboss.as.messaging</title>
-                                            <packages>org.jboss.as.messaging:org.jboss.as.messaging.deployment:org.jboss.as.messaging.jms</packages>
+                                            <packages>org.jboss.as.messaging:org.jboss.as.messaging.deployment:org.jboss.as.messaging.jms:org.jboss.as.messaging.jms.bridge</packages>
                                         </group>
                                         <group>
                                             <title>Module org.jboss.as.modcluster</title>

--- a/build/src/main/resources/configuration/examples/subsystems/messaging-hornetq-colocated.xml
+++ b/build/src/main/resources/configuration/examples/subsystems/messaging-hornetq-colocated.xml
@@ -3,7 +3,7 @@
 <config>
    <!-- This is very different from the normal messaging setup, do duplicating the config is easier -->
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.1">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
        <hornetq-server>
            <clustered>true</clustered>
            <persistence-enabled>true</persistence-enabled>

--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.2">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
        <hornetq-server>
            <?CLUSTERED?>
            <persistence-enabled>true</persistence-enabled>

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -39,6 +39,10 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="hornetq-server" type="hornetq-serverType" />
+<<<<<<< HEAD
+=======
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
+>>>>>>> [AS7-4628] JMS bridge
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -736,7 +740,10 @@
          <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0" />
          <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
          <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+<<<<<<< HEAD
          <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+=======
+>>>>>>> [AS7-4628] JMS bridge
          <!-- ============================================================== -->
          <!-- end of JMS pooled-connection-factoryType specific elements     -->
 
@@ -858,4 +865,122 @@
         </xs:restriction>
     </xs:simpleType>
 
+<<<<<<< HEAD
+=======
+   <xs:complexType name="jms-bridgeType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge.
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long" />
+
+         <xs:element maxOccurs="1" minOccurs="0" name="selector" type="selectorType" />
+         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string" />
+         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string" />
+         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean" />
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+         <xs:annotation>
+            <xs:documentation>
+               The name to use for this JMS bridge. Must be unique across all "jms-bridge" elements
+               in the subsystem. So, this attribute is optional with a default value, but if more than
+               one "jms-bridge" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="module" type="xs:string" use="optional">
+         <xs:annotation>
+            <xs:documentation>
+               The name of the module that contains resources required to lookup source or target JMS resources from another messaging broker than AS7.
+               This does not need to be specified if the bridge uses AS7 instances for both source and target.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="jms-bridgeResourceType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge resource which serves either of the source (from which the messages are consumed)
+               or the destination (to which messages are produced).
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="connection-factory">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the connection factory.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the destination.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The name of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The password of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="contex" type="contextType" />
+      </xs:all>
+   </xs:complexType>
+
+   <xs:complexType name="selectorType">
+      <xs:attribute name="string" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:simpleType name="quality-of-serviceType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="AT_MOST_ONCE"/>
+         <xs:enumeration value="DUPLICATES_OK"/>
+         <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="contextType">
+      <xs:annotation>
+         <xs:documentation>
+             The properties set on the JNDI Context used to lookup the JMS bridge resources.
+             In the absence of a context element, the JMS bridge will lookup resources locally on its own AS7 instance.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="paramType" />
+      </xs:sequence>
+   </xs:complexType>
+
+>>>>>>> [AS7-4628] JMS bridge
 </xs:schema>

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -39,10 +39,7 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="hornetq-server" type="hornetq-serverType" />
-<<<<<<< HEAD
-=======
                 <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
->>>>>>> [AS7-4628] JMS bridge
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -740,10 +737,7 @@
          <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0" />
          <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
          <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-<<<<<<< HEAD
          <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-=======
->>>>>>> [AS7-4628] JMS bridge
          <!-- ============================================================== -->
          <!-- end of JMS pooled-connection-factoryType specific elements     -->
 
@@ -865,8 +859,6 @@
         </xs:restriction>
     </xs:simpleType>
 
-<<<<<<< HEAD
-=======
    <xs:complexType name="jms-bridgeType">
       <xs:annotation>
          <xs:documentation>
@@ -981,6 +973,4 @@
          <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="paramType" />
       </xs:sequence>
    </xs:complexType>
-
->>>>>>> [AS7-4628] JMS bridge
 </xs:schema>

--- a/build/src/main/resources/modules/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/messaging/main/module.xml
@@ -45,6 +45,7 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
+        <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.ironjacamar.impl"/>
@@ -55,5 +56,7 @@
         <module name="org.jboss.metadata"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.jboss-transaction-spi"/>
+        <module name="org.jboss.remote-naming"/>
+        <module name="org.jboss.threads"/>
     </dependencies>
 </module>

--- a/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
 
 /**
  *
@@ -27,7 +28,9 @@ public enum Attribute {
    SOCKET_BINDING(CommonAttributes.SOCKET_BINDING),
    STRING(CommonAttributes.STRING),
    TYPE_ATTR_NAME(CommonAttributes.TYPE_ATTR_NAME),
-   VALUE(CommonAttributes.VALUE);
+   VALUE(CommonAttributes.VALUE),
+   MODULE(JMSBridgeDefinition.MODULE);
+
 
    private final String name;
    private final AttributeDefinition definition;

--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -128,7 +128,9 @@ public interface CommonAttributes {
     SimpleAttributeDefinition CLIENT_FAILURE_CHECK_PERIOD = new SimpleAttributeDefinition("client-failure-check-period",
             new ModelNode().set(HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD), ModelType.LONG,  true, MeasurementUnit.MILLISECONDS);
 
-    SimpleAttributeDefinition CLIENT_ID = new SimpleAttributeDefinition("client-id",  ModelType.STRING, true);
+    SimpleAttributeDefinition CLIENT_ID = create("client-id", ModelType.STRING)
+            .setAllowNull(true)
+            .build();
 
     SimpleAttributeDefinition CLUSTERED = new SimpleAttributeDefinition("clustered",
             new ModelNode().set(ConfigurationImpl.DEFAULT_CLUSTERED), ModelType.BOOLEAN,  true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
@@ -637,7 +639,9 @@ public interface CommonAttributes {
     String CORE_ADDRESS ="core-address";
     String CORE_QUEUE ="core-queue";
     String CORE_QUEUES ="core-queues";
+    String DEFAULT ="default";
     String DELIVERING_COUNT ="delivering-count";
+    String DESTINATION ="destination";
     String DISCOVERY_GROUP = "discovery-group";
     String DISCOVERY_GROUPS = "discovery-groups";
     String DISCOVERY_GROUP_REF ="discovery-group-ref";
@@ -654,6 +658,7 @@ public interface CommonAttributes {
     String INITIAL_MESSAGE_PACKET_SIZE = "initial-message-packet-size";
     String IN_VM_ACCEPTOR ="in-vm-acceptor";
     String IN_VM_CONNECTOR ="in-vm-connector";
+    String JMS_BRIDGE ="jms-bridge";
     String JMS_CONNECTION_FACTORIES ="jms-connection-factories";
     String JMS_DESTINATIONS = "jms-destinations";
     String JMS_QUEUE ="jms-queue";
@@ -775,6 +780,4 @@ public interface CommonAttributes {
     AttributeDefinition[] CONNECTOR_SERVICE_ATTRIBUTES = { FACTORY_CLASS };
 
     String[] PATHS = new String[] {CommonAttributes.BINDINGS_DIRECTORY, CommonAttributes.JOURNAL_DIRECTORY, CommonAttributes.LARGE_MESSAGES_DIRECTORY, CommonAttributes.PAGING_DIRECTORY};
-
-
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/Element.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Element.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -174,7 +175,7 @@ public enum Element {
    CHECK_PERIOD(getCheckPeriodDefinitions()),
    CLIENT_FAILURE_CHECK_PERIOD(CommonAttributes.CLIENT_FAILURE_CHECK_PERIOD),
    CLIENT_ID(CommonAttributes.CLIENT_ID),
-   CONNECTION_FACTORY(CommonAttributes.CONNECTION_FACTORY),
+   CONNECTION_FACTORY(getConnectionFactoryDefinitions()),
    CONNECTION_FACTORIES(CommonAttributes.JMS_CONNECTION_FACTORIES),
    CONNECTION_TTL(getConnectionTTLDefinitions()),
    CONFIRMATION_WINDOW_SIZE(CommonAttributes.CONFIRMATION_WINDOW_SIZE),
@@ -197,7 +198,7 @@ public enum Element {
    MAX_RETRY_INTERVAL(getMaxRetryIntervalDefinitions()),
    MIN_LARGE_MESSAGE_SIZE(CommonAttributes.MIN_LARGE_MESSAGE_SIZE),
    MIN_POOL_SIZE(CommonAttributes.MIN_POOL_SIZE),
-   PASSWORD(CommonAttributes.PASSWORD),
+   PASSWORD(getPasswordDefinitions()),
    PRE_ACK(CommonAttributes.PRE_ACK),
    PRODUCER_WINDOW_SIZE(CommonAttributes.PRODUCER_WINDOW_SIZE),
    PRODUCER_MAX_RATE(CommonAttributes.PRODUCER_MAX_RATE),
@@ -209,7 +210,7 @@ public enum Element {
    SCHEDULED_THREAD_POOL_MAX_SIZE(getScheduledThreadPoolDefinitions()),
    THREAD_POOL_MAX_SIZE(getThreadPoolDefinitions()),
    TRANSACTION_BATH_SIZE(CommonAttributes.TRANSACTION_BATCH_SIZE),
-   USER(CommonAttributes.USER),
+   USER(getUserDefinitions()),
    USE_DUPLICATE_DETECTION(getDuplicateDetectionDefinitions()),
    USE_AUTO_RECOVERY(CommonAttributes.USE_AUTO_RECOVERY),
    USE_GLOBAL_POOLS(CommonAttributes.USE_GLOBAL_POOLS),
@@ -224,6 +225,22 @@ public enum Element {
    SETUP_ATTEMPTS(CommonAttributes.SETUP_ATTEMPTS),
    SETUP_INTERVAL(CommonAttributes.SETUP_INTERVAL),
    SOCKET_BINDING(CommonAttributes.SOCKET_BINDING.getName()),
+
+   // JMS Bridge
+   JMS_BRIDGE(CommonAttributes.JMS_BRIDGE),
+   SOURCE(JMSBridgeDefinition.SOURCE),
+   TARGET(JMSBridgeDefinition.TARGET),
+   DESTINATION(getDestinationDefinitions()),
+   CONTEXT(getContextDefinitions()),
+   PROPERTY("property"),
+   QUALITY_OF_SERVICE(JMSBridgeDefinition.QUALITY_OF_SERVICE),
+   FAILURE_RETRY_INTERVAL(JMSBridgeDefinition.FAILURE_RETRY_INTERVAL),
+   MAX_RETRIES(JMSBridgeDefinition.MAX_RETRIES),
+   MAX_BATCH_SIZE(JMSBridgeDefinition.MAX_BATCH_SIZE),
+   MAX_BATCH_TIME(JMSBridgeDefinition.MAX_BATCH_TIME),
+   SUBSCRIPTION_NAME(JMSBridgeDefinition.SUBSCRIPTION_NAME),
+   ADD_MESSAGE_ID_IN_HEADER(JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER),
+   MODULE(JMSBridgeDefinition.MODULE),
    ;
 
    private final String name;
@@ -393,6 +410,43 @@ public enum Element {
         final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
         result.put("cluster", CommonAttributes.CLUSTER_CONNECTION_CHECK_PERIOD);
         result.put("default", CommonAttributes.CHECK_PERIOD);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getUserDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_USER);
+        result.put("target", JMSBridgeDefinition.TARGET_USER);
+        result.put("default", CommonAttributes.USER);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getPasswordDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_PASSWORD);
+        result.put("target", JMSBridgeDefinition.TARGET_PASSWORD);
+        result.put("default", CommonAttributes.PASSWORD);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getConnectionFactoryDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY);
+        result.put("target", JMSBridgeDefinition.TARGET_CONNECTION_FACTORY);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getDestinationDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_DESTINATION);
+        result.put("target", JMSBridgeDefinition.TARGET_DESTINATION);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getContextDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_CONTEXT);
+        result.put("target", JMSBridgeDefinition.TARGET_CONTEXT);
         return result;
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
@@ -1,26 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package org.jboss.as.messaging;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.parsing.ParseUtils.readStringAttributeElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireSingleAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.DEFAULT;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP_NAME;
-import static org.jboss.as.messaging.CommonAttributes.MAX_POOL_SIZE;
-import static org.jboss.as.messaging.CommonAttributes.MIN_POOL_SIZE;
+import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
+import static org.jboss.as.messaging.CommonAttributes.SELECTOR;
 import static org.jboss.as.messaging.CommonAttributes.TRANSACTION;
 import static org.jboss.as.messaging.CommonAttributes.USE_AUTO_RECOVERY;
+import static org.jboss.as.messaging.Element.SOURCE;
+import static org.jboss.as.messaging.Element.TARGET;
 
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.messaging.jms.JndiEntriesAttribute;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 
+/**
+ * Messaging subsystem 1.3 XML parser.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a>
+ *
+ */
 public class Messaging13SubsystemParser extends Messaging12SubsystemParser {
 
     private static final Messaging13SubsystemParser INSTANCE = new Messaging13SubsystemParser();
@@ -193,5 +237,220 @@ public class Messaging13SubsystemParser extends Messaging12SubsystemParser {
         checkOnlyOneOfElements(reader, seen, Element.CONNECTORS, Element.DISCOVERY_GROUP_REF);
 
         return connectionFactory;
+    }
+
+    protected void processHornetQServers(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Namespace schemaVer = Namespace.forUri(reader.getNamespaceURI());
+            switch (schemaVer) {
+                case MESSAGING_1_0:
+                case UNKNOWN:
+                    throw ParseUtils.unexpectedElement(reader);
+                default: {
+                    final Element element = Element.forName(reader.getLocalName());
+                    switch (element) {
+                        case HORNETQ_SERVER:
+                            processHornetQServer(reader, subsystemAddress, list, schemaVer);
+                            break;
+                        case JMS_BRIDGE:
+                            processJmsBridge(reader, subsystemAddress, list);
+                            break;
+                        default:
+                            throw ParseUtils.unexpectedElement(reader);
+                    }
+                }
+            }
+        }
+    }
+
+    private void processJmsBridge(XMLExtendedStreamReader reader, ModelNode subsystemAddress, List<ModelNode> list) throws XMLStreamException {
+        String bridgeName = null;
+        String moduleName = null;
+
+        final int count = reader.getAttributeCount();
+        for (int n = 0; n < count; n++) {
+            String attrName = reader.getAttributeLocalName(n);
+            Attribute attribute = Attribute.forName(attrName);
+            switch (attribute) {
+                case NAME:
+                    bridgeName = reader.getAttributeValue(n);
+                    break;
+                case MODULE:
+                    moduleName = reader.getAttributeValue(n);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, n);
+            }
+        }
+
+        if (bridgeName == null || bridgeName.length() == 0) {
+            bridgeName = DEFAULT;
+        }
+
+        final ModelNode address = subsystemAddress.clone();
+        address.add(JMS_BRIDGE, bridgeName);
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(ADD);
+        operation.get(OP_ADDR).set(address);
+        list.add(operation);
+
+        if (moduleName != null && moduleName.length() > 0) {
+            JMSBridgeDefinition.MODULE.parseAndSetParameter(moduleName, operation, reader);
+        }
+
+        while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case SOURCE:
+                case TARGET:
+                    processJmsBridgeResource(reader, operation, element.getLocalName());
+                    break;
+                case QUALITY_OF_SERVICE:
+                case FAILURE_RETRY_INTERVAL:
+                case MAX_RETRIES:
+                case MAX_BATCH_SIZE:
+                case MAX_BATCH_TIME:
+                case SUBSCRIPTION_NAME:
+                case CLIENT_ID:
+                case ADD_MESSAGE_ID_IN_HEADER:
+                    handleElementText(reader, element, operation);
+                    break;
+                case SELECTOR:
+                    requireSingleAttribute(reader, CommonAttributes.STRING);
+                    final String selector = readStringAttributeElement(reader, CommonAttributes.STRING);
+                    SELECTOR.parseAndSetParameter(selector, operation, reader);
+                    break;
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
+        }
+    }
+
+    private void processJmsBridgeResource(XMLExtendedStreamReader reader, ModelNode operation, String modelName) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case USER:
+                case PASSWORD:
+                    handleElementText(reader, element, modelName, operation);
+                    break;
+                case CONNECTION_FACTORY:
+                case DESTINATION:
+                    handleSingleAttribute(reader, element, modelName, CommonAttributes.NAME, operation);
+                    break;
+                case CONTEXT:
+                    ModelNode context = operation.get(element.getDefinition(modelName).getName());
+                    processContext(reader, context);
+                    break;
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
+        }
+    }
+
+    private void processContext(XMLExtendedStreamReader reader, ModelNode context) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case PROPERTY:
+                    int count = reader.getAttributeCount();
+                    String key = null;
+                    String value = null;
+                    for (int n = 0; n < count; n++) {
+                        String attrName = reader.getAttributeLocalName(n);
+                        Attribute attribute = Attribute.forName(attrName);
+                        switch (attribute) {
+                            case KEY:
+                                key = reader.getAttributeValue(n);
+                                break;
+                            case VALUE:
+                                value = reader.getAttributeValue(n);
+                                break;
+                            default:
+                                throw unexpectedAttribute(reader, n);
+                        }
+                    }
+                    context.get(key).set(value);
+                    ParseUtils.requireNoContent(reader);
+                    break;
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
+        }
+    }
+
+    public void writeContent(final XMLExtendedStreamWriter writer, final SubsystemMarshallingContext context) throws XMLStreamException {
+        context.startSubsystemElement(getExpectedNamespace().getUriString(), false);
+        final ModelNode node = context.getModelNode();
+
+        if (node.hasDefined(HORNETQ_SERVER)) {
+            final ModelNode servers = node.get(HORNETQ_SERVER);
+            boolean first = true;
+            for (Property prop : servers.asPropertyList()) {
+                writeHornetQServer(writer, prop.getName(), prop.getValue());
+                if (!first) {
+                    writeNewLine(writer);
+                } else {
+                    first = false;
+                }
+            }
+        }
+
+        if (node.hasDefined(JMS_BRIDGE)) {
+            final ModelNode jmsBridges = node.get(JMS_BRIDGE);
+            boolean first = true;for (Property prop : jmsBridges.asPropertyList()) {
+                writeJmsBridge(writer, prop.getName(), prop.getValue());
+                if (!first) {
+                    writeNewLine(writer);
+                } else {
+                    first = false;
+                }
+            }
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeJmsBridge(XMLExtendedStreamWriter writer, String bridgeName, ModelNode value) throws XMLStreamException {
+        writer.writeStartElement(Element.JMS_BRIDGE.getLocalName());
+
+        if (!DEFAULT.equals(bridgeName)) {
+            writer.writeAttribute(Attribute.NAME.getLocalName(), bridgeName);
+        }
+
+        JMSBridgeDefinition.MODULE.marshallAsAttribute(value, writer);
+
+        writer.writeStartElement(SOURCE.getLocalName());
+        for (SimpleAttributeDefinition attr : JMSBridgeDefinition.JMS_SOURCE_ATTRIBUTES) {
+            attr.marshallAsElement(value, writer);
+        }
+        writer.writeEndElement();
+
+        writer.writeStartElement(TARGET.getLocalName());
+        for (SimpleAttributeDefinition attr : JMSBridgeDefinition.JMS_TARGET_ATTRIBUTES) {
+            attr.marshallAsElement(value, writer);
+        }
+        writer.writeEndElement();
+
+        for (SimpleAttributeDefinition attr : JMSBridgeDefinition.JMS_BRIDGE_ATTRIBUTES) {
+            if (attr == JMSBridgeDefinition.MODULE) {
+                // handled as a XML attribute
+                continue;
+            }
+            attr.marshallAsElement(value, writer);
+        }
+
+        writer.writeEndElement();
+    }
+
+    static void handleSingleAttribute(final XMLExtendedStreamReader reader, final Element element, final String modelName, String attributeName, final ModelNode node) throws XMLStreamException {
+        AttributeDefinition attributeDefinition = element.getDefinition(modelName);
+        final String value = readStringAttributeElement(reader, attributeName);
+        if (attributeDefinition instanceof SimpleAttributeDefinition) {
+            ((SimpleAttributeDefinition) attributeDefinition).parseAndSetParameter(value, node, reader);
+        } else if (attributeDefinition instanceof ListAttributeDefinition) {
+            ((ListAttributeDefinition) attributeDefinition).parseAndAddParameterElement(value, node, reader);
+        }
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingDescriptions.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingDescriptions.java
@@ -477,7 +477,6 @@ public class MessagingDescriptions {
         return result;
     }
 
-
     static ModelNode getJmsQueueResource(final Locale locale) {
         final ResourceBundle bundle = getResourceBundle(locale);
 
@@ -1583,7 +1582,7 @@ public class MessagingDescriptions {
         return attr;
     }
 
-    private static ResourceBundle getResourceBundle(Locale locale) {
+    public static ResourceBundle getResourceBundle(Locale locale) {
         if (locale == null) {
             locale = Locale.getDefault();
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -22,6 +22,16 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.messaging.CommonAttributes.QUEUE;
+import static org.jboss.as.messaging.Namespace.MESSAGING_1_0;
+import static org.jboss.as.messaging.Namespace.MESSAGING_1_1;
+import static org.jboss.as.messaging.Namespace.MESSAGING_1_2;
+import static org.jboss.as.messaging.Namespace.MESSAGING_1_3;
+
 import java.util.EnumSet;
 
 import org.jboss.as.controller.Extension;
@@ -59,6 +69,7 @@ import org.jboss.as.messaging.jms.JMSTopicRemove;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryAdd;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryRemove;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryWriteAttributeHandler;
+<<<<<<< HEAD
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
@@ -69,6 +80,9 @@ import static org.jboss.as.messaging.Namespace.MESSAGING_1_0;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_1;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_2;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_3;
+=======
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
+>>>>>>> [AS7-4628] JMS bridge
 
 /**
  * Domain extension that integrates HornetQ.
@@ -104,6 +118,7 @@ public class MessagingExtension implements Extension {
     private static final PathElement DISCOVERY_GROUP_PATH = PathElement.pathElement(CommonAttributes.DISCOVERY_GROUP);
     private static final PathElement DIVERT_PATH = PathElement.pathElement(CommonAttributes.DIVERT);
     private static final PathElement GROUPING_HANDLER_PATH = PathElement.pathElement(CommonAttributes.GROUPING_HANDLER);
+    public static final PathElement JMS_BRIDGE_PATH = PathElement.pathElement(CommonAttributes.JMS_BRIDGE);
 
     static final PathElement SECURITY_ROLE = PathElement.pathElement(CommonAttributes.ROLE);
     static final PathElement SECURITY_SETTING = PathElement.pathElement(CommonAttributes.SECURITY_SETTING);
@@ -112,7 +127,7 @@ public class MessagingExtension implements Extension {
     private static final int MANAGEMENT_API_MINOR_VERSION = 2;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
-    static ResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
+    public static ResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
         return new StandardResourceDescriptionResolver(keyPrefix, RESOURCE_NAME, MessagingExtension.class.getClassLoader(), true, true);
     }
 
@@ -120,6 +135,7 @@ public class MessagingExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
         subsystem.registerXMLElementWriter(Messaging13SubsystemParser.getInstance());
+
         boolean registerRuntimeOnly = context.isRuntimeOnlyRegistrationValid();
 
         // Root resource
@@ -342,6 +358,9 @@ public class MessagingExtension implements Extension {
             JMSTopicConfigurationRuntimeHandler.INSTANCE.registerAttributes(deploymentTopics);
 
         }
+
+        // JMS Bridges
+        rootRegistration.registerSubModel(new JMSBridgeDefinition());
     }
 
     public void initializeParsers(ExtensionParsingContext context) {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -69,20 +69,7 @@ import org.jboss.as.messaging.jms.JMSTopicRemove;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryAdd;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryRemove;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryWriteAttributeHandler;
-<<<<<<< HEAD
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
-import static org.jboss.as.messaging.CommonAttributes.QUEUE;
-import static org.jboss.as.messaging.Namespace.MESSAGING_1_0;
-import static org.jboss.as.messaging.Namespace.MESSAGING_1_1;
-import static org.jboss.as.messaging.Namespace.MESSAGING_1_2;
-import static org.jboss.as.messaging.Namespace.MESSAGING_1_3;
-=======
 import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
->>>>>>> [AS7-4628] JMS bridge
 
 /**
  * Domain extension that integrates HornetQ.

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -159,4 +159,24 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 11609, value = "Attribute %s is deprecated and will not be taken into account")
     void deprecatedXMLAttribute(String name);
 
+    /**
+     * Logs an info message when a service for the given {@code type} and {@code name} is <em>started</em>.
+     *
+     * @param type the type of the service
+     * @param name the name of the service
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 11610, value = "Started %s %s")
+    void startedService(String type, String name);
+
+    /**
+     * Logs an info message when a service for the given {@code type} and {@code name} is <em>stopped</em>.
+     *
+     * @param type the type of the service
+     * @param name the name of the service
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 11611, value = "Stopped %s %s")
+    void stoppedService(String type, String name);
+
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -474,4 +474,17 @@ public interface MessagingMessages {
     @Message(id = 11670, value = "Only one of %s or %s is required")
     String onlyOneRequired(Object obj1, Object obj2);
 
+
+    /**
+     * Create an exception indicating that a messaging resource has failed
+     * to be recovered
+     *
+     * @param cause  the cause of the error.
+     * @param name the name that failed to be recovered.
+     *
+     * @return the message.
+     */
+    @Message(id = 11671, value = "Failed to recover %s")
+    OperationFailedException failedToRecover(@Cause Throwable cause, String name);
+
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.msc.service.ServiceName;
@@ -67,6 +69,10 @@ public class MessagingServices {
 
    public static ServiceName getQueueBaseServiceName(ServiceName hornetqServiceName) {
        return hornetqServiceName.append(CORE_QUEUE_BASE);
+   }
+
+   public static ServiceName getJMSBridgeServiceName(String bridgeName) {
+       return JBOSS_MESSAGING.append(JMS_BRIDGE).append(bridgeName);
    }
 
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemDescribeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemDescribeHandler.java
@@ -41,6 +41,7 @@ import org.jboss.as.messaging.jms.ConnectionFactoryAdd;
 import org.jboss.as.messaging.jms.JMSQueueAdd;
 import org.jboss.as.messaging.jms.JMSTopicAdd;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryAdd;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeAdd;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -76,6 +77,13 @@ class MessagingSubsystemDescribeHandler implements OperationStepHandler, Descrip
                 PathAddress serverAddress = rootAddress.append(PathElement.pathElement(CommonAttributes.HORNETQ_SERVER, prop.getName()));
                 serverAdd.get(OP_ADDR).set(serverAddress.toModelNode());
                 addHornetQServer(prop.getValue(), serverAdd, serverAddress, result);
+            }
+        }
+
+        if (subModel.hasDefined(CommonAttributes.JMS_BRIDGE)) {
+            for (Property prop : subModel.get(CommonAttributes.JMS_BRIDGE).asPropertyList()) {
+                PathAddress jmsBridgeAddress = rootAddress.append(PathElement.pathElement(CommonAttributes.JMS_BRIDGE, prop.getName()));
+                result.add(JMSBridgeAdd.getAddOperation(jmsBridgeAddress.toModelNode(), prop.getValue()));
             }
         }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -43,6 +43,7 @@ import static org.jboss.as.messaging.CommonAttributes.BROADCAST_GROUP;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTION_FACTORY;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTORS;
+import static org.jboss.as.messaging.CommonAttributes.DEFAULT;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP_NAME;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP_REF;
@@ -56,6 +57,7 @@ import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
 import static org.jboss.as.messaging.CommonAttributes.INBOUND_CONFIG;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
 import static org.jboss.as.messaging.CommonAttributes.JMS_CONNECTION_FACTORIES;
 import static org.jboss.as.messaging.CommonAttributes.JMS_DESTINATIONS;
 import static org.jboss.as.messaging.CommonAttributes.JMS_QUEUE;
@@ -169,7 +171,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
 
     }
 
-    private void processHornetQServers(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list) throws XMLStreamException {
+    protected void processHornetQServers(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list) throws XMLStreamException {
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             final Namespace schemaVer = Namespace.forUri(reader.getNamespaceURI());
             switch (schemaVer) {
@@ -190,7 +192,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         }
     }
 
-    private void processHornetQServer(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list, Namespace namespace) throws XMLStreamException {
+    protected void processHornetQServer(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list, Namespace namespace) throws XMLStreamException {
 
         String hqServerName = null;
         String elementName = null;
@@ -211,7 +213,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         }
 
         if (hqServerName == null || hqServerName.length() == 0) {
-            hqServerName = "default";
+            hqServerName = DEFAULT;
         }
 
         final ModelNode address = subsystemAddress.clone();
@@ -524,7 +526,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 }
                 case RETRY_INTERVAL:
                     // Use the "default" variant
-                    handleElementText(reader, element, "default", bridgeAdd);
+                    handleElementText(reader, element, DEFAULT, bridgeAdd);
                     break;
                 case FORWARDING_ADDRESS:
                 case RECONNECT_ATTEMPTS:
@@ -1399,15 +1401,14 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 first = false;
             }
         }
-
         writer.writeEndElement();
     }
 
-    private void writeHornetQServer(final XMLExtendedStreamWriter writer, final String serverName, final ModelNode node) throws XMLStreamException {
+    protected void writeHornetQServer(final XMLExtendedStreamWriter writer, final String serverName, final ModelNode node) throws XMLStreamException {
 
         writer.writeStartElement(Element.HORNETQ_SERVER.getLocalName());
 
-        if (!"default".equals(serverName)) {
+        if (!DEFAULT.equals(serverName)) {
             writer.writeAttribute(Attribute.NAME.getLocalName(), serverName);
         }
 
@@ -2255,7 +2256,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                     break;
                 case RETRY_INTERVAL:
                     // Use the "default" variant
-                    handleElementText(reader, element, "default", connectionFactory);
+                    handleElementText(reader, element, DEFAULT, connectionFactory);
                     break;
                 case RECONNECT_ATTEMPTS:
                 case SCHEDULED_THREAD_POOL_MAX_SIZE:
@@ -2340,7 +2341,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         return connectionFactory;
     }
 
-    private static void writeNewLine(XMLExtendedStreamWriter writer) throws XMLStreamException {
+    protected static void writeNewLine(XMLExtendedStreamWriter writer) throws XMLStreamException {
         writer.writeCharacters(NEW_LINE, 0, 1);
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/SecurityActions.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/SecurityActions.java
@@ -25,7 +25,7 @@ package org.jboss.as.messaging.jms;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-final class SecurityActions {
+public final class SecurityActions {
 
     private SecurityActions() {
         // forbidden inheritance
@@ -36,7 +36,7 @@ final class SecurityActions {
      *
      * @return the current context classloader
      */
-    static ClassLoader getContextClassLoader() {
+    public static ClassLoader getContextClassLoader() {
         if (System.getSecurityManager() == null) {
             return Thread.currentThread().getContextClassLoader();
         } else {
@@ -54,7 +54,7 @@ final class SecurityActions {
      * @param classLoader
      *            the classloader
      */
-    static void setContextClassLoader(final ClassLoader classLoader) {
+    public static void setContextClassLoader(final ClassLoader classLoader) {
         if (System.getSecurityManager() == null) {
             Thread.currentThread().setContextClassLoader(classLoader);
         } else {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/InfiniteOrPositiveValidators.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/InfiniteOrPositiveValidators.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Validates a given parameter is a legal value (-1 or > 0) where -1 means "forever"
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public interface InfiniteOrPositiveValidators {
+
+    ModelTypeValidator LONG_INSTANCE = new ModelTypeValidator(ModelType.LONG) {
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+            long val = value.asLong();
+            if (!(val == -1 || (val > 0 && val < Long.MAX_VALUE))) {
+                throw new OperationFailedException(new ModelNode().set(MESSAGES.illegalValue(value, parameterName)));
+            }
+        }
+    };
+
+    ModelTypeValidator INT_INSTANCE = new ModelTypeValidator(ModelType.INT) {
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+            int val = value.asInt();
+            if (!(val == -1 || (val > 0 && val < Integer.MAX_VALUE))) {
+                throw new OperationFailedException(new ModelNode().set(MESSAGES.illegalValue(value, parameterName)));
+            }
+        }
+    };
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeAdd.java
@@ -25,6 +25,7 @@ package org.jboss.as.messaging.jms.bridge;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.operations.common.Util.getOperation;
+import static org.jboss.as.server.Services.addServerExecutorDependency;
 
 import java.util.List;
 import java.util.Properties;
@@ -107,11 +108,13 @@ public class JMSBridgeAdd extends AbstractAddStepHandler {
                         .addListener(verificationHandler)
                         .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
                         .setInitialMode(Mode.ACTIVE);
+                addServerExecutorDependency(jmsBridgeServiceBuilder, bridgeService.getExecutorInjector(), false);
                 if (dependsOnHornetQServer(context, model)) {
                     // add a dependency to the JMS Manager instead of HornetQ service since it is this service
                     // that effectively start HornetQ
                     jmsBridgeServiceBuilder.addDependency((JMSServices.getJmsManagerBaseServiceName(MessagingServices.getHornetQServiceName("default"))));
                 }
+
                 newControllers.add(jmsBridgeServiceBuilder.install());
 
                 context.completeStep();

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeAdd.java
@@ -1,0 +1,198 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.operations.common.Util.getOperation;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.hornetq.jms.bridge.ConnectionFactoryFactory;
+import org.hornetq.jms.bridge.DestinationFactory;
+import org.hornetq.jms.bridge.JMSBridge;
+import org.hornetq.jms.bridge.QualityOfServiceMode;
+import org.hornetq.jms.bridge.impl.JMSBridgeImpl;
+import org.hornetq.jms.bridge.impl.JNDIConnectionFactoryFactory;
+import org.hornetq.jms.bridge.impl.JNDIDestinationFactory;
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.as.messaging.jms.JMSServices;
+import org.jboss.as.messaging.jms.SelectorAttribute;
+import org.jboss.as.txn.service.TxnServices;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * JMS Bridge add update.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeAdd extends AbstractAddStepHandler {
+    public static final JMSBridgeAdd INSTANCE = new JMSBridgeAdd();
+
+    /**
+     * Create an "add" operation using the existing model
+     */
+    public static ModelNode getAddOperation(final ModelNode address, ModelNode subModel) {
+        return getOperation(ADD, address, subModel);
+    }
+
+    private JMSBridgeAdd() {
+    }
+
+    @Override
+    protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
+        for (final AttributeDefinition attributeDefinition : JMSBridgeDefinition.JMS_BRIDGE_ATTRIBUTES) {
+            attributeDefinition.validateAndSet(operation, model);
+        }
+        for (final AttributeDefinition attributeDefinition : JMSBridgeDefinition.JMS_TARGET_ATTRIBUTES) {
+            attributeDefinition.validateAndSet(operation, model);
+        }
+        for (final AttributeDefinition attributeDefinition : JMSBridgeDefinition.JMS_SOURCE_ATTRIBUTES) {
+            attributeDefinition.validateAndSet(operation, model);
+        }
+    }
+
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model,
+            final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers)
+                    throws OperationFailedException {
+        context.addStep(new OperationStepHandler() {
+
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+
+                String moduleName = resolveAttribute(JMSBridgeDefinition.MODULE, context, model);
+                final JMSBridge bridge = createJMSBridge(context, model);
+
+                final String bridgeName = address.getLastElement().getValue();
+                final JMSBridgeService bridgeService = new JMSBridgeService(moduleName, bridgeName, bridge);
+                final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
+
+                final ServiceBuilder<JMSBridge> jmsBridgeServiceBuilder = context.getServiceTarget().addService(bridgeServiceName, bridgeService)
+                        .addListener(verificationHandler)
+                        .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                        .setInitialMode(Mode.ACTIVE);
+                if (dependsOnHornetQServer(context, model)) {
+                    // add a dependency to the JMS Manager instead of HornetQ service since it is this service
+                    // that effectively start HornetQ
+                    jmsBridgeServiceBuilder.addDependency((JMSServices.getJmsManagerBaseServiceName(MessagingServices.getHornetQServiceName("default"))));
+                }
+                newControllers.add(jmsBridgeServiceBuilder.install());
+
+                context.completeStep();
+            }
+        }, OperationContext.Stage.RUNTIME);
+    }
+
+    private boolean dependsOnHornetQServer(OperationContext context, ModelNode model) throws OperationFailedException {
+        final Properties sourceContextProperties = resolveContextProperties(JMSBridgeDefinition.SOURCE_CONTEXT, context, model);
+        final Properties targetContextProperties = resolveContextProperties(JMSBridgeDefinition.TARGET_CONTEXT, context, model);
+
+        // if either the source or target context properties are null, this means that the JMS resources will be looked up
+        // from the local HornetQ server.
+        return (sourceContextProperties == null || targetContextProperties == null);
+    }
+
+    private JMSBridge createJMSBridge(OperationContext context, ModelNode model) throws OperationFailedException {
+        final Properties sourceContextProperties = resolveContextProperties(JMSBridgeDefinition.SOURCE_CONTEXT, context, model);
+        final String sourceConnectionFactoryName = JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
+        final ConnectionFactoryFactory sourceCff = new JNDIConnectionFactoryFactory(sourceContextProperties , sourceConnectionFactoryName);
+        final String sourceDestinationName = JMSBridgeDefinition.SOURCE_DESTINATION.resolveModelAttribute(context, model).asString();
+        final DestinationFactory sourceDestinationFactory = new JNDIDestinationFactory(sourceContextProperties, sourceDestinationName);
+
+        final Properties targetContextProperties = resolveContextProperties(JMSBridgeDefinition.TARGET_CONTEXT, context, model);
+        final String targetConnectionFactoryName = JMSBridgeDefinition.TARGET_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
+        final ConnectionFactoryFactory targetCff = new JNDIConnectionFactoryFactory(targetContextProperties, targetConnectionFactoryName);
+        final String targetDestinationName = JMSBridgeDefinition.TARGET_DESTINATION.resolveModelAttribute(context, model).asString();
+        final DestinationFactory targetDestinationFactory = new JNDIDestinationFactory(targetContextProperties, targetDestinationName);
+
+        final String sourceUsername = resolveAttribute(JMSBridgeDefinition.SOURCE_USER, context, model);
+        final String sourcePassword = resolveAttribute(JMSBridgeDefinition.SOURCE_PASSWORD, context, model);
+        final String targetUsername = resolveAttribute(JMSBridgeDefinition.TARGET_USER, context, model);
+        final String targetPassword = resolveAttribute(JMSBridgeDefinition.TARGET_PASSWORD, context, model);
+
+        final String selector = resolveAttribute(SelectorAttribute.SELECTOR, context, model);
+        final long failureRetryInterval = JMSBridgeDefinition.FAILURE_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final int maxRetries = JMSBridgeDefinition.MAX_RETRIES.resolveModelAttribute(context, model).asInt();
+        final QualityOfServiceMode qosMode = QualityOfServiceMode.valueOf( JMSBridgeDefinition.QUALITY_OF_SERVICE.resolveModelAttribute(context, model).asString());
+        final int maxBatchSize = JMSBridgeDefinition.MAX_BATCH_SIZE.resolveModelAttribute(context, model).asInt();
+        final long maxBatchTime = JMSBridgeDefinition.MAX_BATCH_TIME.resolveModelAttribute(context, model).asLong();
+        final String subName =  resolveAttribute(JMSBridgeDefinition.SUBSCRIPTION_NAME, context, model);
+        final String clientID = resolveAttribute(JMSBridgeDefinition.CLIENT_ID, context, model);
+        final boolean addMessageIDInHeader = JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER.resolveModelAttribute(context, model).asBoolean();
+
+        return new JMSBridgeImpl(sourceCff,
+                targetCff,
+                sourceDestinationFactory,
+                targetDestinationFactory,
+                sourceUsername,
+                sourcePassword,
+                targetUsername,
+                targetPassword,
+                selector,
+                failureRetryInterval,
+                maxRetries,
+                qosMode,
+                maxBatchSize,
+                maxBatchTime,
+                subName,
+                clientID,
+                addMessageIDInHeader);
+    }
+
+    private Properties resolveContextProperties(AttributeDefinition attribute, OperationContext context, ModelNode model) throws OperationFailedException {
+        final ModelNode contextModel = attribute.resolveModelAttribute(context, model);
+        if (!contextModel.isDefined()) {
+            return null;
+        }
+
+        final Properties contextProperties = new Properties();
+        for (Property property : contextModel.asPropertyList()) {
+            contextProperties.put(property.getName(), property.getValue().asString());
+        }
+        return contextProperties;
+    }
+
+    /**
+     * Return null if the resolved attribute is not defined
+     */
+    private String resolveAttribute(SimpleAttributeDefinition attr, OperationContext context, ModelNode model) throws OperationFailedException {
+        final ModelNode node = attr.resolveModelAttribute(context, model);
+        return node.isDefined() ? node.asString() : null;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
@@ -1,0 +1,197 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
+import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.INT;
+import static org.jboss.dmr.ModelType.LONG;
+import static org.jboss.dmr.ModelType.STRING;
+
+import java.util.Locale;
+
+import org.hornetq.jms.bridge.QualityOfServiceMode;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.MessagingDescriptions;
+import org.jboss.as.messaging.MessagingExtension;
+import org.jboss.as.messaging.jms.SelectorAttribute;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeDefinition extends SimpleResourceDefinition {
+
+    public static final JMSBridgeDefinition INSTANCE = new JMSBridgeDefinition();
+
+    public static final String SOURCE = "source";
+    public static final String TARGET = "target";
+    public static final String CONTEXT = "context";
+
+    public static final String PAUSE = "pause";
+    public static final String RESUME = "resume";
+
+    public static final SimpleAttributeDefinition MODULE = create("module", STRING)
+            .setAllowNull(true).
+            build();
+    public static final SimpleAttributeDefinition SOURCE_CONNECTION_FACTORY = new JNDIResourceAttributeDefinition("source-connection-factory", CommonAttributes.CONNECTION_FACTORY);
+    public static final SimpleAttributeDefinition SOURCE_DESTINATION = new JNDIResourceAttributeDefinition("source-destination", CommonAttributes.DESTINATION);
+    public static final SimpleAttributeDefinition SOURCE_USER = create("source-user", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("user")
+            .build();
+    public static final SimpleAttributeDefinition SOURCE_PASSWORD = create("source-password", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("password")
+            .build();
+    public static final SimpleAttributeDefinition SOURCE_CONTEXT = new JNDIContextAttributeDefinition("source-context", CONTEXT);
+
+    public static final SimpleAttributeDefinition TARGET_CONNECTION_FACTORY = new JNDIResourceAttributeDefinition("target-connection-factory", CommonAttributes.CONNECTION_FACTORY);
+    public static final SimpleAttributeDefinition TARGET_DESTINATION = new JNDIResourceAttributeDefinition("target-destination", CommonAttributes.DESTINATION);
+    public static final SimpleAttributeDefinition TARGET_USER = create("target-user", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("user")
+            .build();
+    public static final SimpleAttributeDefinition TARGET_PASSWORD = create("target-password", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("password")
+            .build();
+    public static final SimpleAttributeDefinition TARGET_CONTEXT = new JNDIContextAttributeDefinition("target-context", CONTEXT);
+
+    public static final SimpleAttributeDefinition QUALITY_OF_SERVICE = create("quality-of-service", STRING)
+            .setValidator(new EnumValidator<QualityOfServiceMode>(QualityOfServiceMode.class, false, false))
+            .build();
+    public static final SimpleAttributeDefinition FAILURE_RETRY_INTERVAL = create("failure-retry-interval", LONG)
+            .setMeasurementUnit(MILLISECONDS)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
+            .build();
+    public static final SimpleAttributeDefinition MAX_RETRIES = create("max-retries", INT)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
+            .build();
+    public static final SimpleAttributeDefinition MAX_BATCH_SIZE = create("max-batch-size", INT)
+            .setValidator(new IntRangeValidator(0, Integer.MAX_VALUE, false, false))
+            .build();
+    public static final SimpleAttributeDefinition MAX_BATCH_TIME = create("max-batch-time", LONG)
+            .setMeasurementUnit(MILLISECONDS)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
+            .build();
+    public static final SimpleAttributeDefinition SUBSCRIPTION_NAME = create("subscription-name", STRING)
+            .setAllowNull(true)
+            .build();
+    public static final SimpleAttributeDefinition CLIENT_ID = create("client-id", STRING)
+            .setAllowNull(true)
+            .build();
+    public static final SimpleAttributeDefinition ADD_MESSAGE_ID_IN_HEADER = create("add-messageID-in-header", BOOLEAN)
+            .setAllowNull(true)
+            .setDefaultValue(new ModelNode().set(false))
+            .build();
+    public static final SimpleAttributeDefinition STARTED = create(CommonAttributes.STARTED, BOOLEAN)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .build();
+    public static final SimpleAttributeDefinition PAUSED = create(CommonAttributes.PAUSED, BOOLEAN)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .build();
+
+    public static final SimpleAttributeDefinition[] JMS_BRIDGE_ATTRIBUTES = {
+        MODULE,
+        SelectorAttribute.SELECTOR,
+        QUALITY_OF_SERVICE,
+        FAILURE_RETRY_INTERVAL, MAX_RETRIES,
+        MAX_BATCH_SIZE, MAX_BATCH_TIME,
+        SUBSCRIPTION_NAME, CommonAttributes.CLIENT_ID,
+        ADD_MESSAGE_ID_IN_HEADER
+    };
+
+    public static final SimpleAttributeDefinition[] JMS_SOURCE_ATTRIBUTES = {
+        SOURCE_CONNECTION_FACTORY, SOURCE_DESTINATION,
+        SOURCE_USER, SOURCE_PASSWORD,
+        SOURCE_CONTEXT
+    };
+
+    public static final SimpleAttributeDefinition[] JMS_TARGET_ATTRIBUTES = {
+        TARGET_CONNECTION_FACTORY, TARGET_DESTINATION,
+        TARGET_USER, TARGET_PASSWORD,
+        TARGET_CONTEXT
+    };
+
+    public static final SimpleAttributeDefinition[] READONLY_ATTRIBUTES = {
+        STARTED, PAUSED
+    };
+
+    public static final String[] OPERATIONS = {
+        ModelDescriptionConstants.START, ModelDescriptionConstants.STOP,
+        PAUSE, RESUME
+    };
+
+    public JMSBridgeDefinition() {
+        super(MessagingExtension.JMS_BRIDGE_PATH,
+                MessagingExtension.getResourceDescriptionResolver(CommonAttributes.JMS_BRIDGE),
+                JMSBridgeAdd.INSTANCE,
+                JMSBridgeRemove.INSTANCE);
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registry) {
+        super.registerAttributes(registry);
+        for (SimpleAttributeDefinition attr : JMS_BRIDGE_ATTRIBUTES) {
+            registry.registerReadWriteAttribute(attr, null, JMSBridgeWriteAttributeHandler.INSTANCE);
+        }
+        for (SimpleAttributeDefinition attr : JMS_SOURCE_ATTRIBUTES) {
+            registry.registerReadWriteAttribute(attr, null, JMSBridgeWriteAttributeHandler.INSTANCE);
+        }
+        for (SimpleAttributeDefinition attr : JMS_TARGET_ATTRIBUTES) {
+            registry.registerReadWriteAttribute(attr, null, JMSBridgeWriteAttributeHandler.INSTANCE);
+        }
+        for (SimpleAttributeDefinition attr : READONLY_ATTRIBUTES) {
+            registry.registerReadOnlyAttribute(attr, JMSBridgeHandler.INSTANCE);
+        }
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration registry) {
+        super.registerOperations(registry);
+        for (final String operationName: OPERATIONS) {
+            registry.registerOperationHandler(operationName, JMSBridgeHandler.INSTANCE, new DescriptionProvider() {
+                @Override
+                public ModelNode getModelDescription(Locale locale) {
+                    return MessagingDescriptions.getDescriptionOnlyOperation(locale, operationName, JMS_BRIDGE);
+                }
+            });
+        }
+    }
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
@@ -68,8 +68,14 @@ public class JMSBridgeHandler extends AbstractRuntimeOnlyHandler {
                 .getValue();
         final String operationName = operation.require(OP).asString();
 
+        final boolean modify;
+        if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+            modify = false;
+        } else {
+            modify = true;
+        }
         final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
-        ServiceController<?> bridgeService = context.getServiceRegistry(true).getService(bridgeServiceName);
+        ServiceController<?> bridgeService = context.getServiceRegistry(modify).getService(bridgeServiceName);
         if (bridgeService == null) {
             throw new OperationFailedException(ControllerMessages.MESSAGES.noHandler(READ_ATTRIBUTE_OPERATION, PathAddress.pathAddress(operation.require(OP_ADDR))));
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP;
+import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.CommonAttributes.PAUSED;
+import static org.jboss.as.messaging.CommonAttributes.STARTED;
+import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+import static org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition.PAUSE;
+import static org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition.RESUME;
+
+import org.hornetq.jms.bridge.JMSBridge;
+import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.ParametersValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeHandler extends AbstractRuntimeOnlyHandler {
+
+    public static final JMSBridgeHandler INSTANCE = new JMSBridgeHandler();
+
+    private ParametersValidator readAttributeValidator = new ParametersValidator();
+
+    private JMSBridgeHandler() {
+        readAttributeValidator.registerValidator(NAME, new StringLengthValidator(1));
+    }
+
+    @Override
+    protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final String bridgeName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement()
+                .getValue();
+        final String operationName = operation.require(OP).asString();
+
+        final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
+        ServiceController<?> bridgeService = context.getServiceRegistry(false).getService(bridgeServiceName);
+        JMSBridge bridge = JMSBridge.class.cast(bridgeService.getValue());
+
+        if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+            readAttributeValidator.validate(operation);
+            final String name = operation.require(NAME).asString();
+            if (STARTED.equals(name)) {
+                context.getResult().set(bridge.isStarted());
+            } else if (PAUSED.equals(name)) {
+                context.getResult().set(bridge.isPaused());
+            } else {
+                throw MESSAGES.unsupportedAttribute(name);
+            }
+        }
+        else if (START.equals(operationName)) {
+            try {
+                // we do not start the bridge directly but call startBridge() instead
+                // to ensure the class loader will be able to load any external resources
+                JMSBridgeService service = (JMSBridgeService) bridgeService.getService();
+                service.startBridge();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else if (STOP.equals(operationName)) {
+            try {
+                bridge.stop();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else if (PAUSE.equals(operationName)) {
+            try {
+                bridge.pause();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else if (RESUME.equals(operationName)) {
+            try {
+                bridge.resume();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else {
+            throw MESSAGES.unsupportedOperation(operationName);
+        }
+
+        if (context.completeStep() != OperationContext.ResultAction.KEEP) {
+            try {
+                if (START.equals(operationName)) {
+                    bridge.stop();
+                } else if (STOP.equals(operationName)) {
+                    JMSBridgeService service = (JMSBridgeService) bridgeService.getService();
+                    service.startBridge();
+                } else if (PAUSE.equals(operationName)) {
+                    bridge.resume();
+                } else if (RESUME.equals(operationName)) {
+                    bridge.pause();
+                }
+            } catch (Exception e) {
+                ROOT_LOGGER.revertOperationFailed(e, getClass().getSimpleName(), operation
+                        .require(ModelDescriptionConstants.OP).asString(), PathAddress.pathAddress(operation
+                                .require(ModelDescriptionConstants.OP_ADDR)));
+            }
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeRemove.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Removes a JMS Bridge.
+ *
+ * @author Jeff Mesnil (c) 2011 Red Hat Inc.
+ */
+public class JMSBridgeRemove extends AbstractRemoveStepHandler {
+
+    public static final String OPERATION_NAME = REMOVE;
+
+    public static JMSBridgeRemove INSTANCE = new JMSBridgeRemove();
+
+    private JMSBridgeRemove() {
+    }
+
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+        final String bridgeName = address.getLastElement().getValue();
+        context.removeService(MessagingServices.getJMSBridgeServiceName(bridgeName));
+    }
+
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
@@ -31,6 +31,7 @@ import javax.transaction.TransactionManager;
 
 import org.hornetq.jms.bridge.JMSBridge;
 import org.jboss.as.messaging.MessagingLogger;
+import org.jboss.as.messaging.jms.SecurityActions;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -90,14 +91,14 @@ class JMSBridgeService implements Service<JMSBridge> {
         if (moduleName == null) {
             bridge.start();
         } else {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            ClassLoader cl = SecurityActions.getContextClassLoader();
             try {
                 ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
                 Module module = Module.getCallerModuleLoader().loadModule(moduleID);
-                Thread.currentThread().setContextClassLoader(module.getClassLoader());
+                SecurityActions.setContextClassLoader(module.getClassLoader());
                 bridge.start();
             } finally {
-                Thread.currentThread().setContextClassLoader(cl);
+                SecurityActions.setContextClassLoader(cl);
             }
         }
         MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
+import java.security.AccessController;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import javax.transaction.TransactionManager;
+
+import org.hornetq.jms.bridge.JMSBridge;
+import org.jboss.as.messaging.MessagingLogger;
+import org.jboss.as.txn.service.TxnServices;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.threads.JBossThreadFactory;
+
+/**
+ * Service responsible for JMS Bridges.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+class JMSBridgeService implements Service<JMSBridge> {
+    private final JMSBridge bridge;
+    private final String bridgeName;
+    private final String moduleName;
+    private final ThreadFactory THREAD_FACTORY = new JBossThreadFactory(new ThreadGroup("JMSBridge-threads"), Boolean.FALSE, null, "%G - %t", null, null, AccessController.getContext());
+    private final Executor executor = Executors.newCachedThreadPool(THREAD_FACTORY);
+
+    public JMSBridgeService(final String moduleName, final String bridgeName, final JMSBridge bridge) {
+        if(bridge == null) {
+            throw MESSAGES.nullVar("bridge");
+        }
+        this.moduleName = moduleName;
+        this.bridgeName = bridgeName;
+        this.bridge = bridge;
+    }
+
+    public static TransactionManager getTransactionManager(StartContext context) {
+        @SuppressWarnings("unchecked")
+        ServiceController<TransactionManager> service = (ServiceController<TransactionManager>) context.getController().getServiceContainer().getService(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER);
+        return service == null ? null : service.getValue();
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    bridge.setTransactionManager(getTransactionManager(context));
+                    startBridge();
+
+                    context.complete();
+                } catch (Throwable e) {
+                    context.failed(MESSAGES.failedToCreate(e, "JMS Bridge"));
+                }
+            }
+        };
+        context.asynchronous();
+        executor.execute(r);
+    }
+
+    public void startBridge() throws Exception {
+        if (moduleName == null) {
+            bridge.start();
+        } else {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            try {
+                ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
+                Module module = Module.getCallerModuleLoader().loadModule(moduleID);
+                Thread.currentThread().setContextClassLoader(module.getClassLoader());
+                bridge.start();
+            } finally {
+                Thread.currentThread().setContextClassLoader(cl);
+            }
+        }
+        MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    bridge.stop();
+                    MessagingLogger.MESSAGING_LOGGER.stoppedService("JMS Bridge", bridgeName);
+
+                    context.complete();
+                } catch(Exception e) {
+                    MESSAGING_LOGGER.failedToDestroy("bridge", bridgeName);
+                }
+            }
+        };
+        context.asynchronous();
+        executor.execute(r);
+    }
+
+    @Override
+    public JMSBridge getValue() throws IllegalStateException {
+        return bridge;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeWriteAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeWriteAttributeHandler.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.global.WriteAttributeHandlers;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Write attribute handler for attributes that update a JMS bridge resource.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeWriteAttributeHandler extends WriteAttributeHandlers.WriteAttributeOperationHandler {
+
+    public static final JMSBridgeWriteAttributeHandler INSTANCE = new JMSBridgeWriteAttributeHandler();
+
+    private final Map<String, AttributeDefinition> attributes = new HashMap<String, AttributeDefinition>();
+
+    private JMSBridgeWriteAttributeHandler() {
+        for (AttributeDefinition attr : JMSBridgeDefinition.JMS_BRIDGE_ATTRIBUTES) {
+            attributes.put(attr.getName(), attr);
+        }
+        for (AttributeDefinition attr : JMSBridgeDefinition.JMS_SOURCE_ATTRIBUTES) {
+            attributes.put(attr.getName(), attr);
+        }
+        for (AttributeDefinition attr : JMSBridgeDefinition.JMS_TARGET_ATTRIBUTES) {
+            attributes.put(attr.getName(), attr);
+        }
+    }
+
+    @Override
+    protected void modelChanged(final OperationContext context, final ModelNode operation, final String attributeName,
+                                final ModelNode newValue, final ModelNode currentValue) throws OperationFailedException {
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                final AttributeDefinition attr = attributes.get(attributeName);
+                final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+                if(attr.hasAlternative(resource.getModel())) {
+                    context.setRollbackOnly();
+                    throw new OperationFailedException(new ModelNode().set(MESSAGES.altAttributeAlreadyDefined(attributeName)));
+                }
+                context.completeStep();
+            }
+        }, OperationContext.Stage.VERIFY);
+
+        context.reloadRequired();
+
+        if (context.completeStep() != OperationContext.ResultAction.KEEP) {
+            context.revertReloadRequired();
+        }
+    }
+
+    @Override
+    protected void validateValue(String name, ModelNode value) throws OperationFailedException {
+        AttributeDefinition attr = attributes.get(name);
+        attr.getValidator().validateParameter(name, value);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIContextAttributeDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIContextAttributeDefinition.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+import static org.jboss.as.messaging.Element.PROPERTY;
+import static org.jboss.dmr.ModelType.OBJECT;
+import static org.jboss.dmr.ModelType.STRING;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.messaging.Attribute;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * {@link org.jboss.as.controller.AttributeDefinition} for a JNDI context hashtable
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JNDIContextAttributeDefinition extends SimpleAttributeDefinition {
+
+    protected JNDIContextAttributeDefinition(String name, String xmlName) {
+        super(name, xmlName, null, OBJECT, true, false, null);
+    }
+
+    @Override
+    public ModelNode addResourceAttributeDescription(ModelNode resourceDescription, ResourceDescriptionResolver resolver,
+            Locale locale, ResourceBundle bundle) {
+        final ModelNode result = super.addResourceAttributeDescription(resourceDescription, resolver, locale, bundle);
+        result.get(VALUE_TYPE).set(STRING);
+        return result;
+    }
+
+    @Override
+    public ModelNode addOperationParameterDescription(ModelNode resourceDescription, String operationName,
+            ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
+        final ModelNode result = super.addOperationParameterDescription(resourceDescription, operationName, resolver, locale,
+                bundle);
+        result.get(VALUE_TYPE).set(STRING);
+        return result;
+    }
+
+    @Override
+    public void marshallAsElement(ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer)
+            throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            ModelNode context = resourceModel.get(getName());
+
+            writer.writeStartElement(getXmlName());
+            for (Property property : context.asPropertyList()) {
+                writer.writeStartElement(PROPERTY.getLocalName());
+                writer.writeAttribute(Attribute.KEY.getLocalName(), property.getName());
+                writer.writeAttribute(Attribute.VALUE.getLocalName(), property.getValue().asString());
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIResourceAttributeDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIResourceAttributeDefinition.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.messaging.Attribute;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@link org.jboss.as.controller.AttributeDefinition} for a JMS JNDI resource to look up.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JNDIResourceAttributeDefinition extends SimpleAttributeDefinition {
+    protected JNDIResourceAttributeDefinition(String name, String xmlName) {
+        super(name, xmlName, null, ModelType.STRING, false, false, null);
+    }
+
+    @Override
+    public void marshallAsElement(ModelNode resourceModel, XMLStreamWriter writer) throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            String name = resourceModel.get(getName()).asString();
+            writer.writeEmptyElement(getXmlName());
+            writer.writeAttribute(Attribute.NAME.getLocalName(), name);
+        }
+    }
+}

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -589,3 +589,33 @@ security-role.manage=This permission allows the user to invoke management operat
 socket-binding=The socket binding reference.
 
 deployed=Runtime resources exposed by messaging resources included in this deployment.
+
+jms-bridge=A JMS bridge instance.
+jms-bridge.add=Add a new JMS bridge.
+jms-bridge.remove=Remove an existing JMS bridge.
+jms-bridge.source-connection-factory=The name of the source connection factory to lookup on the source messaging server.
+jms-bridge.source-destination=The name of the source destination to lookup on the source messaging server.
+jms-bridge.source-user=The name of the user for creating the source connection.
+jms-bridge.source-password=The password for creating the source connection.
+jms-bridge.source-context=he properties used to configure the source JNDI initial context.
+jms-bridge.target-connection-factory=The name of the target connection factory to lookup on the target messaging server.
+jms-bridge.target-destination=The name of the target destination to lookup on the target messaging server.
+jms-bridge.target-user=The name of the user for creating the target connection.
+jms-bridge.target-password=The password for creating the target connection.
+jms-bridge.target-context=The properties used to configure the target JNDI initial context.
+jms-bridge.selector=A JMS selector expression used for consuming messages from the source destination. Only messages that match the selector expression will be bridged from the source to the target destination.
+jms-bridge.quality-of-service=The desired quality of service mode (AT_MOST_ONCE, DUPLICATES_OK or ONCE_AND_ONLY_ONCE).
+jms-bridge.failure-retry-interval=The amount of time in milliseconds to wait between trying to recreate connections to the source or target servers when the bridge has detected they have failed.
+jms-bridge.max-retries=The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.
+jms-bridge.max-batch-size=The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.
+jms-bridge.max-batch-time=The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.
+jms-bridge.subscription-name=The name of the subscription if it is durable and the source destination is a topic.
+jms-bridge.client-id=The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.
+jms-bridge.add-messageID-in-header=If true, then the original message's message ID will be appended in the message sent to the destination in the header HORNETQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.
+jms-bridge.module=The name of AS7 module containing the resources required to lookup source and target JMS resources.
+jms-bridge.started=Whether the JMS bridge is started.
+jms-bridge.paused=Whether the JMS bridge is paused.
+jms-bridge.start=Start the JMS bridge.
+jms-bridge.stop=Stop the JMS bridge.
+jms-bridge.pause=Pause the JMS bridge.
+jms-bridge.resume=Resume the JMS bridge.

--- a/messaging/src/test/java/org/jboss/as/messaging/test/JMSBridge13ParsingUnitTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/JMSBridge13ParsingUnitTestCase.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.test;
+
+import java.io.IOException;
+
+import org.jboss.as.messaging.MessagingExtension;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+
+/**
+ * @author Jeff Mesnil (c) 2012 Red Hat inc
+ */
+public class JMSBridge13ParsingUnitTestCase extends AbstractSubsystemBaseTest {
+
+    public JMSBridge13ParsingUnitTestCase() {
+        super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("jms-bridge_1_3.xml");
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.MANAGEMENT;
+    }
+}

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/jms-bridge_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/jms-bridge_1_3.xml
@@ -1,0 +1,48 @@
+    <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+        <jms-bridge module="org.another.mq.broker">
+            <source>
+               <connection-factory name="/cf/sourceCF" />
+               <destination name="/topic/sourceTopic" />
+               <user>myUser</user>
+               <password>myPassword</password>
+            </source>
+            <target>
+                <connection-factory name="anotherAS7/jms/cf/targetCF" />
+                <destination name="anotherAS7/jms/queue/targetQueue" />
+	            <user>${userInExpression}</user>
+                <password>${passwordInExpression}</password>
+                <context>
+                    <property key="java.naming.factory.initial"  value="org.jnp.interfaces.NamingContextFactory" />
+                    <property key="java.naming.provider.url"     value="jnp://localhost:1099" />
+                    <property key="java.naming.factory.url.pkgs" value="org.jboss.naming:org.jnp.interfaces"/>
+                    <property key="jnp.timeout"                  value="5000"/>
+                    <property key="jnp.sotimeout"                value="5000"/>
+                </context>
+            </target>
+            <selector string="color='red'"/>
+            <quality-of-service>ONCE_AND_ONLY_ONCE</quality-of-service>
+            <failure-retry-interval>-1</failure-retry-interval>
+            <max-retries>-1</max-retries>
+            <max-batch-size>1</max-batch-size>
+            <max-batch-time>-1</max-batch-time>
+            <subscription-name>mySubscription</subscription-name>
+            <client-id>myClientID</client-id>
+            <add-messageID-in-header>true</add-messageID-in-header>
+        </jms-bridge>
+
+        <jms-bridge name="bridgeB">
+            <source>
+                <connection-factory name="/cf/sourceCF" />
+                <destination name="/topic/anotherSourceTopic" />
+            </source>
+            <target>
+                <connection-factory name="/cf/targetCF" />
+                <destination name="anotherMQ/jms/queue/anotherTargetQueue" />
+            </target>
+            <quality-of-service>AT_MOST_ONCE</quality-of-service>
+            <failure-retry-interval>45678</failure-retry-interval>
+            <max-retries>7890</max-retries>
+            <max-batch-size>12345</max-batch-size>
+            <max-batch-time>10000</max-batch-time>
+        </jms-bridge>
+    </subsystem>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/CreateJMSBridgeSetupTask.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/CreateJMSBridgeSetupTask.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms;
+
+import java.io.IOException;
+
+import org.hornetq.jms.bridge.QualityOfServiceMode;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.logging.Logger;
+
+/**
+ * Setup task to create/remove a JMS bridge.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class CreateJMSBridgeSetupTask extends CreateQueueSetupTask {
+
+    public static final String CF_NAME = "myAwesomeCF";
+    public static final String CF_JNDI_NAME = "/myAwesomeCF";
+    public static final String JMS_BRIDGE_NAME = "myAwesomeJMSBridge";
+
+    private static final Logger logger = Logger.getLogger(CreateJMSBridgeSetupTask.class);
+
+    private ManagementClient managementClient;
+
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        super.setup(managementClient, containerId);
+        this.managementClient = managementClient;
+
+        createConnectionFactory(CF_NAME, CF_JNDI_NAME);
+        createJmsBridge(JMS_BRIDGE_NAME);
+    }
+
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        removeJmsBridge(JMS_BRIDGE_NAME);
+        removeConnectionFactory(CF_NAME);
+        super.tearDown(managementClient, containerId);
+    }
+
+
+    private void createConnectionFactory(String cfName, String cfJndiName) {
+        final ModelNode createConnectionFactoryOp = new ModelNode();
+        createConnectionFactoryOp.get(ClientConstants.OP).set(ClientConstants.ADD);
+        createConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        createConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("hornetq-server", "default");
+        createConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("connection-factory", cfName);
+        ModelNode connector = createConnectionFactoryOp.get("connector");
+        connector.get("in-vm").set(ModelType.UNDEFINED);
+
+        createConnectionFactoryOp.get("factory-type").set("XA_GENERIC");
+        createConnectionFactoryOp.get("entries").add(cfJndiName);
+        System.err.println("Create operation =====> " + createConnectionFactoryOp);
+        try {
+            this.applyUpdate(createConnectionFactoryOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void removeConnectionFactory(String cfName) {
+        final ModelNode removeConnectionFactoryOp = new ModelNode();
+        removeConnectionFactoryOp.get(ClientConstants.OP).set("remove");
+        removeConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        removeConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("hornetq-server", "default");
+        removeConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("connection-factory", cfName);
+        try {
+            this.applyUpdate(removeConnectionFactoryOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private void createJmsBridge(String bridgeName) {
+        final ModelNode createJmsBridgeOp = new ModelNode();
+        createJmsBridgeOp.get(ClientConstants.OP).set(ClientConstants.ADD);
+        createJmsBridgeOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        createJmsBridgeOp.get(ClientConstants.OP_ADDR).add("jms-bridge", bridgeName);
+        createJmsBridgeOp.get("source-connection-factory").set(CF_JNDI_NAME);
+        createJmsBridgeOp.get("source-destination").set(QUEUE1_JNDI_NAME);
+        createJmsBridgeOp.get("target-connection-factory").set(CF_JNDI_NAME);
+        createJmsBridgeOp.get("target-destination").set(QUEUE2_JNDI_NAME);
+        createJmsBridgeOp.get("quality-of-service").set(QualityOfServiceMode.ONCE_AND_ONLY_ONCE.toString());
+        createJmsBridgeOp.get("failure-retry-interval").set(500);
+        createJmsBridgeOp.get("max-retries").set(2);
+        createJmsBridgeOp.get("max-batch-size").set(1024);
+        createJmsBridgeOp.get("max-batch-time").set(100);
+        createJmsBridgeOp.get("add-messageID-in-header").set("true");
+        try {
+            this.applyUpdate(createJmsBridgeOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void removeJmsBridge(String bridgeName) {
+        final ModelNode removeJmsBridgeOp = new ModelNode();
+        removeJmsBridgeOp.get(ClientConstants.OP).set("remove");
+        removeJmsBridgeOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        removeJmsBridgeOp.get(ClientConstants.OP_ADDR).add("jms-bridge", bridgeName);
+        try {
+            this.applyUpdate(removeJmsBridgeOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void applyUpdate(final ModelNode update) throws IOException {
+        ModelNode result = managementClient.getControllerClient().execute(update);
+        if (result.hasDefined(ClientConstants.OUTCOME)
+                && ClientConstants.SUCCESS.equals(result.get(ClientConstants.OUTCOME).asString())) {
+            logger.info("Operation successful for update = " + update.toString());
+        } else if (result.hasDefined(ClientConstants.FAILURE_DESCRIPTION)) {
+            final String failureDesc = result.get(ClientConstants.FAILURE_DESCRIPTION).toString();
+            throw new RuntimeException(failureDesc);
+        } else {
+            throw new RuntimeException("Operation not successful; outcome = " + result.get(ClientConstants.OUTCOME));
+        }
+    }
+
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import javax.annotation.Resource;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.hornetq.api.jms.HornetQJMSConstants;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * JMS bridge test.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(CreateJMSBridgeSetupTask.class)
+public class JMSBridgeTest {
+
+    private static final Logger logger = Logger.getLogger(JMSBridgeTest.class);
+
+    private static final String MESSAGE_TEXT = "Hello world!";
+
+    @Resource(mappedName = "/queue/myAwesomeQueue")
+    private Queue sourceQueue;
+
+    @Resource(mappedName = "/queue/myAwesomeQueue2")
+    private Queue targetQueue;
+
+    @Resource(mappedName = "/myAwesomeCF")
+    private ConnectionFactory factory;
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "test.jar")
+                .addPackage(JMSOperations.class.getPackage())
+                .addClass(CreateJMSBridgeSetupTask.class)
+                .addClass(CreateQueueSetupTask.class)
+                .addAsManifestResource(
+                        EmptyAsset.INSTANCE,
+                        ArchivePaths.create("beans.xml"));
+    }
+
+    /**
+     * Send a message on the source queue
+     * Consumes it on the target queue
+     *
+     * The test will pass since a JMS Bridge has been created to bridge the source destination to the target destination.
+     */
+    @Test
+    public void sendAndReceiveMessage() throws Exception {
+        Connection connection = null;
+        Session session = null;
+        Message receivedMessage = null;
+
+        try {
+            // SEND A MESSAGE on the source queue
+            connection = factory.createConnection();
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageProducer producer = session.createProducer(sourceQueue);
+            String text = MESSAGE_TEXT + " " + UUID.randomUUID().toString();
+            Message message = session.createTextMessage(text);
+            message.setJMSDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            producer.send(message);
+            connection.start();
+            connection.close();
+
+            // RECEIVE THE MESSAGE from the target queue
+            connection = factory.createConnection();
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageConsumer consumer = session.createConsumer(targetQueue);
+            connection.start();
+            receivedMessage = consumer.receive(5000);
+
+            // ASSERTIONS
+            assertNotNull("did not receive expected message", receivedMessage);
+            assertTrue(receivedMessage instanceof TextMessage);
+            assertTrue(((TextMessage) receivedMessage).getText().equals(text));
+            assertNotNull("did not get header set by the JMS bridge", receivedMessage.getStringProperty(HornetQJMSConstants.JBOSS_MESSAGING_BRIDGE_MESSAGE_ID_LIST));
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            // CLEANUP
+            if (session != null) {
+                session.close();
+            }
+            if (connection != null) {
+                connection.close();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Add manage JMS Bridge to AS7 messaging subsystem
- update messaging subsystem namespace and XSD to 1.3
- <hornetq-server> is now optional (so that an AS7 instance
  can host only JMS bridges)
- define JMS Bridge using SimpleResourceDefinition
- add integration test JMSBridgeTest using in-vm source and target
  resources
- add management operations start, stop, pause, resume
- add org.jboss.remote-naming to org.jboss.as.messaging dependencies
  to be able to do a JNDI lookup on a remote AS7 instance
  to set up a JMS bridge
- add module attribute for external broker dependencies
- add dependency to HornetQ's JMS service only if one of the JMS resource is looked up locally
- start/stop the JMS Bridge service asynchronously
- add a dependency from org.jboss.as.messaging to org.jboss.threads module to
  create the executor in charge of starting/stopping JMS bridge services asynchronously
