### PR TITLE
[AS7-4949] NPE on :read-attribute in messaging subsystem

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractHornetQComponentControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractHornetQComponentControlHandler.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import org.hornetq.api.core.management.HornetQComponentControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -240,13 +241,18 @@ public abstract class AbstractHornetQComponentControlHandler<T extends HornetQCo
      * @param operation the operation
      * @param forWrite {@code true} if this operation will modify the runtime; {@code false} if not.
      * @return the control object
+     * @throws OperationFailedException
      */
-    protected final T getHornetQComponentControl(final OperationContext context, final ModelNode operation, final boolean forWrite) {
+    protected final T getHornetQComponentControl(final OperationContext context, final ModelNode operation, final boolean forWrite) throws OperationFailedException {
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         ServiceController<?> hqService = context.getServiceRegistry(forWrite).getService(hqServiceName);
         HornetQServer server = HornetQServer.class.cast(hqService.getValue());
         PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        return getHornetQComponentControl(server, address);
+         T control = getHornetQComponentControl(server, address);
+         if (control == null) {
+             throw new OperationFailedException(ControllerMessages.MESSAGES.noHandler(READ_ATTRIBUTE_OPERATION, PathAddress.pathAddress(operation.require(OP_ADDR))));
+         }
+         return control;
 
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractQueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractQueueControlHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging;
 
 import static org.jboss.as.messaging.CommonAttributes.FILTER;
+import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithNoHandler;
 import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
@@ -285,6 +286,11 @@ public abstract class AbstractQueueControlHandler<T> extends AbstractRuntimeOnly
         ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
         DelegatingQueueControl<T> control = getQueueControl(hqServer, queueName);
+
+        if (control == null) {
+            rollbackOperationWithNoHandler(context, operation);
+            return;
+        }
 
         boolean reversible = false;
         Object handback = null;

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
@@ -94,6 +94,11 @@ public class AddressControlHandler extends AbstractRuntimeOnlyHandler implements
 
     private void handleReadAttribute(OperationContext context, ModelNode operation) {
         final AddressControl addressControl = getAddressControl(context, operation);
+        if (addressControl == null) {
+            ManagementUtil.rollbackOperationWithNoHandler(context, operation);
+            return;
+        }
+
         final String name = operation.require(ModelDescriptionConstants.NAME).asString();
 
         try {

--- a/messaging/src/main/java/org/jboss/as/messaging/ManagementUtil.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ManagementUtil.java
@@ -22,7 +22,12 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -84,5 +89,11 @@ public class ManagementUtil {
         }
 
         return result;
+    }
+
+    public static void rollbackOperationWithNoHandler(OperationContext context, ModelNode operation) {
+        context.getFailureDescription().set(ControllerMessages.MESSAGES.noHandler(READ_ATTRIBUTE_OPERATION, PathAddress.pathAddress(operation.require(OP_ADDR))));
+        context.setRollbackOnly();
+        context.completeStep();
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryReadAttributeHandler.java
@@ -26,6 +26,7 @@ import static org.jboss.as.messaging.CommonAttributes.CONNECTION_FACTORY_TYPE;
 import static org.jboss.as.messaging.CommonAttributes.HA;
 import static org.jboss.as.messaging.CommonAttributes.INITIAL_MESSAGE_PACKET_SIZE;
 import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithNoHandler;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.Arrays;
@@ -82,6 +83,11 @@ public class ConnectionFactoryReadAttributeHandler extends AbstractRuntimeOnlyHa
         ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
         ConnectionFactoryControl control = ConnectionFactoryControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_CONNECTION_FACTORY + factoryName));
+
+        if (control == null) {
+            rollbackOperationWithNoHandler(context, operation);
+            return;
+        }
 
         if (HA.getName().equals(attributeName)) {
             context.getResult().set(control.isHA());

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServerControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServerControlHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithNoHandler;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.Locale;
@@ -92,6 +93,10 @@ public class JMSServerControlHandler extends AbstractRuntimeOnlyHandler {
 
         final String operationName = operation.require(OP).asString();
         final JMSServerControl serverControl = getServerControl(context, operation);
+        if (serverControl == null) {
+            rollbackOperationWithNoHandler(context, operation);
+            return;
+        }
 
         try {
             if (LIST_CONNECTIONS_AS_JSON.equals(operationName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicControlHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.messaging.jms;
 import static org.jboss.as.messaging.CommonAttributes.CLIENT_ID;
 import static org.jboss.as.messaging.CommonAttributes.FILTER;
 import static org.jboss.as.messaging.CommonAttributes.QUEUE_NAME;
+import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithNoHandler;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.EnumSet;
@@ -197,6 +198,11 @@ public class JMSTopicControlHandler extends AbstractRuntimeOnlyHandler {
         ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
         TopicControl control = TopicControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_TOPIC + topicName));
+
+        if (control == null) {
+            rollbackOperationWithNoHandler(context, operation);
+            return;
+        }
 
         try {
             if (LIST_ALL_SUBSCRIPTIONS.equals(operationName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicReadAttributeHandler.java
@@ -33,6 +33,7 @@ import static org.jboss.as.messaging.CommonAttributes.NON_DURABLE_SUBSCRIPTION_C
 import static org.jboss.as.messaging.CommonAttributes.SUBSCRIPTION_COUNT;
 import static org.jboss.as.messaging.CommonAttributes.TEMPORARY;
 import static org.jboss.as.messaging.CommonAttributes.TOPIC_ADDRESS;
+import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithNoHandler;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.Arrays;
@@ -90,6 +91,11 @@ public class JMSTopicReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
         TopicControl control = TopicControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_TOPIC + topicName));
+
+        if (control == null) {
+            rollbackOperationWithNoHandler(context, operation);
+            return;
+        }
 
         if (MESSAGE_COUNT.equals(attributeName)) {
             try {


### PR DESCRIPTION
- prevent NPE by checking whether there is a HornetQ control object at
  the specified AS7 address and fails with an informative description
