### PR TITLE
[JBPAPP-9159] Don't use log handlers directory, use the services to set properties.[7.1 only]

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/handlers/FlushingHandlerAddProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/FlushingHandlerAddProperties.java
@@ -55,7 +55,7 @@ public abstract class FlushingHandlerAddProperties<T extends FlushingHandlerServ
     protected void updateRuntime(final OperationContext context, final ServiceBuilder<Handler> serviceBuilder, final String name, final T service, final ModelNode model, final List<ServiceController<?>> newControllers) throws OperationFailedException {
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, model);
         if (autoflush.isDefined()) {
-            service.setAutoflush(autoflush.asBoolean());
+            service.setAutoFlush(autoflush.asBoolean());
         }
     }
 

--- a/logging/src/main/java/org/jboss/as/logging/handlers/FlushingHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/FlushingHandlerService.java
@@ -38,7 +38,7 @@ public abstract class FlushingHandlerService<T extends ExtHandler> extends Handl
         return autoflush;
     }
 
-    public final synchronized void setAutoflush(final boolean autoflush) {
+    public final synchronized void setAutoFlush(final boolean autoflush) {
         this.autoflush = autoflush;
         final T handler = getValue();
         if (handler != null) {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/HandlerLevelChange.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/HandlerLevelChange.java
@@ -26,7 +26,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.logging.CommonAttributes.LEVEL;
 
 import java.util.List;
-import java.util.logging.Handler;
 
 import org.jboss.as.controller.AbstractModelUpdateHandler;
 import org.jboss.as.controller.OperationContext;
@@ -59,11 +58,10 @@ public class HandlerLevelChange extends AbstractModelUpdateHandler {
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
         final ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
-        @SuppressWarnings("unchecked")
-        final ServiceController<Handler> controller = (ServiceController<Handler>) serviceRegistry.getService(LogServices.handlerName(name));
+        final ServiceController<?> controller = serviceRegistry.getService(LogServices.handlerName(name));
         final ModelNode level = LEVEL.resolveModelAttribute(context, model);
         if (controller != null && level.isDefined()) {
-            controller.getValue().setLevel(ModelParser.parseLevel(level));
+            ((HandlerService<?>) controller.getService()).setLevel(ModelParser.parseLevel(level));
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/async/AsyncHandlerUpdateProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/async/AsyncHandlerUpdateProperties.java
@@ -41,7 +41,7 @@ import java.util.Locale;
  * @author John Bailey
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class AsyncHandlerUpdateProperties extends HandlerUpdateProperties<AsyncHandler> {
+public class AsyncHandlerUpdateProperties extends HandlerUpdateProperties<AsyncHandlerService> {
     public static final AsyncHandlerUpdateProperties INSTANCE = new AsyncHandlerUpdateProperties();
 
     public static final String OPERATION_NAME = HandlerUpdateProperties.OPERATION_NAME;
@@ -51,11 +51,11 @@ public class AsyncHandlerUpdateProperties extends HandlerUpdateProperties<AsyncH
     }
 
     @Override
-    protected boolean applyUpdateToRuntime(OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final AsyncHandler handler) throws OperationFailedException {
+    protected boolean applyUpdateToRuntime(OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final AsyncHandlerService handlerService) throws OperationFailedException {
         boolean requireRestart = false;
         final ModelNode overflowAction = OVERFLOW_ACTION.resolveModelAttribute(context, model);
         if (overflowAction.isDefined()) {
-            handler.setOverflowAction(ModelParser.parseOverflowAction(overflowAction));
+            handlerService.setOverflowAction(ModelParser.parseOverflowAction(overflowAction));
         }
 
         final ModelNode queueLength = QUEUE_LENGTH.resolveModelAttribute(context, model);
@@ -75,10 +75,10 @@ public class AsyncHandlerUpdateProperties extends HandlerUpdateProperties<AsyncH
     }
 
     @Override
-    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final AsyncHandler handler) throws OperationFailedException {
+    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final AsyncHandlerService handlerService) throws OperationFailedException {
         final ModelNode overflowAction = OVERFLOW_ACTION.resolveModelAttribute(context, originalModel);
         if (overflowAction.isDefined()) {
-            handler.setOverflowAction(AsyncHandler.OverflowAction.valueOf(overflowAction.asString().toUpperCase(Locale.US)));
+            handlerService.setOverflowAction(AsyncHandler.OverflowAction.valueOf(overflowAction.asString().toUpperCase(Locale.US)));
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/async/AsyncHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/async/AsyncHandlerWriteAttributeHandler.java
@@ -28,17 +28,16 @@ import static org.jboss.as.logging.CommonAttributes.SUBHANDLERS;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.logging.util.ModelParser;
 import org.jboss.as.logging.handlers.AbstractLogHandlerWriteAttributeHandler;
+import org.jboss.as.logging.util.ModelParser;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logmanager.handlers.AsyncHandler;
 
 /**
  * Date: 12.10.2011
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class AsyncHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAttributeHandler<AsyncHandler> {
+public class AsyncHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAttributeHandler<AsyncHandlerService> {
 
     public static final AsyncHandlerWriteAttributeHandler INSTANCE = new AsyncHandlerWriteAttributeHandler();
 
@@ -47,9 +46,9 @@ public class AsyncHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAt
     }
 
     @Override
-    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final AsyncHandler handler) throws OperationFailedException {
+    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final AsyncHandlerService handlerService) throws OperationFailedException {
         if (OVERFLOW_ACTION.getName().equals(attributeName)) {
-            handler.setOverflowAction(ModelParser.parseOverflowAction(resolvedValue));
+            handlerService.setOverflowAction(ModelParser.parseOverflowAction(resolvedValue));
         } else if (SUBHANDLERS.getName().equals(attributeName)) {
             // Remove the subhandlers
             AsyncHandlerUnassignSubhandler.removeHandlers(SUBHANDLERS, currentValue, context, handlerName);
@@ -62,9 +61,9 @@ public class AsyncHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAt
     }
 
     @Override
-    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final AsyncHandler handler) throws OperationFailedException {
+    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final AsyncHandlerService handlerService) throws OperationFailedException {
         if (OVERFLOW_ACTION.getName().equals(attributeName)) {
-            handler.setOverflowAction(ModelParser.parseOverflowAction(valueToRestore));
+            handlerService.setOverflowAction(ModelParser.parseOverflowAction(valueToRestore));
         } else if (SUBHANDLERS.getName().equals(attributeName)) {
             // Remove the subhandlers
             AsyncHandlerUnassignSubhandler.removeHandlers(SUBHANDLERS, valueToRevert, context, handlerName);

--- a/logging/src/main/java/org/jboss/as/logging/handlers/console/ConsoleHandlerUpdateProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/console/ConsoleHandlerUpdateProperties.java
@@ -29,14 +29,13 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.logging.handlers.HandlerUpdateProperties;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logmanager.handlers.ConsoleHandler;
 
 /**
  * Operation responsible for updating the properties of a console logging handler.
  *
  * @author John Bailey
  */
-public class ConsoleHandlerUpdateProperties extends HandlerUpdateProperties<ConsoleHandler> {
+public class ConsoleHandlerUpdateProperties extends HandlerUpdateProperties<ConsoleHandlerService> {
     public static final ConsoleHandlerUpdateProperties INSTANCE = new ConsoleHandlerUpdateProperties();
 
     private ConsoleHandlerUpdateProperties() {
@@ -45,31 +44,13 @@ public class ConsoleHandlerUpdateProperties extends HandlerUpdateProperties<Cons
 
     @Override
     protected boolean applyUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                           final ModelNode originalModel, final ConsoleHandler handler) throws OperationFailedException {
-        switch (Target.fromString(TARGET.resolveModelAttribute(context, model).asString())) {
-            case SYSTEM_ERR: {
-                handler.setTarget(ConsoleHandler.Target.SYSTEM_ERR);
-                break;
-            }
-            case SYSTEM_OUT: {
-                handler.setTarget(ConsoleHandler.Target.SYSTEM_OUT);
-                break;
-            }
-        }
+                                           final ModelNode originalModel, final ConsoleHandlerService handlerService) throws OperationFailedException {
+        handlerService.setTarget(Target.fromString(TARGET.resolveModelAttribute(context, model).asString()));
         return false;
     }
 
     @Override
-    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final ConsoleHandler handler) throws OperationFailedException {
-         switch (Target.fromString(TARGET.resolveModelAttribute(context, originalModel).asString())) {
-            case SYSTEM_ERR: {
-                handler.setTarget(ConsoleHandler.Target.SYSTEM_ERR);
-                break;
-            }
-            case SYSTEM_OUT: {
-                handler.setTarget(ConsoleHandler.Target.SYSTEM_OUT);
-                break;
-            }
-        }
+    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final ConsoleHandlerService handlerService) throws OperationFailedException {
+        handlerService.setTarget(Target.fromString(TARGET.resolveModelAttribute(context, originalModel).asString()));
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/console/ConsoleHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/console/ConsoleHandlerWriteAttributeHandler.java
@@ -36,7 +36,7 @@ import org.jboss.logmanager.handlers.ConsoleHandler;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class ConsoleHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAttributeHandler<ConsoleHandler> {
+public class ConsoleHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAttributeHandler<ConsoleHandlerService> {
     public static final ConsoleHandlerWriteAttributeHandler INSTANCE = new ConsoleHandlerWriteAttributeHandler();
 
     private ConsoleHandlerWriteAttributeHandler() {
@@ -44,39 +44,21 @@ public class ConsoleHandlerWriteAttributeHandler extends AbstractLogHandlerWrite
     }
 
     @Override
-    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final ConsoleHandler handler) throws OperationFailedException {
+    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final ConsoleHandlerService handlerService) throws OperationFailedException {
         if (TARGET.getName().equals(attributeName)) {
-            switch (Target.fromString(resolvedValue.asString())) {
-                case SYSTEM_ERR: {
-                    handler.setTarget(ConsoleHandler.Target.SYSTEM_ERR);
-                    break;
-                }
-                case SYSTEM_OUT: {
-                    handler.setTarget(ConsoleHandler.Target.SYSTEM_OUT);
-                    break;
-                }
-            }
+            handlerService.setTarget(Target.fromString(resolvedValue.asString()));
         } else if (AUTOFLUSH.getName().equals(attributeName)) {
-            handler.setAutoFlush(resolvedValue.asBoolean());
+            handlerService.setAutoFlush(resolvedValue.asBoolean());
         }
         return false;
     }
 
     @Override
-    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final ConsoleHandler handler) throws OperationFailedException {
+    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final ConsoleHandlerService handlerService) throws OperationFailedException {
         if (TARGET.getName().equals(attributeName)) {
-            switch (Target.fromString(valueToRestore.asString())) {
-                case SYSTEM_ERR: {
-                    handler.setTarget(ConsoleHandler.Target.SYSTEM_ERR);
-                    break;
-                }
-                case SYSTEM_OUT: {
-                    handler.setTarget(ConsoleHandler.Target.SYSTEM_OUT);
-                    break;
-                }
-            }
+            handlerService.setTarget(Target.fromString(valueToRestore.asString()));
         } else if (AUTOFLUSH.getName().equals(attributeName)) {
-            handler.setAutoFlush(valueToRestore.asBoolean());
+            handlerService.setAutoFlush(valueToRestore.asBoolean());
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerService.java
@@ -23,7 +23,6 @@
 package org.jboss.as.logging.handlers.custom;
 
 import static org.jboss.as.logging.LoggingMessages.MESSAGES;
-import static org.jboss.as.logging.handlers.custom.PropertiesConfigurator.setProperties;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -91,7 +90,7 @@ public final class CustomHandlerService extends HandlerService<Handler> {
     @Override
     protected void start(final StartContext context, final Handler handler) throws StartException {
         // Set the properties
-        setProperties(handler, properties);
+        PropertiesConfigurator.setProperties(handler, properties);
     }
 
     @Override
@@ -103,7 +102,7 @@ public final class CustomHandlerService extends HandlerService<Handler> {
         properties.add(property);
         final Handler handler = getValue();
         if (handler != null) {
-            setProperties(handler, this.properties);
+            PropertiesConfigurator.setProperties(handler, this.properties);
         }
     }
 
@@ -112,7 +111,12 @@ public final class CustomHandlerService extends HandlerService<Handler> {
         this.properties.addAll(properties);
         final Handler handler = getValue();
         if (handler != null) {
-            setProperties(handler, this.properties);
+            PropertiesConfigurator.setProperties(handler, this.properties);
         }
+    }
+
+    public synchronized void setProperties(final Collection<Property> properties) {
+        this.properties.clear();
+        addProperties(properties);
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerUpdateProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerUpdateProperties.java
@@ -25,8 +25,6 @@ package org.jboss.as.logging.handlers.custom;
 import static org.jboss.as.logging.CommonAttributes.PROPERTIES;
 import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
-import java.util.logging.Handler;
-
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.logging.handlers.HandlerUpdateProperties;
@@ -38,7 +36,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class CustomHandlerUpdateProperties extends HandlerUpdateProperties<Handler> {
+public class CustomHandlerUpdateProperties extends HandlerUpdateProperties<CustomHandlerService> {
     public static final CustomHandlerUpdateProperties INSTANCE = new CustomHandlerUpdateProperties();
 
     private CustomHandlerUpdateProperties() {
@@ -47,25 +45,26 @@ public class CustomHandlerUpdateProperties extends HandlerUpdateProperties<Handl
 
     @Override
     protected boolean applyUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                           final ModelNode originalModel, final Handler handler) throws OperationFailedException {
+                                           final ModelNode originalModel, final CustomHandlerService handlerService) throws OperationFailedException {
         if (model.hasDefined(PROPERTIES)) {
             final ModelNode properties = model.get(PROPERTIES);
             if (properties.getType() != ModelType.LIST) {
                 throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidType(PROPERTIES, ModelType.LIST, properties.getType())));
             }
-            PropertiesConfigurator.setProperties(handler, properties.asPropertyList());
+            handlerService.setProperties(properties.asPropertyList());
         }
         return false;
     }
 
     @Override
-    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final Handler handler) throws OperationFailedException {
+    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
+                                         final ModelNode originalModel, final CustomHandlerService handlerService) throws OperationFailedException {
         if (originalModel.hasDefined(PROPERTIES)) {
             final ModelNode properties = originalModel.get(PROPERTIES);
             if (properties.getType() != ModelType.LIST) {
                 throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidType(PROPERTIES, ModelType.LIST, properties.getType())));
             }
-            PropertiesConfigurator.setProperties(handler, properties.asPropertyList());
+            handlerService.setProperties(properties.asPropertyList());
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerWriteAttributeHandler.java
@@ -38,7 +38,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class CustomHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAttributeHandler<Handler> {
+public class CustomHandlerWriteAttributeHandler extends AbstractLogHandlerWriteAttributeHandler<CustomHandlerService> {
     public static final CustomHandlerWriteAttributeHandler INSTANCE = new CustomHandlerWriteAttributeHandler();
 
     private CustomHandlerWriteAttributeHandler() {
@@ -46,23 +46,23 @@ public class CustomHandlerWriteAttributeHandler extends AbstractLogHandlerWriteA
     }
 
     @Override
-    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final Handler handler) throws OperationFailedException {
+    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final CustomHandlerService handlerService) throws OperationFailedException {
         if (PROPERTIES.equals(attributeName)) {
             if (resolvedValue.getType() != ModelType.LIST) {
                 throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidType(PROPERTIES, ModelType.LIST, resolvedValue.getType())));
             }
-            PropertiesConfigurator.setProperties(handler, resolvedValue.asPropertyList());
+            handlerService.setProperties(resolvedValue.asPropertyList());
         }
         return false;
     }
 
     @Override
-    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final Handler handler) throws OperationFailedException {
+    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final CustomHandlerService handlerService) throws OperationFailedException {
         if (PROPERTIES.equals(attributeName)) {
             if (valueToRestore.getType() != ModelType.LIST) {
                 throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidType(PROPERTIES, ModelType.LIST, valueToRestore.getType())));
             }
-            PropertiesConfigurator.setProperties(handler, valueToRestore.asPropertyList());
+            handlerService.setProperties(valueToRestore.asPropertyList());
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/AbstractFileHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/AbstractFileHandlerWriteAttributeHandler.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.logging.handlers.AbstractLogHandlerWriteAttributeHandler;
+import org.jboss.as.logging.handlers.HandlerService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.handlers.FileHandler;
 
@@ -38,20 +39,20 @@ import org.jboss.logmanager.handlers.FileHandler;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public abstract class AbstractFileHandlerWriteAttributeHandler<T extends FileHandler> extends AbstractLogHandlerWriteAttributeHandler<T> {
+public abstract class AbstractFileHandlerWriteAttributeHandler<T extends AbstractFileHandlerService<?>> extends AbstractLogHandlerWriteAttributeHandler<T> {
 
     protected AbstractFileHandlerWriteAttributeHandler(final AttributeDefinition... attributes) {
         super(joinUnique(attributes, APPEND, AUTOFLUSH, FILE));
     }
 
     @Override
-    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final T handler) throws OperationFailedException {
+    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final T handlerService) throws OperationFailedException {
         boolean requiresRestart = false;
         if (APPEND.getName().equals(attributeName)) {
-            handler.setAppend(resolvedValue.asBoolean());
+            handlerService.setAppend(resolvedValue.asBoolean());
             return true;
         } else if (AUTOFLUSH.getName().equals(attributeName)) {
-            handler.setAutoFlush(resolvedValue.asBoolean());
+            handlerService.setAutoFlush(resolvedValue.asBoolean());
         } else if (FILE.getName().equals(attributeName)) {
             requiresRestart = FileHandlers.changeFile(context, currentValue, resolvedValue, handlerName);
         }
@@ -59,11 +60,11 @@ public abstract class AbstractFileHandlerWriteAttributeHandler<T extends FileHan
     }
 
     @Override
-    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final T handler) throws OperationFailedException {
+    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final T handlerService) throws OperationFailedException {
         if (APPEND.getName().equals(attributeName)) {
-            handler.setAppend(valueToRestore.asBoolean());
+            handlerService.setAppend(valueToRestore.asBoolean());
         } else if (AUTOFLUSH.getName().equals(attributeName)) {
-            handler.setAutoFlush(valueToRestore.asBoolean());
+            handlerService.setAutoFlush(valueToRestore.asBoolean());
         } else if (FILE.getName().equals(attributeName)) {
             FileHandlers.revertFileChange(context, valueToRestore, handlerName);
         }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerAdd.java
@@ -34,7 +34,6 @@ import org.jboss.as.logging.handlers.FlushingHandlerAddProperties;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceTarget;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -60,7 +59,6 @@ public class FileHandlerAdd extends FlushingHandlerAddProperties<FileHandlerServ
         if (append.isDefined()) {
             service.setAppend(append.asBoolean());
         }
-        final ServiceTarget serviceTarget = context.getServiceTarget();
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
             newControllers.add(FileHandlers.addFile(context, serviceBuilder, service, file, name));

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerUpdateProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerUpdateProperties.java
@@ -37,7 +37,7 @@ import org.jboss.logmanager.handlers.FileHandler;
  *
  * @author John Bailey
  */
-public class FileHandlerUpdateProperties extends HandlerUpdateProperties<FileHandler> {
+public class FileHandlerUpdateProperties extends HandlerUpdateProperties<FileHandlerService> {
     public static final FileHandlerUpdateProperties INSTANCE = new FileHandlerUpdateProperties();
 
     private FileHandlerUpdateProperties() {
@@ -46,15 +46,15 @@ public class FileHandlerUpdateProperties extends HandlerUpdateProperties<FileHan
 
     @Override
     protected boolean applyUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                           final ModelNode originalModel, final FileHandler handler) throws OperationFailedException {
+                                           final ModelNode originalModel, final FileHandlerService handlerService) throws OperationFailedException {
         boolean requiresRestart = false;
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, model);
         if (autoflush.isDefined()) {
-            handler.setAutoFlush(autoflush.asBoolean());
+            handlerService.setAutoFlush(autoflush.asBoolean());
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, model);
         if (append.isDefined()) {
-            handler.setAppend(append.asBoolean());
+            handlerService.setAppend(append.asBoolean());
         }
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
@@ -64,14 +64,14 @@ public class FileHandlerUpdateProperties extends HandlerUpdateProperties<FileHan
     }
 
     @Override
-    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final FileHandler handler) throws OperationFailedException {
+    protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model, final ModelNode originalModel, final FileHandlerService handlerService) throws OperationFailedException {
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, originalModel);
         if (autoflush.isDefined()) {
-            handler.setAutoFlush(autoflush.asBoolean());
+            handlerService.setAutoFlush(autoflush.asBoolean());
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, originalModel);
         if (append.isDefined()) {
-            handler.setAppend(append.asBoolean());
+            handlerService.setAppend(append.asBoolean());
         }
         final ModelNode file = FILE.resolveModelAttribute(context, originalModel);
         if (file.isDefined()) {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/FileHandlerWriteAttributeHandler.java
@@ -29,6 +29,6 @@ import org.jboss.logmanager.handlers.FileHandler;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class FileHandlerWriteAttributeHandler extends AbstractFileHandlerWriteAttributeHandler<FileHandler> {
+public class FileHandlerWriteAttributeHandler extends AbstractFileHandlerWriteAttributeHandler<FileHandlerService> {
     public static final FileHandlerWriteAttributeHandler INSTANCE = new FileHandlerWriteAttributeHandler();
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicHandlerUpdateProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicHandlerUpdateProperties.java
@@ -31,14 +31,13 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.logging.handlers.HandlerUpdateProperties;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logmanager.handlers.PeriodicRotatingFileHandler;
 
 /**
  * Operation responsible for updating the properties of a periodic rotating log handler.
  *
  * @author John Bailey
  */
-public class PeriodicHandlerUpdateProperties extends HandlerUpdateProperties<PeriodicRotatingFileHandler> {
+public class PeriodicHandlerUpdateProperties extends HandlerUpdateProperties<PeriodicRotatingFileHandlerService> {
     public static final PeriodicHandlerUpdateProperties INSTANCE = new PeriodicHandlerUpdateProperties();
 
     private PeriodicHandlerUpdateProperties() {
@@ -47,15 +46,15 @@ public class PeriodicHandlerUpdateProperties extends HandlerUpdateProperties<Per
 
     @Override
     protected boolean applyUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                           final ModelNode originalModel, final PeriodicRotatingFileHandler handler) throws OperationFailedException {
+                                           final ModelNode originalModel, final PeriodicRotatingFileHandlerService handlerService) throws OperationFailedException {
         boolean requiresRestart = false;
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, model);
         if (autoflush.isDefined()) {
-            handler.setAutoFlush(autoflush.asBoolean());
+            handlerService.setAutoFlush(autoflush.asBoolean());
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, model);
         if (append.isDefined()) {
-            handler.setAppend(append.asBoolean());
+            handlerService.setAppend(append.asBoolean());
         }
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
@@ -63,25 +62,25 @@ public class PeriodicHandlerUpdateProperties extends HandlerUpdateProperties<Per
         }
         final ModelNode suffix = SUFFIX.resolveModelAttribute(context, model);
         if (suffix.isDefined()) {
-            handler.setSuffix(suffix.asString());
+            handlerService.setSuffix(suffix.asString());
         }
         return requiresRestart;
     }
 
     @Override
     protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                         final ModelNode originalModel, final PeriodicRotatingFileHandler handler) throws OperationFailedException {
+                                         final ModelNode originalModel, final PeriodicRotatingFileHandlerService handlerService) throws OperationFailedException {
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, originalModel);
         if (autoflush.isDefined()) {
-            handler.setAutoFlush(autoflush.asBoolean());
+            handlerService.setAutoFlush(autoflush.asBoolean());
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, originalModel);
         if (append.isDefined()) {
-            handler.setAppend(append.asBoolean());
+            handlerService.setAppend(append.asBoolean());
         }
         final ModelNode suffix = SUFFIX.resolveModelAttribute(context, originalModel);
         if (suffix.isDefined()) {
-            handler.setSuffix(suffix.asString());
+            handlerService.setSuffix(suffix.asString());
         }
         final ModelNode file = FILE.resolveModelAttribute(context, originalModel);
         if (file.isDefined()) {

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/PeriodicHandlerWriteAttributeHandler.java
@@ -35,7 +35,7 @@ import org.jboss.logmanager.handlers.PeriodicRotatingFileHandler;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class PeriodicHandlerWriteAttributeHandler extends AbstractFileHandlerWriteAttributeHandler<PeriodicRotatingFileHandler> {
+public class PeriodicHandlerWriteAttributeHandler extends AbstractFileHandlerWriteAttributeHandler<PeriodicRotatingFileHandlerService> {
     public static final PeriodicHandlerWriteAttributeHandler INSTANCE = new PeriodicHandlerWriteAttributeHandler();
 
     private PeriodicHandlerWriteAttributeHandler() {
@@ -43,24 +43,24 @@ public class PeriodicHandlerWriteAttributeHandler extends AbstractFileHandlerWri
     }
 
     @Override
-    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final PeriodicRotatingFileHandler handler) throws OperationFailedException {
-        boolean result = super.doApplyUpdateToRuntime(context, operation, attributeName, resolvedValue, currentValue, handlerName, handler);
+    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final PeriodicRotatingFileHandlerService handlerService) throws OperationFailedException {
+        boolean result = super.doApplyUpdateToRuntime(context, operation, attributeName, resolvedValue, currentValue, handlerName, handlerService);
         if (APPEND.getName().equals(attributeName)) {
-            handler.setAppend(resolvedValue.asBoolean());
+            handlerService.setAppend(resolvedValue.asBoolean());
         } else if (SUFFIX.getName().equals(attributeName)) {
-            handler.setSuffix(resolvedValue.asString());
+            handlerService.setSuffix(resolvedValue.asString());
             result = false;
         }
         return result;
     }
 
     @Override
-    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final PeriodicRotatingFileHandler handler) throws OperationFailedException {
-        super.doRevertUpdateToRuntime(context, operation, attributeName, valueToRestore, valueToRevert, handlerName, handler);
+    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final PeriodicRotatingFileHandlerService handlerService) throws OperationFailedException {
+        super.doRevertUpdateToRuntime(context, operation, attributeName, valueToRestore, valueToRevert, handlerName, handlerService);
         if (APPEND.getName().equals(attributeName)) {
-            handler.setAppend(valueToRestore.asBoolean());
+            handlerService.setAppend(valueToRestore.asBoolean());
         } else if (SUFFIX.getName().equals(attributeName)) {
-            handler.setSuffix(valueToRestore.asString());
+            handlerService.setSuffix(valueToRestore.asString());
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingHandlerUpdateProperties.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingHandlerUpdateProperties.java
@@ -33,14 +33,13 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.logging.handlers.HandlerUpdateProperties;
 import org.jboss.as.logging.util.ModelParser;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
 
 /**
  * Operation responsible for updating the properties of a size based rotating log handler.
  *
  * @author John Bailey
  */
-public class SizeRotatingHandlerUpdateProperties extends HandlerUpdateProperties<SizeRotatingFileHandler> {
+public class SizeRotatingHandlerUpdateProperties extends HandlerUpdateProperties<SizeRotatingFileHandlerService> {
     public static final SizeRotatingHandlerUpdateProperties INSTANCE = new SizeRotatingHandlerUpdateProperties();
 
     private SizeRotatingHandlerUpdateProperties() {
@@ -49,15 +48,15 @@ public class SizeRotatingHandlerUpdateProperties extends HandlerUpdateProperties
 
     @Override
     protected boolean applyUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                           final ModelNode originalModel, final SizeRotatingFileHandler handler) throws OperationFailedException {
+                                           final ModelNode originalModel, final SizeRotatingFileHandlerService handlerService) throws OperationFailedException {
         boolean requiresRestart = false;
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, model);
         if (autoflush.isDefined()) {
-            handler.setAutoFlush(autoflush.asBoolean());
+            handlerService.setAutoFlush(autoflush.asBoolean());
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, model);
         if (append.isDefined()) {
-            handler.setAppend(append.asBoolean());
+            handlerService.setAppend(append.asBoolean());
         }
         final ModelNode file = FILE.resolveModelAttribute(context, model);
         if (file.isDefined()) {
@@ -65,26 +64,26 @@ public class SizeRotatingHandlerUpdateProperties extends HandlerUpdateProperties
         }
         final ModelNode maxBackupIndex = MAX_BACKUP_INDEX.resolveModelAttribute(context, model);
         if (maxBackupIndex.isDefined()) {
-            handler.setMaxBackupIndex(maxBackupIndex.asInt());
+            handlerService.setMaxBackupIndex(maxBackupIndex.asInt());
         }
 
         final ModelNode rotateSizeNode = ROTATE_SIZE.resolveModelAttribute(context, model);
         if (rotateSizeNode.isDefined()) {
-            handler.setRotateSize(ModelParser.parseSize(rotateSizeNode));
+            handlerService.setRotateSize(ModelParser.parseSize(rotateSizeNode));
         }
         return requiresRestart;
     }
 
     @Override
     protected void revertUpdateToRuntime(final OperationContext context, final String handlerName, final ModelNode model,
-                                         final ModelNode originalModel, final SizeRotatingFileHandler handler) throws OperationFailedException {
+                                         final ModelNode originalModel, final SizeRotatingFileHandlerService handlerService) throws OperationFailedException {
         final ModelNode autoflush = AUTOFLUSH.resolveModelAttribute(context, originalModel);
         if (autoflush.isDefined()) {
-            handler.setAutoFlush(autoflush.asBoolean());
+            handlerService.setAutoFlush(autoflush.asBoolean());
         }
         final ModelNode append = APPEND.resolveModelAttribute(context, originalModel);
         if (append.isDefined()) {
-            handler.setAppend(append.asBoolean());
+            handlerService.setAppend(append.asBoolean());
         }
         final ModelNode file = FILE.resolveModelAttribute(context, originalModel);
         if (file.isDefined()) {
@@ -92,12 +91,12 @@ public class SizeRotatingHandlerUpdateProperties extends HandlerUpdateProperties
         }
         final ModelNode maxBackupIndex = MAX_BACKUP_INDEX.resolveModelAttribute(context, originalModel);
         if (maxBackupIndex.isDefined()) {
-            handler.setMaxBackupIndex(maxBackupIndex.asInt());
+            handlerService.setMaxBackupIndex(maxBackupIndex.asInt());
         }
 
         final ModelNode rotateSizeNode = ROTATE_SIZE.resolveModelAttribute(context, originalModel);
         if (rotateSizeNode.isDefined()) {
-            handler.setRotateSize(ModelParser.parseSize(rotateSizeNode));
+            handlerService.setRotateSize(ModelParser.parseSize(rotateSizeNode));
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingHandlerWriteAttributeHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/file/SizeRotatingHandlerWriteAttributeHandler.java
@@ -36,7 +36,7 @@ import org.jboss.logmanager.handlers.SizeRotatingFileHandler;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class SizeRotatingHandlerWriteAttributeHandler extends AbstractFileHandlerWriteAttributeHandler<SizeRotatingFileHandler> {
+public class SizeRotatingHandlerWriteAttributeHandler extends AbstractFileHandlerWriteAttributeHandler<SizeRotatingFileHandlerService> {
     public static final SizeRotatingHandlerWriteAttributeHandler INSTANCE = new SizeRotatingHandlerWriteAttributeHandler();
 
     private SizeRotatingHandlerWriteAttributeHandler() {
@@ -44,25 +44,25 @@ public class SizeRotatingHandlerWriteAttributeHandler extends AbstractFileHandle
     }
 
     @Override
-    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final SizeRotatingFileHandler handler) throws OperationFailedException {
-        boolean result = super.doApplyUpdateToRuntime(context, operation, attributeName, resolvedValue, currentValue, handlerName, handler);
+    protected boolean doApplyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final String handlerName, final SizeRotatingFileHandlerService handlerService) throws OperationFailedException {
+        boolean result = super.doApplyUpdateToRuntime(context, operation, attributeName, resolvedValue, currentValue, handlerName, handlerService);
         if (MAX_BACKUP_INDEX.getName().equals(attributeName)) {
-            handler.setMaxBackupIndex(resolvedValue.asInt());
+            handlerService.setMaxBackupIndex(resolvedValue.asInt());
             result = false;
         } else if (ROTATE_SIZE.getName().equals(attributeName)) {
-            handler.setRotateSize(ModelParser.parseSize(resolvedValue));
+            handlerService.setRotateSize(ModelParser.parseSize(resolvedValue));
             result = false;
         }
         return result;
     }
 
     @Override
-    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final SizeRotatingFileHandler handler) throws OperationFailedException {
-        super.doRevertUpdateToRuntime(context, operation, attributeName, valueToRestore, valueToRevert, handlerName, handler);
+    protected void doRevertUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode valueToRestore, final ModelNode valueToRevert, final String handlerName, final SizeRotatingFileHandlerService handlerService) throws OperationFailedException {
+        super.doRevertUpdateToRuntime(context, operation, attributeName, valueToRestore, valueToRevert, handlerName, handlerService);
         if (MAX_BACKUP_INDEX.getName().equals(attributeName)) {
-            handler.setMaxBackupIndex(valueToRestore.asInt());
+            handlerService.setMaxBackupIndex(valueToRestore.asInt());
         } else if (ROTATE_SIZE.getName().equals(attributeName)) {
-            handler.setRotateSize(ModelParser.parseSize(valueToRestore));
+            handlerService.setRotateSize(ModelParser.parseSize(valueToRestore));
         }
     }
 }


### PR DESCRIPTION
Don't use log handlers directory, use the services to set properties. The fix for this in 7.2.x is contained in PR #2548 by removing the services.
