### PR TITLE
cli: AS7-2676 properties in command and operation parameters

### DIFF
--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -13,6 +13,10 @@
     
     <validate-operation-requests>true</validate-operation-requests>
     
+    <!-- whether to resolve system properties specified as command argument or operation parameter values
+         in the CLI VM before sending the operation requests to the controller -->
+    <resolve-parameter-values>false</resolve-parameter-values>
+    
     <!-- Command and operation history log configuration -->
     <history>
         <enabled>true</enabled>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:cli:1.1"
+           targetNamespace="urn:jboss:cli:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+
+    <xs:element name="jboss-cli">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the JBoss Command Line Interface configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="default-controller" minOccurs="0"/>
+                <xs:element ref="validate-operation-requests" minOccurs="0"/>
+                <xs:element ref="history" minOccurs="0"/>
+
+                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs=0 maxOccurs="1" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether to resolve system properties specified as command argument (or operation parameter)
+                            values before sending the operation request to the controller or let the resolution happen
+                            on the server side.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element ref="ssl" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="default-controller">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration of the default controller to connect to
+                when the connect command is executed w/o arguments.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="host" type="xs:string" minOccurs="0" default="localhost"/>
+                <xs:element name="port" type="xs:int" minOccurs="0" default="9999"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="validate-operation-requests" type="xs:boolean" default="true">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates whether the parameter list of the operation reuqests
+                should be validated before the requests are sent to the controller
+                for the execution.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    
+    <xs:element name="history">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration for the commands and operations history log.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="enabled" type="xs:boolean" minOccurs="0" default="true"/>
+                <xs:element name="file-name" type="xs:string" minOccurs="0" default=".jboss-cli-history"/>
+                <xs:element name="file-dir" type="xs:string" minOccurs="0" default="${user.home}"/>
+                <xs:element name="max-size" type="xs:int" minOccurs="0" default="500"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:element name="ssl">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration for the Key and Trust stores
+                used for SSL.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="key-store" type="xs:string" minOccurs="0" />
+                <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
+                <xs:element name="alias" type="xs:string" minOccurs="0" />
+                <xs:element name="key-password" type="xs:string" minOccurs="0" />                
+                <xs:element name="trust-store" type="xs:string" minOccurs="0" />
+                <xs:element name="trust-store-password" type="xs:string" minOccurs="0" />
+                <xs:element name="modify-trust-store" type="xs:boolean" default="true" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Setting to true will cause the CLI to prompt when unrecognised certificates are received
+                            and allow them to be stored in the truststore.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
@@ -42,7 +42,7 @@
                 <xs:element ref="validate-operation-requests" minOccurs="0"/>
                 <xs:element ref="history" minOccurs="0"/>
 
-                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs=0 maxOccurs="1" default="false">
+                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
                     <xs:annotation>
                         <xs:documentation>
                             Whether to resolve system properties specified as command argument (or operation parameter)

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -86,4 +86,17 @@ public interface CliConfig {
      * @return  true is the operation requests should be validated, false - otherwise.
      */
     boolean isValidateOperationRequests();
+
+    /**
+     * Whether to resolve system properties specified as command argument
+     * (or operation parameter) values before sending the operation request
+     * to the controller or let the resolution happen on the server side.
+     * If the method returns true, the resolution should be performed by the CLI,
+     * otherwise - on the server side.
+     *
+     * @return  true if the system properties specified as operation parameter
+     * values should be resolved by the CLI, false if the resolution
+     * of the parameter values should happen on the server side.
+     */
+    boolean isResolveParameterValues();
 }

--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -319,4 +319,28 @@ public interface CommandContext {
      * @param dir  the new default directory
      */
     void setCurrentDir(File dir);
+
+    /**
+     * Command argument or operation parameter values may contain system properties.
+     * If this method returns true then the CLI will try to resolve
+     * the system properties before sending the operation request to the controller.
+     * Otherwise, the resolution will happen on the server side.
+     *
+     * @return true if system properties in the operation parameter values
+     * should be resolved by the CLI before the request is sent to the controller,
+     * false if system properties should be resolved on the server side.
+     */
+    boolean isResolveParameterValues();
+
+    /**
+     * Command argument or operation parameter values may contain system properties.
+     * If this property is set to true then the CLI will try to resolve
+     * the system properties before sending the operation request to the controller.
+     * Otherwise, the resolution will happen on the server side.
+     *
+     * @param resolve  true if system properties in the operation parameter values
+     * should be resolved by the CLI before the request is sent to the controller,
+     * false if system properties should be resolved on the server side.
+     */
+    void setResolveParameterValues(boolean resolve);
 }

--- a/cli/src/main/java/org/jboss/as/cli/StringPropertyReplacer.java
+++ b/cli/src/main/java/org/jboss/as/cli/StringPropertyReplacer.java
@@ -36,7 +36,7 @@ import java.io.File;
  */
 final class StringPropertyReplacer {
     /** New line string constant */
-    public static final String NEWLINE = Util.getLineSeparator();
+    public static final String NEWLINE = Util.LINE_SEPARATOR;
 
     /** File separator value */
     private static final String FILE_SEPARATOR = File.separator;

--- a/cli/src/main/java/org/jboss/as/cli/StringPropertyReplacer.java
+++ b/cli/src/main/java/org/jboss/as/cli/StringPropertyReplacer.java
@@ -1,0 +1,248 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli;
+
+import java.util.Properties;
+import java.io.File;
+
+/**
+ * A utility class for replacing properties in strings.
+ *
+ * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
+ * @author <a href="Scott.Stark@jboss.org">Scott Stark</a>
+ * @author <a href="claudio.vesco@previnet.it">Claudio Vesco</a>
+ * @author <a href="mailto:adrian@jboss.com">Adrian Brock</a>
+ * @author <a href="mailto:dimitris@jboss.org">Dimitris Andreadis</a>
+ * @version <tt>$Revision$</tt>
+ */
+final class StringPropertyReplacer {
+    /** New line string constant */
+    public static final String NEWLINE = Util.getLineSeparator();
+
+    /** File separator value */
+    private static final String FILE_SEPARATOR = File.separator;
+
+    /** Path separator value */
+    private static final String PATH_SEPARATOR = File.pathSeparator;
+
+    /** File separator alias */
+    private static final String FILE_SEPARATOR_ALIAS = "/";
+
+    /** Path separator alias */
+    private static final String PATH_SEPARATOR_ALIAS = ":";
+
+    // States used in property parsing
+    private static final int NORMAL = 0;
+    private static final int SEEN_DOLLAR = 1;
+    private static final int IN_BRACKET = 2;
+
+    /**
+     * Go through the input string and replace any occurance of ${p} with the
+     * System.getProperty(p) value. If there is no such property p defined, then
+     * the ${p} reference will remain unchanged.
+     *
+     * If the property reference is of the form ${p:v} and there is no such
+     * property p, then the default value v will be returned.
+     *
+     * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then the
+     * primary and the secondary properties will be tried in turn, before
+     * returning either the unchanged input, or the default value.
+     *
+     * The property ${/} is replaced with System.getProperty("file.separator")
+     * value and the property ${:} is replaced with
+     * System.getProperty("path.separator").
+     *
+     * @param string
+     *            - the string with possible ${} references
+     * @return the input string with all property references replaced if any. If
+     *         there are no valid references the input string will be returned.
+     */
+    public static String replaceProperties(final String string) {
+        return replaceProperties(string, null);
+    }
+
+    /**
+     * Go through the input string and replace any occurance of ${p} with the
+     * props.getProperty(p) value. If there is no such property p defined, then
+     * the ${p} reference will remain unchanged.
+     *
+     * If the property reference is of the form ${p:v} and there is no such
+     * property p, then the default value v will be returned.
+     *
+     * If the property reference is of the form ${p1,p2} or ${p1,p2:v} then the
+     * primary and the secondary properties will be tried in turn, before
+     * returning either the unchanged input, or the default value.
+     *
+     * The property ${/} is replaced with System.getProperty("file.separator")
+     * value and the property ${:} is replaced with
+     * System.getProperty("path.separator").
+     *
+     * @param string
+     *            - the string with possible ${} references
+     * @param props
+     *            - the source for ${x} property ref values, null means use
+     *            System.getProperty()
+     * @return the input string with all property references replaced if any. If
+     *         there are no valid references the input string will be returned.
+     */
+    public static String replaceProperties(final String string, final Properties props) {
+        final char[] chars = string.toCharArray();
+        StringBuffer buffer = new StringBuffer();
+        boolean properties = false;
+        int state = NORMAL;
+        int start = 0;
+        for (int i = 0; i < chars.length; ++i) {
+            char c = chars[i];
+
+            // Dollar sign outside brackets
+            if (c == '$' && state != IN_BRACKET)
+                state = SEEN_DOLLAR;
+
+            // Open bracket immediatley after dollar
+            else if (c == '{' && state == SEEN_DOLLAR) {
+                buffer.append(string.substring(start, i - 1));
+                state = IN_BRACKET;
+                start = i - 1;
+            }
+
+            // No open bracket after dollar
+            else if (state == SEEN_DOLLAR)
+                state = NORMAL;
+
+            // Closed bracket after open bracket
+            else if (c == '}' && state == IN_BRACKET) {
+                // No content
+                if (start + 2 == i) {
+                    buffer.append("${}"); // REVIEW: Correct?
+                } else { // Collect the system property
+                    String value = null;
+
+                    String key = string.substring(start + 2, i);
+
+                    // check for alias
+                    if (FILE_SEPARATOR_ALIAS.equals(key)) {
+                        value = FILE_SEPARATOR;
+                    } else if (PATH_SEPARATOR_ALIAS.equals(key)) {
+                        value = PATH_SEPARATOR;
+                    } else {
+                        // check from the properties
+                        if (props != null)
+                            value = props.getProperty(key);
+                        else
+                            value = SecurityActions.getSystemProperty(key);
+
+                        if (value == null) {
+                            // Check for a default value ${key:default}
+                            int colon = key.indexOf(':');
+                            if (colon > 0) {
+                                String realKey = key.substring(0, colon);
+                                if (props != null)
+                                    value = props.getProperty(realKey);
+                                else
+                                    value = SecurityActions
+                                            .getSystemProperty(realKey);
+
+                                if (value == null) {
+                                    // Check for a composite key, "key1,key2"
+                                    value = resolveCompositeKey(realKey, props);
+
+                                    // Not a composite key either, use the
+                                    // specified default
+                                    if (value == null)
+                                        value = key.substring(colon + 1);
+                                }
+                            } else {
+                                // No default, check for a composite key,
+                                // "key1,key2"
+                                value = resolveCompositeKey(key, props);
+                            }
+                        }
+                    }
+
+                    if (value != null) {
+                        properties = true;
+                        buffer.append(value);
+                    } else {
+                        buffer.append("${");
+                        buffer.append(key);
+                        buffer.append('}');
+                    }
+
+                }
+                start = i + 1;
+                state = NORMAL;
+            }
+        }
+
+        // No properties
+        if (properties == false)
+            return string;
+
+        // Collect the trailing characters
+        if (start != chars.length)
+            buffer.append(string.substring(start, chars.length));
+
+        // Done
+        return buffer.toString();
+    }
+
+    /**
+     * Try to resolve a "key" from the provided properties by checking if it is
+     * actually a "key1,key2", in which case try first "key1", then "key2". If
+     * all fails, return null.
+     *
+     * It also accepts "key1," and ",key2".
+     *
+     * @param key
+     *            the key to resolve
+     * @param props
+     *            the properties to use
+     * @return the resolved key or null
+     */
+    private static String resolveCompositeKey(String key, Properties props) {
+        String value = null;
+
+        // Look for the comma
+        int comma = key.indexOf(',');
+        if (comma > -1) {
+            // If we have a first part, try resolve it
+            if (comma > 0) {
+                // Check the first part
+                String key1 = key.substring(0, comma);
+                if (props != null)
+                    value = props.getProperty(key1);
+                else
+                    value = SecurityActions.getSystemProperty(key1);
+            }
+            // Check the second part, if there is one and first lookup failed
+            if (value == null && comma < key.length() - 1) {
+                String key2 = key.substring(comma + 1);
+                if (props != null)
+                    value = props.getProperty(key2);
+                else
+                    value = SecurityActions.getSystemProperty(key2);
+            }
+        }
+        // Return whatever we've found or null
+        return value;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -738,4 +738,8 @@ public class Util {
         }
         return commands;
     }
+
+    public static String resolveProperties(String s) {
+        return StringPropertyReplacer.replaceProperties(s);
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
@@ -61,12 +61,12 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
     private Boolean addressAvailable;
     private String requiredType;
 
-    protected ArgumentWithValue headers;
+    protected final ArgumentWithValue headers;
 
     public BaseOperationCommand(CommandContext ctx, String command, boolean connectionRequired) {
         super(command, connectionRequired);
         ctx.addEventListener(this);
-        headers = new ArgumentWithValue(this, HeadersCompleter.INSTANCE, new HeadersArgumentValueConverter(ctx), "--headers");
+        headers = new ArgumentWithValue(this, HeadersCompleter.INSTANCE, HeadersArgumentValueConverter.INSTANCE, "--headers");
     }
 
     /**
@@ -233,7 +233,7 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
             return;
         }
         final String headersValue = headers.getValue(ctx.getParsedCommandLine());
-        final ModelNode headersNode = headers.getValueConverter().fromString(headersValue);
+        final ModelNode headersNode = headers.getValueConverter().fromString(ctx, headersValue);
         final ModelNode opHeaders = request.get(Util.OPERATION_HEADERS);
         opHeaders.set(headersNode);
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
@@ -321,8 +321,6 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                                     } else {
                                         valueConverter = ArgumentValueConverter.LIST;
                                     }
-                                } else if(ModelType.OBJECT == type) {
-                                    valueConverter = ArgumentValueConverter.OBJECT;
                                 }
                             }
                         }
@@ -390,8 +388,6 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                                 } else {
                                     valueConverter = ArgumentValueConverter.LIST;
                                 }
-                            } else if(ModelType.OBJECT == type) {
-                                valueConverter = ArgumentValueConverter.OBJECT;
                             }
                         }
                     }
@@ -911,7 +907,7 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                 builder.addProperty(Util.NAME, propName);
 
                 final String valueString = args.getPropertyValue(argName);
-                ModelNode nodeValue = arg.getValueConverter().fromString(valueString);
+                ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
                 builder.getModelNode().get(Util.VALUE).set(nodeValue);
 
                 steps.add(builder.buildRequest());
@@ -983,7 +979,7 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                 }
 
                 final String valueString = parsedArgs.getPropertyValue(argName);
-                ModelNode nodeValue = arg.getValueConverter().fromString(valueString);
+                ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
                 request.get(propName).set(nodeValue);
             }
             return request;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ResourceCompositeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ResourceCompositeOperationHandler.java
@@ -198,7 +198,7 @@ public class ResourceCompositeOperationHandler extends BaseOperationCommand {
 
                 final String valueString = arg.getValue(parsedArgs);
                 if(valueString != null) {
-                    ModelNode nodeValue = arg.getValueConverter().fromString(valueString);
+                    ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
                     req.get(propName).set(nodeValue);
                 }
             }
@@ -324,8 +324,6 @@ public class ResourceCompositeOperationHandler extends BaseOperationCommand {
                             } else {
                                 valueConverter = ArgumentValueConverter.LIST;
                             }
-                        } else if(ModelType.OBJECT == type) {
-                            valueConverter = ArgumentValueConverter.OBJECT;
                         }
                     }
                 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/jca/XADataSourceAddCompositeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/jca/XADataSourceAddCompositeHandler.java
@@ -68,7 +68,7 @@ public class XADataSourceAddCompositeHandler extends ResourceCompositeOperationH
 
         final String xaPropsStr = xaProps.getValue(ctx.getParsedCommandLine());
         if(xaPropsStr != null) {
-            final List<Property> propsList = xaProps.getValueConverter().fromString(xaPropsStr).asPropertyList();
+            final List<Property> propsList = xaProps.getValueConverter().fromString(ctx, xaPropsStr).asPropertyList();
             for(Property prop : propsList) {
                 final ModelNode address = this.buildOperationAddress(ctx);
                 address.add(XA_DATASOURCE_PROPERTIES, prop.getName());

--- a/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithValue.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithValue.java
@@ -39,7 +39,7 @@ public class ArgumentWithValue extends ArgumentWithoutValue {
     private final ArgumentValueConverter valueConverter;
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, String fullName) {
-        this(handler, fullName, null);
+        this(handler, null, ArgumentValueConverter.DEFAULT, fullName, null);
     }
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter, String fullName) {
@@ -49,10 +49,6 @@ public class ArgumentWithValue extends ArgumentWithoutValue {
     public ArgumentWithValue(CommandHandlerWithArguments handler, CommandLineCompleter valueCompleter,
             ArgumentValueConverter valueConverter, String fullName) {
         this(handler, valueCompleter, valueConverter, fullName, null);
-    }
-
-    public ArgumentWithValue(CommandHandlerWithArguments handler, String fullName, String shortName) {
-        this(handler, null, ArgumentValueConverter.DEFAULT, fullName, shortName);
     }
 
     public ArgumentWithValue(CommandHandlerWithArguments handler, int index, String fullName) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -58,6 +58,7 @@ class CliConfigImpl implements CliConfig {
     private static final String HOST = "host";
     private static final String MAX_SIZE = "max-size";
     private static final String PORT = "port";
+    private static final String RESOLVE_PARAMETER_VALUES = "resolve-parameter-values";
     private static final String VALIDATE_OPERATION_REQUESTS = "validate-operation-requests";
 
     static CliConfig load(final CommandContext ctx) throws CliInitializationException {
@@ -115,6 +116,10 @@ class CliConfigImpl implements CliConfig {
         return str;
     }
 
+    private static boolean resolveBoolean(String str) throws XMLStreamException {
+        return Boolean.parseBoolean(resolveString(str));
+    }
+
     private CliConfigImpl() {
         defaultControllerHost = "localhost";
         defaultControllerPort = 9999;
@@ -134,6 +139,7 @@ class CliConfigImpl implements CliConfig {
     private int historyMaxSize;
 
     private boolean validateOperationRequests = true;
+    private boolean resolveParameterValues = false;
 
     private SSLConfig sslConfig;
 
@@ -170,6 +176,11 @@ class CliConfigImpl implements CliConfig {
     @Override
     public boolean isValidateOperationRequests() {
         return validateOperationRequests;
+    }
+
+    @Override
+    public boolean isResolveParameterValues() {
+        return resolveParameterValues;
     }
 
     @Override
@@ -285,8 +296,9 @@ class CliConfigImpl implements CliConfig {
                         }
                         config.sslConfig = sslConfig;
                     } else if(localName.equals(VALIDATE_OPERATION_REQUESTS)) {
-                        final String resolved = resolveString(reader.getElementText());
-                        config.validateOperationRequests = Boolean.parseBoolean(resolved);
+                        config.validateOperationRequests = resolveBoolean(reader.getElementText());
+                    } else if(localName.equals(RESOLVE_PARAMETER_VALUES)) {
+                        config.resolveParameterValues = resolveBoolean(reader.getElementText());
                     } else {
                         throw new XMLStreamException("Unexpected element: " + localName);
                     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -49,6 +49,8 @@ import org.jboss.staxmapper.XMLMapper;
  */
 class CliConfigImpl implements CliConfig {
 
+    private static final String JBOSS_XML_CONFIG = "jboss.cli.config";
+
     private static final String DEFAULT_CONTROLLER = "default-controller";
     private static final String ENABLED = "enabled";
     private static final String FILE_DIR = "file-dir";
@@ -62,12 +64,19 @@ class CliConfigImpl implements CliConfig {
     private static final String VALIDATE_OPERATION_REQUESTS = "validate-operation-requests";
 
     static CliConfig load(final CommandContext ctx) throws CliInitializationException {
-        final String jbossHome = SecurityActions.getEnvironmentVariable("JBOSS_HOME");
-        if(jbossHome == null) {
-            System.err.println("WARN: can't load the config file because JBOSS_HOME environment variable is not set.");
-            return new CliConfigImpl();
+        final String jbossCliConfig = SecurityActions.getSystemProperty(JBOSS_XML_CONFIG);
+        final File jbossCliFile;
+        if(jbossCliConfig == null) {
+            final String jbossHome = SecurityActions.getEnvironmentVariable("JBOSS_HOME");
+            if(jbossHome == null) {
+                System.err.println("WARN: can't load the config file because JBOSS_HOME environment variable is not set.");
+                return new CliConfigImpl();
+            }
+            jbossCliFile = new File(jbossHome + File.separatorChar + "bin", "jboss-cli.xml");
+        } else {
+            jbossCliFile = new File(jbossCliConfig);
         }
-        return parse(ctx, new File(jbossHome + File.separatorChar + "bin", "jboss-cli.xml"));
+        return parse(ctx, jbossCliFile);
     }
 
     static CliConfig parse(final CommandContext ctx, File f) throws CliInitializationException {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -197,7 +197,7 @@ public class CliLauncher {
                 } else {
                     // assume it's commands
                     if(file != null) {
-                        argError = "Only one of '--file', '--commands' or '--command' can appear as the argument at a time.";
+                        argError = "Only one of '--file', '--commands' or '--command' can appear as the argument at a time: " + arg;
                         break;
                     }
                     if(commands != null) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -23,9 +23,12 @@ package org.jboss.as.cli.impl;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
@@ -162,6 +165,35 @@ public class CliLauncher {
                     password = (arg.startsWith("--") ? arg.substring(11) : arg.substring(9)).toCharArray();
                 } else if (arg.equals("--help") || arg.equals("-h")) {
                     commands = Collections.singletonList("help");
+                } else if (arg.startsWith("--properties=")) {
+                    final String value  = arg.substring(13);
+                    final File propertiesFile = new File(value);
+                    if(!propertiesFile.exists()) {
+                        argError = "File doesn't exist: " + propertiesFile.getAbsolutePath();
+                        break;
+                    }
+                    final Properties props = new Properties();
+                    FileInputStream fis = null;
+                    try {
+                        fis = new FileInputStream(propertiesFile);
+                        props.load(fis);
+                    } catch(FileNotFoundException e) {
+                        argError = e.getLocalizedMessage();
+                        break;
+                    } catch(java.io.IOException e) {
+                        argError = "Failed to load properties from " + propertiesFile.getAbsolutePath() + ": " + e.getLocalizedMessage();
+                        break;
+                    } finally {
+                        if(fis != null) {
+                            try {
+                                fis.close();
+                            } catch(java.io.IOException e) {
+                            }
+                        }
+                    }
+                    for(Object prop : props.keySet()) {
+                        SecurityActions.setSystemProperty((String)prop, (String)props.get(prop));
+                    }
                 } else {
                     // assume it's commands
                     if(file != null) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -206,6 +206,9 @@ class CommandContextImpl implements CommandContext {
 
     private File currentDir = new File("");
 
+    /** whether to resolve system properties passed in as values of operation parameters*/
+    private boolean resolveParameterValues;
+
     /**
      * Version mode - only used when --version is called from the command line.
      *
@@ -220,6 +223,7 @@ class CommandContextImpl implements CommandContext {
         config = CliConfigImpl.load(this);
         defaultControllerHost = config.getDefaultControllerHost();
         defaultControllerPort = config.getDefaultControllerPort();
+        resolveParameterValues = config.isResolveParameterValues();
         initSSLContext();
     }
 
@@ -250,6 +254,7 @@ class CommandContextImpl implements CommandContext {
         } else {
             this.defaultControllerPort = config.getDefaultControllerPort();
         }
+        resolveParameterValues = config.isResolveParameterValues();
         initCommands();
 
         initSSLContext();
@@ -286,6 +291,7 @@ class CommandContextImpl implements CommandContext {
         } else {
             this.defaultControllerPort = config.getDefaultControllerPort();
         }
+        resolveParameterValues = config.isResolveParameterValues();
         initCommands();
 
         initSSLContext();
@@ -374,7 +380,7 @@ class CommandContextImpl implements CommandContext {
 
         // rollout plan
         final GenericTypeOperationHandler rolloutPlan = new GenericTypeOperationHandler(this, "/management-client-content=rollout-plans/rollout-plan", null);
-        rolloutPlan.addValueConverter("content", new HeadersArgumentValueConverter(this));
+        rolloutPlan.addValueConverter("content", HeadersArgumentValueConverter.INSTANCE);
         rolloutPlan.addValueCompleter("content", RolloutPlanCompleter.INSTANCE);
         cmdRegistry.registerHandler(rolloutPlan, "rollout-plan");
 
@@ -1144,6 +1150,16 @@ class CommandContextImpl implements CommandContext {
         } catch (Throwable t) {
             t.printStackTrace();
         }
+    }
+
+    @Override
+    public boolean isResolveParameterValues() {
+        return resolveParameterValues;
+    }
+
+    @Override
+    public void setResolveParameterValues(boolean resolve) {
+        this.resolveParameterValues = resolve;
     }
 
     private enum ConnectStatus {

--- a/cli/src/main/java/org/jboss/as/cli/impl/HeadersArgumentValueConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/HeadersArgumentValueConverter.java
@@ -39,23 +39,16 @@ import org.jboss.dmr.ModelNode;
 */
 public final class HeadersArgumentValueConverter extends DMRWithFallbackConverter {
 
+    public static final HeadersArgumentValueConverter INSTANCE = new HeadersArgumentValueConverter();
+
     private final DefaultCallbackHandler callback = new DefaultCallbackHandler();
     private final DefaultParsingState initialState = new DefaultParsingState("INITIAL_STATE");
     {
         initialState.enterState('{', HeaderListState.INSTANCE);
     }
 
-    private final CommandContext ctx;
-
-    public HeadersArgumentValueConverter(CommandContext ctx) {
-        if(ctx == null) {
-            throw new IllegalArgumentException("The command context can't be null.");
-        }
-        this.ctx = ctx;
-    }
-
     @Override
-    protected ModelNode fromNonDMRString(String value) throws CommandFormatException {
+    protected ModelNode fromNonDMRString(CommandContext ctx, String value) throws CommandFormatException {
         callback.reset();
         ParserUtil.parse(value, callback, initialState);
         final Collection<ParsedOperationRequestHeader> headers = callback.getHeaders();

--- a/cli/src/main/java/org/jboss/as/cli/impl/SecurityActions.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/SecurityActions.java
@@ -46,6 +46,10 @@ class SecurityActions {
                 return getTCLAction().getSystemProperty(name);
             }
 
+            public static void setSystemProperty(String name, String value) {
+                getTCLAction().setSystemProperty(name, value);
+            }
+
             public static ClassLoader getClassLoader(Class<?> cls) {
                 return getTCLAction().getClassLoader(cls);
             }
@@ -65,6 +69,11 @@ class SecurityActions {
             @Override
             public String getSystemProperty(String name) {
                 return System.getProperty(name);
+            }
+
+            @Override
+            public void setSystemProperty(String name, String value) {
+                System.setProperty(name, value);
             }
 
             @Override
@@ -99,6 +108,16 @@ class SecurityActions {
             }
 
             @Override
+            public void setSystemProperty(final String name, final String value) {
+                AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                    public Object run() {
+                        System.setProperty(name, value);
+                        return null;
+                    }
+                });
+            }
+
+            @Override
             public ClassLoader getClassLoader(final Class<?> cls) {
                 return (ClassLoader) AccessController.doPrivileged(new PrivilegedAction<Object>() {
                     public Object run() {
@@ -123,6 +142,8 @@ class SecurityActions {
 
         String getSystemProperty(String name);
 
+        void setSystemProperty(String name, String value);
+
         String getEnvironmentVariable(String name);
     }
 
@@ -132,6 +153,10 @@ class SecurityActions {
 
     protected static String getSystemProperty(String name) {
         return TCLAction.UTIL.getSystemProperty(name);
+    }
+
+    protected static void setSystemProperty(String name, String value) {
+        TCLAction.UTIL.setSystemProperty(name, value);
     }
 
     protected static ClassLoader getClassLoader(Class<?> cls) {

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
@@ -589,7 +589,7 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
                 throw new OperationFormatException("The argument name is not specified: '" + propName + "'");
             if(value == null || value.trim().isEmpty())
                 throw new OperationFormatException("The argument value is not specified for " + propName + ": '" + value + "'");
-            final ModelNode toSet = ArgumentValueConverter.DEFAULT.fromString(value);
+            final ModelNode toSet = ArgumentValueConverter.DEFAULT.fromString(ctx, value);
             request.get(propName).set(toSet);
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueState.java
@@ -24,6 +24,7 @@ package org.jboss.as.cli.parsing.arguments;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.parsing.CharacterHandler;
 import org.jboss.as.cli.parsing.DefaultParsingState;
+import org.jboss.as.cli.parsing.EscapeCharacterState;
 import org.jboss.as.cli.parsing.GlobalCharacterHandlers;
 import org.jboss.as.cli.parsing.ParsingContext;
 
@@ -50,6 +51,7 @@ public class ArgumentValueState extends DefaultParsingState {
         enterState('=', NameValueSeparatorState.INSTANCE);
         enterState(',', ListItemSeparatorState.INSTANCE);
         enterState('[', new ListState(this));
+        enterState('\\', EscapeCharacterState.INSTANCE);
         //leaveState(',');
         leaveState(']');
         enterState('{', this);

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -70,4 +70,9 @@ public class MockCliConfig implements CliConfig {
     public boolean isValidateOperationRequests() {
         return true;
     }
+
+    @Override
+    public boolean isResolveParameterValues() {
+        return false;
+    }
 }

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -65,6 +65,7 @@ public class MockCommandContext implements CommandContext {
     private int exitCode;
 
     private File curDir = new File("");
+    private boolean resolveParameterValues;
 
     public void parseCommandLine(String buffer) throws CommandFormatException {
         try {
@@ -333,5 +334,14 @@ public class MockCommandContext implements CommandContext {
     public Object remove(String key) {
         // TODO Auto-generated method stub
         return null;
+    }
+
+    public boolean isResolveParameterValues() {
+        return resolveParameterValues;
+    }
+
+    @Override
+    public void setResolveParameterValues(boolean resolve) {
+        resolveParameterValues = resolve;
     }
 }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueConverterTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueConverterTestCase.java
@@ -27,6 +27,9 @@ import static org.junit.Assert.assertNotNull;
 import java.util.List;
 
 import org.jboss.as.cli.ArgumentValueConverter;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.completion.mock.MockCommandContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -38,9 +41,11 @@ import org.junit.Test;
  */
 public class ArgumentValueConverterTestCase {
 
+    private final CommandContext ctx = new MockCommandContext();
+    
     @Test
     public void testDefault_String() throws Exception {
-        final ModelNode value = ArgumentValueConverter.DEFAULT.fromString("text");
+        final ModelNode value = parseObject("text");
         assertNotNull(value);
         assertEquals(ModelType.STRING, value.getType());
         assertEquals("text", value.asString());
@@ -48,7 +53,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testDefault_List() throws Exception {
-        final ModelNode value = ArgumentValueConverter.DEFAULT.fromString("[\"item1\",\"item2\"]");
+        final ModelNode value = parseObject("[\"item1\",\"item2\"]");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<ModelNode> list = value.asList();
@@ -59,7 +64,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testDefault_Object() throws Exception {
-        final ModelNode value = ArgumentValueConverter.DEFAULT.fromString("{\"item1\"=>\"value1\",\"item2\"=>\"value2\"}");
+        final ModelNode value = parseObject("{\"item1\"=>\"value1\",\"item2\"=>\"value2\"}");
         assertNotNull(value);
         assertEquals(ModelType.OBJECT, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -72,7 +77,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testList_NoBrackets() throws Exception {
-        final ModelNode value = ArgumentValueConverter.LIST.fromString("a,b,c");
+        final ModelNode value = parseList("a,b,c");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<ModelNode> list = value.asList();
@@ -87,7 +92,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testList_NoBracketsOneItem() throws Exception {
-        final ModelNode value = ArgumentValueConverter.LIST.fromString("a");
+        final ModelNode value = parseList("a");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<ModelNode> list = value.asList();
@@ -98,7 +103,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testList_WithBrackets() throws Exception {
-        final ModelNode value = ArgumentValueConverter.LIST.fromString("[a,b,c]");
+        final ModelNode value = parseList("[a,b,c]");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<ModelNode> list = value.asList();
@@ -113,7 +118,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testList_DMR() throws Exception {
-        final ModelNode value = ArgumentValueConverter.LIST.fromString("[\"a\",\"b\",\"c\"]");
+        final ModelNode value = parseList("[\"a\",\"b\",\"c\"]");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<ModelNode> list = value.asList();
@@ -128,7 +133,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testPropertyList_DMR() throws Exception {
-        final ModelNode value = ArgumentValueConverter.PROPERTIES.fromString("[(\"a\"=>\"b\"),(\"c\"=>\"d\")]");
+        final ModelNode value = parseProperties("[(\"a\"=>\"b\"),(\"c\"=>\"d\")]");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -145,7 +150,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testPropertyList_SimpleCommaSeparated() throws Exception {
-        final ModelNode value = ArgumentValueConverter.PROPERTIES.fromString("a=b,c=d");
+        final ModelNode value = parseProperties("a=b,c=d");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -162,7 +167,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testPropertyList_SimpleCommaSeparatedInBrackets() throws Exception {
-        final ModelNode value = ArgumentValueConverter.PROPERTIES.fromString("[a=b,c=d]");
+        final ModelNode value = parseProperties("[a=b,c=d]");
         assertNotNull(value);
         assertEquals(ModelType.LIST, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -179,7 +184,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testObject_DMR() throws Exception {
-        final ModelNode value = ArgumentValueConverter.OBJECT.fromString("{\"a\"=>\"b\",\"c\"=>\"d\"}");
+        final ModelNode value = parseObject("{\"a\"=>\"b\",\"c\"=>\"d\"}");
         assertNotNull(value);
         assertEquals(ModelType.OBJECT, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -196,7 +201,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testObject_SimpleCommaSeparated() throws Exception {
-        final ModelNode value = ArgumentValueConverter.OBJECT.fromString("a=b,c=d");
+        final ModelNode value = parseObject("a=b,c=d");
         assertNotNull(value);
         assertEquals(ModelType.OBJECT, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -213,7 +218,7 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testObject_SimpleCommaSeparatedInCurlyBraces() throws Exception {
-        final ModelNode value = ArgumentValueConverter.OBJECT.fromString("{a=b,c=d}");
+        final ModelNode value = parseObject("{a=b,c=d}");
         assertNotNull(value);
         assertEquals(ModelType.OBJECT, value.getType());
         final List<Property> list = value.asPropertyList();
@@ -230,9 +235,21 @@ public class ArgumentValueConverterTestCase {
 
     @Test
     public void testObject_TextValue() throws Exception {
-        final ModelNode value = ArgumentValueConverter.OBJECT.fromString("\"text\"");
+        final ModelNode value = parseObject("\"text\"");
         assertNotNull(value);
         assertEquals(ModelType.STRING, value.getType());
         assertEquals("text", value.asString());
+    }
+
+    protected ModelNode parseObject(String value) throws CommandFormatException {
+        return ArgumentValueConverter.DEFAULT.fromString(ctx, value);
+    }
+
+    protected ModelNode parseList(String value) throws CommandFormatException {
+        return ArgumentValueConverter.LIST.fromString(ctx, value);
+    }
+
+    protected ModelNode parseProperties(String value) throws CommandFormatException {
+        return ArgumentValueConverter.PROPERTIES.fromString(ctx, value);
     }
 }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandHeadersParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandHeadersParsingTestCase.java
@@ -41,12 +41,13 @@ import org.junit.Test;
  */
 public class CommandHeadersParsingTestCase {
 
+    private final MockCommandContext ctx = new MockCommandContext();
     private final DefaultCallbackHandler handler = new DefaultCallbackHandler();
-    private final HeadersArgumentValueConverter converter = new HeadersArgumentValueConverter(new MockCommandContext());
+    private final HeadersArgumentValueConverter converter = HeadersArgumentValueConverter.INSTANCE;
 
     @Test
     public void testSingleHeader() throws Exception {
-        final ModelNode headers = converter.fromString("{rollback-on-runtime-failure=false}");
+        final ModelNode headers = converter.fromString(ctx, "{rollback-on-runtime-failure=false}");
         final ModelNode expected = new ModelNode();
         expected.get("rollback-on-runtime-failure").set("false");
         assertEquals(expected, headers);
@@ -54,7 +55,7 @@ public class CommandHeadersParsingTestCase {
 
     @Test
     public void testTwoHeaders() throws Exception {
-        final ModelNode headers = converter.fromString("{rollback-on-runtime-failure=false;allow-resource-service-restart=true}");
+        final ModelNode headers = converter.fromString(ctx, "{rollback-on-runtime-failure=false;allow-resource-service-restart=true}");
         final ModelNode expected = new ModelNode();
         expected.get("rollback-on-runtime-failure").set("false");
         expected.get("allow-resource-service-restart").set("true");
@@ -64,7 +65,7 @@ public class CommandHeadersParsingTestCase {
     @Test
     public void testArgumentValueConverter() throws Exception {
 
-        final ModelNode node = converter.fromString("{ rollout groupA rollback-across-groups; rollback-on-runtime-failure=false}");
+        final ModelNode node = converter.fromString(ctx, "{ rollout groupA rollback-across-groups; rollback-on-runtime-failure=false}");
 
         final ModelNode expectedHeaders = new ModelNode();
         final ModelNode rolloutPlan = expectedHeaders.get(Util.ROLLOUT_PLAN);
@@ -99,7 +100,7 @@ public class CommandHeadersParsingTestCase {
 
         final String headers = handler.getPropertyValue("--headers");
         assertNotNull(headers);
-        final ModelNode node = converter.fromString(headers);
+        final ModelNode node = converter.fromString(ctx, headers);
         assertTrue(node.hasDefined(Util.ROLLOUT_PLAN));
         assertTrue(node.hasDefined(Util.ROLLBACK_ON_RUNTIME_FAILURE));
         assertEquals("tr", node.get(Util.ALLOW_RESOURCE_SERVICE_RESTART).asString());

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ParameterValueResolutionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ParameterValueResolutionTestCase.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.parsing.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+
+import org.jboss.as.cli.ArgumentValueConverter;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.completion.mock.MockCommandContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ParameterValueResolutionTestCase {
+
+    @Test
+    public void testSimpleText() throws Exception {
+        final CommandContext ctx = new MockCommandContext();
+        ModelNode value = parseObject(ctx, "the value is $\\{cli.test.prop\\}");
+        assertNotNull(value);
+        assertEquals(ModelType.STRING, value.getType());
+        assertEquals("the value is ${cli.test.prop}", value.asString());
+
+        ctx.setResolveParameterValues(true);
+        setProperty("cli.test.prop", "valuable");
+        value = parseObject(ctx, "the value is ${cli.test.prop}");
+        assertNotNull(value);
+        assertEquals(ModelType.STRING, value.getType());
+        assertEquals("the value is valuable", value.asString());
+    }
+
+    @Test
+    public void testDefault_List() throws Exception {
+        final CommandContext ctx = new MockCommandContext();
+        ctx.setResolveParameterValues(true);
+        setProperty("cli.test.prop1", "one");
+        setProperty("cli.test.prop2", "two");
+        final ModelNode value = parseObject(ctx, "[\"${cli.test.prop1}\",\"${cli.test.prop2}\"]");
+        assertNotNull(value);
+        assertEquals(ModelType.LIST, value.getType());
+        final List<ModelNode> list = value.asList();
+        assertEquals(2, list.size());
+        assertEquals("one", list.get(0).asString());
+        assertEquals("two", list.get(1).asString());
+    }
+
+    @Test
+    public void testDefault_Object() throws Exception {
+        final CommandContext ctx = new MockCommandContext();
+        ctx.setResolveParameterValues(true);
+        setProperty("cli.test.prop1", "one");
+        setProperty("cli.test.prop2", "two");
+        setProperty("cli.test.prop3", "three");
+        setProperty("cli.test.prop4", "four");
+        final ModelNode value = parseObject(ctx, "{\"${cli.test.prop1}\"=>\"${cli.test.prop2}\",\"${cli.test.prop3}\"=>\"${cli.test.prop4}\"}");
+        assertNotNull(value);
+        assertEquals(ModelType.OBJECT, value.getType());
+        final List<Property> list = value.asPropertyList();
+        assertEquals(2, list.size());
+        assertEquals("one", list.get(0).getName());
+        assertEquals("two", list.get(0).getValue().asString());
+        assertEquals("three", list.get(1).getName());
+        assertEquals("four", list.get(1).getValue().asString());
+    }
+
+    @Test
+    public void testList_NoBrackets() throws Exception {
+        final CommandContext ctx = new MockCommandContext();
+        ctx.setResolveParameterValues(true);
+        setProperty("cli.test.prop1", "a");
+        setProperty("cli.test.prop2", "b");
+        setProperty("cli.test.prop3", "c");
+        final ModelNode value = parseList(ctx, "${cli.test.prop1},${cli.test.prop2},${cli.test.prop3}");
+        assertNotNull(value);
+        assertEquals(ModelType.LIST, value.getType());
+        final List<ModelNode> list = value.asList();
+        assertEquals(3, list.size());
+        assertNotNull(list.get(0));
+        assertEquals("a", list.get(0).asString());
+        assertNotNull(list.get(1));
+        assertEquals("b", list.get(1).asString());
+        assertNotNull(list.get(2));
+        assertEquals("c", list.get(2).asString());
+    }
+
+    @Test
+    public void testPropertyList_SimpleCommaSeparated() throws Exception {
+        final CommandContext ctx = new MockCommandContext();
+        ctx.setResolveParameterValues(true);
+        setProperty("cli.test.prop1", "a");
+        setProperty("cli.test.prop2", "b");
+        setProperty("cli.test.prop3", "c");
+        setProperty("cli.test.prop4", "d");
+        final ModelNode value = parseProperties(ctx, "${cli.test.prop1}=${cli.test.prop2},${cli.test.prop3}=${cli.test.prop4}");
+        assertNotNull(value);
+        assertEquals(ModelType.LIST, value.getType());
+        final List<Property> list = value.asPropertyList();
+        assertEquals(2, list.size());
+        Property prop = list.get(0);
+        assertNotNull(prop);
+        assertEquals("a", prop.getName());
+        assertEquals("b", prop.getValue().asString());
+        prop = list.get(1);
+        assertNotNull(prop);
+        assertEquals("c", prop.getName());
+        assertEquals("d", prop.getValue().asString());
+    }
+
+    protected void setProperty(final String name, final String value) {
+        if(System.getSecurityManager() == null) {
+            System.setProperty(name, value);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                public Object run() {
+                    System.setProperty(name, value);
+                    return null;
+                }});
+        }
+    }
+
+    protected ModelNode parseObject(CommandContext ctx, String value) throws CommandFormatException {
+        return ArgumentValueConverter.DEFAULT.fromString(ctx, value);
+    }
+
+    protected ModelNode parseList(CommandContext ctx, String value) throws CommandFormatException {
+        return ArgumentValueConverter.LIST.fromString(ctx, value);
+    }
+
+    protected ModelNode parseProperties(CommandContext ctx, String value) throws CommandFormatException {
+        return ArgumentValueConverter.PROPERTIES.fromString(ctx, value);
+    }
+}

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/RolloutPlanParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/RolloutPlanParsingTestCase.java
@@ -1030,7 +1030,7 @@ public class RolloutPlanParsingTestCase extends TestCase {
     @Test
     public void testArgumentValueConverter() throws Exception {
 
-        final ModelNode node = new HeadersArgumentValueConverter(new MockCommandContext()).fromString("{ rollout " +
+        final ModelNode node = HeadersArgumentValueConverter.INSTANCE.fromString(ctx, "{ rollout " +
                 "groupA(rolling-to-servers=true,max-failure-percentage=20) ^ groupB, groupC," +
                 "groupD(rolling-to-servers=true,max-failed-servers=1) ^ groupE rollback-across-groups}");
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileWithPropertiesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileWithPropertiesTestCase.java
@@ -1,0 +1,321 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class FileWithPropertiesTestCase {
+
+    private static final int CLI_PROC_TIMEOUT = 10000;
+    private static final int STATUS_CHECK_INTERVAL = 2000;
+
+    private static final String SERVER_PROP_NAME = "cli-arg-test";
+    private static final String CLI_PROP_NAME = "cli.prop.name";
+    private static final String CLI_PROP_VALUE = "cli.prop.value";
+    private static final String SET_PROP_COMMAND = "/system-property=" + SERVER_PROP_NAME + ":add(value=${cli.prop.name})";
+    private static final String GET_PROP_COMMAND = "/system-property=" + SERVER_PROP_NAME + ":read-resource";
+    private static final String REMOVE_PROP_COMMAND = "/system-property=" + SERVER_PROP_NAME + ":remove";
+
+    private static final String SCRIPT_NAME = "jboss-cli-file-arg-test.cli";
+    private static final String PROPS_NAME = "jboss-cli-file-arg-test.properties";
+    private static final File SCRIPT_FILE;
+    private static final File PROPS_FILE;
+    private static final File TMP_JBOSS_CLI_FILE;
+    static {
+        SCRIPT_FILE = new File(new File(System.getProperty("java.io.tmpdir")), SCRIPT_NAME);
+        PROPS_FILE = new File(new File(System.getProperty("java.io.tmpdir")), PROPS_NAME);
+        TMP_JBOSS_CLI_FILE = new File(new File(System.getProperty("java.io.tmpdir")), "tmp-jboss-cli.xml");
+    }
+
+    @BeforeClass
+    public static void setup() {
+        ensureRemoved(TMP_JBOSS_CLI_FILE);
+        jbossDist = System.getProperty("jboss.dist");
+        if(jbossDist == null) {
+            fail("jboss.dist system property is not set");
+        }
+        final File jbossCliXml = new File(jbossDist, "bin" + File.separator + "jboss-cli.xml");
+        if(!jbossCliXml.exists()) {
+            fail(jbossCliXml + " doesn't exist.");
+        }
+        BufferedReader reader = null;
+        BufferedWriter writer = null;
+        try {
+            reader = new BufferedReader(new FileReader(jbossCliXml));
+            writer = new BufferedWriter(new FileWriter(TMP_JBOSS_CLI_FILE));
+            String line = reader.readLine();
+            boolean replaced = false;
+            while(line != null) {
+                if(!replaced) {
+                    final int i = line.indexOf("<resolve-parameter-values>false</resolve-parameter-values>");
+                    if(i >= 0) {
+                        line = line.substring(0, i) + "<resolve-parameter-values>true</resolve-parameter-values>" +
+                               line.substring(i + "<resolve-parameter-values>false</resolve-parameter-values>".length());
+                        replaced = true;
+                    }
+                }
+                writer.write(line);
+                writer.newLine();
+                line = reader.readLine();
+            }
+            if(!replaced) {
+                fail(jbossCliXml.getAbsoluteFile() + " doesn't contain resolve-parameter-values element set to false.");
+            }
+        } catch(IOException e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if(reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {}
+            }
+            if(writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {}
+            }
+        }
+
+        ensureRemoved(SCRIPT_FILE);
+        ensureRemoved(PROPS_FILE);
+        try {
+            writer = new BufferedWriter(new FileWriter(SCRIPT_FILE));
+            writer.write(SET_PROP_COMMAND);
+            writer.newLine();
+            writer.write(GET_PROP_COMMAND);
+            writer.newLine();
+            writer.write(REMOVE_PROP_COMMAND);
+            writer.newLine();
+        } catch (IOException e) {
+            fail("Failed to write to " + SCRIPT_FILE.getAbsolutePath() + ": " + e.getLocalizedMessage());
+        } finally {
+            if(writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+
+        writer = null;
+        try {
+            writer = new BufferedWriter(new FileWriter(PROPS_FILE));
+            writer.write(CLI_PROP_NAME);
+            writer.write('=');
+            writer.write(CLI_PROP_VALUE);
+            writer.write('\n');
+        } catch (IOException e) {
+            fail("Failed to write to " + PROPS_FILE.getAbsolutePath() + ": " + e.getLocalizedMessage());
+        } finally {
+            if(writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        ensureRemoved(SCRIPT_FILE);
+        ensureRemoved(PROPS_FILE);
+        ensureRemoved(TMP_JBOSS_CLI_FILE);
+    }
+
+    protected static void ensureRemoved(File f) {
+        if(f.exists()) {
+            if(!f.delete()) {
+                fail("Failed to delete " + f.getAbsolutePath());
+            }
+        }
+    }
+
+    private String cliOutput;
+    private static String jbossDist;
+
+    /**
+     * Ensures that system properties are resolved by the CLI.
+     * @throws Exception
+     */
+    @Test
+    public void testResolved() {
+        assertEquals(0, execute(true, true));
+        assertNotNull(cliOutput);
+        final String valuePrefix = "\"value\" => \"";
+        int i = cliOutput.indexOf(valuePrefix, 0);
+        if(i < 0) {
+            fail("The output doesn't contain a value: " + cliOutput);
+        }
+        int endQuote = cliOutput.indexOf('\"', valuePrefix.length() + i);
+        if(endQuote < 0) {
+            fail("The output doesn't contain a value: " + cliOutput);
+        }
+
+        final String value = cliOutput.substring(i + valuePrefix.length(), endQuote);
+        assertEquals(CLI_PROP_VALUE, value);
+    }
+
+    /**
+     * Ensures that system properties are not resolved by the CLI.
+     * @throws Exception
+     */
+    @Test
+    public void testNotresolved() {
+        assertEquals(0, execute(false, true));
+        assertNotNull(cliOutput);
+        final String valuePrefix = "\"value\" => \"";
+        int i = cliOutput.indexOf(valuePrefix, 0);
+        if(i < 0) {
+            fail("The output doesn't contain a value: " + cliOutput);
+        }
+        int endQuote = cliOutput.indexOf('\"', valuePrefix.length() + i);
+        if(endQuote < 0) {
+            fail("The output doesn't contain a value: " + cliOutput);
+        }
+
+        final String value = cliOutput.substring(i + valuePrefix.length(), endQuote);
+        //assertEquals(CLI_PROP_NAME, value);
+        assertEquals("$", value);
+    }
+
+    protected int execute(boolean resolveProps, boolean logFailure) {
+        if(jbossDist == null) {
+            fail("jboss.dist system property is not set");
+        }
+        final String modulePath = System.getProperty("module.path");
+        if(modulePath == null) {
+            fail("module.path system property is not set");
+        }
+
+        final ProcessBuilder builder = new ProcessBuilder();
+        builder.redirectErrorStream(true);
+        final List<String> command = new ArrayList<String>();
+        command.add("java");
+        TestSuiteEnvironment.getIpv6Args(command);
+        if(resolveProps) {
+            command.add("-Djboss.cli.config=" + TMP_JBOSS_CLI_FILE.getAbsolutePath());
+        }
+        command.add("-jar");
+        command.add(jbossDist + File.separatorChar + "jboss-modules.jar");
+        command.add("-mp");
+        command.add(modulePath);
+        command.add("org.jboss.as.cli");
+        command.add("-c");
+        command.add("--controller=" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getServerPort());
+        command.add("--file=" + SCRIPT_FILE.getAbsolutePath());
+        command.add("--properties=" + PROPS_FILE.getAbsolutePath());
+        builder.command(command);
+
+        Process cliProc = null;
+        try {
+            cliProc = builder.start();
+        } catch (IOException e) {
+            fail("Failed to start CLI process: " + e.getLocalizedMessage());
+        }
+
+        final InputStream cliStream = cliProc.getInputStream();
+        final StringBuilder cliOutBuf = new StringBuilder();
+        boolean wait = true;
+        int runningTime = 0;
+        int exitCode = 0;
+        do {
+            try {
+                Thread.sleep(STATUS_CHECK_INTERVAL);
+            } catch (InterruptedException e) {
+            }
+            runningTime += STATUS_CHECK_INTERVAL;
+            readStream(cliOutBuf, cliStream);
+            try {
+                exitCode = cliProc.exitValue();
+                wait = false;
+                readStream(cliOutBuf, cliStream);
+            } catch(IllegalThreadStateException e) {
+                // cli still working
+            }
+            if(runningTime >= CLI_PROC_TIMEOUT) {
+                readStream(cliOutBuf, cliStream);
+                cliProc.destroy();
+                wait = false;
+            }
+        } while(wait);
+
+        cliOutput = cliOutBuf.toString();
+
+        if (logFailure && exitCode != 0) {
+            System.out.println("Command's output: '" + cliOutput + "'");
+            try {
+                int bytesTotal = cliProc.getErrorStream().available();
+                if (bytesTotal > 0) {
+                    final byte[] bytes = new byte[bytesTotal];
+                    cliProc.getErrorStream().read(bytes);
+                    System.out.println("Command's error log: '" + new String(bytes) + "'");
+                } else {
+                    System.out.println("No output data for the command.");
+                }
+            } catch (IOException e) {
+                fail("Failed to read command's error output: " + e.getLocalizedMessage());
+            }
+        }
+        return exitCode;
+    }
+
+
+    protected void readStream(final StringBuilder cliOutBuf, InputStream cliStream) {
+        try {
+            int bytesTotal = cliStream.available();
+            if (bytesTotal > 0) {
+                final byte[] bytes = new byte[bytesTotal];
+                cliStream.read(bytes);
+                cliOutBuf.append(new String(bytes));
+            }
+        } catch (IOException e) {
+            fail("Failed to read command's output: " + e.getLocalizedMessage());
+        }
+    }
+}


### PR DESCRIPTION
By default, system properties in operation parameter values are resolved on the server side.

This change allows to make it a user's choice. There is a new config option in jboss-cli.xml resolve-parameter-values which when set to true will make the CLI resolve the values before sending the request to the server. The default is false.

This makes it possible to have a script with commands and operations in a file with system properties as values. And do things like
./jboss-admin.sh --connect --file=some/location/my-script.cli --properties=/some/location/environment.properties

Thanks,
Alexey
