### PR TITLE
AS7-4946 Read bytes into buffer to avoid transforming output

### DIFF
--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -289,16 +289,16 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
         @Override
         public void run() {
             final InputStream stream = process.getInputStream();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
             final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
 
-            String line = null;
             try {
-                while ((line = reader.readLine()) != null) {
-                    if (writeOutput) {
-                        System.out.println(line);
-                    }
-                }
+               byte[] buf = new byte[32];
+               int num;
+               // Do not try reading a line cos it considers '\r' end of line
+               while((num = stream.read(buf)) != -1){
+                  if (writeOutput)
+                     System.out.write(buf, 0, num);
+               }
             } catch (IOException e) {
             }
         }

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -325,18 +325,18 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
         @Override
         public void run() {
             final InputStream stream = process.getInputStream();
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
             final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
 
-            String line = null;
-            try {
-                while ((line = reader.readLine()) != null) {
-                    if (writeOutput) {
-                        System.out.println(line);
-                    }
-                }
-            } catch (IOException e) {
-            }
+           try {
+              byte[] buf = new byte[32];
+              int num;
+              // Do not try reading a line cos it considers '\r' end of line
+              while((num = stream.read(buf)) != -1){
+                 if (writeOutput)
+                    System.out.write(buf, 0, num);
+              }
+           } catch (IOException e) {
+           }
         }
 
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/util/ProcessWrapper.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/util/ProcessWrapper.java
@@ -136,14 +136,13 @@ class ProcessWrapper {
         public void run() {
             final InputStream source = this.source;
             try {
-                final BufferedReader reader = new BufferedReader(new InputStreamReader(new BufferedInputStream(source)));
-                String s;
-                while ((s = reader.readLine()) != null) {
-                    if(writeOutput) {
-                        target.println(s);
-                    }
-                }
-                source.close();
+               byte[] buf = new byte[32];
+               int num;
+               // Do not try reading a line cos it considers '\r' end of line
+               while((num = source.read(buf)) != -1){
+                  if (writeOutput)
+                     System.out.write(buf, 0, num);
+               }
             } catch (IOException e) {
                 if(! ProcessWrapper.this.stopped) {
                     e.printStackTrace(target);


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-4946

With readLine(), '\r' was considered end of line and it was not being printed correctly. The result was that progress related console outputs could not be generated.
