### PR TITLE
Batch files, JAVA_OPTS handling, comments and -Dprogram.name

### DIFF
--- a/build/src/main/resources/bin/appclient.bat
+++ b/build/src/main/resources/bin/appclient.bat
@@ -59,9 +59,9 @@ rem Find jboss-modules.jar, or we can't continue
 if exist "%JBOSS_HOME%\jboss-modules.jar" (
     set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
-  echo Please check that you are in the bin directory when running this script.
-  goto END
+    echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+    echo Please check that you are in the bin directory when running this script.
+    goto END
 )
 
 rem Setup JBoss specific properties
@@ -78,7 +78,7 @@ if "x%JBOSS_MODULEPATH%" == "x" (
 "%JAVA%" %JAVA_OPTS% ^
   "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\boot.log" ^
   "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
-  -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+  -jar "%RUNJAR%" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -jaxpmodule "javax.xml.jaxp-provider" ^
     org.jboss.as.appclient ^

--- a/build/src/main/resources/bin/appclient.bat
+++ b/build/src/main/resources/bin/appclient.bat
@@ -3,12 +3,10 @@ rem -------------------------------------------------------------------------
 rem JBoss Application Client Bootstrap Script for Windows
 rem -------------------------------------------------------------------------
 
-rem $Id$
-
 @if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
+  setlocal
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
@@ -43,15 +41,6 @@ if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
 
 set DIRNAME=
 
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=appclient.bat"
-)
-
-rem Setup JBoss specific properties
-set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
-
 if "x%JAVA_HOME%" == "x" (
   set  JAVA=java
   echo JAVA_HOME is not set. Unexpected results may occur.
@@ -66,7 +55,7 @@ if not errorlevel == 1 (
   set "JAVA_OPTS=%JAVA_OPTS% -server"
 )
 
-rem Find run.jar, or we can't continue
+rem Find jboss-modules.jar, or we can't continue
 if exist "%JBOSS_HOME%\jboss-modules.jar" (
     set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
 ) else (
@@ -87,12 +76,12 @@ if "x%JBOSS_MODULEPATH%" == "x" (
 
 
 "%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\boot.log" ^
- "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+  "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\boot.log" ^
+  "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
+  -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -jaxpmodule "javax.xml.jaxp-provider" ^
-     org.jboss.as.appclient ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-    -Djboss.server.base.dir="%JBOSS_HOME%\appclient" ^
+    org.jboss.as.appclient ^
+    "-Djboss.home.dir=%JBOSS_HOME%" ^
+    "-Djboss.server.base.dir=%JBOSS_HOME%\appclient" ^
      %*

--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -43,15 +43,6 @@ if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
 
 set DIRNAME=
 
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=domain.bat"
-)
-
-rem Setup JBoss specific properties
-set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
-
 if "x%JAVA_HOME%" == "x" (
   set  JAVA=java
   echo JAVA_HOME is not set. Unexpected results may occur.

--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -3,12 +3,11 @@ rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------
 
-rem $Id$
 
 @if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
+  setlocal
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
@@ -21,6 +20,7 @@ if "x%DOMAIN_CONF%" == "x" (
 if exist "%DOMAIN_CONF%" (
    echo Calling "%DOMAIN_CONF%"
    call "%DOMAIN_CONF%" %*
+   set JAVA_OPTS=
 ) else (
    echo Config file not found "%DOMAIN_CONF%"
 )
@@ -107,28 +107,29 @@ echo   JBOSS_HOME: %JBOSS_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
-echo   JAVA_OPTS: %JAVA_OPTS%
+echo   PC JAVA_OPTS: %PROCESS_CONTROLLER_JAVA_OPTS%
+echo   HC JAVA_OPTS: %HOST_CONTROLLER_JAVA_OPTS%
 echo.
 echo ===============================================================================
 echo.
 
 :RESTART
 "%JAVA%" %PROCESS_CONTROLLER_JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\process-controller.log" ^
- "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\process-controller.log" ^
+  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+  -jar "%RUNJAR%" ^
     -mp "%JBOSS_MODULEPATH%" ^
-     org.jboss.as.process-controller ^
+    org.jboss.as.process-controller ^
     -jboss-home "%JBOSS_HOME%" ^
     -jvm "%JAVA%" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -- ^
-    "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\host-controller.log" ^
-    "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    %HOST_CONTROLLER_JAVA_OPTS% ^
-    -- ^
-    -default-jvm "%JAVA%" ^
-    %*
+      "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\host-controller.log" ^
+      "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+      %HOST_CONTROLLER_JAVA_OPTS% ^
+      -- ^
+        -default-jvm "%JAVA%" ^
+        %*
 
 if ERRORLEVEL 10 goto RESTART
 

--- a/build/src/main/resources/bin/domain.conf.bat
+++ b/build/src/main/resources/bin/domain.conf.bat
@@ -4,12 +4,10 @@ rem #  JBoss Bootstrap Script Configuration                                    #
 rem #                                                                          ##
 rem #############################################################################
 
-rem # $Id: run.conf.bat 88820 2009-05-13 15:25:44Z dimitris@jboss.org $
-
 rem #
-rem # This batch file is executed by run.bat to initialize the environment
-rem # variables that run.bat uses. It is recommended to use this file to
-rem # configure these variables, rather than modifying run.bat itself.
+rem # This batch file is executed by domain.bat to initialize the environment
+rem # variables that domain.bat uses. It is recommended to use this file to
+rem # configure these variables, rather than modifying domain.bat itself.
 rem #
 
 if not "x%JAVA_OPTS%" == "x" (
@@ -29,13 +27,13 @@ rem # Specify the location of the Java home directory (it is recommended that
 rem # this always be set). If set, then "%JAVA_HOME%\bin\java" will be used as
 rem # the Java VM executable; otherwise, "%JAVA%" will be used (see below).
 rem #
-rem set "JAVA_HOME=C:\opt\jdk1.6.0_23"
+rem set "JAVA_HOME=C:\opt\jdk1.7.0_04"
 
 rem #
 rem # Specify the exact Java VM executable to use - only used if JAVA_HOME is
 rem # not set. Default is "java".
 rem #
-rem set "JAVA=C:\opt\jdk1.6.0_23\bin\java"
+rem set "JAVA=%JAVA_HOME%\bin\java"
 
 rem #
 rem # Specify options to pass to the Java VM. Note, there are some additional
@@ -61,6 +59,8 @@ set "JAVA_OPTS=%JAVA_OPTS% -Djboss.domain.default.config=domain.xml -Djboss.host
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"
 
+:JAVA_OPTS_SET
+
 rem The ProcessController process uses its own set of java options
 set "PROCESS_CONTROLLER_JAVA_OPTS=%JAVA_OPTS%"
 
@@ -74,6 +74,3 @@ rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transpo
 rem # Sample JPDA settings for shared memory debugging
 rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
 rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
-
-:JAVA_OPTS_SET
-

--- a/build/src/main/resources/bin/jboss-cli.bat
+++ b/build/src/main/resources/bin/jboss-cli.bat
@@ -3,12 +3,11 @@ rem -------------------------------------------------------------------------
 rem JBoss Admin CLI Script for Windows
 rem -------------------------------------------------------------------------
 
-rem $Id$
 
 @if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
+  setlocal
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
@@ -32,15 +31,6 @@ if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
 
 set DIRNAME=
 
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=jboss-cli.bat"
-)
-
-rem Setup JBoss specific properties
-set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
-
 if "x%JAVA_HOME%" == "x" (
   set  JAVA=java
   echo JAVA_HOME is not set. Unexpected results may occur.
@@ -49,7 +39,7 @@ if "x%JAVA_HOME%" == "x" (
   set "JAVA=%JAVA_HOME%\bin\java"
 )
 
-rem Find run.jar, or we can't continue
+rem Find jboss-modules.jar, or we can't continue
 if exist "%JBOSS_HOME%\jboss-modules.jar" (
     set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
 ) else (
@@ -62,10 +52,10 @@ rem Add base package for L&F
 set JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=com.sun.java.swing
 
 "%JAVA%" %JAVA_OPTS% ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+  -jar "%RUNJAR%" ^
     -mp "%JBOSS_HOME%\modules" ^
-     org.jboss.as.cli ^
-     %*
+    org.jboss.as.cli ^
+    %*
 
 :END
 if "x%NOPAUSE%" == "x" pause

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -3,12 +3,11 @@ rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------
 
-rem $Id$
 
 @if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
 
 if "%OS%" == "Windows_NT" (
+  setlocal
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
@@ -43,15 +42,6 @@ if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
 
 set DIRNAME=
 
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=standalone.bat"
-)
-
-rem Setup JBoss specific properties
-set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
-
 if "x%JAVA_HOME%" == "x" (
   set  JAVA=java
   echo JAVA_HOME is not set. Unexpected results may occur.
@@ -69,9 +59,7 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
       set "JAVA_OPTS=-client %JAVA_OPTS%"
     )
   )
-)
 
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
   rem Add compressed oops, if supported (64 bit VM), and not overriden
   echo "%JAVA_OPTS%" | findstr /I "\-XX:\-UseCompressedOops \-client" > nul
   if errorlevel == 1 (
@@ -80,9 +68,7 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
       set "JAVA_OPTS=-XX:+UseCompressedOops %JAVA_OPTS%"
     )
   )
-)
 
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
   rem Add tiered compilation, if supported (64 bit VM), and not overriden
   echo "%JAVA_OPTS%" | findstr /I "\-XX:\-TieredCompilation \-client" > nul
   if errorlevel == 1 (
@@ -140,14 +126,15 @@ echo.
 
 :RESTART
 "%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\boot.log" ^
- "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\boot.log" ^
+  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
+  -jar "%RUNJAR%" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -jaxpmodule "javax.xml.jaxp-provider" ^
-     org.jboss.as.standalone ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-     %*
+    org.jboss.as.standalone ^
+    "-Djboss.home.dir=%JBOSS_HOME%" ^
+    "-Djboss.server.base.dir=%JBOSS_HOME%\standalone" ^
+    %*
 
 if ERRORLEVEL 10 goto RESTART
 


### PR DESCRIPTION
The program.name system property is nowhere used in Java code
the CVS identifiers are old
some comments refer to run.bat from old jboss
domain.bat needs to use new JAVA_OPTS system
indention for java command to group the arguments
some quoting fix for home/base directory properties
