### PR TITLE
Remove properties from handlers in logging schema

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_0.xsd
@@ -123,7 +123,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="target" minOccurs="0">
                 <xs:complexType>
                     <xs:attribute name="name" use="required">
@@ -152,7 +151,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="file" type="pathType" minOccurs="1"/>
             <xs:element name="append" type="booleanValueType" minOccurs="0"/>
         </xs:all>
@@ -172,7 +170,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="file" type="pathType"/>
             <xs:element name="suffix" type="valueType"/>
             <xs:element name="append" type="booleanValueType" minOccurs="0"/>
@@ -193,7 +190,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="file" type="pathType"/>
             <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
             <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
@@ -213,7 +209,6 @@
         <xs:all>
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
             <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
             <xs:element name="subhandlers" type="handlersType"/>

--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_1.xsd
@@ -124,7 +124,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="target" minOccurs="0">
                 <xs:complexType>
                     <xs:attribute name="name" use="required">
@@ -153,7 +152,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="file" type="pathType" minOccurs="1"/>
             <xs:element name="append" type="booleanValueType" minOccurs="0"/>
         </xs:all>
@@ -173,7 +171,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="file" type="pathType"/>
             <xs:element name="suffix" type="valueType"/>
             <xs:element name="append" type="booleanValueType" minOccurs="0"/>
@@ -194,7 +191,6 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
             <xs:element name="formatter" type="formatterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="file" type="pathType"/>
             <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
             <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
@@ -214,7 +210,6 @@
         <xs:all>
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="filter" type="filterType" minOccurs="0"/>
-            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
             <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
             <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
             <xs:element name="subhandlers" type="handlersType"/>


### PR DESCRIPTION
Removed the <properties/> tag from the handlers with the exception of the custom-handler.
