### PR TITLE
[master branch] Fix for AS7-4992 - Filesystem deployment issue

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -330,7 +330,8 @@ class FileSystemDeploymentService implements DeploymentScanner {
 
 
     void oneOffScan(final DeploymentOperations deploymentOperations) {
-            scan(true, deploymentOperations);
+        this.establishDeployedContentList(this.deploymentDir);
+        scan(true, deploymentOperations);
     }
 
     void scan() {


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4992 where the boot time filesystem deployment scanner was ignoring previously deployed deployments on restart of the server.
