### PR TITLE
[7.1] [AS7-4980] upgrade HornetQ to 2.2.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         <version.org.hibernate3>3.6.6.Final</version.org.hibernate3>
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
-        <version.org.hornetq>2.2.16.Final</version.org.hornetq>
+        <version.org.hornetq>2.2.18.Final</version.org.hornetq>
         <version.org.infinispan>5.1.5.FINAL</version.org.infinispan>
         <version.org.jacorb>2.3.2.jbossorg-0</version.org.jacorb>
         <version.org.javassist>3.15.0-GA</version.org.javassist>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/ReplyingMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/ReplyingMDB.java
@@ -21,22 +21,27 @@
  */
 package org.jboss.as.test.integration.ejb.mdb.containerstart;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.jms.DeliveryMode.NON_PERSISTENT;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Resource;
 import javax.ejb.ActivationConfigProperty;
 import javax.ejb.MessageDriven;
-import javax.jms.*;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
 
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.ejb3.annotation.ResourceAdapter;
 import org.jboss.logging.Logger;
-
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.TimeoutException;
-
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static javax.jms.DeliveryMode.NON_PERSISTENT;
 
 /**
  * @author <a href="cdewolf@redhat.com">Carlo de Wolf</a>
@@ -45,47 +50,44 @@ import static javax.jms.DeliveryMode.NON_PERSISTENT;
         @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
         @ActivationConfigProperty(propertyName = "destination", propertyValue = "java:jboss/exported/queue/sendMessage"),
         @ActivationConfigProperty(propertyName = "maxSession", propertyValue = "1"),
+        @ActivationConfigProperty(propertyName = "transactionTimeout", propertyValue = "10"),
         @ActivationConfigProperty(propertyName = "useDLQ", propertyValue = "false") })
 @ResourceAdapter(value = "hornetq-ra.rar")
 public class ReplyingMDB implements MessageListener {
     private static final Logger log = Logger.getLogger(ReplyingMDB.class);
     
-    @Resource(mappedName = "java:/ConnectionFactory")
-    private QueueConnectionFactory factory;
+    @Resource(lookup = "java:/ConnectionFactory")
+    private ConnectionFactory factory;
 
-    private QueueConnection connection;
-    private QueueSession session;
-    private QueueSender sender;
+    private Connection connection;
+    private Session session;
+    private MessageProducer sender;
     
     private static final int WAIT_S = TimeoutUtil.adjust(10);
 
-    public void onMessage(Message message) {
+    public void onMessage(Message m) {
         try {
+            TextMessage message = (TextMessage) m;
+            String text = message.getText();
+
             TextMessage replyMessage;
             if (message instanceof TextMessage) {
-                String text = ((TextMessage) message).getText();
-                if (text.equals("await")) {
+                if (text.equals("await") && !message.getJMSRedelivered()) {
                     // we have received the first message
                     HelperSingletonImpl.barrier.await(WAIT_S, SECONDS);
                     HelperSingletonImpl.barrier.reset();
-                    // wait for undeploy
-                    HelperSingletonImpl.barrier.await(WAIT_S, SECONDS);
-                    HelperSingletonImpl.barrier.reset();
+                    // wait for undeploy, the MDB will be interrupted when it is undeployed
+                    Thread.sleep(SECONDS.toMillis(WAIT_S));
                 }
                 replyMessage = session.createTextMessage("Reply: " + text);
             } else {
                 replyMessage = session.createTextMessage("Unknown message");
             }
             Destination destination = message.getJMSReplyTo();
-            sender.send(destination, replyMessage, NON_PERSISTENT, 1, SECONDS.toMillis(WAIT_S));
+            message.setJMSDeliveryMode(NON_PERSISTENT);
+            sender.send(destination, replyMessage);
             log.info("onMessage method [OK], msg: " + message.toString());
-        } catch (JMSException e) {
-            throw new RuntimeException(e);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        } catch (BrokenBarrierException e) {
-            throw new RuntimeException(e);
-        } catch (TimeoutException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
@@ -94,9 +96,9 @@ public class ReplyingMDB implements MessageListener {
     public void postConstruct() {
         log.info(ReplyingMDB.class.getSimpleName() + " was created");
         try {
-            connection = factory.createQueueConnection();
-            session = connection.createQueueSession(false, QueueSession.AUTO_ACKNOWLEDGE);
-            sender = session.createSender(null);
+            connection = factory.createConnection();
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            sender = session.createProducer(null);
         } catch (JMSException e) {
             throw new RuntimeException(e);
         }
@@ -106,10 +108,6 @@ public class ReplyingMDB implements MessageListener {
     public void preDestroy() {
         log.info("Destroying MDB " + ReplyingMDB.class.getSimpleName());
         try {
-            if (sender != null)
-                sender.close();
-            if (session != null)
-                session.close();
             if (connection != null)
                 connection.close();
         } catch (JMSException e) {


### PR DESCRIPTION
- Refactor SendMessagesTestCase to take into account MDB interruption
  - decrease transaction timeout to ensure that the "await" message
    will be properly redelivered when the MDB is redeployed
  - simplify code by using JMS unified API
