### PR TITLE
AS7-5036 init.d startscript should not rely on the text of the start message JBoss...started

### DIFF
--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -98,7 +98,7 @@ start() {
 
   until [ $count -gt $STARTUP_WAIT ]
   do
-    grep 'JBoss AS.*started in' $JBOSS_CONSOLE_LOG > /dev/null 
+    grep 'JBAS015874:' $JBOSS_CONSOLE_LOG > /dev/null 
     if [ $? -eq 0 ] ; then
       launched=true
       break


### PR DESCRIPTION
Use the unique indentifier JBAS015874: of the message
