### PR TITLE
AS7-5149 Create shaded jar for CLI and jconsole

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -121,6 +121,7 @@
 
     <target name="copy-client">
         <copy file="${org.jboss.as:jboss-as-client-all:jar}" tofile="${output.dir}/bin/client/jboss-client.jar"/>
+        <copy file="${org.jboss.as:jboss-as-cli:jar:client}" tofile="${output.dir}/bin/client/jboss-cli-client.jar"/>
     </target>
 
     <target name="minimalistic" depends="base, copy-standalone-minimalistic"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -749,6 +749,12 @@
 
                 <dependency>
                     <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-cli</artifactId>
+                    <classifier>client</classifier>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-client-all</artifactId>
                     <scope>provided</scope>
                 </dependency>

--- a/build/src/main/resources/bin/client/README-CLI-JCONSOLE.txt
+++ b/build/src/main/resources/bin/client/README-CLI-JCONSOLE.txt
@@ -1,0 +1,16 @@
+The jboss-cli-client jar can be used to remotely manage a JBoss AS instance with CLI or jconsole.  Copy jboss-cli-client.jar to your client machine.  You do not need to install JBoss AS.
+
+TO RUN CLI:
+java -jar <PATH TO jboss-cli-client.jar> [--help] [--version] [--controller=host:port]
+                                         [--gui] [--connect] [--file=file_path]
+                                         [--commands=command_or_operation1,command_or_operation2...]
+                                         [--command=command_or_operation]
+                                         [--user=username --password=password]
+
+Use --help for an explanation of the CLI command line options.
+
+
+TO RUN JCONSOLE:
+jconsole -J-Djava.class.path=<PATH TO jconsole.jar>;<PATH TO tools.jar>;<PATH TO jboss-cli-client.jar>
+
+Path to jconsole.jar and tools.jar is typically <JAVA_HOME>/lib/jconsole.jar and <JAVA_HOME>/lib/tools.jar.

--- a/build/src/main/resources/bin/client/README-EJB-JMS.txt
+++ b/build/src/main/resources/bin/client/README-EJB-JMS.txt
@@ -1,4 +1,4 @@
-This folder contains a combined client jar for JBoss AS7, for use in non-maven environments. This jar should be used
+jboss-client.jar is a combined client jar for JBoss AS7, for use in non-maven environments. This jar should be used
 with standalone clients only, not with deployments are that deployed to an AS7 instance.
 
 This jar contains the classes required for remote JMS and EJB usage, and consists of the following shaded artifacts:

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -58,6 +58,27 @@
                     </compilerArgument>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>client</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.jboss.as.cli.CommandLineMain</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -106,7 +127,7 @@
            <groupId>org.jboss.remotingjmx</groupId>
            <artifactId>remoting-jmx</artifactId>
         </dependency>
-        
+
         <dependency>
            <groupId>org.jboss</groupId>
            <artifactId>jboss-vfs</artifactId>
@@ -119,7 +140,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <profiles>
         <profile>
             <id>linux-windows</id>
@@ -151,5 +172,5 @@
                 </dependency>
             </dependencies>
         </profile>
-    </profiles>    
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -897,6 +897,13 @@
 
             <dependency>
                 <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-cli</artifactId>
+                <classifier>client</classifier>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-client-all</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
For usage, see README-CLI-JCONSOLE.txt included in this commit.

This works nicely.  However, there are a few things that need to be considered.
- When you run CLI with the shaded jar you will get a warning that it can't load jboss-cli.xml because JBOSS_HOME is not set.  So it just uses default values.  Since this is intended to be run where AS is not present, we need to come up with an alternative way to load jboss-cli.xml.
- The shaded jar is about 4.5 MB.  Is that too big?  We can reduce the size using Shade's "minimizeJar" feature.  This tries to determine classes of dependencies that are not used by the project.  However, I'm not sure I trust that feature.  So if 4.5 MB is acceptable I'd prefer to leave it alone.
- When using the shaded jar for CLI, it does not use the modules system.  I couldn't find any reason that it really needs it since everything is loaded as one uber-jar.
- Should we also ship a sh/bat file that makes the command line a little easier?
