### PR TITLE
[7.1 branch] Fix for AS7-5103

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
@@ -147,7 +147,10 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
         if (view == null) {
             throw EjbLogger.EJB3_LOGGER.viewNotFound(viewClass.getName(), ejb.getEjbName());
         }
-
+        // make sure it's a remote view
+        if (!ejb.isRemoteView(viewClass.getName())) {
+            throw EjbLogger.EJB3_LOGGER.viewNotFound(viewClass.getName(), ejb.getEjbName());
+        }
         final ClonerConfiguration paramConfig = new ClonerConfiguration();
         paramConfig.setClassCloner(new ClassLoaderClassCloner(ejb.getDeploymentClassLoader()));
         final ObjectCloner parameterCloner = ObjectCloners.getSerializingObjectClonerFactory().createCloner(paramConfig);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/LocalViewRemoteInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/view/LocalViewRemoteInvocationTestCase.java
@@ -46,7 +46,6 @@ import java.util.Hashtable;
  * @see https://issues.jboss.org/browse/AS7-3939
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class LocalViewRemoteInvocationTestCase {
 
     private static final Logger logger = Logger.getLogger(LocalViewRemoteInvocationTestCase.class);
@@ -77,6 +76,7 @@ public class LocalViewRemoteInvocationTestCase {
      * @throws Exception
      */
     @Test
+    @RunAsClient
     public void testLocalViewInvocationRemotelyOnSLSB() throws Exception {
         final LocalEcho localEcho = (LocalEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + StatelessEcho.class.getSimpleName() + "!" + LocalEcho.class.getName());
         final String message = "Silence!";
@@ -95,6 +95,7 @@ public class LocalViewRemoteInvocationTestCase {
      * @throws Exception
      */
     @Test
+    @RunAsClient
     public void testLocalViewInvocationRemotelyOnSFSB() throws Exception {
         final LocalEcho localEcho = (LocalEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + StatefulEcho.class.getSimpleName() + "!" + LocalEcho.class.getName() + "?stateful");
         final String message = "Silence!";
@@ -113,6 +114,7 @@ public class LocalViewRemoteInvocationTestCase {
      * @throws Exception
      */
     @Test
+    @RunAsClient
     public void testLocalViewInvocationRemotelyOnSingleton() throws Exception {
         final LocalEcho localEcho = (LocalEcho) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + SingletonEcho.class.getSimpleName() + "!" + LocalEcho.class.getName());
         final String message = "Silence!";
@@ -125,5 +127,65 @@ public class LocalViewRemoteInvocationTestCase {
         }
     }
 
+
+    /**
+     * Test that an in-vm invocation on a local business interface, of a SLSB, using the ejb: namespace fails, since only
+     * remote view invocations are allowed for ejb: namespace
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testServerInVMInvocationOnLocalViewOfSLSB() throws Exception {
+        final Context jndiContext = new InitialContext();
+        final LocalEcho localEcho = (LocalEcho) jndiContext.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + StatelessEcho.class.getSimpleName() + "!" + LocalEcho.class.getName());
+        final String message = "Silence!";
+        try {
+            final String echo = localEcho.echo(message);
+            Assert.fail("Remote invocation on a local view " + LocalEcho.class.getName() + " was expected to fail");
+        } catch (IllegalStateException nsee) {
+            // expected
+            logger.info("Got the expected exception on invoking on a local view, remotely", nsee);
+        }
+    }
+
+    /**
+     * Test that an in-vm invocation on a local business interface, of a SFSB, using the ejb: namespace fails, since only
+     * remote view invocations are allowed for ejb: namespace
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testServerInVMInvocationOnLocalViewOfSFSB() throws Exception {
+        final Context jndiContext = new InitialContext();
+        final LocalEcho localEcho = (LocalEcho) jndiContext.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + StatefulEcho.class.getSimpleName() + "!" + LocalEcho.class.getName() + "?stateful");
+        final String message = "Silence!";
+        try {
+            final String echo = localEcho.echo(message);
+            Assert.fail("Remote invocation on a local view " + LocalEcho.class.getName() + " was expected to fail");
+        } catch (IllegalStateException nsee) {
+            // expected
+            logger.info("Got the expected exception on invoking on a local view, remotely", nsee);
+        }
+    }
+
+    /**
+     * Test that an in-vm invocation on a local business interface, of a singleton bean, using the ejb: namespace fails, since only
+     * remote view invocations are allowed for ejb: namespace
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testServerInVMInvocationOnLocalViewOfSingleton() throws Exception {
+        final Context jndiContext = new InitialContext();
+        final LocalEcho localEcho = (LocalEcho) jndiContext.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + SingletonEcho.class.getSimpleName() + "!" + LocalEcho.class.getName());
+        final String message = "Silence!";
+        try {
+            final String echo = localEcho.echo(message);
+            Assert.fail("Remote invocation on a local view " + LocalEcho.class.getName() + " was expected to fail");
+        } catch (IllegalStateException nsee) {
+            // expected
+            logger.info("Got the expected exception on invoking on a local view, remotely", nsee);
+        }
+    }
 
 }


### PR DESCRIPTION
The commit (along with a testcase) fixes the issue reported in https://issues.jboss.org/browse/AS7-5103. Local business interface view(s) will no longer be invokable via the remote ejb: namespace.
