### PR TITLE
[AS7-5098] HornetQ cluster connections default values

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/ClusterConnectionAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ClusterConnectionAdd.java
@@ -25,6 +25,11 @@ package org.jboss.as.messaging;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.messaging.CommonAttributes.CALL_TIMEOUT;
 import static org.jboss.as.messaging.CommonAttributes.CHECK_PERIOD;
+import static org.jboss.as.messaging.CommonAttributes.CLUSTER_CONNECTION_CHECK_PERIOD;
+import static org.jboss.as.messaging.CommonAttributes.CLUSTER_CONNECTION_CONNECTION_TTL;
+import static org.jboss.as.messaging.CommonAttributes.CLUSTER_CONNECTION_MAX_RETRY_INTERVAL;
+import static org.jboss.as.messaging.CommonAttributes.CLUSTER_CONNECTION_RECONNECT_ATTEMPTS;
+import static org.jboss.as.messaging.CommonAttributes.CLUSTER_CONNECTION_RETRY_INTERVAL_MULTIPLIER;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTION_TTL;
 import static org.jboss.as.messaging.CommonAttributes.MAX_RETRY_INTERVAL;
 import static org.jboss.as.messaging.CommonAttributes.MIN_LARGE_MESSAGE_SIZE;
@@ -136,12 +141,12 @@ public class ClusterConnectionAdd extends AbstractAddStepHandler implements Desc
         final List<String> staticConnectors = discoveryGroupName == null ? getStaticConnectors(model) : null;
         final boolean allowDirectOnly = CommonAttributes.ALLOW_DIRECT_CONNECTIONS_ONLY.resolveModelAttribute(context, model).asBoolean();
         final int minLargeMessageSize = MIN_LARGE_MESSAGE_SIZE.resolveModelAttribute(context, model).asInt();
-        final long clientFailureCheckPeriod = CHECK_PERIOD.resolveModelAttribute(context, model).asInt();
-        final long connectionTTL = CONNECTION_TTL.resolveModelAttribute(context, model).asInt();
+        final long clientFailureCheckPeriod = CLUSTER_CONNECTION_CHECK_PERIOD.resolveModelAttribute(context, model).asInt();
+        final long connectionTTL = CLUSTER_CONNECTION_CONNECTION_TTL.resolveModelAttribute(context, model).asInt();
         final long callTimeout = CALL_TIMEOUT.resolveModelAttribute(context, model).asLong();
-        final int reconnectAttempts = RECONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt();
-        final long maxRetryInterval = MAX_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
-        final double retryIntervalMultiplier = RETRY_INTERVAL_MULTIPLIER.resolveModelAttribute(context, model).asDouble();
+        final int reconnectAttempts = CLUSTER_CONNECTION_RECONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt();
+        final long maxRetryInterval = CLUSTER_CONNECTION_MAX_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final double retryIntervalMultiplier = CLUSTER_CONNECTION_RETRY_INTERVAL_MULTIPLIER.resolveModelAttribute(context, model).asDouble();
 
         if (discoveryGroupName != null) {
             return new ClusterConnectionConfiguration(name, address, connectorName, minLargeMessageSize, clientFailureCheckPeriod, connectionTTL,


### PR DESCRIPTION
- use the CLUSTER_CONNECTION_XXX attributes variants when
  creating the cluster connection configuration to ensure
  the correct default values are picked up
