### PR TITLE
[7.1 only] Split JSF SPI implementation off into its own module.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -211,7 +211,7 @@
         <module-def name="org.jboss.common-beans">
             <maven-resource group="org.jboss.common" artifact="jboss-common-beans"/>
         </module-def>
-    	
+
         <module-def name="org.jboss.common-core">
             <maven-resource group="org.jboss" artifact="jboss-common-core"/>
         </module-def>
@@ -779,6 +779,10 @@
 
         <module-def name="org.jboss.as.host-controller">
             <maven-resource group="org.jboss.as" artifact="jboss-as-host-controller"/>
+        </module-def>
+
+        <module-def name="org.jboss.as.jsf">
+            <maven-resource group="org.jboss.as" artifact="jboss-as-jsf"/>
         </module-def>
 
         <module-def name="org.jboss.as.jsr77">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -696,7 +696,7 @@
                     <groupId>org.javassist</groupId>
                     <artifactId>javassist</artifactId>
                 </dependency>
-                
+
                 <dependency>
                     <groupId>org.jboss.common</groupId>
                     <artifactId>jboss-common-beans</artifactId>
@@ -877,6 +877,11 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-jdr</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-jsf</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1793,7 +1798,7 @@
                                         <include>javax.mail:mail</include>
                                         <include>javax.validation:validation-api</include>
                                         <include>joda-time:joda-time</include>
-                                        
+
                                         <include>org.apache.juddi:juddi-client</include>
                                         <include>org.apache.juddi.scout:scout</include>
                                         <include>org.apache.juddi:uddi-ws</include>
@@ -1820,7 +1825,7 @@
                                         <include>org.jboss:jboss-remote-naming</include>
                                         <include>org.jboss.jbossts:jbosstxbridge</include>
 
-                                        <!--                                        
+                                        <!--
                                         <include>org.jboss.jbossts:jbossxts</include>
                                         <include>org.jboss.jbossts:jbossxts-api</include>
                                         -->
@@ -1834,7 +1839,7 @@
                                         <include>org.jboss.remotingjmx:remoting-jmx</include>
                                         <include>org.jboss.remoting3:jboss-remoting</include>
                                         <include>org.jboss.sasl:jboss-sasl</include>
-                                        
+
                                         <include>org.jboss.spec.javax.annotation:jboss-annotations-api_1.1_spec</include>
                                         <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec</include>
                                         <include>org.jboss.spec.javax.el:jboss-el-api_2.2_spec</include>
@@ -1866,7 +1871,7 @@
                                         <include>org.jgroups:jgroups</include>
                                         <include>org.osgi:org.osgi.core</include>
                                         <include>org.picketbox:picketbox</include>
-                                        <!-- 
+                                        <!--
                                         <include>org.picketbox:picketbox-commons</include>
                                         -->
                                         <include>org.picketbox:picketbox-infinispan</include>
@@ -1888,7 +1893,7 @@
                                     <dependencySourceExcludes>
                                         <exclude>org.jboss.weld:weld-core</exclude>
                                     </dependencySourceExcludes>
-                                    
+
                                     <groups>
                                         <group>
                                             <title>Module org.apache.log4j</title>
@@ -2780,7 +2785,7 @@
                                         </group>
 
                                     </groups>
-                                    
+
                                 </configuration>
                             </execution>
                         </executions>
@@ -2788,8 +2793,8 @@
                 </plugins>
             </build>
         </profile>
-        
-        
+
+
     </profiles>
 
 </project>

--- a/build/src/main/resources/modules/org/jboss/as/jsf/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jsf/main/module.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jsf">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="sun.jdk"/>
+        <module name="com.sun.jsf-impl"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.api"/>
+        <module name="javax.faces.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.as.web"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.common-core"/>
+    </dependencies>
+</module>

--- a/jsf/pom.xml
+++ b/jsf/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-parent</artifactId>
+        <version>7.1.3.Final-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jboss-as-jsf</artifactId>
+
+    <packaging>jar</packaging>
+
+    <name>JBoss Application Server: JSF Support jar</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>
+                        -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
+                    </compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.faces</groupId>
+            <artifactId>jboss-jsf-api_2.1_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.faces</groupId>
+            <artifactId>jsf-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jsf/src/main/java/org/jboss/as/jsf/deployment/JandexAnnotationProvider.java
+++ b/jsf/src/main/java/org/jboss/as/jsf/deployment/JandexAnnotationProvider.java
@@ -20,13 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.web.deployment.jsf;
+package org.jboss.as.jsf.deployment;
 
-import com.sun.faces.spi.AnnotationProvider;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 import java.util.Set;
+
 import javax.servlet.ServletContext;
+
+import com.sun.faces.spi.AnnotationProvider;
+import org.jboss.as.web.deployment.jsf.JsfAnnotationProcessor;
 
 /**
  * {@link }AnnotationProvider} implementation which provides the JSF annotations which we parsed from from a
@@ -35,14 +38,13 @@ import javax.servlet.ServletContext;
  * @author John Bailey
  */
 public class JandexAnnotationProvider extends AnnotationProvider {
-    static final String FACES_ANNOTATIONS = "FACES_ANNOTATIONS";
 
     private final Map<Class<? extends Annotation>, Set<Class<?>>> annotations;
 
     @SuppressWarnings("unchecked")
     public JandexAnnotationProvider(final ServletContext servletContext) {
         super(servletContext);
-        annotations = (Map<Class<? extends Annotation>, Set<Class<?>>>) servletContext.getAttribute(FACES_ANNOTATIONS);
+        annotations = (Map<Class<? extends Annotation>, Set<Class<?>>>) servletContext.getAttribute(JsfAnnotationProcessor.FACES_ANNOTATIONS);
     }
 
     // Note: The Mojarra 2.0 SPI specifies that this method takes Set<URL> as its argument.  The Mojarra 2.1 SPI

--- a/jsf/src/main/java/org/jboss/as/jsf/deployment/JsfInjectionProvider.java
+++ b/jsf/src/main/java/org/jboss/as/jsf/deployment/JsfInjectionProvider.java
@@ -19,29 +19,28 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.web.deployment.jsf;
+package org.jboss.as.jsf.deployment;
 
-import static org.jboss.as.web.WebMessages.MESSAGES;
+
+import java.lang.reflect.InvocationTargetException;
+
+import javax.naming.NamingException;
 
 import com.sun.faces.spi.DiscoverableInjectionProvider;
 import com.sun.faces.spi.InjectionProviderException;
 import org.jboss.as.web.deployment.WebInjectionContainer;
 
-import javax.naming.NamingException;
-import java.lang.reflect.InvocationTargetException;
+import static org.jboss.as.web.WebMessages.MESSAGES;
 
 /**
  * @author Stuart Douglas
  */
 public class JsfInjectionProvider extends DiscoverableInjectionProvider {
 
-
-    private static final ThreadLocal<WebInjectionContainer> injectionContainer = new ThreadLocal<WebInjectionContainer>();
-
     private final WebInjectionContainer container;
 
     public JsfInjectionProvider() {
-        this.container = injectionContainer.get();
+        this.container = WebInjectionContainer.currentWebInjectionContainer();
         if (this.container == null) {
             throw MESSAGES.noThreadLocalInjectionContainer();
         }
@@ -76,7 +75,4 @@ public class JsfInjectionProvider extends DiscoverableInjectionProvider {
         }
     }
 
-    public static ThreadLocal<WebInjectionContainer> getInjectionContainer() {
-        return injectionContainer;
-    }
 }

--- a/jsf/src/main/resources/META-INF/services/com.sun.faces.spi.annotationprovider
+++ b/jsf/src/main/resources/META-INF/services/com.sun.faces.spi.annotationprovider
@@ -1,0 +1,1 @@
+org.jboss.as.jsf.deployment.JandexAnnotationProvider

--- a/jsf/src/main/resources/META-INF/services/com.sun.faces.spi.injectionprovider
+++ b/jsf/src/main/resources/META-INF/services/com.sun.faces.spi.injectionprovider
@@ -1,0 +1,1 @@
+org.jboss.as.jsf.deployment.JsfInjectionProvider:org.jboss.as.jsf.deployment.JsfInjectionProvider

--- a/pom.xml
+++ b/pom.xml
@@ -977,6 +977,12 @@
 
             <dependency>
                 <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-jsf</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-logging</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -5906,6 +5912,7 @@
                 <module>jaxrs</module>
                 <module>jdr</module>
                 <module>jpa</module>
+                <module>jsf</module>
                 <module>jsr77</module>
                 <module>logging</module>
                 <module>mail</module>

--- a/web/src/main/java/org/jboss/as/web/deployment/WarClassloadingDependencyProcessor.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/WarClassloadingDependencyProcessor.java
@@ -49,6 +49,7 @@ public class WarClassloadingDependencyProcessor implements DeploymentUnitProcess
 
     private static final ModuleIdentifier JSF_IMPL = ModuleIdentifier.create("com.sun.jsf-impl");
     private static final ModuleIdentifier JSF_API = ModuleIdentifier.create("javax.faces.api");
+    private static final ModuleIdentifier JSF_INTEGRATION = ModuleIdentifier.create("org.jboss.as.jsf");
     private static final ModuleIdentifier JSF_1_2_IMPL = ModuleIdentifier.create("com.sun.jsf-impl", "1.2");
     private static final ModuleIdentifier JSF_1_2_API = ModuleIdentifier.create("javax.faces.api", "1.2");
     private static final ModuleIdentifier BEAN_VALIDATION = ModuleIdentifier.create("org.hibernate.validator");
@@ -94,9 +95,13 @@ public class WarClassloadingDependencyProcessor implements DeploymentUnitProcess
     private void addJSFAPI(String jsfVersion, ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {
         if (jsfVersion.equals(JsfVersionMarker.WAR_BUNDLES_JSF_IMPL)) return;
 
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JSF_INTEGRATION, false, false, true, false));
+
         ModuleIdentifier jsfModule = JSF_API;
         if (jsfVersion.equals(JsfVersionMarker.JSF_1_2)) jsfModule = JSF_1_2_API;
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, jsfModule, false, false, false, false));
+
+
     }
 
     private void addJSFImpl(String jsfVersion, ModuleSpecification moduleSpecification, ModuleLoader moduleLoader) {

--- a/web/src/main/java/org/jboss/as/web/deployment/WebDeploymentService.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/WebDeploymentService.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.web.deployment;
 
-import static org.jboss.as.web.WebMessages.MESSAGES;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,12 +33,13 @@ import org.apache.catalina.core.StandardContext;
 import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.web.ThreadSetupBindingListener;
 import org.jboss.as.web.WebLogger;
-import org.jboss.as.web.deployment.jsf.JsfInjectionProvider;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+
+import static org.jboss.as.web.WebMessages.MESSAGES;
 
 /**
  * A service starting a web deployment.
@@ -75,7 +74,7 @@ class WebDeploymentService implements Service<Context> {
 
         context.setRealm(realm.getValue());
 
-        JsfInjectionProvider.getInjectionContainer().set(injectionContainer);
+        WebInjectionContainer.setWebInjectionContainer(injectionContainer);
         final List<SetupAction> actions = new ArrayList<SetupAction>();
         actions.addAll(setupActions);
         context.setInstanceManager(injectionContainer);
@@ -96,7 +95,7 @@ class WebDeploymentService implements Service<Context> {
             }
             WebLogger.WEB_LOGGER.registerWebapp(context.getName());
         } finally {
-            JsfInjectionProvider.getInjectionContainer().set(null);
+            WebInjectionContainer.clearCurrentInjectionContainer();
         }
     }
 

--- a/web/src/main/java/org/jboss/as/web/deployment/WebInjectionContainer.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/WebInjectionContainer.java
@@ -21,13 +21,6 @@
  */
 package org.jboss.as.web.deployment;
 
-import org.apache.tomcat.InstanceManager;
-import org.jboss.as.naming.ManagedReference;
-import org.jboss.as.web.deployment.ConcurrentReferenceHashMap.Option;
-import org.jboss.as.web.deployment.component.ComponentInstantiator;
-import org.jboss.msc.service.ServiceName;
-
-import javax.naming.NamingException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -35,6 +28,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import javax.naming.NamingException;
+
+import org.apache.tomcat.InstanceManager;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.web.deployment.ConcurrentReferenceHashMap.Option;
+import org.jboss.as.web.deployment.component.ComponentInstantiator;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * The web injection container.
@@ -47,6 +48,8 @@ public class WebInjectionContainer implements InstanceManager {
     private final Map<String, ComponentInstantiator> webComponentInstantiatorMap = new HashMap<String, ComponentInstantiator>();
     private final Set<ServiceName> serviceNames = new HashSet<ServiceName>();
     private final Map<Object, ManagedReference> instanceMap;
+
+    private static final ThreadLocal<WebInjectionContainer> CURRENT_INJECTION_CONTAINER = new ThreadLocal<WebInjectionContainer>();
 
     public WebInjectionContainer(ClassLoader classloader) {
         this.classloader = classloader;
@@ -103,5 +106,17 @@ public class WebInjectionContainer implements InstanceManager {
 
     public Set<ServiceName> getServiceNames() {
         return Collections.unmodifiableSet(serviceNames);
+    }
+
+    static void setWebInjectionContainer(WebInjectionContainer webInjectionContainer) {
+        CURRENT_INJECTION_CONTAINER.set(webInjectionContainer);
+    }
+
+    static void clearCurrentInjectionContainer() {
+        CURRENT_INJECTION_CONTAINER.remove();
+    }
+
+    public static WebInjectionContainer currentWebInjectionContainer() {
+        return CURRENT_INJECTION_CONTAINER.get();
     }
 }

--- a/web/src/main/java/org/jboss/as/web/deployment/jsf/JsfAnnotationProcessor.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/jsf/JsfAnnotationProcessor.java
@@ -22,14 +22,13 @@
 
 package org.jboss.as.web.deployment.jsf;
 
-import static org.jboss.as.web.WebMessages.MESSAGES;
-
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.faces.bean.ManagedBean;
 import javax.faces.component.FacesComponent;
 import javax.faces.component.behavior.FacesBehavior;
@@ -38,6 +37,7 @@ import javax.faces.event.NamedEvent;
 import javax.faces.render.FacesBehaviorRenderer;
 import javax.faces.render.FacesRenderer;
 import javax.faces.validator.FacesValidator;
+
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -51,6 +51,8 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.modules.Module;
 
+import static org.jboss.as.web.WebMessages.MESSAGES;
+
 /**
  * {@link DeploymentUnitProcessor} implementation responsible for extracting JSF annotations from a deployment and attaching them
  * to the deployment unit to eventually be added to the {@link javax.servlet.ServletContext}.
@@ -58,6 +60,8 @@ import org.jboss.modules.Module;
  * @author John Bailey
  */
 public class JsfAnnotationProcessor implements DeploymentUnitProcessor {
+
+    public static final String FACES_ANNOTATIONS = "org.jboss.as.jsf.FACES_ANNOTATIONS";
 
     private enum FacesAnnotation {
         FACES_COMPONENT(FacesComponent.class),
@@ -118,7 +122,7 @@ public class JsfAnnotationProcessor implements DeploymentUnitProcessor {
                 }
             }
         }
-        deploymentUnit.addToAttachmentList(ServletContextAttribute.ATTACHMENT_KEY, new ServletContextAttribute(JandexAnnotationProvider.FACES_ANNOTATIONS, instances));
+        deploymentUnit.addToAttachmentList(ServletContextAttribute.ATTACHMENT_KEY, new ServletContextAttribute(FACES_ANNOTATIONS, instances));
     }
 
     public void undeploy(DeploymentUnit context) {

--- a/web/src/main/java/org/jboss/as/web/deployment/jsf/JsfVersionProcessor.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/jsf/JsfVersionProcessor.java
@@ -72,17 +72,36 @@ public class JsfVersionProcessor implements DeploymentUnitProcessor {
         //if the user does have an ear with two wars with two different
         //JSF versions they are going to need to use deployment descriptors
         //to manually sort out the dependencies
+
+        boolean valueSet = false;
+
         for (final ParamValueMetaData param : contextParams) {
             if ((param.getParamName().equals(WAR_BUNDLES_JSF_IMPL_PARAM) &&
                     (param.getParamValue() != null) &&
                     (param.getParamValue().toLowerCase(Locale.ENGLISH).equals("true")))) {
                 JsfVersionMarker.setVersion(topLevelDeployment, JsfVersionMarker.WAR_BUNDLES_JSF_IMPL);
+                valueSet = true;
                 break; // WAR_BUNDLES_JSF_IMPL always wins
             }
 
             if (param.getParamName().equals(JSF_CONFIG_NAME_PARAM)) {
+                valueSet = true;
                 JsfVersionMarker.setVersion(topLevelDeployment, param.getParamValue());
             }
+        }
+
+        //we also support setting this by system property
+        //although when we add the JSF subsystem this will probably go away, and be replaced
+        //by a real management API feature
+        if(!valueSet) {
+            final String warBundles = SecurityActions.getSystemProperty(WAR_BUNDLES_JSF_IMPL_PARAM);
+            final String version = SecurityActions.getSystemProperty(JSF_CONFIG_NAME_PARAM);
+            if("true".equals(warBundles)) {
+                JsfVersionMarker.setVersion(topLevelDeployment, JsfVersionMarker.WAR_BUNDLES_JSF_IMPL);
+            } else if(version != null) {
+                JsfVersionMarker.setVersion(topLevelDeployment, version);
+            }
+
         }
     }
 

--- a/web/src/main/java/org/jboss/as/web/deployment/jsf/SecurityActions.java
+++ b/web/src/main/java/org/jboss/as/web/deployment/jsf/SecurityActions.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.web.deployment.jsf;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Privileged actions used by this package.
+ *
+ * @author Thomas.Diesler@jboss.com
+ * @since 19-Jan-2010
+ */
+class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    static String getSystemProperty(final String key) {
+        if (System.getSecurityManager() == null) {
+            return System.getProperty(key);
+        }
+        return AccessController.doPrivileged(new PrivilegedAction<String>() {
+
+            @Override
+            public String run() {
+                return System.getProperty(key);
+            }
+        });
+    }
+
+}

--- a/web/src/main/resources/META-INF/services/com.sun.faces.spi.annotationprovider
+++ b/web/src/main/resources/META-INF/services/com.sun.faces.spi.annotationprovider
@@ -1,1 +1,0 @@
-org.jboss.as.web.deployment.jsf.JandexAnnotationProvider

--- a/web/src/main/resources/META-INF/services/com.sun.faces.spi.injectionprovider
+++ b/web/src/main/resources/META-INF/services/com.sun.faces.spi.injectionprovider
@@ -1,1 +1,0 @@
-org.jboss.as.web.deployment.jsf.JsfInjectionProvider:org.jboss.as.web.deployment.jsf.JsfInjectionProvider


### PR DESCRIPTION
This is a 7.1 only fix, 7.2 will have a seperate JSF subsystem.
