### PR TITLE
AS7-4893 Initialize configuration data from persistent storage on startup

### DIFF
--- a/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminExtension.java
+++ b/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminExtension.java
@@ -68,7 +68,8 @@ public class ConfigAdminExtension implements Extension {
         ManagementResourceRegistration configuration = registration.registerSubModel(PathElement.pathElement(ModelConstants.CONFIGURATION), ConfigAdminProviders.CONFIGURATION_DESCRIPTION);
         configuration.registerOperationHandler(ModelDescriptionConstants.ADD, ConfigurationAdd.INSTANCE, ConfigurationAdd.DESCRIPTION, false);
         configuration.registerOperationHandler(ModelDescriptionConstants.REMOVE, ConfigurationRemove.INSTANCE, ConfigurationRemove.DESCRIPTION, false);
-        configuration.registerOperationHandler(ModelConstants.UPDATE, ConfigurationUpdate.INSTANCE, ConfigurationUpdate.DESCRIPTION, false);
+        // The update operation is marked private on the 7.1 branch to not change the public API. On the master branch (7.2 and onwards) this operation should be public
+        configuration.registerOperationHandler(ModelConstants.UPDATE, ConfigurationUpdate.INSTANCE, ConfigurationUpdate.DESCRIPTION, false, OperationEntry.EntryType.PRIVATE);
         configuration.registerReadOnlyAttribute(ModelConstants.ENTRIES, null, AttributeAccess.Storage.CONFIGURATION);
 
         subsystem.registerXMLElementWriter(ConfigAdminWriter.INSTANCE);

--- a/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminExtension.java
+++ b/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigAdminExtension.java
@@ -58,9 +58,6 @@ public class ConfigAdminExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
-
-        boolean registerRuntimeOnly = context.isRuntimeOnlyRegistrationValid();
-
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0);
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(ConfigAdminProviders.SUBSYSTEM);
         registration.registerOperationHandler(ModelDescriptionConstants.ADD, ConfigAdminAdd.INSTANCE, ConfigAdminAdd.DESCRIPTION, false);
@@ -71,7 +68,8 @@ public class ConfigAdminExtension implements Extension {
         ManagementResourceRegistration configuration = registration.registerSubModel(PathElement.pathElement(ModelConstants.CONFIGURATION), ConfigAdminProviders.CONFIGURATION_DESCRIPTION);
         configuration.registerOperationHandler(ModelDescriptionConstants.ADD, ConfigurationAdd.INSTANCE, ConfigurationAdd.DESCRIPTION, false);
         configuration.registerOperationHandler(ModelDescriptionConstants.REMOVE, ConfigurationRemove.INSTANCE, ConfigurationRemove.DESCRIPTION, false);
-        configuration.registerReadOnlyAttribute(ModelConstants.ENTRIES,null, AttributeAccess.Storage.CONFIGURATION);
+        configuration.registerOperationHandler(ModelConstants.UPDATE, ConfigurationUpdate.INSTANCE, ConfigurationUpdate.DESCRIPTION, false);
+        configuration.registerReadOnlyAttribute(ModelConstants.ENTRIES, null, AttributeAccess.Storage.CONFIGURATION);
 
         subsystem.registerXMLElementWriter(ConfigAdminWriter.INSTANCE);
     }

--- a/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigurationUpdate.java
+++ b/configadmin/src/main/java/org/jboss/as/configadmin/parser/ConfigurationUpdate.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.configadmin.parser;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.configadmin.service.ConfigAdminServiceImpl;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Process a Configuration Update.
+ *
+ * @author David Bosschaert
+ */
+public class ConfigurationUpdate implements OperationStepHandler {
+    static final ConfigurationUpdate INSTANCE = new ConfigurationUpdate();
+
+    private ConfigurationUpdate() {
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        // Remove the resource from the model
+        context.removeResource(PathAddress.EMPTY_ADDRESS);
+        // Add the new resource with the updated information
+        Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
+        resource.getModel().get(ModelConstants.ENTRIES).set(operation.get(ModelConstants.ENTRIES));
+
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                ModelNode entries = operation.get(ModelConstants.ENTRIES);
+                String pid = operation.get(ModelDescriptionConstants.OP_ADDR).asObject().get(ModelConstants.CONFIGURATION).asString();
+
+                Dictionary<String, String> dictionary = new Hashtable<String, String>();
+                for (String key : entries.keys()) {
+                    dictionary.put(key, entries.get(key).asString());
+                }
+
+                ConfigAdminServiceImpl configAdmin = ConfigAdminExtension.getConfigAdminService(context);
+                if (configAdmin != null) {
+                    configAdmin.putConfigurationFromDMR(pid, dictionary);
+                }
+
+                context.completeStep();
+            }
+        }, OperationContext.Stage.RUNTIME);
+
+        context.completeStep();
+    }
+
+    static DescriptionProvider DESCRIPTION = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            ModelNode node = new ModelNode();
+            ResourceBundle resbundle = ConfigAdminProviders.getResourceBundle(locale);
+            node.get(ModelDescriptionConstants.OPERATION_NAME).set(ModelConstants.UPDATE);
+            node.get(ModelDescriptionConstants.DESCRIPTION).set(resbundle.getString("configuration.update"));
+            node.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelConstants.ENTRIES, ModelDescriptionConstants.DESCRIPTION).set(
+                    resbundle.getString("configuration.entries"));
+            node.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelConstants.ENTRIES, ModelDescriptionConstants.TYPE).set(ModelType.LIST);
+            node.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelConstants.ENTRIES, ModelDescriptionConstants.REQUIRED).set(true);
+            node.get(ModelDescriptionConstants.REQUEST_PROPERTIES, ModelConstants.ENTRIES, ModelDescriptionConstants.VALUE_TYPE).set(ModelType.PROPERTY);
+            node.get(ModelDescriptionConstants.REPLY_PROPERTIES).setEmptyObject();
+            return node;
+        }
+    };
+}

--- a/configadmin/src/main/java/org/jboss/as/configadmin/parser/ModelConstants.java
+++ b/configadmin/src/main/java/org/jboss/as/configadmin/parser/ModelConstants.java
@@ -33,4 +33,5 @@ public interface ModelConstants {
 
     String CONFIGURATION = "configuration";
     String ENTRIES = "entries";
+    String UPDATE = "update";
 }

--- a/configadmin/src/main/java/org/jboss/as/configadmin/service/ConfigAdminService.java
+++ b/configadmin/src/main/java/org/jboss/as/configadmin/service/ConfigAdminService.java
@@ -34,8 +34,16 @@ import org.jboss.msc.service.ServiceName;
  * @since 29-Nov-2010
  */
 public interface ConfigAdminService extends Service<ConfigAdminService> {
+    // The SOURCE_PROPERTY_KEY is a private property used on the Config Admin entries to
+    // avoid inifinite loops. There are multiple potential sources of configuration updates:
+    // 1. The DMR API
+    // 2. The OSGi Configuration Admin Service
+    // 3. The MSC Config Admin Sevice
+    // Since updates from the DMR need to be propagated to the services and vice versa
+    // this source property is used to stop the system from looping around forever.
     String SOURCE_PROPERTY_KEY = ".org.jboss.source";
     String FROM_DMR_SOURCE_VALUE = "fromdmr";
+    String FROM_NONDMR_SOURCE_VALUE = "notfromdmr";
 
     ServiceName SERVICE_NAME = ServiceName.JBOSS.append("configadmin");
 

--- a/configadmin/src/main/resources/org/jboss/as/configadmin/parser/LocalDescriptions.properties
+++ b/configadmin/src/main/resources/org/jboss/as/configadmin/parser/LocalDescriptions.properties
@@ -9,4 +9,5 @@ configuration.entries=The list of configuration entries.
 
 configuration.add=Add a configuration entry.
 configuration.remove=Remove a configuration entry.
+configuration.update=Update a configuration entry.
 

--- a/configadmin/src/test/java/org/jboss/as/configadmin/parser/ConfigurationAddTestCase.java
+++ b/configadmin/src/test/java/org/jboss/as/configadmin/parser/ConfigurationAddTestCase.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.configadmin.parser;
+
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Field;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.jboss.as.configadmin.service.ConfigAdminService;
+import org.jboss.as.configadmin.service.ConfigAdminServiceImpl;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.ImmediateValue;
+import org.jboss.msc.value.InjectedValue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author David Bosschaert
+ */
+public class ConfigurationAddTestCase {
+    @Before
+    public void setUp() throws Exception {
+        clearInitializationService();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        clearInitializationService();
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void testConfigAdminPresent() throws Exception {
+        // Set up some mock objects
+        ConfigAdminServiceImpl mockCAS = Mockito.mock(ConfigAdminServiceImpl.class);
+
+        ServiceController mockCASServiceController = Mockito.mock(ServiceController.class);
+        Mockito.when(mockCASServiceController.getValue()).thenReturn(mockCAS);
+
+        ServiceRegistry mockServiceRegistry = Mockito.mock(ServiceRegistry.class);
+        Mockito.when(mockServiceRegistry.getService(ConfigAdminService.SERVICE_NAME)).thenReturn(mockCASServiceController);
+
+        OperationContext mockOperationContext = Mockito.mock(OperationContext.class);
+        Mockito.when(mockOperationContext.getServiceRegistry(true)).thenReturn(mockServiceRegistry);
+
+        // Create the operation model node
+        Hashtable<String, String> dict = new Hashtable<String, String>();
+        dict.put("x.y", "a b");
+        ModelNode operation = getOperationModelNode("some.config", dict);
+
+        // Invoke the Add operation
+        ConfigurationAdd.INSTANCE.performRuntime(mockOperationContext, operation, null, null, null);
+
+        // Verify the results
+        Mockito.verify(mockCAS).putConfigurationFromDMR("some.config", dict);
+        assertNull(getInitializationService());
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public void testConfigAdminArrivesLater() throws Exception {
+        // Set up some mock objects
+        ServiceRegistry mockServiceRegistry = Mockito.mock(ServiceRegistry.class);
+
+        ServiceBuilder mockBuilder = Mockito.mock(ServiceBuilder.class);
+
+        ServiceTarget mockServiceTarget = Mockito.mock(ServiceTarget.class);
+        Mockito.when(mockServiceTarget.addService(
+                Mockito.eq(ServiceName.JBOSS.append("configadmin", "data_initialization")),
+                Mockito.any(Service.class))).
+            thenReturn(mockBuilder);
+
+        OperationContext mockOperationContext = Mockito.mock(OperationContext.class);
+        Mockito.when(mockOperationContext.getServiceRegistry(true)).thenReturn(mockServiceRegistry);
+        Mockito.when(mockOperationContext.getServiceTarget()).thenReturn(mockServiceTarget);
+
+        // Create the operation model node
+        Hashtable<String, String> values = new Hashtable<String, String>();
+        values.put("a", "aa");
+        values.put("b", "bb");
+        ModelNode operation = getOperationModelNode("a.b.c", values);
+
+        // Invoke the Add operation
+        ConfigurationAdd.INSTANCE.performRuntime(mockOperationContext, operation, null, null, null);
+
+        // Check that the service that depends on the Config Admin Service has been created
+        Mockito.verify(mockBuilder).addDependency(
+                Mockito.eq(ConfigAdminService.SERVICE_NAME),
+                Mockito.eq(ConfigAdminService.class),
+                Mockito.any(Injector.class));
+        Mockito.verify(mockBuilder).install();
+
+        // Set up the mock Config Admin Service
+        ConfigAdminServiceImpl mockCAS = Mockito.mock(ConfigAdminServiceImpl.class);
+        ConfigurationAdd.InitializeConfigAdminService initSvc = getInitializationService();
+        Field injectedCASField = initSvc.getClass().getDeclaredField("injectedConfigAdminService");
+        injectedCASField.setAccessible(true);
+        InjectedValue<ConfigAdminService> injectedCAS = (InjectedValue<ConfigAdminService>) injectedCASField.get(initSvc);
+        injectedCAS.setValue(new ImmediateValue<ConfigAdminService>(mockCAS));
+
+        // Invoke the operation again
+        Hashtable<String, String> values2 = new Hashtable<String, String>();
+        values2.put("x", "x");
+        values2.put(ConfigAdminService.SOURCE_PROPERTY_KEY, ConfigAdminService.FROM_NONDMR_SOURCE_VALUE);
+        ModelNode op2 = getOperationModelNode("xx", values2);
+        ConfigurationAdd.INSTANCE.performRuntime(mockOperationContext, op2, null, null, null);
+
+        initSvc.start(null);
+
+        Mockito.verify(mockCAS).putConfigurationFromDMR("a.b.c", values);
+        Mockito.verify(mockCAS).putConfigurationFromDMR("xx", values2);
+    }
+
+    private ModelNode getOperationModelNode(String pid, Map<String, String> props) {
+        ModelNode addr = new ModelNode();
+        addr.add(new ModelNode().set(ModelDescriptionConstants.SUBSYSTEM, ConfigAdminExtension.SUBSYSTEM_NAME));
+        addr.add(new ModelNode().set(ModelConstants.CONFIGURATION, pid));
+        ModelNode operation = Util.getEmptyOperation(ModelDescriptionConstants.ADD, addr);
+        ModelNode entries = new ModelNode();
+
+        for (Map.Entry<String, String> entry : props.entrySet()) {
+            entries.get(entry.getKey()).set(entry.getValue());
+        }
+        operation.get(ModelConstants.ENTRIES).set(entries);
+        return operation;
+    }
+
+    private ConfigurationAdd.InitializeConfigAdminService getInitializationService() throws Exception {
+        Field field = ConfigurationAdd.class.getDeclaredField("initializationService");
+        field.setAccessible(true);
+        return (ConfigurationAdd.InitializeConfigAdminService) field.get(ConfigurationAdd.INSTANCE);
+    }
+
+    private void clearInitializationService() throws Exception {
+        Field field = ConfigurationAdd.class.getDeclaredField("initializationService");
+        field.setAccessible(true);
+        field.set(ConfigurationAdd.INSTANCE, null);
+    }
+}

--- a/configadmin/src/test/java/org/jboss/as/configadmin/parser/ConfigurationUpdateTestCase.java
+++ b/configadmin/src/test/java/org/jboss/as/configadmin/parser/ConfigurationUpdateTestCase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.configadmin.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.jboss.as.configadmin.service.ConfigAdminService;
+import org.jboss.as.configadmin.service.ConfigAdminServiceImpl;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceRegistry;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+/**
+ * Process a Configuration Update.
+ *
+ * @author David Bosschaert
+ */
+public class ConfigurationUpdateTestCase {
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testConfigurationUpdate() throws Exception {
+        // Set up some mock objects
+        ModelNode targetModel = new ModelNode();
+        Resource mockResource = Mockito.mock(Resource.class);
+        Mockito.when(mockResource.getModel()).thenReturn(targetModel);
+
+        OperationContext mockOperationContext = Mockito.mock(OperationContext.class);
+        Mockito.when(mockOperationContext.createResource(PathAddress.EMPTY_ADDRESS)).thenReturn(mockResource);
+
+        Hashtable<String, String> dict = new Hashtable<String, String>();
+        dict.put("foo", "bar");
+        ModelNode operation = getOperationModelNode("mypid", dict);
+
+        // Call the update operation
+        ConfigurationUpdate.INSTANCE.execute(mockOperationContext, operation);
+
+        // Verify the interactions made during the update operation
+        InOrder inOrder = Mockito.inOrder(mockOperationContext);
+        inOrder.verify(mockOperationContext).removeResource(PathAddress.EMPTY_ADDRESS);
+        inOrder.verify(mockOperationContext).createResource(PathAddress.EMPTY_ADDRESS);
+        ArgumentCaptor<OperationStepHandler> addedStep = ArgumentCaptor.forClass(OperationStepHandler.class);
+        inOrder.verify(mockOperationContext).addStep(
+                addedStep.capture(), Mockito.eq(OperationContext.Stage.RUNTIME));
+        inOrder.verify(mockOperationContext).completeStep();
+
+        ModelNode expectedModel = new ModelNode();
+        ModelNode subModel = new ModelNode();
+        subModel.get("foo").set("bar");
+        expectedModel.get("entries").set(subModel);
+        assertEquals(expectedModel, targetModel);
+
+        // now check the runtime operation, as added by the update operation
+        OperationStepHandler step = addedStep.getValue();
+
+        // Set up some more mock objects for the runtime operation
+        ConfigAdminServiceImpl mockCAS = Mockito.mock(ConfigAdminServiceImpl.class);
+
+        ServiceController mockCASServiceController = Mockito.mock(ServiceController.class);
+        Mockito.when(mockCASServiceController.getValue()).thenReturn(mockCAS);
+
+        ServiceRegistry mockServiceRegistry = Mockito.mock(ServiceRegistry.class);
+        Mockito.when(mockServiceRegistry.getService(ConfigAdminService.SERVICE_NAME)).thenReturn(mockCASServiceController);
+
+        OperationContext mockContext2 = Mockito.mock(OperationContext.class);
+        Mockito.when(mockContext2.getServiceRegistry(true)).thenReturn(mockServiceRegistry);
+        step.execute(mockContext2, operation);
+
+        Mockito.verify(mockCAS).putConfigurationFromDMR("mypid", dict);
+        Mockito.verify(mockContext2).completeStep();
+    }
+
+    private ModelNode getOperationModelNode(String pid, Map<String, String> props) {
+        ModelNode addr = new ModelNode();
+        addr.add(new ModelNode().set(ModelDescriptionConstants.SUBSYSTEM, ConfigAdminExtension.SUBSYSTEM_NAME));
+        addr.add(new ModelNode().set(ModelConstants.CONFIGURATION, pid));
+        ModelNode operation = Util.getEmptyOperation(ModelConstants.UPDATE, addr);
+        ModelNode entries = new ModelNode();
+
+        for (Map.Entry<String, String> entry : props.entrySet()) {
+            entries.get(entry.getKey()).set(entry.getValue());
+        }
+        operation.get(ModelConstants.ENTRIES).set(entries);
+        return operation;
+    }
+}

--- a/configadmin/src/test/java/org/jboss/as/configadmin/service/ConfigAdminServiceImplTestCase.java
+++ b/configadmin/src/test/java/org/jboss/as/configadmin/service/ConfigAdminServiceImplTestCase.java
@@ -1,0 +1,285 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.configadmin.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import org.jboss.as.configadmin.parser.ConfigAdminExtension;
+import org.jboss.as.configadmin.parser.ConfigAdminState;
+import org.jboss.as.configadmin.parser.ModelConstants;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.value.ImmediateValue;
+import org.jboss.msc.value.InjectedValue;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author David Bosschaert
+ */
+public class ConfigAdminServiceImplTestCase {
+    @Test
+    public void testPutConfiguration() throws Exception {
+        // Set up some mocks
+        ConfigAdminState mockState = Mockito.mock(ConfigAdminState.class);
+
+        ModelNode expectedAddr = new ModelNode();
+        expectedAddr.add(new ModelNode().set(ModelDescriptionConstants.SUBSYSTEM, ConfigAdminExtension.SUBSYSTEM_NAME));
+        expectedAddr.add(new ModelNode().set(ModelConstants.CONFIGURATION, "a.b.c"));
+        ModelNode expectedOp = Util.getEmptyOperation(ModelDescriptionConstants.ADD, expectedAddr);
+        ModelNode entries = new ModelNode();
+        entries.get(ConfigAdminService.SOURCE_PROPERTY_KEY).set(ConfigAdminService.FROM_NONDMR_SOURCE_VALUE);
+        entries.get("a.key").set("A Value");
+        expectedOp.get(ModelConstants.ENTRIES).set(entries);
+
+        ModelNode success = new ModelNode();
+        success.set(ModelDescriptionConstants.OUTCOME, ModelDescriptionConstants.SUCCESS);
+
+        ModelControllerClient mockControllerClient = Mockito.mock(ModelControllerClient.class);
+        Mockito.when(mockControllerClient.execute(expectedOp)).thenReturn(success);
+
+        // Initialize the ConfigAdminServiceImpl object
+        ConfigAdminServiceImpl cas = createConfigAdminServiceImpl();
+        setControllerClient(cas, mockControllerClient);
+        injectSubsystemState(cas, mockState);
+        setSynchronousExecutor(cas);
+
+        // Register listener
+        TestConfigAdminListener testListener = new TestConfigAdminListener();
+        cas.addListener(testListener);
+
+        Hashtable<String, String> config = new Hashtable<String, String>();
+        config.put("a.key", "A Value");
+
+        assertEquals("Precondition", 0, testListener.pidList.size());
+        // Call the operation
+        assertNull(cas.putConfiguration("a.b.c", config));
+
+        // Verify expected behaviour
+        Mockito.verify(mockState).putConfiguration("a.b.c", config);
+        assertEquals(Arrays.asList("a.b.c"), testListener.pidList);
+        assertEquals(Arrays.asList((Object) config), testListener.propList);
+    }
+
+    @Test
+    public void testUpdateConfiguration() throws Exception {
+        Dictionary<String, String> initial = new Hashtable<String, String>();
+        initial.put("some.key", "some value");
+
+        // Set up some mocks
+        ConfigAdminState mockState = Mockito.mock(ConfigAdminState.class);
+        Mockito.when(mockState.getConfiguration("a.b.c")).thenReturn(initial);
+
+        ModelNode expectedAddr = new ModelNode();
+        expectedAddr.add(new ModelNode().set(ModelDescriptionConstants.SUBSYSTEM, ConfigAdminExtension.SUBSYSTEM_NAME));
+        expectedAddr.add(new ModelNode().set(ModelConstants.CONFIGURATION, "a.b.c"));
+        ModelNode expectedOp = Util.getEmptyOperation(ModelConstants.UPDATE, expectedAddr);
+        ModelNode entries = new ModelNode();
+        entries.get(ConfigAdminService.SOURCE_PROPERTY_KEY).set(ConfigAdminService.FROM_NONDMR_SOURCE_VALUE);
+        entries.get("a.key").set("A Value");
+        expectedOp.get(ModelConstants.ENTRIES).set(entries);
+
+        ModelNode success = new ModelNode();
+        success.set(ModelDescriptionConstants.OUTCOME, ModelDescriptionConstants.SUCCESS);
+
+        ModelControllerClient mockControllerClient = Mockito.mock(ModelControllerClient.class);
+        Mockito.when(mockControllerClient.execute(expectedOp)).thenReturn(success);
+
+        // Initialize the ConfigAdminServiceImpl object
+        ConfigAdminServiceImpl cas = createConfigAdminServiceImpl();
+        setControllerClient(cas, mockControllerClient);
+        injectSubsystemState(cas, mockState);
+        setSynchronousExecutor(cas);
+
+        // Register listener
+        TestConfigAdminListener testListener = new TestConfigAdminListener();
+        cas.addListener(testListener);
+
+        Hashtable<String, String> config = new Hashtable<String, String>();
+        config.put("a.key", "A Value");
+
+        assertEquals("Precondition", 0, testListener.pidList.size());
+        // Call the operation
+        assertEquals(initial, cas.putConfiguration("a.b.c", config));
+
+        // Verify expected behaviour
+        Mockito.verify(mockState).putConfiguration("a.b.c", config);
+        assertEquals(Arrays.asList("a.b.c"), testListener.pidList);
+        assertEquals(Arrays.asList((Object) config), testListener.propList);
+    }
+
+    @Test
+    public void testPutConfigurationFromDMR() throws Exception {
+        // Set up some mocks
+        ConfigAdminState mockState = Mockito.mock(ConfigAdminState.class);
+
+        // Initialize the ConfigAdminServiceImpl object
+        ConfigAdminServiceImpl cas = createConfigAdminServiceImpl();
+        injectSubsystemState(cas, mockState);
+        setSynchronousExecutor(cas);
+
+        Hashtable<String, String> config = new Hashtable<String, String>();
+        config.put("a.b.c.d.e.f.g", "a value");
+
+        // Call the operation
+        cas.putConfigurationFromDMR("someconfig", config);
+
+        // Verify expected behaviour
+        Dictionary<String, String> expected = new Hashtable<String, String>(config);
+        expected.put(ConfigAdminService.SOURCE_PROPERTY_KEY, ConfigAdminService.FROM_DMR_SOURCE_VALUE);
+        Mockito.verify(mockState).putConfiguration("someconfig", expected);
+    }
+
+    @Test
+    public void testRemoveConfiguration() throws Exception {
+        Hashtable<String, String> initialConfig = new Hashtable<String, String>();
+        initialConfig.put("x", "y");
+
+        // Set up some mocks
+        ConfigAdminState mockState = Mockito.mock(ConfigAdminState.class);
+        Mockito.when(mockState.getConfiguration("abc")).thenReturn(initialConfig);
+
+        ModelNode expectedAddr = new ModelNode();
+        expectedAddr.add(new ModelNode().set(ModelDescriptionConstants.SUBSYSTEM, ConfigAdminExtension.SUBSYSTEM_NAME));
+        expectedAddr.add(new ModelNode().set(ModelConstants.CONFIGURATION, "abc"));
+        ModelNode expectedOp = Util.getEmptyOperation(ModelDescriptionConstants.REMOVE, expectedAddr);
+
+        ModelNode success = new ModelNode();
+        success.set(ModelDescriptionConstants.OUTCOME, ModelDescriptionConstants.SUCCESS);
+
+        ModelControllerClient mockControllerClient = Mockito.mock(ModelControllerClient.class);
+        Mockito.when(mockControllerClient.execute(expectedOp)).thenReturn(success);
+
+        // Initialize the ConfigAdminServiceImpl object
+        ConfigAdminServiceImpl cas = createConfigAdminServiceImpl();
+        setControllerClient(cas, mockControllerClient);
+        injectSubsystemState(cas, mockState);
+        setSynchronousExecutor(cas);
+
+        // Register listener
+        TestConfigAdminListener testListener = new TestConfigAdminListener();
+        cas.addListener(testListener);
+
+        assertEquals("Precondition", 0, testListener.pidList.size());
+        // Call the remove operation
+        assertEquals(initialConfig, cas.removeConfiguration("abc"));
+
+        // Verify expected behaviour
+        Mockito.verify(mockState).removeConfiguration("abc");
+        assertEquals(Arrays.asList("abc"), testListener.pidList);
+        assertEquals(Arrays.asList((Object) null), testListener.propList);
+    }
+
+    @Test
+    public void testRemoveConfigurationFromDMR() throws Exception {
+        ConfigAdminState mockState = Mockito.mock(ConfigAdminState.class);
+
+        // Initialize the ConfigAdminServiceImpl object
+        ConfigAdminServiceImpl cas = createConfigAdminServiceImpl();
+        injectSubsystemState(cas, mockState);
+        setSynchronousExecutor(cas);
+
+        // Register listener
+        TestConfigAdminListener testListener = new TestConfigAdminListener();
+        cas.addListener(testListener);
+
+        assertEquals("Precondition", 0, testListener.pidList.size());
+        // Call the remove operation
+        cas.removeConfigurationFromDMR("xx.yy");
+
+        // Verify expected behaviour
+        Mockito.verify(mockState).removeConfiguration("xx.yy");
+        assertEquals(Arrays.asList("xx.yy"), testListener.pidList);
+        assertEquals(Arrays.asList((String) null), testListener.propList);
+    }
+
+    private static ConfigAdminServiceImpl createConfigAdminServiceImpl() throws Exception {
+        Constructor<ConfigAdminServiceImpl> ctor = ConfigAdminServiceImpl.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        return ctor.newInstance();
+    }
+
+    private static void injectSubsystemState(ConfigAdminServiceImpl cas, ConfigAdminState mockState) throws Exception {
+        Field field = cas.getClass().getDeclaredField("injectedSubsystemState");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        InjectedValue<ConfigAdminState> injected = (InjectedValue<ConfigAdminState>) field.get(cas);
+        injected.setValue(new ImmediateValue<ConfigAdminState>(mockState));
+    }
+
+    private static void setControllerClient(ConfigAdminServiceImpl cas, ModelControllerClient value) throws Exception {
+        Field field = cas.getClass().getDeclaredField("controllerClient");
+        field.setAccessible(true);
+        unFinal(field);
+        field.set(cas, value);
+    }
+
+    private static void setSynchronousExecutor(ConfigAdminServiceImpl cas) throws Exception {
+        Field field = cas.getClass().getDeclaredField("executor");
+        field.setAccessible(true);
+        unFinal(field);
+        field.set(cas, new TestSynchronousExecutor());
+    }
+
+    private static void unFinal(Field field) throws NoSuchFieldException, IllegalAccessException {
+        Field modifiers = Field.class.getDeclaredField("modifiers");
+        modifiers.setAccessible(true);
+        modifiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+    }
+
+    private static class TestConfigAdminListener implements ConfigAdminListener {
+        List<String> pidList = new ArrayList<String>();
+        List<Dictionary<String, String>> propList = new ArrayList<Dictionary<String, String>>();
+
+        @Override
+        public void configurationModified(String pid, Dictionary<String, String> props) {
+            pidList.add(pid);
+            propList.add(props);
+        }
+
+        @Override
+        public Set<String> getPIDs() {
+            return null;
+        }
+    }
+
+    private static class TestSynchronousExecutor implements Executor {
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+    }
+}

--- a/osgi/configadmin/pom.xml
+++ b/osgi/configadmin/pom.xml
@@ -54,6 +54,16 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build -->

--- a/osgi/configadmin/src/test/java/org/jboss/as/osgi/configadmin/DomainModelPersistenceManagerTestCase.java
+++ b/osgi/configadmin/src/test/java/org/jboss/as/osgi/configadmin/DomainModelPersistenceManagerTestCase.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.configadmin;
+
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Set;
+
+import org.apache.felix.cm.PersistenceManager;
+import org.jboss.as.configadmin.service.ConfigAdminService;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author David Bosschaert
+ */
+public class DomainModelPersistenceManagerTestCase {
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void testInitialization() throws Exception {
+        // Set up some mock objects
+        ConfigurationAdmin mockOSGiCAS = Mockito.mock(ConfigurationAdmin.class);
+
+        ServiceReference mockCASSR = Mockito.mock(ServiceReference.class);
+        ServiceReference mockSCSR = Mockito.mock(ServiceReference.class);
+
+        ConfigAdminService mockJBCAS = Mockito.mock(ConfigAdminService.class);
+        Set<String> pids = new HashSet<String>(Arrays.asList("a.b", "1"));
+        Mockito.when(mockJBCAS.getConfigurations()).thenReturn(pids);
+
+        ServiceController mockJBCASController = Mockito.mock(ServiceController.class);
+        Mockito.when(mockJBCASController.getValue()).thenReturn(mockJBCAS);
+
+        ServiceContainer mockServiceContainer = Mockito.mock(ServiceContainer.class);
+        Mockito.when(mockServiceContainer.getRequiredService(ConfigAdminService.SERVICE_NAME)).thenReturn(mockJBCASController);
+
+        BundleContext mockBundleContext = Mockito.mock(BundleContext.class);
+        Mockito.when(mockBundleContext.getServiceReferences(ConfigurationAdmin.class.getName(), null)).
+            thenReturn(new ServiceReference [] {mockCASSR}); // call used by OSGi ServiceTracker
+        Mockito.when(mockBundleContext.getServiceReference(ServiceContainer.class.getName())).thenReturn(mockSCSR);
+        Mockito.when(mockBundleContext.getService(mockSCSR)).thenReturn(mockServiceContainer);
+        Mockito.when(mockBundleContext.getService(mockCASSR)).thenReturn(mockOSGiCAS);
+
+        DomainModelPersistenceManager dmpm = new DomainModelPersistenceManager();
+
+        // Start the bundle
+        dmpm.start(mockBundleContext);
+
+        // Verify that the persistence manager was registered in the Service Registry.
+        Hashtable<String, Object> props = new Hashtable<String, Object>();
+        props.put(Constants.SERVICE_RANKING, Integer.MAX_VALUE);
+        Mockito.verify(mockBundleContext).registerService(PersistenceManager.class.getName(), dmpm, props);
+
+        // The OSGi ConfigAdmin needs to be primed with the configurations known to the JBoss ConfigAdmin
+        Mockito.verify(mockOSGiCAS).getConfiguration("a.b", null);
+        Mockito.verify(mockOSGiCAS).getConfiguration("1", null);
+    }
+
+    @Test
+    public void testModificationFromDMRCausesUpdate() throws Exception {
+        DomainModelPersistenceManager dmpm = new DomainModelPersistenceManager();
+        Configuration mockConfiguration = initPersistenceManager(dmpm, "abc");
+
+        Dictionary<String, String> dict = new Hashtable<String, String>();
+        dict.put("a", "b");
+        dict.put(ConfigAdminService.SOURCE_PROPERTY_KEY, ConfigAdminService.FROM_DMR_SOURCE_VALUE);
+        dmpm.configurationModified("abc", dict);
+
+        Mockito.verify(mockConfiguration).update(dict);
+        Mockito.verifyNoMoreInteractions(mockConfiguration);
+    }
+
+    @Test
+    public void testModificationNoUpdate() throws Exception {
+        DomainModelPersistenceManager dmpm = new DomainModelPersistenceManager();
+        Configuration mockConfiguration = initPersistenceManager(dmpm, "abc");
+
+        Dictionary<String, String> dict = new Hashtable<String, String>();
+        dict.put("a", "b");
+        dmpm.configurationModified("abc", dict);
+
+        // Because the modification is not marked to come from DMR it is assumed to come from the
+        // OSGi Config Admin system, so it does not need to be fed back into it. Therefore the
+        // Configuration.update() should not be called.
+        Mockito.verify(mockConfiguration, Mockito.never()).update(dict);
+        Mockito.verifyNoMoreInteractions(mockConfiguration);
+    }
+
+    @Test
+    public void testConfigurationDeleted() throws Exception {
+        DomainModelPersistenceManager dmpm = new DomainModelPersistenceManager();
+        Configuration mockConfiguration = initPersistenceManager(dmpm, "abc");
+
+        dmpm.configurationModified("abc", null);
+
+        Mockito.verify(mockConfiguration).delete();
+        Mockito.verifyNoMoreInteractions(mockConfiguration);
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private Configuration initPersistenceManager(DomainModelPersistenceManager dmpm, String pid) throws Exception {
+        Configuration mockConfiguration = Mockito.mock(Configuration.class);
+
+        ConfigurationAdmin mockOSGiCAS = Mockito.mock(ConfigurationAdmin.class);
+        Mockito.when(mockOSGiCAS.getConfiguration(pid, null)).thenReturn(mockConfiguration);
+        Mockito.when(mockOSGiCAS.listConfigurations("(" + Constants.SERVICE_PID + "=" + pid + ")")).
+            thenReturn(new Configuration [] {mockConfiguration});
+
+        ServiceReference mockCASSR = Mockito.mock(ServiceReference.class);
+        ServiceReference mockSCSR = Mockito.mock(ServiceReference.class);
+
+        ConfigAdminService mockJBCAS = Mockito.mock(ConfigAdminService.class);
+
+        ServiceController mockJBCASController = Mockito.mock(ServiceController.class);
+        Mockito.when(mockJBCASController.getValue()).thenReturn(mockJBCAS);
+
+        ServiceContainer mockServiceContainer = Mockito.mock(ServiceContainer.class);
+        Mockito.when(mockServiceContainer.getRequiredService(ConfigAdminService.SERVICE_NAME)).thenReturn(mockJBCASController);
+
+        BundleContext mockBundleContext = Mockito.mock(BundleContext.class);
+        Mockito.when(mockBundleContext.getServiceReferences(ConfigurationAdmin.class.getName(), null)).
+        thenReturn(new ServiceReference [] {mockCASSR}); // call used by OSGi ServiceTracker
+        Mockito.when(mockBundleContext.getServiceReference(ServiceContainer.class.getName())).thenReturn(mockSCSR);
+        Mockito.when(mockBundleContext.getService(mockSCSR)).thenReturn(mockServiceContainer);
+        Mockito.when(mockBundleContext.getService(mockCASSR)).thenReturn(mockOSGiCAS);
+
+        dmpm.start(mockBundleContext);
+        return mockConfiguration;
+    }
+}

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -121,6 +121,15 @@
                                         </parameter>
                                     </parameters>
                                 </transformationSet>
+                                <transformationSet>
+                                    <dir>${basedir}/target/jbossas/standalone/configuration</dir>
+                                    <skipDefaultExcludes>true</skipDefaultExcludes>
+                                    <includes>
+                                        <include>standalone*.xml</include>
+                                    </includes>
+                                    <stylesheet>${basedir}/src/test/xslt/configAdminPopulate.xsl</stylesheet>
+                                    <outputDir>${basedir}/target/jbossas/standalone/configuration</outputDir>
+                                </transformationSet>
                             </transformationSets>
                         </configuration>
                     </plugin>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/configadmin/ConfigurationAdminTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/configadmin/ConfigurationAdminTestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2010, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,6 +22,18 @@
 
 package org.jboss.as.test.integration.osgi.configadmin;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.InputStream;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.osgi.xservice.bundle.ConfiguredService;
@@ -36,6 +48,7 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationEvent;
@@ -43,21 +56,11 @@ import org.osgi.service.cm.ConfigurationListener;
 import org.osgi.service.cm.ManagedService;
 import org.osgi.service.startlevel.StartLevel;
 
-import javax.inject.Inject;
-import java.io.InputStream;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 /**
  * A test that shows how an OSGi {@link ManagedService} can be configured through the {@link ConfigurationAdmin}.
  *
  * @author Thomas.Diesler@jboss.com
+ * @author David Bosschaert
  * @since 11-Dec-2010
  */
 @RunWith(Arquillian.class)
@@ -132,6 +135,22 @@ public class ConfigurationAdminTestCase {
         finally
         {
             config.delete();
+        }
+    }
+
+    @Test
+    public void testManagedServiceConfiguredFromXML() throws Exception {
+        ConfiguredService ms = new ConfiguredService();
+
+        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put(Constants.SERVICE_PID, "a.test.pid");
+        // This configuration is present in the standalone.xml used for this test
+
+        ServiceRegistration reg = context.registerService(ManagedService.class.getName(), ms, props);
+        try {
+            assertEquals("test value", ms.getValue("testkey"));
+        } finally {
+            reg.unregister();
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/configadmin/bundle/TestBundleActivator2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/osgi/configadmin/bundle/TestBundleActivator2.java
@@ -43,9 +43,9 @@ public class TestBundleActivator2 implements BundleActivator {
         st.open();
         try {
             ConfigurationAdmin cadmin = (ConfigurationAdmin) st.waitForService(30000);
-            Configuration configuration = cadmin.getConfiguration(getClass().getName(), null);
+            Configuration configuration = cadmin.getConfiguration(TestBundleActivator2.class.getName(), null);
             Dictionary<String, Object> dictionary = new Hashtable<String, Object>();
-            dictionary.put("from.activator", "hi from a bundle activator");
+            dictionary.put("from.bundle", "initial");
             configuration.update(dictionary);
         } finally {
             st.close();
@@ -54,5 +54,16 @@ public class TestBundleActivator2 implements BundleActivator {
 
     @Override
     public void stop(BundleContext context) throws Exception {
+        ServiceTracker st = new ServiceTracker(context, ConfigurationAdmin.class.getName(), null);
+        st.open();
+        try {
+            ConfigurationAdmin cadmin = (ConfigurationAdmin) st.waitForService(30000);
+            Configuration configuration = cadmin.getConfiguration(TestBundleActivator2.class.getName(), null);
+            Dictionary<String, Object> d = new Hashtable<String, Object>();
+            d.put("from.bundle", "updated");
+            configuration.update(d);
+        } finally {
+            st.close();
+        }
     }
 }

--- a/testsuite/integration/basic/src/test/xslt/configAdminPopulate.xsl
+++ b/testsuite/integration/basic/src/test/xslt/configAdminPopulate.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  JBoss, Home of Professional Open Source.
+  Copyright 2012, Red Hat, Inc., and individual contributors
+  as indicated by the @author tags. See the copyright.txt file in the
+  distribution for a full listing of individual contributors.
+ 
+  This is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of
+  the License, or (at your option) any later version.
+ 
+  This software is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  Lesser General Public License for more details.
+ 
+  You should have received a copy of the GNU Lesser General Public
+  License along with this software; if not, write to the Free
+  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+  Author: David Bosschaert 
+ -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:ca="urn:jboss:domain:configadmin:1.0"
+                xmlns="urn:jboss:domain:1.3">
+    <xsl:output indent="yes"/>
+
+    <xsl:template match="ca:subsystem" priority="100" xmlns="urn:jboss:domain:configadmin:1.0">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | *"/>
+            <xsl:element name="configuration">
+                <xsl:attribute name="pid">a.test.pid</xsl:attribute>
+                <xsl:element name="property">
+                    <xsl:attribute name="name">testkey</xsl:attribute>
+                    <xsl:attribute name="value">test value</xsl:attribute>
+                </xsl:element>
+                <xsl:element name="property">
+                    <xsl:attribute name="name">test.key.2</xsl:attribute>
+                    <xsl:attribute name="value">nothing</xsl:attribute>
+                </xsl:element>
+            </xsl:element>
+        </xsl:copy>   
+    </xsl:template>
+
+    <xsl:template match="@*|node()" priority="1">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>
+    

--- a/testsuite/shared/src/main/java/org/jboss/as/test/configadmin/ConfigAdminManagementOperations.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/configadmin/ConfigAdminManagementOperations.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jboss.as.configadmin.parser.ModelConstants;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.management.ManagementOperations;
@@ -41,14 +42,7 @@ import org.jboss.dmr.ModelNode;
  */
 public class ConfigAdminManagementOperations {
     public static boolean addConfiguration(ModelControllerClient client, String pid, Map<String, String> entries) throws IOException, MgmtOperationException {
-        ModelNode op = ModelUtil.createOpNode("subsystem=configadmin/configuration=" + pid, ModelDescriptionConstants.ADD);
-        ModelNode en = new ModelNode();
-        for (Map.Entry<String, String> entry : entries.entrySet()) {
-            en.get(entry.getKey()).set(entry.getValue());
-        }
-        op.get("entries").set(en);
-        ModelNode result = executeOperation(client, op, false);
-        return ModelDescriptionConstants.SUCCESS.equals(result.get(ModelDescriptionConstants.OUTCOME).asString());
+        return addOrUpdateConfiguration(client, pid, entries, ModelDescriptionConstants.ADD);
     }
 
     public static List<String> listConfigurations(ModelControllerClient client) throws IOException, MgmtOperationException {
@@ -69,6 +63,22 @@ public class ConfigAdminManagementOperations {
 
     public static boolean removeConfiguration(ModelControllerClient client, String pid) throws IOException, MgmtOperationException {
         return removeResource(client, "configuration", pid);
+    }
+
+    public static boolean updateConfiguration(ModelControllerClient client, String pid, Map<String, String> entries)  throws IOException, MgmtOperationException {
+        return addOrUpdateConfiguration(client, pid, entries, ModelConstants.UPDATE);
+    }
+
+    private static boolean addOrUpdateConfiguration(ModelControllerClient client, String pid, Map<String, String> entries, String operation)
+            throws IOException, MgmtOperationException {
+        ModelNode op = ModelUtil.createOpNode("subsystem=configadmin/configuration=" + pid, operation);
+        ModelNode en = new ModelNode();
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            en.get(entry.getKey()).set(entry.getValue());
+        }
+        op.get("entries").set(en);
+        ModelNode result = executeOperation(client, op, false);
+        return ModelDescriptionConstants.SUCCESS.equals(result.get(ModelDescriptionConstants.OUTCOME).asString());
     }
 
     private static ModelNode executeOperation(final ModelControllerClient client, ModelNode op, boolean unwrapResult) throws IOException, MgmtOperationException {


### PR DESCRIPTION
Included are a fairly large number of mock-based unit tests,
DMR-based system tests and remote Arquillian-based system tests.
