### PR TITLE
[master branch] Fix for A7-4943

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
@@ -105,17 +105,19 @@ class EJBClientCommonConnectionConfig implements EJBClientConfiguration.CommonCo
         private final ServiceRegistry serviceRegistry;
         private final String userName;
         private final String securityRealmName;
-        private final ServiceName securityRealmServiceName;
 
         CallbackHandlerProvider(final ServiceRegistry serviceRegistry, final String userName, final String securityRealm) {
             this.serviceRegistry = serviceRegistry;
             this.userName = userName;
             this.securityRealmName = securityRealm;
-            this.securityRealmServiceName = SecurityRealmService.BASE_SERVICE_NAME.append(securityRealm);
         }
 
         CallbackHandler getCallbackHandler() {
-            final ServiceController<SecurityRealm> securityRealmController = (ServiceController<SecurityRealm>) this.serviceRegistry.getService(this.securityRealmServiceName);
+            if (this.securityRealmName == null || this.securityRealmName.trim().isEmpty()) {
+                return new AnonymousCallbackHandler();
+            }
+            final ServiceName securityRealmServiceName = SecurityRealmService.BASE_SERVICE_NAME.append(this.securityRealmName);
+            final ServiceController<SecurityRealm> securityRealmController = (ServiceController<SecurityRealm>) this.serviceRegistry.getService(securityRealmServiceName);
             if (securityRealmController == null) {
                 return new AnonymousCallbackHandler();
             }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
@@ -32,6 +32,11 @@
                     <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>
                 </connection-creation-options>
             </cluster>
+            <!-- A dummy cluster configuration. It's here to make sure that such a cluster configuration
+                which doesn't have any specific configurations, doesn't result in deployment errors like the
+                one reported in https://issues.jboss.org/browse/AS7-4943 -->
+            <cluster name="dummy">
+            </cluster>
         </clusters>
     </client-context>
 </jboss-ejb-client>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4943 where a deployment would fail if the jboss-ejb-client.xml did not contain an optional security-realm attribute.
