### PR TITLE
AS7-4017 CLI --commands attribute don't work with comma separated

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
@@ -29,6 +29,7 @@ import org.jboss.as.cli.impl.CommandCandidatesProvider;
 import org.jboss.as.cli.operation.OperationCandidatesProvider;
 import org.jboss.as.cli.operation.OperationRequestCompleter;
 import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
+import org.jboss.as.cli.parsing.command.CommandFormat;
 
 
 /**
@@ -82,19 +83,13 @@ public class CommandCompleter implements CommandLineCompleter {
             }
         }
 
-        OperationCandidatesProvider candidatesProvider = cmdProvider;
-        if(!buffer.isEmpty()) {
-            int cmdFirstIndex = 0;
-            while(cmdFirstIndex < buffer.length()) {
-                final char ch = buffer.charAt(cmdFirstIndex++);
-                if(!Character.isWhitespace(ch)) {
-                    if(ch == '.' || ch == ':' || ch == '/') {
-                        candidatesProvider = ctx.getOperationCandidatesProvider();
-                    }
-                    break;
-                }
-            }
+        final OperationCandidatesProvider candidatesProvider;
+        if(buffer.isEmpty() || parsedCmd.getFormat() == CommandFormat.INSTANCE) {
+            candidatesProvider = cmdProvider;
+        } else  {
+            candidatesProvider = ctx.getOperationCandidatesProvider();
         }
+
         int result = OperationRequestCompleter.INSTANCE.complete(ctx, parsedCmd, candidatesProvider, buffer, cursor, candidates);
         if(result <= 0) {
             return result;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -24,11 +24,14 @@ package org.jboss.as.cli.impl;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.util.Collections;
+import java.util.List;
 
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
 import org.jboss.as.cli.gui.GuiMain;
 import org.jboss.as.cli.handlers.VersionHandler;
 import org.jboss.as.protocol.StreamUtils;
@@ -45,7 +48,7 @@ public class CliLauncher {
         boolean gui = false;
         try {
             String argError = null;
-            String[] commands = null;
+            List<String> commands = null;
             File file = null;
             boolean connect = false;
             String defaultControllerHost = null;
@@ -141,7 +144,7 @@ public class CliLauncher {
                         break;
                     }
                     final String value = arg.startsWith("--") ? arg.substring(11) : arg.substring(9);
-                    commands = value.split(",+");
+                    commands = Util.splitCommands(value);
                 } else if(arg.startsWith("--command=") || arg.startsWith("command=")) {
                     if(file != null) {
                         argError = "Only one of '--file', '--commands' or '--command' can appear as the argument at a time.";
@@ -152,13 +155,13 @@ public class CliLauncher {
                         break;
                     }
                     final String value = arg.startsWith("--") ? arg.substring(10) : arg.substring(8);
-                    commands = new String[]{value};
+                    commands = Collections.singletonList(value);
                 } else if (arg.startsWith("--user=")) {
                     username = arg.startsWith("--") ? arg.substring(7) : arg.substring(5);
                 } else if (arg.startsWith("--password=")) {
                     password = (arg.startsWith("--") ? arg.substring(11) : arg.substring(9)).toCharArray();
                 } else if (arg.equals("--help") || arg.equals("-h")) {
-                    commands = new String[]{"help"};
+                    commands = Collections.singletonList("help");
                 } else {
                     // assume it's commands
                     if(file != null) {
@@ -169,7 +172,7 @@ public class CliLauncher {
                         argError = "Duplicate argument '--command'/'--commands'.";
                         break;
                     }
-                    commands = arg.split(",+");
+                    commands = Util.splitCommands(arg);
                 }
             }
 
@@ -240,11 +243,11 @@ public class CliLauncher {
         }
     }
 
-    private static void processCommands(String[] commands, CommandContext cmdCtx) {
+    private static void processCommands(List<String> commands, CommandContext cmdCtx) {
         int i = 0;
         try {
-            while (cmdCtx.getExitCode() == 0 && i < commands.length && !cmdCtx.isTerminated()) {
-                cmdCtx.handleSafe(commands[i]);
+            while (cmdCtx.getExitCode() == 0 && i < commands.size() && !cmdCtx.isTerminated()) {
+                cmdCtx.handleSafe(commands.get(i));
                 ++i;
             }
         } finally {

--- a/cli/src/main/java/org/jboss/as/cli/parsing/LineBreakHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/LineBreakHandler.java
@@ -30,7 +30,6 @@ import org.jboss.as.cli.Util;
  */
 public class LineBreakHandler implements CharacterHandler {
 
-    private static final String LN_SEP = Util.getLineSeparator();
     private final boolean fallbackToEscape;
     private final boolean leaveOnLnBreak;
 
@@ -42,7 +41,7 @@ public class LineBreakHandler implements CharacterHandler {
     @Override
     public void handle(ParsingContext ctx) throws CommandFormatException {
         if(ctx.getCharacter() == '\\') {
-            if(ctx.getInput().regionMatches(ctx.getLocation() + 1, LN_SEP, 0, LN_SEP.length())) {
+            if(ctx.getInput().regionMatches(ctx.getLocation() + 1, Util.LINE_SEPARATOR, 0, Util.LINE_SEPARATOR.length())) {
                 if(leaveOnLnBreak) {
                     ctx.leaveState();
                 }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandsArgumentSplitTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandsArgumentSplitTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.parsing.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.jboss.as.cli.Util;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class CommandsArgumentSplitTestCase {
+
+    @Test
+    public void testSingleOperationWithParameters() throws Exception {
+        final String op = ":read-resource(recursive=false,include-defaults=true)";
+        final List<String> split = split(op);
+        assertEquals(1, split.size());
+        assertEquals(op, split.get(0));
+    }
+
+    @Test
+    public void testCommaSeparatedWords() throws Exception {
+        final List<String> words = split("one,two,three");
+        assertEquals(3, words.size());
+        assertEquals("one", words.get(0));
+        assertEquals("two", words.get(1));
+        assertEquals("three", words.get(2));
+    }
+
+    @Test
+    public void testParenthesesCommaSeparatedWords() throws Exception {
+        final List<String> words = split("(one,two),three");
+        assertEquals(2, words.size());
+        assertEquals("(one,two)", words.get(0));
+        assertEquals("three", words.get(1));
+    }
+
+    @Test
+    public void testCurliesCommaSeparatedWords() throws Exception {
+        final List<String> words = split("{one,two},three");
+        assertEquals(2, words.size());
+        assertEquals("{one,two}", words.get(0));
+        assertEquals("three", words.get(1));
+    }
+
+    @Test
+    public void testBracketsCommaSeparatedWords() throws Exception {
+        final List<String> words = split("[one,two],three");
+        assertEquals(2, words.size());
+        assertEquals("[one,two]", words.get(0));
+        assertEquals("three", words.get(1));
+    }
+
+    @Test
+    public void testQuotesCommaSeparatedWords() throws Exception {
+        final List<String> words = split("\"one,two\",three");
+        assertEquals(2, words.size());
+        assertEquals("\"one,two\"", words.get(0));
+        assertEquals("three", words.get(1));
+    }
+
+    @Test
+    public void testEscapeCommaSeparatedWords() throws Exception {
+        final List<String> words = split("one\\,two,three");
+        assertEquals(2, words.size());
+        assertEquals("one\\,two", words.get(0));
+        assertEquals("three", words.get(1));
+    }
+
+    protected List<String> split(String line) {
+        return Util.splitCommands(line);
+    }
+
+}


### PR DESCRIPTION
Proper parsing of --commands argument of the jboss-cli.sh/bat script.

Thanks,
Alexey
