### PR TITLE
Removed JBoss 6 cruft, adopt to HC/PC JAVA_OPTS

### DIFF
--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -3,12 +3,11 @@ rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------
 
-rem $Id$
 
 @if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
+  setlocal
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
@@ -21,6 +20,7 @@ if "x%DOMAIN_CONF%" == "x" (
 if exist "%DOMAIN_CONF%" (
    echo Calling "%DOMAIN_CONF%"
    call "%DOMAIN_CONF%" %*
+   set JAVA_OPTS=
 ) else (
    echo Config file not found "%DOMAIN_CONF%"
 )
@@ -107,28 +107,29 @@ echo   JBOSS_HOME: %JBOSS_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
-echo   JAVA_OPTS: %JAVA_OPTS%
+echo   PC JAVA_OPTS: %PROCESS_CONTROLLER_JAVA_OPTS%
+echo   HC JAVA_OPTS: %HOST_CONTROLLER_JAVA_OPTS%
 echo.
 echo ===============================================================================
 echo.
 
 :RESTART
 "%JAVA%" %PROCESS_CONTROLLER_JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\process-controller.log" ^
- "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\process-controller.log" ^
+  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+  -jar "%RUNJAR%" ^
     -mp "%JBOSS_MODULEPATH%" ^
-     org.jboss.as.process-controller ^
+    org.jboss.as.process-controller ^
     -jboss-home "%JBOSS_HOME%" ^
     -jvm "%JAVA%" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -- ^
-    "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\host-controller.log" ^
-    "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    %HOST_CONTROLLER_JAVA_OPTS% ^
-    -- ^
-    -default-jvm "%JAVA%" ^
-    %*
+      "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\host-controller.log" ^
+      "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+      %HOST_CONTROLLER_JAVA_OPTS% ^
+      -- ^
+        -default-jvm "%JAVA%" ^
+        %*
 
 if ERRORLEVEL 10 goto RESTART
 

--- a/build/src/main/resources/bin/domain.conf.bat
+++ b/build/src/main/resources/bin/domain.conf.bat
@@ -4,12 +4,10 @@ rem #  JBoss Bootstrap Script Configuration                                    #
 rem #                                                                          ##
 rem #############################################################################
 
-rem # $Id: run.conf.bat 88820 2009-05-13 15:25:44Z dimitris@jboss.org $
-
 rem #
-rem # This batch file is executed by run.bat to initialize the environment
-rem # variables that run.bat uses. It is recommended to use this file to
-rem # configure these variables, rather than modifying run.bat itself.
+rem # This batch file is executed by domain.bat to initialize the environment
+rem # variables that domain.bat uses. It is recommended to use this file to
+rem # configure these variables, rather than modifying domain.bat itself.
 rem #
 
 if not "x%JAVA_OPTS%" == "x" (
@@ -29,13 +27,13 @@ rem # Specify the location of the Java home directory (it is recommended that
 rem # this always be set). If set, then "%JAVA_HOME%\bin\java" will be used as
 rem # the Java VM executable; otherwise, "%JAVA%" will be used (see below).
 rem #
-rem set "JAVA_HOME=C:\opt\jdk1.6.0_23"
+rem set "JAVA_HOME=C:\opt\jdk1.7.0_04"
 
 rem #
 rem # Specify the exact Java VM executable to use - only used if JAVA_HOME is
 rem # not set. Default is "java".
 rem #
-rem set "JAVA=C:\opt\jdk1.6.0_23\bin\java"
+rem set "JAVA=%JAVA_HOME%\bin\java"
 
 rem #
 rem # Specify options to pass to the Java VM. Note, there are some additional
@@ -61,6 +59,8 @@ set "JAVA_OPTS=%JAVA_OPTS% -Djboss.domain.default.config=domain.xml -Djboss.host
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"
 
+:JAVA_OPTS_SET
+
 rem The ProcessController process uses its own set of java options
 set "PROCESS_CONTROLLER_JAVA_OPTS=%JAVA_OPTS%"
 
@@ -74,6 +74,3 @@ rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transpo
 rem # Sample JPDA settings for shared memory debugging
 rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
 rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
-
-:JAVA_OPTS_SET
-


### PR DESCRIPTION
This will fix the domain.bat and domain.conf.bat in regards to some old comments and the changed behaviour for JAVA_OPTS. I also formatted the command line with indention based on the group of options
