### PR TITLE
bump up messaging subsystem's management interface to 1.2

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -112,7 +112,7 @@ public class MessagingExtension implements Extension {
     }
 
     public void initialize(ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 1);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 2);
         subsystem.registerXMLElementWriter(Messaging12SubsystemParser.getInstance());
         boolean registerRuntimeOnly = context.isRuntimeOnlyRegistrationValid();
 


### PR DESCRIPTION
I forgot to bump up the messaging's management interface version when I create the PR for AS7-4756
