### PR TITLE
[7.1] [AS7-4268] JMS Bridge

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -2485,7 +2485,7 @@
                                         </group>
                                         <group>
                                             <title>Module org.jboss.as.messaging</title>
-                                            <packages>org.jboss.as.messaging:org.jboss.as.messaging.deployment:org.jboss.as.messaging.jms</packages>
+                                            <packages>org.jboss.as.messaging:org.jboss.as.messaging.deployment:org.jboss.as.messaging.jms:org.jboss.as.messaging.jms.bridge</packages>
                                         </group>
                                         <group>
                                             <title>Module org.jboss.as.modcluster</title>

--- a/build/src/main/resources/configuration/examples/subsystems/messaging-hornetq-colocated.xml
+++ b/build/src/main/resources/configuration/examples/subsystems/messaging-hornetq-colocated.xml
@@ -3,7 +3,7 @@
 <config>
    <!-- This is very different from the normal messaging setup, do duplicating the config is easier -->
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.1">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
        <hornetq-server>
            <clustered>true</clustered>
            <persistence-enabled>true</persistence-enabled>

--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.2">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
        <hornetq-server>
            <?CLUSTERED?>
            <persistence-enabled>true</persistence-enabled>

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -1,0 +1,976 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:messaging:1.3"
+           targetNamespace="urn:jboss:domain:messaging:1.3"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.3">
+
+    <!-- The messaging subsystem root element -->
+    <xs:element name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the messaging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="hornetq-server" type="hornetq-serverType" />
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="hornetq-serverType">
+      <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+                The configuration of an individual HornetQ Server.
+            ]]>
+          </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+          <xs:element maxOccurs="1" minOccurs="0" name="clustered" type="xs:boolean" />
+          <!-- no file system deployment in AS
+          <xs:element maxOccurs="1" minOccurs="0" type="file-deployment-enabled"/>
+           -->
+          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean" />
+          <!--  TODO use thread subsystem?  -->
+          <xs:element maxOccurs="1" minOccurs="0" name="scheduled-thread-pool-max-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                     Maximum number of threads to use for the scheduled thread pool
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="thread-pool-max-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Maximum number of threads to use for the thread pool
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string" />
+          <!-- no logging configuration for AS needed
+          <xs:element maxOccurs="1" minOccurs="0" name="log-delegate-factory-class-name" type="xs:string" />
+           -->
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="live-connector-ref" type="live-connectorType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="perf-blast-pages" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long" />
+
+          <xs:element maxOccurs="1" minOccurs="0" name="paging-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="bindings-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="large-messages-directory" type="directoryType" />
+
+          <xs:element maxOccurs="1" minOccurs="0" name="connectors">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-connector" type="netty-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-connector" type="inVM-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector" type="connectorType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="acceptors">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-acceptor" type="netty-acceptorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-acceptor" type="inVM-acceptorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="acceptor" type="acceptorType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="broadcast-groups">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="broadcast-group" type="broadcast-groupType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="discovery-groups">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="discovery-group" type="discovery-groupType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="diverts">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="divert" type="divertType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="core-queues" type="queuesType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="bridges">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="bridge" type="bridgeType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-connections">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="cluster-connection" type="clusterConnectionType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="grouping-handler" type="groupingHandlerType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-settings" type="security-settingsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="address-settings" type="address-settingsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connector-services">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-service" type="connectorServiceType"/>
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jms-connection-factories">
+              <xs:complexType>
+                  <xs:sequence>
+                  <xs:element name="connection-factory" maxOccurs="unbounded" minOccurs="0" type="connection-factoryType" />
+                  <xs:element name="pooled-connection-factory" maxOccurs="unbounded" minOccurs="0" type="pooled-connection-factoryType" />
+                </xs:sequence>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jms-destinations">
+              <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="jms-queue" maxOccurs="unbounded" minOccurs="0" type="jmsQueueType" />
+                    <xs:element name="jms-topic" maxOccurs="unbounded" minOccurs="0" type="jmsTopicType" />
+                </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+        <xs:annotation>
+            <xs:documentation>
+                The name to use for this HornetQ Server. Must be unique across all "hornetq-server" elements
+                in the subsystem. So, this attribute is optional with a default value, but if more than
+                one "hornetq-server" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="local-bind-address" type="xs:string"/>
+    <xs:element name="local-bind-port" type="xs:int"/>
+    <xs:element name="group-address" type="xs:string"/>
+    <xs:element name="group-port" type="xs:int"/>
+    <xs:element name="broadcast-period" type="xs:long"/>
+    <xs:element name="initial-wait-timeout" type="xs:int"/>
+
+    <xs:complexType name="broadcast-groupType">
+       <xs:sequence>
+           <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+           </xs:choice>
+           <xs:element maxOccurs="1" minOccurs="0" ref="broadcast-period" />
+           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-groupType">
+        <xs:sequence>
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+            </xs:choice>
+            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int" />
+            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-interceptorsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+       <xs:attribute name="key" type="xs:string" use="required"/>
+       <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="netty-connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The netty connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="inVM-connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The inVM connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:attribute name="server-id" type="xs:int" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Generic connector type, with optional socket-binding depending on whether
+              the implementation requires a Host/Port parameter.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+             </xs:sequence>
+             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-connectorType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="netty-acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The netty acceptor type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="inVM-acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The inVM connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:attribute name="server-id" type="xs:int" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Generic acceptor type, with optional socket-binding depending on whether
+              the implementation requires a Host/Port parameter.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+             </xs:sequence>
+             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-acceptorType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="bridgeType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long"  />
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-server-shutdown" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string" />
+          <xs:choice>
+             <xs:element maxOccurs="1" minOccurs="1" name="static-connectors">
+                <xs:complexType>
+                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="1" name="connector-ref" type="xs:string"/>
+                   </xs:sequence>
+                </xs:complexType>
+             </xs:element>
+             <xs:element maxOccurs="1" minOccurs="1" name="discovery-group-ref" type="discovery-group-refType" />
+          </xs:choice>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="clusterConnectionType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
+          <xs:choice>
+             <xs:element maxOccurs="1" minOccurs="0" name="static-connectors">
+                <xs:complexType>
+                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string"/>
+                   </xs:sequence>
+                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional"/>
+                </xs:complexType>
+             </xs:element>
+             <xs:element maxOccurs="1" minOccurs="0" name="discovery-group-ref" type="discovery-group-refType" />
+          </xs:choice>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="divertType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="journalType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="ASYNCIO"/>
+          <xs:enumeration value="NIO"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="groupingHandlerType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="type" type="groupingHandlerTypeType"/>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string"/>
+          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int"/>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="groupingHandlerTypeType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="LOCAL"/>
+          <xs:enumeration value="REMOTE"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="security-settingsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="security-setting" type="security-settingType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="security-settingType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="permission">
+             <xs:complexType>
+                <xs:attribute name="type" type="xs:string" use="required"/>
+                <xs:attribute name="roles" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+       </xs:sequence>
+       <xs:attribute name="match" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="address-settingsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="address-setting" type="address-settingType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="address-settingType">
+       <xs:all>
+          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean" />
+       </xs:all>
+       <xs:attribute name="match" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="queuesType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="queue" type="queueType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="queueType">
+       <xs:all>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean" />
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="live-connectorType">
+       <xs:attribute name="connector-name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:simpleType name="addressFullMessagePolicyType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="DROP"/>
+          <xs:enumeration value="PAGE"/>
+          <xs:enumeration value="BLOCK"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="connectorServiceType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="directoryType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A directory location configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem pathname where the directory should be
+                located.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir" />
+        <xs:attribute name="path" type="xs:string" />
+    </xs:complexType>
+
+
+   <!-- using a xs:all does not allow to factorize connection-factoryType and pooled-connection-factoryType
+        in a common base type definition.
+        The elements/attributes common to both are copied/pasted...
+    -->
+   <xs:complexType name="connection-factoryType">
+      <xs:all>
+         <!-- start of JMS connection-factoryType specific elements          -->
+         <!-- ============================================================== -->
+         <xs:element name="factory-type" type="connectionFactoryType" minOccurs="0" maxOccurs="1"/>
+         <!-- ============================================================== -->
+         <!-- end of JMS connection-factoryType specific elements            -->
+
+         <!-- start of common elements                                       -->
+         <!--  ============================================================= -->
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="connector-ref" type="connector-refType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="entries" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1">
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <!-- ============================================================= -->
+         <!-- end of common elements                                        -->
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" />
+   </xs:complexType>
+
+   <xs:simpleType name="connectionFactoryType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="GENERIC"/>
+         <xs:enumeration value="QUEUE"/>
+         <xs:enumeration value="TOPIC"/>
+         <xs:enumeration value="XA_GENERIC"/>
+         <xs:enumeration value="XA_QUEUE"/>
+         <xs:enumeration value="XA_TOPIC"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="pooled-connection-factoryType">
+      <xs:all>
+         <!-- start of JMS pooled-connection-factoryType specific elements   -->
+         <!-- ============================================================== -->
+         <xs:element name="inbound-config" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <!-- ============================================================== -->
+         <!-- end of JMS pooled-connection-factoryType specific elements     -->
+
+         <!-- start of common elements                                       -->
+         <!--  ============================================================= -->
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="connector-ref" type="connector-refType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="entries" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1">
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <!-- ============================================================= -->
+         <!-- end of common elements                                        -->
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" />
+   </xs:complexType>
+
+
+   <xs:complexType name="connector-refType">
+      <xs:attribute name="connector-name" type="xs:string" use="required" />
+      <xs:attribute name="backup-connector-name" type="xs:string" use="optional">
+          <xs:annotation>
+              <xs:documentation>
+                  Deprecated. the backup-connector-name attribute is no longer taken into account when configuring a connector-ref.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="entryType">
+      <xs:attribute name="name" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:complexType name="discovery-group-refType">
+      <xs:attribute name="discovery-group-name" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:complexType name="jmsQueueType">
+      <xs:sequence>
+         <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
+         <xs:element name="selector" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:attribute name="string" type="xs:string" use="required" />
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:complexType name="jmsTopicType">
+      <xs:sequence>
+         <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required" />
+   </xs:complexType>
+
+    <xs:complexType name="transactionType">
+        <xs:attribute name="mode" use="required" type="modeType"/>
+    </xs:complexType>
+
+    <xs:simpleType name="modeType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="xa">
+                <xs:annotation>
+                    <xs:documentation></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="local">
+                <xs:annotation>
+                    <xs:documentation></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+   <xs:complexType name="jms-bridgeType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge.
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long" />
+
+         <xs:element maxOccurs="1" minOccurs="0" name="selector" type="selectorType" />
+         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string" />
+         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string" />
+         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean" />
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+         <xs:annotation>
+            <xs:documentation>
+               The name to use for this JMS bridge. Must be unique across all "jms-bridge" elements
+               in the subsystem. So, this attribute is optional with a default value, but if more than
+               one "jms-bridge" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="module" type="xs:string" use="optional">
+         <xs:annotation>
+            <xs:documentation>
+               The name of the module that contains resources required to lookup source or target JMS resources from another messaging broker than AS7.
+               This does not need to be specified if the bridge uses AS7 instances for both source and target.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="jms-bridgeResourceType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge resource which serves either of the source (from which the messages are consumed)
+               or the destination (to which messages are produced).
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="connection-factory">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the connection factory.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the destination.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The name of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The password of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="contex" type="contextType" />
+      </xs:all>
+   </xs:complexType>
+
+   <xs:complexType name="selectorType">
+      <xs:attribute name="string" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:simpleType name="quality-of-serviceType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="AT_MOST_ONCE"/>
+         <xs:enumeration value="DUPLICATES_OK"/>
+         <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="contextType">
+      <xs:annotation>
+         <xs:documentation>
+             The properties set on the JNDI Context used to lookup the JMS bridge resources.
+             In the absence of a context element, the JMS bridge will lookup resources locally on its own AS7 instance.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="paramType" />
+      </xs:sequence>
+   </xs:complexType>
+
+</xs:schema>

--- a/build/src/main/resources/modules/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/messaging/main/module.xml
@@ -45,6 +45,7 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
+        <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.ironjacamar.impl"/>
@@ -55,5 +56,7 @@
         <module name="org.jboss.metadata"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.jboss-transaction-spi"/>
+        <module name="org.jboss.remote-naming"/>
+        <module name="org.jboss.threads"/>
     </dependencies>
 </module>

--- a/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
 
 /**
  *
@@ -27,7 +28,9 @@ public enum Attribute {
    SOCKET_BINDING(CommonAttributes.SOCKET_BINDING),
    STRING(CommonAttributes.STRING),
    TYPE_ATTR_NAME(CommonAttributes.TYPE_ATTR_NAME),
-   VALUE(CommonAttributes.VALUE);
+   VALUE(CommonAttributes.VALUE),
+   MODULE(JMSBridgeDefinition.MODULE);
+
 
    private final String name;
    private final AttributeDefinition definition;

--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -34,6 +34,7 @@ import static org.hornetq.core.config.impl.ConfigurationImpl.DEFAULT_MEMORY_MEAS
 import static org.hornetq.core.config.impl.ConfigurationImpl.DEFAULT_MEMORY_WARNING_THRESHOLD;
 import static org.hornetq.core.config.impl.ConfigurationImpl.DEFAULT_SCHEDULED_THREAD_POOL_MAX_SIZE;
 import static org.hornetq.core.config.impl.ConfigurationImpl.DEFAULT_THREAD_POOL_MAX_SIZE;
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.PERCENTAGE;
 import static org.jboss.as.controller.registry.AttributeAccess.Flag.RESTART_ALL_SERVICES;
@@ -127,7 +128,9 @@ public interface CommonAttributes {
     SimpleAttributeDefinition CLIENT_FAILURE_CHECK_PERIOD = new SimpleAttributeDefinition("client-failure-check-period",
             new ModelNode().set(HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD), ModelType.INT,  true, MeasurementUnit.MILLISECONDS);
 
-    SimpleAttributeDefinition CLIENT_ID = new SimpleAttributeDefinition("client-id",  ModelType.STRING, true);
+    SimpleAttributeDefinition CLIENT_ID = create("client-id", ModelType.STRING)
+            .setAllowNull(true)
+            .build();
 
     SimpleAttributeDefinition CLUSTERED = new SimpleAttributeDefinition("clustered",
             new ModelNode().set(ConfigurationImpl.DEFAULT_CLUSTERED), ModelType.BOOLEAN,  true, AttributeAccess.Flag.RESTART_ALL_SERVICES);
@@ -628,7 +631,9 @@ public interface CommonAttributes {
     String CORE_ADDRESS ="core-address";
     String CORE_QUEUE ="core-queue";
     String CORE_QUEUES ="core-queues";
+    String DEFAULT ="default";
     String DELIVERING_COUNT ="delivering-count";
+    String DESTINATION ="destination";
     String DISCOVERY_GROUP = "discovery-group";
     String DISCOVERY_GROUPS = "discovery-groups";
     String DISCOVERY_GROUP_REF ="discovery-group-ref";
@@ -645,6 +650,7 @@ public interface CommonAttributes {
     String INITIAL_MESSAGE_PACKET_SIZE = "initial-message-packet-size";
     String IN_VM_ACCEPTOR ="in-vm-acceptor";
     String IN_VM_CONNECTOR ="in-vm-connector";
+    String JMS_BRIDGE ="jms-bridge";
     String JMS_CONNECTION_FACTORIES ="jms-connection-factories";
     String JMS_DESTINATIONS = "jms-destinations";
     String JMS_QUEUE ="jms-queue";
@@ -766,6 +772,4 @@ public interface CommonAttributes {
     AttributeDefinition[] CONNECTOR_SERVICE_ATTRIBUTES = { FACTORY_CLASS };
 
     String[] PATHS = new String[] {CommonAttributes.BINDINGS_DIRECTORY, CommonAttributes.JOURNAL_DIRECTORY, CommonAttributes.LARGE_MESSAGES_DIRECTORY, CommonAttributes.PAGING_DIRECTORY};
-
-
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/Element.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Element.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -174,7 +175,7 @@ public enum Element {
    CHECK_PERIOD(getCheckPeriodDefinitions()),
    CLIENT_FAILURE_CHECK_PERIOD(CommonAttributes.CLIENT_FAILURE_CHECK_PERIOD),
    CLIENT_ID(CommonAttributes.CLIENT_ID),
-   CONNECTION_FACTORY(CommonAttributes.CONNECTION_FACTORY),
+   CONNECTION_FACTORY(getConnectionFactoryDefinitions()),
    CONNECTION_FACTORIES(CommonAttributes.JMS_CONNECTION_FACTORIES),
    CONNECTION_TTL(getConnectionTTLDefinitions()),
    CONFIRMATION_WINDOW_SIZE(CommonAttributes.CONFIRMATION_WINDOW_SIZE),
@@ -197,7 +198,7 @@ public enum Element {
    MAX_RETRY_INTERVAL(getMaxRetryIntervalDefinitions()),
    MIN_LARGE_MESSAGE_SIZE(CommonAttributes.MIN_LARGE_MESSAGE_SIZE),
    MIN_POOL_SIZE(CommonAttributes.MIN_POOL_SIZE),
-   PASSWORD(CommonAttributes.PASSWORD),
+   PASSWORD(getPasswordDefinitions()),
    PRE_ACK(CommonAttributes.PRE_ACK),
    PRODUCER_WINDOW_SIZE(CommonAttributes.PRODUCER_WINDOW_SIZE),
    PRODUCER_MAX_RATE(CommonAttributes.PRODUCER_MAX_RATE),
@@ -209,7 +210,7 @@ public enum Element {
    SCHEDULED_THREAD_POOL_MAX_SIZE(getScheduledThreadPoolDefinitions()),
    THREAD_POOL_MAX_SIZE(getThreadPoolDefinitions()),
    TRANSACTION_BATH_SIZE(CommonAttributes.TRANSACTION_BATCH_SIZE),
-   USER(CommonAttributes.USER),
+   USER(getUserDefinitions()),
    USE_DUPLICATE_DETECTION(getDuplicateDetectionDefinitions()),
    USE_GLOBAL_POOLS(CommonAttributes.USE_GLOBAL_POOLS),
    POOLED_CONNECTION_FACTORY(CommonAttributes.POOLED_CONNECTION_FACTORY),
@@ -223,6 +224,22 @@ public enum Element {
    SETUP_ATTEMPTS(CommonAttributes.SETUP_ATTEMPTS),
    SETUP_INTERVAL(CommonAttributes.SETUP_INTERVAL),
    SOCKET_BINDING(CommonAttributes.SOCKET_BINDING.getName()),
+
+   // JMS Bridge
+   JMS_BRIDGE(CommonAttributes.JMS_BRIDGE),
+   SOURCE(JMSBridgeDefinition.SOURCE),
+   TARGET(JMSBridgeDefinition.TARGET),
+   DESTINATION(getDestinationDefinitions()),
+   CONTEXT(getContextDefinitions()),
+   PROPERTY("property"),
+   QUALITY_OF_SERVICE(JMSBridgeDefinition.QUALITY_OF_SERVICE),
+   FAILURE_RETRY_INTERVAL(JMSBridgeDefinition.FAILURE_RETRY_INTERVAL),
+   MAX_RETRIES(JMSBridgeDefinition.MAX_RETRIES),
+   MAX_BATCH_SIZE(JMSBridgeDefinition.MAX_BATCH_SIZE),
+   MAX_BATCH_TIME(JMSBridgeDefinition.MAX_BATCH_TIME),
+   SUBSCRIPTION_NAME(JMSBridgeDefinition.SUBSCRIPTION_NAME),
+   ADD_MESSAGE_ID_IN_HEADER(JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER),
+   MODULE(JMSBridgeDefinition.MODULE),
    ;
 
    private final String name;
@@ -392,6 +409,43 @@ public enum Element {
         final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
         result.put("cluster", CommonAttributes.CLUSTER_CONNECTION_CHECK_PERIOD);
         result.put("default", CommonAttributes.CHECK_PERIOD);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getUserDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_USER);
+        result.put("target", JMSBridgeDefinition.TARGET_USER);
+        result.put("default", CommonAttributes.USER);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getPasswordDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_PASSWORD);
+        result.put("target", JMSBridgeDefinition.TARGET_PASSWORD);
+        result.put("default", CommonAttributes.PASSWORD);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getConnectionFactoryDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY);
+        result.put("target", JMSBridgeDefinition.TARGET_CONNECTION_FACTORY);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getDestinationDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_DESTINATION);
+        result.put("target", JMSBridgeDefinition.TARGET_DESTINATION);
+        return result;
+    }
+
+    private static Map<String, AttributeDefinition> getContextDefinitions() {
+        final Map<String, AttributeDefinition> result = new HashMap<String, AttributeDefinition>();
+        result.put("source", JMSBridgeDefinition.SOURCE_CONTEXT);
+        result.put("target", JMSBridgeDefinition.TARGET_CONTEXT);
         return result;
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
@@ -1,0 +1,291 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.readStringAttributeElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireSingleAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.messaging.CommonAttributes.DEFAULT;
+import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
+import static org.jboss.as.messaging.CommonAttributes.SELECTOR;
+import static org.jboss.as.messaging.Element.SOURCE;
+import static org.jboss.as.messaging.Element.TARGET;
+
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+
+/**
+ * Messaging subsystem 1.3 XML parser.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a>
+ *
+ */
+public class Messaging13SubsystemParser extends Messaging12SubsystemParser {
+
+    private static final Messaging13SubsystemParser INSTANCE = new Messaging13SubsystemParser();
+
+    public static MessagingSubsystemParser getInstance() {
+        return INSTANCE;
+    }
+
+    protected Messaging13SubsystemParser() {
+    }
+
+    @Override
+    public Namespace getExpectedNamespace() {
+        return Namespace.MESSAGING_1_3;
+    }
+
+    @Override
+    protected void processHornetQServers(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Namespace schemaVer = Namespace.forUri(reader.getNamespaceURI());
+            switch (schemaVer) {
+                case MESSAGING_1_0:
+                case UNKNOWN:
+                    throw ParseUtils.unexpectedElement(reader);
+                default: {
+                    final Element element = Element.forName(reader.getLocalName());
+                    switch (element) {
+                        case HORNETQ_SERVER:
+                            processHornetQServer(reader, subsystemAddress, list, schemaVer);
+                            break;
+                        case JMS_BRIDGE:
+                            processJmsBridge(reader, subsystemAddress, list);
+                            break;
+                        default:
+                            throw ParseUtils.unexpectedElement(reader);
+                    }
+                }
+            }
+        }
+    }
+
+    private void processJmsBridge(XMLExtendedStreamReader reader, ModelNode subsystemAddress, List<ModelNode> list) throws XMLStreamException {
+        String bridgeName = null;
+        String moduleName = null;
+
+        final int count = reader.getAttributeCount();
+        for (int n = 0; n < count; n++) {
+            String attrName = reader.getAttributeLocalName(n);
+            Attribute attribute = Attribute.forName(attrName);
+            switch (attribute) {
+                case NAME:
+                    bridgeName = reader.getAttributeValue(n);
+                    break;
+                case MODULE:
+                    moduleName = reader.getAttributeValue(n);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, n);
+            }
+        }
+
+        if (bridgeName == null || bridgeName.length() == 0) {
+            bridgeName = DEFAULT;
+        }
+
+        final ModelNode address = subsystemAddress.clone();
+        address.add(JMS_BRIDGE, bridgeName);
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(ADD);
+        operation.get(OP_ADDR).set(address);
+        list.add(operation);
+
+        if (moduleName != null && moduleName.length() > 0) {
+            JMSBridgeDefinition.MODULE.parseAndSetParameter(moduleName, operation, reader);
+        }
+
+        while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case SOURCE:
+                case TARGET:
+                    processJmsBridgeResource(reader, operation, element.getLocalName());
+                    break;
+                case QUALITY_OF_SERVICE:
+                case FAILURE_RETRY_INTERVAL:
+                case MAX_RETRIES:
+                case MAX_BATCH_SIZE:
+                case MAX_BATCH_TIME:
+                case SUBSCRIPTION_NAME:
+                case CLIENT_ID:
+                case ADD_MESSAGE_ID_IN_HEADER:
+                    handleElementText(reader, element, operation);
+                    break;
+                case SELECTOR:
+                    requireSingleAttribute(reader, CommonAttributes.STRING);
+                    final String selector = readStringAttributeElement(reader, CommonAttributes.STRING);
+                    SELECTOR.parseAndSetParameter(selector, operation, reader);
+                    break;
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
+        }
+    }
+
+    private void processJmsBridgeResource(XMLExtendedStreamReader reader, ModelNode operation, String modelName) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case USER:
+                case PASSWORD:
+                    handleElementText(reader, element, modelName, operation);
+                    break;
+                case CONNECTION_FACTORY:
+                case DESTINATION:
+                    handleSingleAttribute(reader, element, modelName, CommonAttributes.NAME, operation);
+                    break;
+                case CONTEXT:
+                    ModelNode context = operation.get(element.getDefinition(modelName).getName());
+                    processContext(reader, context);
+                    break;
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
+        }
+    }
+
+    private void processContext(XMLExtendedStreamReader reader, ModelNode context) throws XMLStreamException {
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case PROPERTY:
+                    int count = reader.getAttributeCount();
+                    String key = null;
+                    String value = null;
+                    for (int n = 0; n < count; n++) {
+                        String attrName = reader.getAttributeLocalName(n);
+                        Attribute attribute = Attribute.forName(attrName);
+                        switch (attribute) {
+                            case KEY:
+                                key = reader.getAttributeValue(n);
+                                break;
+                            case VALUE:
+                                value = reader.getAttributeValue(n);
+                                break;
+                            default:
+                                throw unexpectedAttribute(reader, n);
+                        }
+                    }
+                    context.get(key).set(value);
+                    ParseUtils.requireNoContent(reader);
+                    break;
+                default:
+                    throw ParseUtils.unexpectedElement(reader);
+            }
+        }
+    }
+
+    public void writeContent(final XMLExtendedStreamWriter writer, final SubsystemMarshallingContext context) throws XMLStreamException {
+        context.startSubsystemElement(getExpectedNamespace().getUriString(), false);
+        final ModelNode node = context.getModelNode();
+
+        if (node.hasDefined(HORNETQ_SERVER)) {
+            final ModelNode servers = node.get(HORNETQ_SERVER);
+            boolean first = true;
+            for (Property prop : servers.asPropertyList()) {
+                writeHornetQServer(writer, prop.getName(), prop.getValue());
+                if (!first) {
+                    writeNewLine(writer);
+                } else {
+                    first = false;
+                }
+            }
+        }
+
+        if (node.hasDefined(JMS_BRIDGE)) {
+            final ModelNode jmsBridges = node.get(JMS_BRIDGE);
+            boolean first = true;for (Property prop : jmsBridges.asPropertyList()) {
+                writeJmsBridge(writer, prop.getName(), prop.getValue());
+                if (!first) {
+                    writeNewLine(writer);
+                } else {
+                    first = false;
+                }
+            }
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeJmsBridge(XMLExtendedStreamWriter writer, String bridgeName, ModelNode value) throws XMLStreamException {
+        writer.writeStartElement(Element.JMS_BRIDGE.getLocalName());
+
+        if (!DEFAULT.equals(bridgeName)) {
+            writer.writeAttribute(Attribute.NAME.getLocalName(), bridgeName);
+        }
+
+        JMSBridgeDefinition.MODULE.marshallAsAttribute(value, writer);
+
+        writer.writeStartElement(SOURCE.getLocalName());
+        for (SimpleAttributeDefinition attr : JMSBridgeDefinition.JMS_SOURCE_ATTRIBUTES) {
+            attr.marshallAsElement(value, writer);
+        }
+        writer.writeEndElement();
+
+        writer.writeStartElement(TARGET.getLocalName());
+        for (SimpleAttributeDefinition attr : JMSBridgeDefinition.JMS_TARGET_ATTRIBUTES) {
+            attr.marshallAsElement(value, writer);
+        }
+        writer.writeEndElement();
+
+        for (SimpleAttributeDefinition attr : JMSBridgeDefinition.JMS_BRIDGE_ATTRIBUTES) {
+            if (attr == JMSBridgeDefinition.MODULE) {
+                // handled as a XML attribute
+                continue;
+            }
+            attr.marshallAsElement(value, writer);
+        }
+
+        writer.writeEndElement();
+    }
+
+    static void handleSingleAttribute(final XMLExtendedStreamReader reader, final Element element, final String modelName, String attributeName, final ModelNode node) throws XMLStreamException {
+        AttributeDefinition attributeDefinition = element.getDefinition(modelName);
+        final String value = readStringAttributeElement(reader, attributeName);
+        if (attributeDefinition instanceof SimpleAttributeDefinition) {
+            ((SimpleAttributeDefinition) attributeDefinition).parseAndSetParameter(value, node, reader);
+        } else if (attributeDefinition instanceof ListAttributeDefinition) {
+            ((ListAttributeDefinition) attributeDefinition).parseAndAddParameterElement(value, node, reader);
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingDescriptions.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingDescriptions.java
@@ -71,6 +71,7 @@ import static org.jboss.as.messaging.CommonAttributes.FILTER;
 import static org.jboss.as.messaging.CommonAttributes.GROUPING_HANDLER;
 import static org.jboss.as.messaging.CommonAttributes.HA;
 import static org.jboss.as.messaging.CommonAttributes.INITIAL_MESSAGE_PACKET_SIZE;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
 import static org.jboss.as.messaging.CommonAttributes.JMS_QUEUE;
 import static org.jboss.as.messaging.CommonAttributes.MESSAGES_ADDED;
 import static org.jboss.as.messaging.CommonAttributes.MESSAGE_COUNT;
@@ -108,6 +109,7 @@ import org.jboss.as.messaging.jms.ConnectionFactoryTypeValidator;
 import org.jboss.as.messaging.jms.JMSServerControlHandler;
 import org.jboss.as.messaging.jms.JMSServices;
 import org.jboss.as.messaging.jms.JMSTopicControlHandler;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -478,7 +480,6 @@ public class MessagingDescriptions {
 
         return result;
     }
-
 
     static ModelNode getJmsQueueResource(final Locale locale) {
         final ResourceBundle bundle = getResourceBundle(locale);
@@ -1586,7 +1587,7 @@ public class MessagingDescriptions {
         return attr;
     }
 
-    private static ResourceBundle getResourceBundle(Locale locale) {
+    public static ResourceBundle getResourceBundle(Locale locale) {
         if (locale == null) {
             locale = Locale.getDefault();
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -159,4 +159,24 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 11609, value = "Attribute %s is deprecated and will not be taken into account")
     void deprecatedXMLAttribute(String name);
 
+    /**
+     * Logs an info message when a service for the given {@code type} and {@code name} is <em>started</em>.
+     *
+     * @param type the type of the service
+     * @param name the name of the service
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 11610, value = "Started %s %s")
+    void startedService(String type, String name);
+
+    /**
+     * Logs an info message when a service for the given {@code type} and {@code name} is <em>stopped</em>.
+     *
+     * @param type the type of the service
+     * @param name the name of the service
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 11611, value = "Stopped %s %s")
+    void stoppedService(String type, String name);
+
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.msc.service.ServiceName;
@@ -71,6 +73,10 @@ public class MessagingServices {
 
    public static ServiceName getQueueBaseServiceName(ServiceName hornetqServiceName) {
        return hornetqServiceName.append(CORE_QUEUE_BASE);
+   }
+
+   public static ServiceName getJMSBridgeServiceName(String bridgeName) {
+       return JBOSS_MESSAGING.append(JMS_BRIDGE).append(bridgeName);
    }
 
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemDescribeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemDescribeHandler.java
@@ -41,6 +41,7 @@ import org.jboss.as.messaging.jms.ConnectionFactoryAdd;
 import org.jboss.as.messaging.jms.JMSQueueAdd;
 import org.jboss.as.messaging.jms.JMSTopicAdd;
 import org.jboss.as.messaging.jms.PooledConnectionFactoryAdd;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeAdd;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -76,6 +77,13 @@ class MessagingSubsystemDescribeHandler implements OperationStepHandler, Descrip
                 PathAddress serverAddress = rootAddress.append(PathElement.pathElement(CommonAttributes.HORNETQ_SERVER, prop.getName()));
                 serverAdd.get(OP_ADDR).set(serverAddress.toModelNode());
                 addHornetQServer(prop.getValue(), serverAdd, serverAddress, result);
+            }
+        }
+
+        if (subModel.hasDefined(CommonAttributes.JMS_BRIDGE)) {
+            for (Property prop : subModel.get(CommonAttributes.JMS_BRIDGE).asPropertyList()) {
+                PathAddress jmsBridgeAddress = rootAddress.append(PathElement.pathElement(CommonAttributes.JMS_BRIDGE, prop.getName()));
+                result.add(JMSBridgeAdd.getAddOperation(jmsBridgeAddress.toModelNode(), prop.getValue()));
             }
         }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -43,6 +43,7 @@ import static org.jboss.as.messaging.CommonAttributes.BROADCAST_GROUP;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTION_FACTORY;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTORS;
+import static org.jboss.as.messaging.CommonAttributes.DEFAULT;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP_NAME;
 import static org.jboss.as.messaging.CommonAttributes.DISCOVERY_GROUP_REF;
@@ -56,6 +57,7 @@ import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
 import static org.jboss.as.messaging.CommonAttributes.INBOUND_CONFIG;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
 import static org.jboss.as.messaging.CommonAttributes.JMS_CONNECTION_FACTORIES;
 import static org.jboss.as.messaging.CommonAttributes.JMS_DESTINATIONS;
 import static org.jboss.as.messaging.CommonAttributes.JMS_QUEUE;
@@ -160,6 +162,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 break;
             case MESSAGING_1_1:
             case MESSAGING_1_2:
+            case MESSAGING_1_3:
                 processHornetQServers(reader, address, list);
                 break;
             default:
@@ -168,7 +171,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
 
     }
 
-    private void processHornetQServers(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list) throws XMLStreamException {
+    protected void processHornetQServers(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list) throws XMLStreamException {
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             final Namespace schemaVer = Namespace.forUri(reader.getNamespaceURI());
             switch (schemaVer) {
@@ -189,7 +192,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         }
     }
 
-    private void processHornetQServer(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list, Namespace namespace) throws XMLStreamException {
+    protected void processHornetQServer(final XMLExtendedStreamReader reader, final ModelNode subsystemAddress, final List<ModelNode> list, Namespace namespace) throws XMLStreamException {
 
         String hqServerName = null;
         String elementName = null;
@@ -210,7 +213,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         }
 
         if (hqServerName == null || hqServerName.length() == 0) {
-            hqServerName = "default";
+            hqServerName = DEFAULT;
         }
 
         final ModelNode address = subsystemAddress.clone();
@@ -523,7 +526,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 }
                 case RETRY_INTERVAL:
                     // Use the "default" variant
-                    handleElementText(reader, element, "default", bridgeAdd);
+                    handleElementText(reader, element, DEFAULT, bridgeAdd);
                     break;
                 case FORWARDING_ADDRESS:
                 case RECONNECT_ATTEMPTS:
@@ -1398,15 +1401,14 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 first = false;
             }
         }
-
         writer.writeEndElement();
     }
 
-    private void writeHornetQServer(final XMLExtendedStreamWriter writer, final String serverName, final ModelNode node) throws XMLStreamException {
+    protected void writeHornetQServer(final XMLExtendedStreamWriter writer, final String serverName, final ModelNode node) throws XMLStreamException {
 
         writer.writeStartElement(Element.HORNETQ_SERVER.getLocalName());
 
-        if (!"default".equals(serverName)) {
+        if (!DEFAULT.equals(serverName)) {
             writer.writeAttribute(Attribute.NAME.getLocalName(), serverName);
         }
 
@@ -2254,7 +2256,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                     break;
                 case RETRY_INTERVAL:
                     // Use the "default" variant
-                    handleElementText(reader, element, "default", connectionFactory);
+                    handleElementText(reader, element, DEFAULT, connectionFactory);
                     break;
                 case RECONNECT_ATTEMPTS:
                 case SCHEDULED_THREAD_POOL_MAX_SIZE:
@@ -2339,7 +2341,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         return connectionFactory;
     }
 
-    private static void writeNewLine(XMLExtendedStreamWriter writer) throws XMLStreamException {
+    protected static void writeNewLine(XMLExtendedStreamWriter writer) throws XMLStreamException {
         writer.writeCharacters(NEW_LINE, 0, 1);
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/Namespace.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Namespace.java
@@ -38,12 +38,13 @@ public enum Namespace {
 
    MESSAGING_1_0("urn:jboss:domain:messaging:1.0"),
    MESSAGING_1_1("urn:jboss:domain:messaging:1.1"),
-   MESSAGING_1_2("urn:jboss:domain:messaging:1.2");
+   MESSAGING_1_2("urn:jboss:domain:messaging:1.2"),
+   MESSAGING_1_3("urn:jboss:domain:messaging:1.3");
 
    /**
     * The current namespace version.
     */
-   public static final Namespace CURRENT = MESSAGING_1_1;
+   public static final Namespace CURRENT = MESSAGING_1_3;
 
    private final String name;
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/InfiniteOrPositiveValidators.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/InfiniteOrPositiveValidators.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Validates a given parameter is a legal value (-1 or > 0) where -1 means "forever"
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public interface InfiniteOrPositiveValidators {
+
+    ModelTypeValidator LONG_INSTANCE = new ModelTypeValidator(ModelType.LONG) {
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+            long val = value.asLong();
+            if (!(val == -1 || (val > 0 && val < Long.MAX_VALUE))) {
+                throw new OperationFailedException(new ModelNode().set(MESSAGES.illegalValue(value, parameterName)));
+            }
+        }
+    };
+
+    ModelTypeValidator INT_INSTANCE = new ModelTypeValidator(ModelType.INT) {
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName, value);
+            int val = value.asInt();
+            if (!(val == -1 || (val > 0 && val < Integer.MAX_VALUE))) {
+                throw new OperationFailedException(new ModelNode().set(MESSAGES.illegalValue(value, parameterName)));
+            }
+        }
+    };
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeAdd.java
@@ -1,0 +1,198 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.operations.common.Util.getOperation;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.hornetq.jms.bridge.ConnectionFactoryFactory;
+import org.hornetq.jms.bridge.DestinationFactory;
+import org.hornetq.jms.bridge.JMSBridge;
+import org.hornetq.jms.bridge.QualityOfServiceMode;
+import org.hornetq.jms.bridge.impl.JMSBridgeImpl;
+import org.hornetq.jms.bridge.impl.JNDIConnectionFactoryFactory;
+import org.hornetq.jms.bridge.impl.JNDIDestinationFactory;
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.as.messaging.jms.JMSServices;
+import org.jboss.as.messaging.jms.SelectorAttribute;
+import org.jboss.as.txn.service.TxnServices;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * JMS Bridge add update.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeAdd extends AbstractAddStepHandler {
+    public static final JMSBridgeAdd INSTANCE = new JMSBridgeAdd();
+
+    /**
+     * Create an "add" operation using the existing model
+     */
+    public static ModelNode getAddOperation(final ModelNode address, ModelNode subModel) {
+        return getOperation(ADD, address, subModel);
+    }
+
+    private JMSBridgeAdd() {
+    }
+
+    @Override
+    protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
+        for (final AttributeDefinition attributeDefinition : JMSBridgeDefinition.JMS_BRIDGE_ATTRIBUTES) {
+            attributeDefinition.validateAndSet(operation, model);
+        }
+        for (final AttributeDefinition attributeDefinition : JMSBridgeDefinition.JMS_TARGET_ATTRIBUTES) {
+            attributeDefinition.validateAndSet(operation, model);
+        }
+        for (final AttributeDefinition attributeDefinition : JMSBridgeDefinition.JMS_SOURCE_ATTRIBUTES) {
+            attributeDefinition.validateAndSet(operation, model);
+        }
+    }
+
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model,
+            final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers)
+                    throws OperationFailedException {
+        context.addStep(new OperationStepHandler() {
+
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+
+                String moduleName = resolveAttribute(JMSBridgeDefinition.MODULE, context, model);
+                final JMSBridge bridge = createJMSBridge(context, model);
+
+                final String bridgeName = address.getLastElement().getValue();
+                final JMSBridgeService bridgeService = new JMSBridgeService(moduleName, bridgeName, bridge);
+                final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
+
+                final ServiceBuilder<JMSBridge> jmsBridgeServiceBuilder = context.getServiceTarget().addService(bridgeServiceName, bridgeService)
+                        .addListener(verificationHandler)
+                        .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                        .setInitialMode(Mode.ACTIVE);
+                if (dependsOnHornetQServer(context, model)) {
+                    // add a dependency to the JMS Manager instead of HornetQ service since it is this service
+                    // that effectively start HornetQ
+                    jmsBridgeServiceBuilder.addDependency((JMSServices.getJmsManagerBaseServiceName(MessagingServices.getHornetQServiceName("default"))));
+                }
+                newControllers.add(jmsBridgeServiceBuilder.install());
+
+                context.completeStep();
+            }
+        }, OperationContext.Stage.RUNTIME);
+    }
+
+    private boolean dependsOnHornetQServer(OperationContext context, ModelNode model) throws OperationFailedException {
+        final Properties sourceContextProperties = resolveContextProperties(JMSBridgeDefinition.SOURCE_CONTEXT, context, model);
+        final Properties targetContextProperties = resolveContextProperties(JMSBridgeDefinition.TARGET_CONTEXT, context, model);
+
+        // if either the source or target context properties are null, this means that the JMS resources will be looked up
+        // from the local HornetQ server.
+        return (sourceContextProperties == null || targetContextProperties == null);
+    }
+
+    private JMSBridge createJMSBridge(OperationContext context, ModelNode model) throws OperationFailedException {
+        final Properties sourceContextProperties = resolveContextProperties(JMSBridgeDefinition.SOURCE_CONTEXT, context, model);
+        final String sourceConnectionFactoryName = JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
+        final ConnectionFactoryFactory sourceCff = new JNDIConnectionFactoryFactory(sourceContextProperties , sourceConnectionFactoryName);
+        final String sourceDestinationName = JMSBridgeDefinition.SOURCE_DESTINATION.resolveModelAttribute(context, model).asString();
+        final DestinationFactory sourceDestinationFactory = new JNDIDestinationFactory(sourceContextProperties, sourceDestinationName);
+
+        final Properties targetContextProperties = resolveContextProperties(JMSBridgeDefinition.TARGET_CONTEXT, context, model);
+        final String targetConnectionFactoryName = JMSBridgeDefinition.TARGET_CONNECTION_FACTORY.resolveModelAttribute(context, model).asString();
+        final ConnectionFactoryFactory targetCff = new JNDIConnectionFactoryFactory(targetContextProperties, targetConnectionFactoryName);
+        final String targetDestinationName = JMSBridgeDefinition.TARGET_DESTINATION.resolveModelAttribute(context, model).asString();
+        final DestinationFactory targetDestinationFactory = new JNDIDestinationFactory(targetContextProperties, targetDestinationName);
+
+        final String sourceUsername = resolveAttribute(JMSBridgeDefinition.SOURCE_USER, context, model);
+        final String sourcePassword = resolveAttribute(JMSBridgeDefinition.SOURCE_PASSWORD, context, model);
+        final String targetUsername = resolveAttribute(JMSBridgeDefinition.TARGET_USER, context, model);
+        final String targetPassword = resolveAttribute(JMSBridgeDefinition.TARGET_PASSWORD, context, model);
+
+        final String selector = resolveAttribute(SelectorAttribute.SELECTOR, context, model);
+        final long failureRetryInterval = JMSBridgeDefinition.FAILURE_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final int maxRetries = JMSBridgeDefinition.MAX_RETRIES.resolveModelAttribute(context, model).asInt();
+        final QualityOfServiceMode qosMode = QualityOfServiceMode.valueOf( JMSBridgeDefinition.QUALITY_OF_SERVICE.resolveModelAttribute(context, model).asString());
+        final int maxBatchSize = JMSBridgeDefinition.MAX_BATCH_SIZE.resolveModelAttribute(context, model).asInt();
+        final long maxBatchTime = JMSBridgeDefinition.MAX_BATCH_TIME.resolveModelAttribute(context, model).asLong();
+        final String subName =  resolveAttribute(JMSBridgeDefinition.SUBSCRIPTION_NAME, context, model);
+        final String clientID = resolveAttribute(JMSBridgeDefinition.CLIENT_ID, context, model);
+        final boolean addMessageIDInHeader = JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER.resolveModelAttribute(context, model).asBoolean();
+
+        return new JMSBridgeImpl(sourceCff,
+                targetCff,
+                sourceDestinationFactory,
+                targetDestinationFactory,
+                sourceUsername,
+                sourcePassword,
+                targetUsername,
+                targetPassword,
+                selector,
+                failureRetryInterval,
+                maxRetries,
+                qosMode,
+                maxBatchSize,
+                maxBatchTime,
+                subName,
+                clientID,
+                addMessageIDInHeader);
+    }
+
+    private Properties resolveContextProperties(AttributeDefinition attribute, OperationContext context, ModelNode model) throws OperationFailedException {
+        final ModelNode contextModel = attribute.resolveModelAttribute(context, model);
+        if (!contextModel.isDefined()) {
+            return null;
+        }
+
+        final Properties contextProperties = new Properties();
+        for (Property property : contextModel.asPropertyList()) {
+            contextProperties.put(property.getName(), property.getValue().asString());
+        }
+        return contextProperties;
+    }
+
+    /**
+     * Return null if the resolved attribute is not defined
+     */
+    private String resolveAttribute(SimpleAttributeDefinition attr, OperationContext context, ModelNode model) throws OperationFailedException {
+        final ModelNode node = attr.resolveModelAttribute(context, model);
+        return node.isDefined() ? node.asString() : null;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeDefinition.java
@@ -1,0 +1,197 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
+import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
+import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.INT;
+import static org.jboss.dmr.ModelType.LONG;
+import static org.jboss.dmr.ModelType.STRING;
+
+import java.util.Locale;
+
+import org.hornetq.jms.bridge.QualityOfServiceMode;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.MessagingDescriptions;
+import org.jboss.as.messaging.MessagingExtension;
+import org.jboss.as.messaging.jms.SelectorAttribute;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeDefinition extends SimpleResourceDefinition {
+
+    public static final JMSBridgeDefinition INSTANCE = new JMSBridgeDefinition();
+
+    public static final String SOURCE = "source";
+    public static final String TARGET = "target";
+    public static final String CONTEXT = "context";
+
+    public static final String PAUSE = "pause";
+    public static final String RESUME = "resume";
+
+    public static final SimpleAttributeDefinition MODULE = create("module", STRING)
+            .setAllowNull(true).
+            build();
+    public static final SimpleAttributeDefinition SOURCE_CONNECTION_FACTORY = new JNDIResourceAttributeDefinition("source-connection-factory", CommonAttributes.CONNECTION_FACTORY);
+    public static final SimpleAttributeDefinition SOURCE_DESTINATION = new JNDIResourceAttributeDefinition("source-destination", CommonAttributes.DESTINATION);
+    public static final SimpleAttributeDefinition SOURCE_USER = create("source-user", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("user")
+            .build();
+    public static final SimpleAttributeDefinition SOURCE_PASSWORD = create("source-password", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("password")
+            .build();
+    public static final SimpleAttributeDefinition SOURCE_CONTEXT = new JNDIContextAttributeDefinition("source-context", CONTEXT);
+
+    public static final SimpleAttributeDefinition TARGET_CONNECTION_FACTORY = new JNDIResourceAttributeDefinition("target-connection-factory", CommonAttributes.CONNECTION_FACTORY);
+    public static final SimpleAttributeDefinition TARGET_DESTINATION = new JNDIResourceAttributeDefinition("target-destination", CommonAttributes.DESTINATION);
+    public static final SimpleAttributeDefinition TARGET_USER = create("target-user", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("user")
+            .build();
+    public static final SimpleAttributeDefinition TARGET_PASSWORD = create("target-password", STRING)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setXmlName("password")
+            .build();
+    public static final SimpleAttributeDefinition TARGET_CONTEXT = new JNDIContextAttributeDefinition("target-context", CONTEXT);
+
+    public static final SimpleAttributeDefinition QUALITY_OF_SERVICE = create("quality-of-service", STRING)
+            .setValidator(new EnumValidator<QualityOfServiceMode>(QualityOfServiceMode.class, false, false))
+            .build();
+    public static final SimpleAttributeDefinition FAILURE_RETRY_INTERVAL = create("failure-retry-interval", LONG)
+            .setMeasurementUnit(MILLISECONDS)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
+            .build();
+    public static final SimpleAttributeDefinition MAX_RETRIES = create("max-retries", INT)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
+            .build();
+    public static final SimpleAttributeDefinition MAX_BATCH_SIZE = create("max-batch-size", INT)
+            .setValidator(new IntRangeValidator(0, Integer.MAX_VALUE, false, false))
+            .build();
+    public static final SimpleAttributeDefinition MAX_BATCH_TIME = create("max-batch-time", LONG)
+            .setMeasurementUnit(MILLISECONDS)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
+            .build();
+    public static final SimpleAttributeDefinition SUBSCRIPTION_NAME = create("subscription-name", STRING)
+            .setAllowNull(true)
+            .build();
+    public static final SimpleAttributeDefinition CLIENT_ID = create("client-id", STRING)
+            .setAllowNull(true)
+            .build();
+    public static final SimpleAttributeDefinition ADD_MESSAGE_ID_IN_HEADER = create("add-messageID-in-header", BOOLEAN)
+            .setAllowNull(true)
+            .setDefaultValue(new ModelNode().set(false))
+            .build();
+    public static final SimpleAttributeDefinition STARTED = create(CommonAttributes.STARTED, BOOLEAN)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .build();
+    public static final SimpleAttributeDefinition PAUSED = create(CommonAttributes.PAUSED, BOOLEAN)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .build();
+
+    public static final SimpleAttributeDefinition[] JMS_BRIDGE_ATTRIBUTES = {
+        MODULE,
+        SelectorAttribute.SELECTOR,
+        QUALITY_OF_SERVICE,
+        FAILURE_RETRY_INTERVAL, MAX_RETRIES,
+        MAX_BATCH_SIZE, MAX_BATCH_TIME,
+        SUBSCRIPTION_NAME, CommonAttributes.CLIENT_ID,
+        ADD_MESSAGE_ID_IN_HEADER
+    };
+
+    public static final SimpleAttributeDefinition[] JMS_SOURCE_ATTRIBUTES = {
+        SOURCE_CONNECTION_FACTORY, SOURCE_DESTINATION,
+        SOURCE_USER, SOURCE_PASSWORD,
+        SOURCE_CONTEXT
+    };
+
+    public static final SimpleAttributeDefinition[] JMS_TARGET_ATTRIBUTES = {
+        TARGET_CONNECTION_FACTORY, TARGET_DESTINATION,
+        TARGET_USER, TARGET_PASSWORD,
+        TARGET_CONTEXT
+    };
+
+    public static final SimpleAttributeDefinition[] READONLY_ATTRIBUTES = {
+        STARTED, PAUSED
+    };
+
+    public static final String[] OPERATIONS = {
+        ModelDescriptionConstants.START, ModelDescriptionConstants.STOP,
+        PAUSE, RESUME
+    };
+
+    public JMSBridgeDefinition() {
+        super(MessagingExtension.JMS_BRIDGE_PATH,
+                MessagingExtension.getResourceDescriptionResolver(CommonAttributes.JMS_BRIDGE),
+                JMSBridgeAdd.INSTANCE,
+                JMSBridgeRemove.INSTANCE);
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registry) {
+        super.registerAttributes(registry);
+        for (SimpleAttributeDefinition attr : JMS_BRIDGE_ATTRIBUTES) {
+            registry.registerReadWriteAttribute(attr, null, JMSBridgeWriteAttributeHandler.INSTANCE);
+        }
+        for (SimpleAttributeDefinition attr : JMS_SOURCE_ATTRIBUTES) {
+            registry.registerReadWriteAttribute(attr, null, JMSBridgeWriteAttributeHandler.INSTANCE);
+        }
+        for (SimpleAttributeDefinition attr : JMS_TARGET_ATTRIBUTES) {
+            registry.registerReadWriteAttribute(attr, null, JMSBridgeWriteAttributeHandler.INSTANCE);
+        }
+        for (SimpleAttributeDefinition attr : READONLY_ATTRIBUTES) {
+            registry.registerReadOnlyAttribute(attr, JMSBridgeHandler.INSTANCE);
+        }
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration registry) {
+        super.registerOperations(registry);
+        for (final String operationName: OPERATIONS) {
+            registry.registerOperationHandler(operationName, JMSBridgeHandler.INSTANCE, new DescriptionProvider() {
+                @Override
+                public ModelNode getModelDescription(Locale locale) {
+                    return MessagingDescriptions.getDescriptionOnlyOperation(locale, operationName, JMS_BRIDGE);
+                }
+            });
+        }
+    }
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP;
+import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.CommonAttributes.PAUSED;
+import static org.jboss.as.messaging.CommonAttributes.STARTED;
+import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+import static org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition.PAUSE;
+import static org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition.RESUME;
+
+import org.hornetq.jms.bridge.JMSBridge;
+import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.ParametersValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeHandler extends AbstractRuntimeOnlyHandler {
+
+    public static final JMSBridgeHandler INSTANCE = new JMSBridgeHandler();
+
+    private ParametersValidator readAttributeValidator = new ParametersValidator();
+
+    private JMSBridgeHandler() {
+        readAttributeValidator.registerValidator(NAME, new StringLengthValidator(1));
+    }
+
+    @Override
+    protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final String bridgeName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement()
+                .getValue();
+        final String operationName = operation.require(OP).asString();
+
+        final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
+        ServiceController<?> bridgeService = context.getServiceRegistry(false).getService(bridgeServiceName);
+        JMSBridge bridge = JMSBridge.class.cast(bridgeService.getValue());
+
+        if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+            readAttributeValidator.validate(operation);
+            final String name = operation.require(NAME).asString();
+            if (STARTED.equals(name)) {
+                context.getResult().set(bridge.isStarted());
+            } else if (PAUSED.equals(name)) {
+                context.getResult().set(bridge.isPaused());
+            } else {
+                throw MESSAGES.unsupportedAttribute(name);
+            }
+        }
+        else if (START.equals(operationName)) {
+            try {
+                // we do not start the bridge directly but call startBridge() instead
+                // to ensure the class loader will be able to load any external resources
+                JMSBridgeService service = (JMSBridgeService) bridgeService.getService();
+                service.startBridge();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else if (STOP.equals(operationName)) {
+            try {
+                bridge.stop();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else if (PAUSE.equals(operationName)) {
+            try {
+                bridge.pause();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else if (RESUME.equals(operationName)) {
+            try {
+                bridge.resume();
+            } catch (Exception e) {
+                context.getFailureDescription().set(e.getLocalizedMessage());
+            }
+        } else {
+            throw MESSAGES.unsupportedOperation(operationName);
+        }
+
+        if (context.completeStep() != OperationContext.ResultAction.KEEP) {
+            try {
+                if (START.equals(operationName)) {
+                    bridge.stop();
+                } else if (STOP.equals(operationName)) {
+                    JMSBridgeService service = (JMSBridgeService) bridgeService.getService();
+                    service.startBridge();
+                } else if (PAUSE.equals(operationName)) {
+                    bridge.resume();
+                } else if (RESUME.equals(operationName)) {
+                    bridge.pause();
+                }
+            } catch (Exception e) {
+                ROOT_LOGGER.revertOperationFailed(e, getClass().getSimpleName(), operation
+                        .require(ModelDescriptionConstants.OP).asString(), PathAddress.pathAddress(operation
+                                .require(ModelDescriptionConstants.OP_ADDR)));
+            }
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeRemove.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Removes a JMS Bridge.
+ *
+ * @author Jeff Mesnil (c) 2011 Red Hat Inc.
+ */
+public class JMSBridgeRemove extends AbstractRemoveStepHandler {
+
+    public static final String OPERATION_NAME = REMOVE;
+
+    public static JMSBridgeRemove INSTANCE = new JMSBridgeRemove();
+
+    private JMSBridgeRemove() {
+    }
+
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+        final String bridgeName = address.getLastElement().getValue();
+        context.removeService(MessagingServices.getJMSBridgeServiceName(bridgeName));
+    }
+
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
+import java.security.AccessController;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import javax.transaction.TransactionManager;
+
+import org.hornetq.jms.bridge.JMSBridge;
+import org.jboss.as.messaging.MessagingLogger;
+import org.jboss.as.txn.service.TxnServices;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.threads.JBossThreadFactory;
+
+/**
+ * Service responsible for JMS Bridges.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+class JMSBridgeService implements Service<JMSBridge> {
+    private final JMSBridge bridge;
+    private final String bridgeName;
+    private final String moduleName;
+    private final ThreadFactory THREAD_FACTORY = new JBossThreadFactory(new ThreadGroup("JMSBridge-threads"), Boolean.FALSE, null, "%G - %t", null, null, AccessController.getContext());
+    private final Executor executor = Executors.newCachedThreadPool(THREAD_FACTORY);
+
+    public JMSBridgeService(final String moduleName, final String bridgeName, final JMSBridge bridge) {
+        if(bridge == null) {
+            throw MESSAGES.nullVar("bridge");
+        }
+        this.moduleName = moduleName;
+        this.bridgeName = bridgeName;
+        this.bridge = bridge;
+    }
+
+    public static TransactionManager getTransactionManager(StartContext context) {
+        @SuppressWarnings("unchecked")
+        ServiceController<TransactionManager> service = (ServiceController<TransactionManager>) context.getController().getServiceContainer().getService(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER);
+        return service == null ? null : service.getValue();
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    bridge.setTransactionManager(getTransactionManager(context));
+                    startBridge();
+
+                    context.complete();
+                } catch (Throwable e) {
+                    context.failed(MESSAGES.failedToCreate(e, "JMS Bridge"));
+                }
+            }
+        };
+        context.asynchronous();
+        executor.execute(r);
+    }
+
+    public void startBridge() throws Exception {
+        if (moduleName == null) {
+            bridge.start();
+        } else {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            try {
+                ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
+                Module module = Module.getCallerModuleLoader().loadModule(moduleID);
+                Thread.currentThread().setContextClassLoader(module.getClassLoader());
+                bridge.start();
+            } finally {
+                Thread.currentThread().setContextClassLoader(cl);
+            }
+        }
+        MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        final Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    bridge.stop();
+                    MessagingLogger.MESSAGING_LOGGER.stoppedService("JMS Bridge", bridgeName);
+
+                    context.complete();
+                } catch(Exception e) {
+                    MESSAGING_LOGGER.failedToDestroy("bridge", bridgeName);
+                }
+            }
+        };
+        context.asynchronous();
+        executor.execute(r);
+    }
+
+    @Override
+    public JMSBridge getValue() throws IllegalStateException {
+        return bridge;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeWriteAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeWriteAttributeHandler.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.global.WriteAttributeHandlers;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Write attribute handler for attributes that update a JMS bridge resource.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JMSBridgeWriteAttributeHandler extends WriteAttributeHandlers.WriteAttributeOperationHandler {
+
+    public static final JMSBridgeWriteAttributeHandler INSTANCE = new JMSBridgeWriteAttributeHandler();
+
+    private final Map<String, AttributeDefinition> attributes = new HashMap<String, AttributeDefinition>();
+
+    private JMSBridgeWriteAttributeHandler() {
+        for (AttributeDefinition attr : JMSBridgeDefinition.JMS_BRIDGE_ATTRIBUTES) {
+            attributes.put(attr.getName(), attr);
+        }
+        for (AttributeDefinition attr : JMSBridgeDefinition.JMS_SOURCE_ATTRIBUTES) {
+            attributes.put(attr.getName(), attr);
+        }
+        for (AttributeDefinition attr : JMSBridgeDefinition.JMS_TARGET_ATTRIBUTES) {
+            attributes.put(attr.getName(), attr);
+        }
+    }
+
+    @Override
+    protected void modelChanged(final OperationContext context, final ModelNode operation, final String attributeName,
+                                final ModelNode newValue, final ModelNode currentValue) throws OperationFailedException {
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                final AttributeDefinition attr = attributes.get(attributeName);
+                final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+                if(attr.hasAlternative(resource.getModel())) {
+                    context.setRollbackOnly();
+                    throw new OperationFailedException(new ModelNode().set(MESSAGES.altAttributeAlreadyDefined(attributeName)));
+                }
+                context.completeStep();
+            }
+        }, OperationContext.Stage.VERIFY);
+
+        context.reloadRequired();
+
+        if (context.completeStep() != OperationContext.ResultAction.KEEP) {
+            context.revertReloadRequired();
+        }
+    }
+
+    @Override
+    protected void validateValue(String name, ModelNode value) throws OperationFailedException {
+        AttributeDefinition attr = attributes.get(name);
+        attr.getValidator().validateParameter(name, value);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIContextAttributeDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIContextAttributeDefinition.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+import static org.jboss.as.messaging.Element.PROPERTY;
+import static org.jboss.dmr.ModelType.OBJECT;
+import static org.jboss.dmr.ModelType.STRING;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.messaging.Attribute;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * {@link org.jboss.as.controller.AttributeDefinition} for a JNDI context hashtable
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JNDIContextAttributeDefinition extends SimpleAttributeDefinition {
+
+    protected JNDIContextAttributeDefinition(String name, String xmlName) {
+        super(name, xmlName, null, OBJECT, true, false, null);
+    }
+
+    @Override
+    public ModelNode addResourceAttributeDescription(ModelNode resourceDescription, ResourceDescriptionResolver resolver,
+            Locale locale, ResourceBundle bundle) {
+        final ModelNode result = super.addResourceAttributeDescription(resourceDescription, resolver, locale, bundle);
+        result.get(VALUE_TYPE).set(STRING);
+        return result;
+    }
+
+    @Override
+    public ModelNode addOperationParameterDescription(ModelNode resourceDescription, String operationName,
+            ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
+        final ModelNode result = super.addOperationParameterDescription(resourceDescription, operationName, resolver, locale,
+                bundle);
+        result.get(VALUE_TYPE).set(STRING);
+        return result;
+    }
+
+    @Override
+    public void marshallAsElement(ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer)
+            throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            ModelNode context = resourceModel.get(getName());
+
+            writer.writeStartElement(getXmlName());
+            for (Property property : context.asPropertyList()) {
+                writer.writeStartElement(PROPERTY.getLocalName());
+                writer.writeAttribute(Attribute.KEY.getLocalName(), property.getName());
+                writer.writeAttribute(Attribute.VALUE.getLocalName(), property.getValue().asString());
+                writer.writeEndElement();
+            }
+            writer.writeEndElement();
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIResourceAttributeDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JNDIResourceAttributeDefinition.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.bridge;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.messaging.Attribute;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@link org.jboss.as.controller.AttributeDefinition} for a JMS JNDI resource to look up.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class JNDIResourceAttributeDefinition extends SimpleAttributeDefinition {
+    protected JNDIResourceAttributeDefinition(String name, String xmlName) {
+        super(name, xmlName, null, ModelType.STRING, false, false, null);
+    }
+
+    @Override
+    public void marshallAsElement(ModelNode resourceModel, XMLStreamWriter writer) throws XMLStreamException {
+        if (resourceModel.hasDefined(getName())) {
+            String name = resourceModel.get(getName()).asString();
+            writer.writeEmptyElement(getXmlName());
+            writer.writeAttribute(Attribute.NAME.getLocalName(), name);
+        }
+    }
+}

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -588,3 +588,33 @@ security-role.manage=This permission allows the user to invoke management operat
 socket-binding=The socket binding reference.
 
 deployed=Runtime resources exposed by messaging resources included in this deployment.
+
+jms-bridge=A JMS bridge instance.
+jms-bridge.add=Add a new JMS bridge.
+jms-bridge.remove=Remove an existing JMS bridge.
+jms-bridge.source-connection-factory=The name of the source connection factory to lookup on the source messaging server.
+jms-bridge.source-destination=The name of the source destination to lookup on the source messaging server.
+jms-bridge.source-user=The name of the user for creating the source connection.
+jms-bridge.source-password=The password for creating the source connection.
+jms-bridge.source-context=he properties used to configure the source JNDI initial context.
+jms-bridge.target-connection-factory=The name of the target connection factory to lookup on the target messaging server.
+jms-bridge.target-destination=The name of the target destination to lookup on the target messaging server.
+jms-bridge.target-user=The name of the user for creating the target connection.
+jms-bridge.target-password=The password for creating the target connection.
+jms-bridge.target-context=The properties used to configure the target JNDI initial context.
+jms-bridge.selector=A JMS selector expression used for consuming messages from the source destination. Only messages that match the selector expression will be bridged from the source to the target destination.
+jms-bridge.quality-of-service=The desired quality of service mode (AT_MOST_ONCE, DUPLICATES_OK or ONCE_AND_ONLY_ONCE).
+jms-bridge.failure-retry-interval=The amount of time in milliseconds to wait between trying to recreate connections to the source or target servers when the bridge has detected they have failed.
+jms-bridge.max-retries=The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.
+jms-bridge.max-batch-size=The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.
+jms-bridge.max-batch-time=The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.
+jms-bridge.subscription-name=The name of the subscription if it is durable and the source destination is a topic.
+jms-bridge.client-id=The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.
+jms-bridge.add-messageID-in-header=If true, then the original message's message ID will be appended in the message sent to the destination in the header HORNETQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.
+jms-bridge.module=The name of AS7 module containing the resources required to lookup source and target JMS resources.
+jms-bridge.started=Whether the JMS bridge is started.
+jms-bridge.paused=Whether the JMS bridge is paused.
+jms-bridge.start=Start the JMS bridge.
+jms-bridge.stop=Stop the JMS bridge.
+jms-bridge.pause=Pause the JMS bridge.
+jms-bridge.resume=Resume the JMS bridge.

--- a/messaging/src/test/java/org/jboss/as/messaging/test/JMSBridge13ParsingUnitTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/JMSBridge13ParsingUnitTestCase.java
@@ -29,27 +29,21 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 
 /**
- * @author Emanuel Muckenhuber
+ * @author Jeff Mesnil (c) 2012 Red Hat inc
  */
-public class Subsystem12ParsingUnitTestCase extends AbstractSubsystemBaseTest {
+public class JMSBridge13ParsingUnitTestCase extends AbstractSubsystemBaseTest {
 
-    public Subsystem12ParsingUnitTestCase() {
+    public JMSBridge13ParsingUnitTestCase() {
         super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
     }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_1_2.xml");
+        return readResource("jms-bridge_1_3.xml");
     }
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.MANAGEMENT;
-    }
-
-    @Override
-    protected void compareXml(String configId, String original, String marshalled) throws Exception {
-        // XML from messaging 1.2 does not have the same output than 1.3
-        return;
     }
 }

--- a/messaging/src/test/java/org/jboss/as/messaging/test/Subsystem13ParsingUnitTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/Subsystem13ParsingUnitTestCase.java
@@ -31,25 +31,19 @@ import org.jboss.as.subsystem.test.AdditionalInitialization;
 /**
  * @author Emanuel Muckenhuber
  */
-public class Subsystem12ParsingUnitTestCase extends AbstractSubsystemBaseTest {
+public class Subsystem13ParsingUnitTestCase extends AbstractSubsystemBaseTest {
 
-    public Subsystem12ParsingUnitTestCase() {
+    public Subsystem13ParsingUnitTestCase() {
         super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
     }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_1_2.xml");
+        return readResource("subsystem_1_3.xml");
     }
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.MANAGEMENT;
-    }
-
-    @Override
-    protected void compareXml(String configId, String original, String marshalled) throws Exception {
-        // XML from messaging 1.2 does not have the same output than 1.3
-        return;
     }
 }

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/jms-bridge_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/jms-bridge_1_3.xml
@@ -1,0 +1,48 @@
+    <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+        <jms-bridge module="org.another.mq.broker">
+            <source>
+               <connection-factory name="/cf/sourceCF" />
+               <destination name="/topic/sourceTopic" />
+               <user>myUser</user>
+               <password>myPassword</password>
+            </source>
+            <target>
+                <connection-factory name="anotherAS7/jms/cf/targetCF" />
+                <destination name="anotherAS7/jms/queue/targetQueue" />
+	            <user>${userInExpression}</user>
+                <password>${passwordInExpression}</password>
+                <context>
+                    <property key="java.naming.factory.initial"  value="org.jnp.interfaces.NamingContextFactory" />
+                    <property key="java.naming.provider.url"     value="jnp://localhost:1099" />
+                    <property key="java.naming.factory.url.pkgs" value="org.jboss.naming:org.jnp.interfaces"/>
+                    <property key="jnp.timeout"                  value="5000"/>
+                    <property key="jnp.sotimeout"                value="5000"/>
+                </context>
+            </target>
+            <selector string="color='red'"/>
+            <quality-of-service>ONCE_AND_ONLY_ONCE</quality-of-service>
+            <failure-retry-interval>-1</failure-retry-interval>
+            <max-retries>-1</max-retries>
+            <max-batch-size>1</max-batch-size>
+            <max-batch-time>-1</max-batch-time>
+            <subscription-name>mySubscription</subscription-name>
+            <client-id>myClientID</client-id>
+            <add-messageID-in-header>true</add-messageID-in-header>
+        </jms-bridge>
+
+        <jms-bridge name="bridgeB">
+            <source>
+                <connection-factory name="/cf/sourceCF" />
+                <destination name="/topic/anotherSourceTopic" />
+            </source>
+            <target>
+                <connection-factory name="/cf/targetCF" />
+                <destination name="anotherMQ/jms/queue/anotherTargetQueue" />
+            </target>
+            <quality-of-service>AT_MOST_ONCE</quality-of-service>
+            <failure-retry-interval>45678</failure-retry-interval>
+            <max-retries>7890</max-retries>
+            <max-batch-size>12345</max-batch-size>
+            <max-batch-time>10000</max-batch-time>
+        </jms-bridge>
+    </subsystem>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
@@ -1,0 +1,270 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+        <hornetq-server>
+            <!-- disable messaging persistence -->
+            <persistence-enabled>false</persistence-enabled>
+            <thread-pool-max-size>${messaging.thread.pool.max.size:5}</thread-pool-max-size>
+            <security-domain>someDomain</security-domain>
+            <cluster-user>${messaging.cluster.user.name}</cluster-user>
+            <cluster-password>${messaging.cluster.user.password}</cluster-password>
+            <remoting-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-interceptors>
+            <live-connector-ref connector-name="in-vm"/>
+            <journal-type>NIO</journal-type>
+            <!-- Default journal file size is 10Mb, reduced here to 100k for faster first boot -->
+            <journal-file-size>102400</journal-file-size>
+            <journal-min-files>2</journal-min-files>
+            <page-max-concurrent-io>10</page-max-concurrent-io>
+            <paging-directory path="test" relative-to="test" />
+            <bindings-directory path="test" relative-to="test" />
+            <journal-directory path="test" relative-to="test" />
+            <large-messages-directory path="test" relative-to="test" />
+            <connectors>
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+               </connector>
+               <netty-connector name="netty" socket-binding="messaging" />
+               <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+               </netty-connector>
+               <in-vm-connector name="in-vm" server-id="0" />
+            </connectors>
+            <acceptors>
+               <netty-acceptor name="netty" socket-binding="messaging" />
+               <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+                  <param key="direct-deliver" value="false"/>
+               </netty-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0" />
+            </acceptors>
+            <broadcast-groups>
+                <broadcast-group name="groupA">
+                    <local-bind-address>localhost</local-bind-address>
+                    <local-bind-port>12345</local-bind-port>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>23456</group-port>
+                    <broadcast-period>2500</broadcast-period>
+                    <connector-ref>netty</connector-ref>
+                    <connector-ref>netty-throughput</connector-ref>
+                </broadcast-group>
+                <broadcast-group name="groupB">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>34567</group-port>
+                </broadcast-group>
+                <broadcast-group name="groupS">
+                    <socket-binding>group-s-binding</socket-binding>
+                </broadcast-group>
+            </broadcast-groups>
+            <discovery-groups>
+                <discovery-group name="groupC">
+                    <local-bind-address>localhost</local-bind-address>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>45678</group-port>
+                    <refresh-timeout>3500</refresh-timeout>
+                    <initial-wait-timeout>7500</initial-wait-timeout>
+                </discovery-group>
+                <discovery-group name="groupD">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>56789</group-port>
+                </discovery-group>
+                <discovery-group name="groupT">
+                    <socket-binding>group-t-binding</socket-binding>
+                </discovery-group>
+            </discovery-groups>
+            <diverts>
+                <divert name="testDivert1">
+                    <routing-name>routing</routing-name>
+                    <address>address1</address>
+                    <forwarding-address>forwardingaddress1</forwarding-address>
+                    <filter string="afilter"/>
+                    <transformer-class-name>org.jboss.test.Transformer</transformer-class-name>
+                    <exclusive>true</exclusive>
+                </divert>
+                <divert name="testDivert2">
+                    <address>address2</address>
+                    <forwarding-address>forwardingaddress2</forwarding-address>
+                </divert>
+            </diverts>
+            <core-queues>
+                <queue name="coreQueueA">
+                    <address>addressA</address>
+                    <filter string="afilter"/>
+                    <durable>true</durable>
+                </queue>
+                <queue name="coreQueueB">
+                    <address>addressB</address>
+                </queue>
+            </core-queues>
+            <bridges>
+                <bridge name="bridge1">
+                    <queue-name>coreQueueA</queue-name>
+                    <forwarding-address>forwardingaddress1</forwarding-address>
+                    <ha>true</ha>
+                    <filter string="afilter"/>
+                    <transformer-class-name>foo.bar</transformer-class-name>
+                    <min-large-message-size>10240</min-large-message-size>
+                    <connection-ttl>36000</connection-ttl>
+                    <retry-interval>750</retry-interval>
+                    <retry-interval-multiplier>2</retry-interval-multiplier>
+                    <max-retry-interval>3000</max-retry-interval>
+                    <check-period>666</check-period>
+                    <reconnect-attempts>3</reconnect-attempts>
+                    <failover-on-server-shutdown>true</failover-on-server-shutdown>
+                    <use-duplicate-detection>true</use-duplicate-detection>
+                    <confirmation-window-size>350</confirmation-window-size>
+                    <user>Brian</user>
+                    <password>secret</password>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </bridge>
+                <bridge name="bridge2">
+                    <queue-name>coreQueueB</queue-name>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </bridge>
+            </bridges>
+            <cluster-connections>
+                <cluster-connection name="cc1">
+                    <address>cc1-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <min-large-message-size>10245</min-large-message-size>
+                    <connection-ttl>1234</connection-ttl>
+                    <retry-interval>987</retry-interval>
+                    <retry-interval-multiplier>3.0</retry-interval-multiplier>
+                    <max-retry-interval>3600</max-retry-interval>
+                    <reconnect-attempts>-1</reconnect-attempts>
+                    <use-duplicate-detection>true</use-duplicate-detection>
+                    <check-period>2345</check-period>
+                    <call-timeout>3456</call-timeout>
+                    <forward-when-no-consumers>true</forward-when-no-consumers>
+                    <max-hops>7</max-hops>
+                    <confirmation-window-size>459</confirmation-window-size>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc2">
+                    <address>cc2-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <static-connectors allow-direct-connections-only="true">
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc3">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </cluster-connection>
+                <cluster-connection name="cc4">
+                    <address>cc4-address</address>
+                    <connector-ref>netty-throughput</connector-ref>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+            </cluster-connections>
+            <grouping-handler name="grouping-handler">
+                <type>LOCAL</type>
+                <address>handler-address</address>
+                <timeout>5000</timeout>
+            </grouping-handler>
+            <security-settings>
+               <security-setting match="#">
+                   <permission roles="guest" type="send"/>
+                   <permission roles="guest" type="consume"/>
+                   <permission roles="guest" type="createNonDurableQueue"/>
+                   <permission roles="guest" type="deleteNonDurableQueue"/>
+                   <permission roles="adming" type="manage"/>
+               </security-setting>
+            </security-settings>
+            <address-settings>
+               <!--default for catch all-->
+               <address-setting match="#">
+                  <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+                  <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+                  <redelivery-delay>0</redelivery-delay>
+                  <max-delivery-attempts>5</max-delivery-attempts>
+                  <max-size-bytes>10485760</max-size-bytes>
+                  <page-size-bytes>10485760</page-size-bytes>
+                  <page-max-cache-size>7</page-max-cache-size>
+                  <address-full-policy>BLOCK</address-full-policy>
+                  <message-counter-history-day-limit>10</message-counter-history-day-limit>
+                  <last-value-queue>false</last-value-queue>
+                  <redistribution-delay>0</redistribution-delay>
+                  <send-to-dla-on-no-route>false</send-to-dla-on-no-route>
+               </address-setting>
+            </address-settings>
+
+            <connector-services>
+                <connector-service name="a">
+                    <factory-class>foo.bar</factory-class>
+                </connector-service>
+                <connector-service name="b">
+                    <factory-class>bar.foo</factory-class>
+                    <param key="foo" value="bar"/>
+                    <param key="bar" value="2"/>
+                </connector-service>
+            </connector-services>
+
+            <!--JMS Stuff-->
+            <jms-connection-factories>
+              <connection-factory name="InVmConnectionFactory">
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/ConnectionFactory"/>
+                 </entries>
+              </connection-factory>
+              <connection-factory name="RemoteConnectionFactory">
+                 <factory-type>XA_QUEUE</factory-type>
+                 <connectors>
+                    <connector-ref connector-name="netty"/>
+                 </connectors>
+                 <entries>
+                    <entry name="RemoteConnectionFactory"/>
+                 </entries>
+                 <client-id>testClient</client-id>
+              </connection-factory>
+              <connection-factory name="otherConnectionFactory">
+                 <discovery-group-ref discovery-group-name="groupC"/>
+                 <entries>
+                    <entry name="otherConnectionFactory"/>
+                 </entries>
+              </connection-factory>
+              <pooled-connection-factory name="hornetq-ra">
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <transaction mode="xa"/>
+                 <min-pool-size>42</min-pool-size>
+                 <max-pool-size>242</max-pool-size>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsXA"/>
+                 </entries>
+              </pooled-connection-factory>
+           </jms-connection-factories>
+
+           <jms-destinations>
+              <jms-queue name="testQueue">
+                 <entry name="queue/test"/>
+                 <selector string="color='red'"/>
+              </jms-queue>
+              <jms-topic name="testTopic">
+                 <entry name="topic/test"/>
+              </jms-topic>
+           </jms-destinations>
+        </hornetq-server>
+
+        <hornetq-server name="empty"/>
+    </subsystem>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/CreateJMSBridgeSetupTask.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/CreateJMSBridgeSetupTask.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms;
+
+import java.io.IOException;
+
+import org.hornetq.jms.bridge.QualityOfServiceMode;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.logging.Logger;
+
+/**
+ * Setup task to create/remove a JMS bridge.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+public class CreateJMSBridgeSetupTask extends CreateQueueSetupTask {
+
+    public static final String CF_NAME = "myAwesomeCF";
+    public static final String CF_JNDI_NAME = "/myAwesomeCF";
+    public static final String JMS_BRIDGE_NAME = "myAwesomeJMSBridge";
+
+    private static final Logger logger = Logger.getLogger(CreateJMSBridgeSetupTask.class);
+
+    private ManagementClient managementClient;
+
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        super.setup(managementClient, containerId);
+        this.managementClient = managementClient;
+
+        createConnectionFactory(CF_NAME, CF_JNDI_NAME);
+        createJmsBridge(JMS_BRIDGE_NAME);
+    }
+
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        removeJmsBridge(JMS_BRIDGE_NAME);
+        removeConnectionFactory(CF_NAME);
+        super.tearDown(managementClient, containerId);
+    }
+
+
+    private void createConnectionFactory(String cfName, String cfJndiName) {
+        final ModelNode createConnectionFactoryOp = new ModelNode();
+        createConnectionFactoryOp.get(ClientConstants.OP).set(ClientConstants.ADD);
+        createConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        createConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("hornetq-server", "default");
+        createConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("connection-factory", cfName);
+        ModelNode connector = createConnectionFactoryOp.get("connector");
+        connector.get("in-vm").set(ModelType.UNDEFINED);
+
+        createConnectionFactoryOp.get("factory-type").set("XA_GENERIC");
+        createConnectionFactoryOp.get("entries").add(cfJndiName);
+        System.err.println("Create operation =====> " + createConnectionFactoryOp);
+        try {
+            this.applyUpdate(createConnectionFactoryOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void removeConnectionFactory(String cfName) {
+        final ModelNode removeConnectionFactoryOp = new ModelNode();
+        removeConnectionFactoryOp.get(ClientConstants.OP).set("remove");
+        removeConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        removeConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("hornetq-server", "default");
+        removeConnectionFactoryOp.get(ClientConstants.OP_ADDR).add("connection-factory", cfName);
+        try {
+            this.applyUpdate(removeConnectionFactoryOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private void createJmsBridge(String bridgeName) {
+        final ModelNode createJmsBridgeOp = new ModelNode();
+        createJmsBridgeOp.get(ClientConstants.OP).set(ClientConstants.ADD);
+        createJmsBridgeOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        createJmsBridgeOp.get(ClientConstants.OP_ADDR).add("jms-bridge", bridgeName);
+        createJmsBridgeOp.get("source-connection-factory").set(CF_JNDI_NAME);
+        createJmsBridgeOp.get("source-destination").set(QUEUE1_JNDI_NAME);
+        createJmsBridgeOp.get("target-connection-factory").set(CF_JNDI_NAME);
+        createJmsBridgeOp.get("target-destination").set(QUEUE2_JNDI_NAME);
+        createJmsBridgeOp.get("quality-of-service").set(QualityOfServiceMode.ONCE_AND_ONLY_ONCE.toString());
+        createJmsBridgeOp.get("failure-retry-interval").set(500);
+        createJmsBridgeOp.get("max-retries").set(2);
+        createJmsBridgeOp.get("max-batch-size").set(1024);
+        createJmsBridgeOp.get("max-batch-time").set(100);
+        createJmsBridgeOp.get("add-messageID-in-header").set("true");
+        try {
+            this.applyUpdate(createJmsBridgeOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void removeJmsBridge(String bridgeName) {
+        final ModelNode removeJmsBridgeOp = new ModelNode();
+        removeJmsBridgeOp.get(ClientConstants.OP).set("remove");
+        removeJmsBridgeOp.get(ClientConstants.OP_ADDR).add("subsystem", "messaging");
+        removeJmsBridgeOp.get(ClientConstants.OP_ADDR).add("jms-bridge", bridgeName);
+        try {
+            this.applyUpdate(removeJmsBridgeOp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void applyUpdate(final ModelNode update) throws IOException {
+        ModelNode result = managementClient.getControllerClient().execute(update);
+        if (result.hasDefined(ClientConstants.OUTCOME)
+                && ClientConstants.SUCCESS.equals(result.get(ClientConstants.OUTCOME).asString())) {
+            logger.info("Operation successful for update = " + update.toString());
+        } else if (result.hasDefined(ClientConstants.FAILURE_DESCRIPTION)) {
+            final String failureDesc = result.get(ClientConstants.FAILURE_DESCRIPTION).toString();
+            throw new RuntimeException(failureDesc);
+        } else {
+            throw new RuntimeException("Operation not successful; outcome = " + result.get(ClientConstants.OUTCOME));
+        }
+    }
+
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import javax.annotation.Resource;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.hornetq.api.jms.HornetQJMSConstants;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * JMS bridge test.
+ *
+ * @author Jeff Mesnil (c) 2012 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(CreateJMSBridgeSetupTask.class)
+public class JMSBridgeTest {
+
+    private static final Logger logger = Logger.getLogger(JMSBridgeTest.class);
+
+    private static final String MESSAGE_TEXT = "Hello world!";
+
+    @Resource(mappedName = "/queue/myAwesomeQueue")
+    private Queue sourceQueue;
+
+    @Resource(mappedName = "/queue/myAwesomeQueue2")
+    private Queue targetQueue;
+
+    @Resource(mappedName = "/myAwesomeCF")
+    private ConnectionFactory factory;
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "test.jar")
+                .addPackage(JMSOperations.class.getPackage())
+                .addClass(CreateJMSBridgeSetupTask.class)
+                .addClass(CreateQueueSetupTask.class)
+                .addAsManifestResource(
+                        EmptyAsset.INSTANCE,
+                        ArchivePaths.create("beans.xml"));
+    }
+
+    /**
+     * Send a message on the source queue
+     * Consumes it on the target queue
+     *
+     * The test will pass since a JMS Bridge has been created to bridge the source destination to the target destination.
+     */
+    @Test
+    public void sendAndReceiveMessage() throws Exception {
+        Connection connection = null;
+        Session session = null;
+        Message receivedMessage = null;
+
+        try {
+            // SEND A MESSAGE on the source queue
+            connection = factory.createConnection();
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageProducer producer = session.createProducer(sourceQueue);
+            String text = MESSAGE_TEXT + " " + UUID.randomUUID().toString();
+            Message message = session.createTextMessage(text);
+            message.setJMSDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            producer.send(message);
+            connection.start();
+            connection.close();
+
+            // RECEIVE THE MESSAGE from the target queue
+            connection = factory.createConnection();
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageConsumer consumer = session.createConsumer(targetQueue);
+            connection.start();
+            receivedMessage = consumer.receive(5000);
+
+            // ASSERTIONS
+            assertNotNull("did not receive expected message", receivedMessage);
+            assertTrue(receivedMessage instanceof TextMessage);
+            assertTrue(((TextMessage) receivedMessage).getText().equals(text));
+            assertNotNull("did not get header set by the JMS bridge", receivedMessage.getStringProperty(HornetQJMSConstants.JBOSS_MESSAGING_BRIDGE_MESSAGE_ID_LIST));
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            // CLEANUP
+            if (session != null) {
+                session.close();
+            }
+            if (connection != null) {
+                connection.close();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Add manage JMS Bridge to AS7 messaging subsystem
- update messaging subsystem namespace and XSD to 1.3
- <hornetq-server> is now optional (so that an AS7 instance
  can host only JMS bridges)
- define JMS Bridge using SimpleResourceDefinition
- add integration test JMSBridgeTest using in-vm source and target
  resources
- add management operations start, stop, pause, resume
- add org.jboss.remote-naming to org.jboss.as.messaging dependencies
  to be able to do a JNDI lookup on a remote AS7 instance
  to set up a JMS bridge
- add module attribute for external broker dependencies
- add dependency to HornetQ's JMS service only if one of the JMS resource is looked up locally
- start/stop the JMS Bridge service asynchronously
- add a dependency from org.jboss.as.messaging to org.jboss.threads module to
  create the executor in charge of starting/stopping JMS bridge services asynchronously
