### PR TITLE
JBPAPP-9018 [7.1] IBM's JDK result of Class.getMethods() differs from the Oracle's one

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/WebSecurityPasswordBasedBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/WebSecurityPasswordBasedBase.java
@@ -21,35 +21,31 @@
  */
 package org.jboss.as.test.integration.web.security;
 
+import org.apache.log4j.Logger;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 
 /**
  * Base class for web security tests that are based on passwords
- *
+ * 
  * @author Anil Saldhana
  */
 public abstract class WebSecurityPasswordBasedBase {
 
-    /**
-     * Obtain the context path of the {@link WebArchive}
-     *
-     * @return
-     */
-    public abstract String getContextPath();
+    private static Logger LOGGER = Logger.getLogger(WebSecurityPasswordBasedBase.class);
 
     /**
      * Print the contents of the {@link WebArchive}
-     *
+     * 
      * @param war
      */
     public static void printWar(WebArchive war) {
-        System.out.println(war.toString(true));
+        LOGGER.info(war.toString(true));
     }
 
     /**
      * Test with user "anil" who has the right password and the right role to access the servlet
-     *
+     * 
      * @throws Exception
      */
     @Test
@@ -64,7 +60,7 @@ public abstract class WebSecurityPasswordBasedBase {
      * <p>
      * Should be a HTTP/403
      * </p>
-     *
+     * 
      * @throws Exception
      */
     @Test
@@ -74,7 +70,7 @@ public abstract class WebSecurityPasswordBasedBase {
 
     /**
      * Method that needs to be overridden with the HTTPClient code
-     *
+     * 
      * @param user username
      * @param pass password
      * @param expectedCode http status code

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/basic/WebSecurityBASICTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/basic/WebSecurityBASICTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.web.security.basic;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.URL;
 
 import org.apache.http.HttpEntity;
@@ -43,11 +45,9 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * Unit Test the BASIC authentication
- *
+ * 
  * @author Anil Saldhana
  */
 @RunWith(Arquillian.class)
@@ -73,6 +73,7 @@ public class WebSecurityBASICTestCase extends WebSecurityPasswordBasedBase {
     @ArquillianResource
     private URL url;
 
+    @Override
     protected void makeCall(String user, String pass, int expectedStatusCode) throws Exception {
         DefaultHttpClient httpclient = new DefaultHttpClient();
         try {
@@ -99,10 +100,5 @@ public class WebSecurityBASICTestCase extends WebSecurityPasswordBasedBase {
             // immediate deallocation of all system resources
             httpclient.getConnectionManager().shutdown();
         }
-    }
-
-    @Override
-    public String getContextPath() {
-        return "web-secure-basic";
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/AbstractWebSecurityFORMTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/AbstractWebSecurityFORMTestCase.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.security.form;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.StatusLine;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.protocol.HTTP;
+import org.apache.http.util.EntityUtils;
+import org.apache.log4j.Logger;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase;
+
+/**
+ * A Abstract parent of the FORM based authentication tests. <br/>
+ * <i>This class was introduced as a workaround for JBPAPP-9018 - {@link Class#getMethods()} method returns different values in
+ * Oracle JDK and IBM JDK.</i>
+ * 
+ * @author Josef Cacek
+ */
+public abstract class AbstractWebSecurityFORMTestCase extends WebSecurityPasswordBasedBase {
+    private static Logger LOGGER = Logger.getLogger(AbstractWebSecurityFORMTestCase.class);
+
+    @ArquillianResource
+    private URL url;
+
+    // Protected methods -----------------------------------------------------
+
+    /**
+     * Makes a HTTP request to the protected web application.
+     * 
+     * @param user
+     * @param pass
+     * @param expectedStatusCode
+     * @throws Exception
+     * @see org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase#makeCall(java.lang.String, java.lang.String,
+     *      int)
+     */
+    @Override
+    protected void makeCall(String user, String pass, int expectedStatusCode) throws Exception {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        try {
+            String req = url.toExternalForm() + "secured/";
+            HttpGet httpget = new HttpGet(req);
+
+            HttpResponse response = httpclient.execute(httpget);
+
+            HttpEntity entity = response.getEntity();
+            if (entity != null)
+                EntityUtils.consume(entity);
+
+            // We should get the Login Page
+            StatusLine statusLine = response.getStatusLine();
+            LOGGER.info("Login form get: " + statusLine);
+            assertEquals(200, statusLine.getStatusCode());
+
+            LOGGER.info("Initial set of cookies:");
+            List<Cookie> cookies = httpclient.getCookieStore().getCookies();
+            if (cookies.isEmpty()) {
+                LOGGER.info("None");
+            } else {
+                for (int i = 0; i < cookies.size(); i++) {
+                    LOGGER.info("- " + cookies.get(i).toString());
+                }
+            }
+            req = url.toExternalForm() + "secured/j_security_check";
+            // We should now login with the user name and password
+            HttpPost httpPost = new HttpPost(req);
+
+            List<NameValuePair> nvps = new ArrayList<NameValuePair>();
+            nvps.add(new BasicNameValuePair("j_username", user));
+            nvps.add(new BasicNameValuePair("j_password", pass));
+
+            httpPost.setEntity(new UrlEncodedFormEntity(nvps, HTTP.UTF_8));
+
+            response = httpclient.execute(httpPost);
+            entity = response.getEntity();
+            if (entity != null)
+                EntityUtils.consume(entity);
+
+            statusLine = response.getStatusLine();
+
+            // Post authentication - we have a 302
+            assertEquals(302, statusLine.getStatusCode());
+            Header locationHeader = response.getFirstHeader("Location");
+            String location = locationHeader.getValue();
+
+            HttpGet httpGet = new HttpGet(location);
+            response = httpclient.execute(httpGet);
+
+            entity = response.getEntity();
+            if (entity != null)
+                EntityUtils.consume(entity);
+
+            LOGGER.info("Post logon cookies:");
+            cookies = httpclient.getCookieStore().getCookies();
+            if (cookies.isEmpty()) {
+                LOGGER.info("None");
+            } else {
+                for (int i = 0; i < cookies.size(); i++) {
+                    LOGGER.info("- " + cookies.get(i).toString());
+                }
+            }
+
+            // Either the authentication passed or failed based on the expected status code
+            statusLine = response.getStatusLine();
+            assertEquals(expectedStatusCode, statusLine.getStatusCode());
+        } finally {
+            // When HttpClient instance is no longer needed,
+            // shut down the connection manager to ensure
+            // immediate deallocation of all system resources
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/WebSecurityFORMTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/WebSecurityFORMTestCase.java
@@ -21,28 +21,9 @@
  */
 package org.jboss.as.test.integration.web.security.form;
 
-
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.NameValuePair;
-import org.apache.http.StatusLine;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.cookie.Cookie;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.protocol.HTTP;
-import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.web.security.SecuredServlet;
 import org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase;
@@ -51,17 +32,15 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * Unit Test web security
- *
+ * 
  * @author Anil Saldhana
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(WebTestsSecurityDomainSetup.class)
-public class WebSecurityFORMTestCase extends WebSecurityPasswordBasedBase {
+public class WebSecurityFORMTestCase extends AbstractWebSecurityFORMTestCase {
 
     @Deployment
     public static WebArchive deployment() throws Exception {
@@ -79,89 +58,5 @@ public class WebSecurityFORMTestCase extends WebSecurityPasswordBasedBase {
         war.addAsResource(WebSecurityFORMTestCase.class.getPackage(), "roles.properties", "roles.properties");
         WebSecurityPasswordBasedBase.printWar(war);
         return war;
-    }
-
-    @ArquillianResource
-    private URL url;
-
-    protected void makeCall(String user, String pass, int expectedStatusCode) throws Exception {
-        DefaultHttpClient httpclient = new DefaultHttpClient();
-        try {
-            String req = url.toExternalForm() + "secured/";
-            HttpGet httpget = new HttpGet(req);
-
-            HttpResponse response = httpclient.execute(httpget);
-
-            HttpEntity entity = response.getEntity();
-            if (entity != null)
-                EntityUtils.consume(entity);
-
-            // We should get the Login Page
-            StatusLine statusLine = response.getStatusLine();
-            System.out.println("Login form get: " + statusLine);
-            assertEquals(200, statusLine.getStatusCode());
-
-            System.out.println("Initial set of cookies:");
-            List<Cookie> cookies = httpclient.getCookieStore().getCookies();
-            if (cookies.isEmpty()) {
-                System.out.println("None");
-            } else {
-                for (int i = 0; i < cookies.size(); i++) {
-                    System.out.println("- " + cookies.get(i).toString());
-                }
-            }
-            req = url.toExternalForm() + "secured/j_security_check";
-            // We should now login with the user name and password
-            HttpPost httpPost = new HttpPost(req);
-
-            List<NameValuePair> nvps = new ArrayList<NameValuePair>();
-            nvps.add(new BasicNameValuePair("j_username", user));
-            nvps.add(new BasicNameValuePair("j_password", pass));
-
-            httpPost.setEntity(new UrlEncodedFormEntity(nvps, HTTP.UTF_8));
-
-            response = httpclient.execute(httpPost);
-            entity = response.getEntity();
-            if (entity != null)
-                EntityUtils.consume(entity);
-
-            statusLine = response.getStatusLine();
-
-            // Post authentication - we have a 302
-            assertEquals(302, statusLine.getStatusCode());
-            Header locationHeader = response.getFirstHeader("Location");
-            String location = locationHeader.getValue();
-
-            HttpGet httpGet = new HttpGet(location);
-            response = httpclient.execute(httpGet);
-
-            entity = response.getEntity();
-            if (entity != null)
-                EntityUtils.consume(entity);
-
-            System.out.println("Post logon cookies:");
-            cookies = httpclient.getCookieStore().getCookies();
-            if (cookies.isEmpty()) {
-                System.out.println("None");
-            } else {
-                for (int i = 0; i < cookies.size(); i++) {
-                    System.out.println("- " + cookies.get(i).toString());
-                }
-            }
-
-            // Either the authentication passed or failed based on the expected status code
-            statusLine = response.getStatusLine();
-            assertEquals(expectedStatusCode, statusLine.getStatusCode());
-        } finally {
-            // When HttpClient instance is no longer needed,
-            // shut down the connection manager to ensure
-            // immediate deallocation of all system resources
-            httpclient.getConnectionManager().shutdown();
-        }
-    }
-
-    @Override
-    public String getContextPath() {
-        return "web-secure";
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/WebSecurityJBossSimpleRoleMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/WebSecurityJBossSimpleRoleMappingTestCase.java
@@ -21,13 +21,9 @@
  */
 package org.jboss.as.test.integration.web.security.form;
 
-import java.net.URL;
-
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.web.security.SecuredServlet;
 import org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase;
@@ -39,21 +35,15 @@ import org.junit.runner.RunWith;
 
 /**
  * Unit Test web security
- *
+ * 
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(WebSimpleRoleMappingSecurityDomainSetup.class)
-public class WebSecurityJBossSimpleRoleMappingTestCase extends WebSecurityFORMTestCase {
+public class WebSecurityJBossSimpleRoleMappingTestCase extends AbstractWebSecurityFORMTestCase {
 
-    public static final String deploymentName = "web-secure.war";
-
-    @ArquillianResource
-    @OperateOnDeployment(deploymentName)
-    URL deploymentUrl;
-
-    @Deployment(name = deploymentName, order = 1, testable = false)
+    @Deployment(testable = false)
     public static WebArchive deployment() throws Exception {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "web-secure.war");
@@ -62,7 +52,8 @@ public class WebSecurityJBossSimpleRoleMappingTestCase extends WebSecurityFORMTe
         war.addAsWebResource(WebSecurityJBossSimpleRoleMappingTestCase.class.getPackage(), "login.jsp", "login.jsp");
         war.addAsWebResource(WebSecurityJBossSimpleRoleMappingTestCase.class.getPackage(), "error.jsp", "error.jsp");
 
-        war.addAsWebInfResource(WebSecurityJBossSimpleRoleMappingTestCase.class.getPackage(), "jboss-web-role-mapping.xml", "jboss-web.xml");
+        war.addAsWebInfResource(WebSecurityJBossSimpleRoleMappingTestCase.class.getPackage(), "jboss-web-role-mapping.xml",
+                "jboss-web.xml");
         war.addAsWebInfResource(WebSecurityJBossSimpleRoleMappingTestCase.class.getPackage(), "web.xml", "web.xml");
 
         war.addAsResource(WebSecurityJBossSimpleRoleMappingTestCase.class.getPackage(), "users.properties", "users.properties");
@@ -71,19 +62,9 @@ public class WebSecurityJBossSimpleRoleMappingTestCase extends WebSecurityFORMTe
         return war;
     }
 
-
-    /**
-     * Negative test as marcus doesn't have proper role in module mapping created.
-     */
-    @Override
-    @Test
-    public void testPasswordBasedUnsuccessfulAuth() throws Exception {
-        makeCall("marcus", "marcus", 403);
-    }
-
     /**
      * At this time peter can go through because he has role mapped in the map-module option.
-     *
+     * 
      * @throws Exception
      */
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/WebSecurityJBossWebXmlSecurityRolesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/form/WebSecurityJBossWebXmlSecurityRolesTestCase.java
@@ -21,13 +21,9 @@
  */
 package org.jboss.as.test.integration.web.security.form;
 
-import java.net.URL;
-
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.web.security.SecuredServlet;
 import org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase;
@@ -39,22 +35,15 @@ import org.junit.runner.RunWith;
 
 /**
  * Unit Test web security
- *
+ * 
  * @author <a href="mailto:mmoyses@redhat.com">Marcus Moyses</a>
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(WebTestsSecurityDomainSetup.class)
-public class WebSecurityJBossWebXmlSecurityRolesTestCase extends WebSecurityFORMTestCase {
+public class WebSecurityJBossWebXmlSecurityRolesTestCase extends AbstractWebSecurityFORMTestCase {
 
-    public static final String deploymentName = "web-secure.war";
-
-    @ArquillianResource
-
-    @OperateOnDeployment(deploymentName)
-    URL deploymentUrl;
-
-    @Deployment(name = deploymentName, order = 1, testable = false)
+    @Deployment(testable = false)
     public static WebArchive deployment() throws Exception {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "web-secure.war");
@@ -63,18 +52,20 @@ public class WebSecurityJBossWebXmlSecurityRolesTestCase extends WebSecurityFORM
         war.addAsWebResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "login.jsp", "login.jsp");
         war.addAsWebResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "error.jsp", "error.jsp");
 
-        war.addAsWebInfResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "jboss-web-role-mapping.xml", "jboss-web.xml");
+        war.addAsWebInfResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "jboss-web-role-mapping.xml",
+                "jboss-web.xml");
         war.addAsWebInfResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "web.xml", "web.xml");
 
-        war.addAsResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "users.properties", "users.properties");
-        war.addAsResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "roles.properties", "roles.properties");
+        war.addAsResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "users.properties",
+                "users.properties");
+        war.addAsResource(WebSecurityJBossWebXmlSecurityRolesTestCase.class.getPackage(), "roles.properties",
+                "roles.properties");
         WebSecurityPasswordBasedBase.printWar(war);
         return war;
     }
 
-
     /**
-     * Override test behavior to check if role mapping in jboss-web.xml works.
+     * Negative test as marcus doesn't have proper role in module mapping created.
      */
     @Override
     @Test
@@ -84,7 +75,7 @@ public class WebSecurityJBossWebXmlSecurityRolesTestCase extends WebSecurityFORM
 
     /**
      * Negative test to see if mapping is not performed on username instead of role.
-     *
+     * 
      * @throws Exception
      */
     @Test


### PR DESCRIPTION
Instead of a WebSecurityFORMTestCase parent class for JBossSimpleRoleMappingTestCase and JBossWebXmlSecurityRolesTestCase is used an abstract class AbstractWebSecurityFORMTestCase now.
It's used as a parent for all 3 test classes (with FORM authentication) and it doesn't contain static deployment() method, which caused problems on IBM JDKs.
