### PR TITLE
AS7-4996 PersistenceUnitInfo.addTransformer(ClassTransformer transformer) needs to occur before class definition

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/DsDeploymentActivator.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/DsDeploymentActivator.java
@@ -56,6 +56,6 @@ public class DsDeploymentActivator {
         updateContext.addDeploymentProcessor(DataSourcesExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_DSXML_DEPLOYMENT, new DsXmlDeploymentParsingProcessor());
         updateContext.addDeploymentProcessor(DataSourcesExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_DATA_SOURCE_DEFINITION_ANNOTATION, new DataSourceDefinitionAnnotationParser());
         updateContext.addDeploymentProcessor(DataSourcesExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_DATASOURCE_REF, new DataSourceDefinitionDeploymentDescriptorParser());
-        updateContext.addDeploymentProcessor(DataSourcesExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_DSXML_DEPLOYMENT, new DsXmlDeploymentInstallProcessor());
+        updateContext.addDeploymentProcessor(DataSourcesExtension.SUBSYSTEM_NAME, Phase.FIRST_MODULE_USE, Phase.FIRST_MODULE_USE_DSXML_DEPLOYMENT, new DsXmlDeploymentInstallProcessor());
     }
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -25,6 +25,8 @@ package org.jboss.as.jpa.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
+
 /**
  * configuration properties that may appear in persistence.xml
  *
@@ -151,6 +153,29 @@ public class Configuration {
      */
     public static String getProviderModuleNameFromProviderClassName(final String providerClassName) {
         return providerClassToModuleName.get(providerClassName);
+    }
+
+    /**
+     * Determine if class file transformer is needed for the specified persistence unit
+     *
+     * if the persistence provider is Hibernate and use_class_enhancer is not true, don't need a class transformer.
+     * for other persistence providers, the transformer is assumed to be needed.
+     *
+     * @param pu
+     * @return true if class file transformer support is needed for pu
+     */
+    public static boolean needClassFileTransformer(PersistenceUnitMetadata pu) {
+        boolean result = true;
+        String provider = pu.getPersistenceProviderClassName();
+        if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
+            result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
+        }
+        else if (provider == null
+            || provider.equals(Configuration.PROVIDER_CLASS_HIBERNATE)) {
+            String useHibernateClassEnhancer = pu.getProperties().getProperty("hibernate.ejb.use_class_enhancer");
+            result = "true".equals(useHibernateClassEnhancer);
+        }
+        return result;
     }
 
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -121,6 +121,11 @@ public class Configuration {
     public static final String JPA_CONTAINER_MANAGED = "jboss.as.jpa.managed";
 
     /**
+     * defaults to true, if false, persistence unit will not support javax.persistence.spi.ClassTransformer Interface
+     * which means no application class rewriting
+     */
+    public static final String JPA_CONTAINER_CLASS_TRANSFORMER = "jboss.as.jpa.classtransformer";
+    /**
      * name of the persistence provider adapter class
      */
     public static final String ADAPTER_CLASS = "jboss.as.jpa.adapterClass";

--- a/jpa/core/src/main/java/org/jboss/as/jpa/persistenceprovider/PersistenceProviderResolverImpl.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/persistenceprovider/PersistenceProviderResolverImpl.java
@@ -74,9 +74,10 @@ public class PersistenceProviderResolverImpl implements PersistenceProviderResol
             if (persistenceProviderPerClassLoader.size() > 0) {
                 // get the deployment or subdeployment classloader
                 ClassLoader deploymentClassLoader = findParentModuleCl(SecurityActions.getContextClassLoader());
-
+                ROOT_LOGGER.tracef("get application level Persistence Provider for classloader %s" , deploymentClassLoader);
                 // collect persistence providers associated with deployment/each sub-deployment
                 List<Class> deploymentSpecificPersistenceProviders = persistenceProviderPerClassLoader.get(deploymentClassLoader);
+                ROOT_LOGGER.tracef("got application level Persistence Provider list %s" , deploymentSpecificPersistenceProviders);
                 if (deploymentSpecificPersistenceProviders != null) {
 
                     for (Class providerClass : deploymentSpecificPersistenceProviders) {
@@ -138,11 +139,14 @@ public class PersistenceProviderResolverImpl implements PersistenceProviderResol
 
             for (ClassLoader deploymentClassLoader: deploymentClassLoaders) {
                 List<Class> list = persistenceProviderPerClassLoader.get(deploymentClassLoader);
+                ROOT_LOGGER.tracef("getting persistence provider list (%s) for deployment (%s)", list, deploymentClassLoader );
                 if (list == null) {
                     list = new ArrayList<Class>();
                     persistenceProviderPerClassLoader.put(deploymentClassLoader, list);
+                    ROOT_LOGGER.tracef("saving new persistence provider list (%s) for deployment (%s)", list, deploymentClassLoader );
                 }
                 list.add(persistenceProvider.getClass());
+                ROOT_LOGGER.tracef("added new persistence provider (%s) to provider list (%s)", persistenceProvider.getClass().getName(), list);
             }
         }
     }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPAAnnotationProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPAAnnotationProcessor.java
@@ -69,7 +69,7 @@ import org.jboss.msc.service.ServiceName;
  *
  * @author Scott Marlow (based on ResourceInjectionAnnotationParsingProcessor)
  */
-public class JPAAnnotationParseProcessor implements DeploymentUnitProcessor {
+public class JPAAnnotationProcessor implements DeploymentUnitProcessor {
 
 
     private static final DotName PERSISTENCE_CONTEXT_ANNOTATION_NAME = DotName.createSimple(PersistenceContext.class.getName());

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
@@ -62,29 +62,13 @@ public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor
                 PersistenceUnitMetadataHolder holder = resourceRoot.getAttachment(PersistenceUnitMetadataHolder.PERSISTENCE_UNITS);
                 if (holder != null) {
                     for (PersistenceUnitMetadata pu : holder.getPersistenceUnits()) {
-                        if ( needClassFileTransformer(pu)) {
+                        if (Configuration.needClassFileTransformer(pu)) {
                             transformer.addTransformer(new JPADelegatingClassFileTransformer(pu));
                         }
                     }
                 }
             }
         }
-    }
-
-    // if the persistence provider is hibernate and use_class_enhancer is not true, don't add a transformer
-    // for all other providers, add the transformer in case its needed.
-    private boolean needClassFileTransformer(PersistenceUnitMetadata pu) {
-        boolean result = true;
-        String provider = pu.getPersistenceProviderClassName();
-        if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
-            result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
-        }
-        else if (provider == null
-            || provider.equals(Configuration.PROVIDER_CLASS_HIBERNATE)) {
-            String useHibernateClassEnhancer = pu.getProperties().getProperty("hibernate.ejb.use_class_enhancer");
-            result = "true".equals(useHibernateClassEnhancer);
-        }
-        return result;
     }
 
 

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
@@ -76,7 +76,10 @@ public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor
     private boolean needClassFileTransformer(PersistenceUnitMetadata pu) {
         boolean result = true;
         String provider = pu.getPersistenceProviderClassName();
-        if (provider == null
+        if (pu.getProperties().containsKey(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER)) {
+            result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_CONTAINER_CLASS_TRANSFORMER));
+        }
+        else if (provider == null
             || provider.equals(Configuration.PROVIDER_CLASS_HIBERNATE)) {
             String useHibernateClassEnhancer = pu.getProperties().getProperty("hibernate.ejb.use_class_enhancer");
             result = "true".equals(useHibernateClassEnhancer);

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceBeginInstallProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceBeginInstallProcessor.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.processor;
+
+import org.jboss.as.jpa.config.PersistenceProviderDeploymentHolder;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.DeploymentUtils;
+
+/**
+ * begin installation of persistence unit service and persistence providers in deployment
+ *
+ * @author Scott Marlow
+ */
+public class PersistenceBeginInstallProcessor implements DeploymentUnitProcessor {
+
+    /**
+     * {@inheritDoc}
+     */
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+
+        // deploy any persistence providers found in deployment
+        PersistenceProviderHandler.deploy(phaseContext);
+
+        // start each PU service (except the PUs with property Configuration.JPA_CONTAINER_CLASS_TRANSFORMER = false)
+        PersistenceUnitServiceHandler.deploy(phaseContext, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void undeploy(final DeploymentUnit deploymentUnit) {
+        PersistenceProviderHandler.undeploy(deploymentUnit);
+    }
+
+}
+

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceCompleteInstallProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceCompleteInstallProcessor.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jpa.processor;
+
+import org.jboss.as.jpa.config.PersistenceProviderDeploymentHolder;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.DeploymentUtils;
+
+/**
+ * complete installation of persistence unit service and persistence providers in deployment
+ *
+ * @author Scott Marlow
+ */
+public class PersistenceCompleteInstallProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        if (deploymentHasPersistenceProvider(phaseContext.getDeploymentUnit())) {
+            // finish registration of persistence provider
+            PersistenceProviderHandler.finishDeploy(phaseContext);
+        }
+
+        // only install PUs with property Configuration.JPA_CONTAINER_CLASS_TRANSFORMER = false (since they weren't started before)
+        // this allows @DataSourceDefinition to work (which don't start until the Install phase)
+        PersistenceUnitServiceHandler.deploy(phaseContext, false);
+
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+        PersistenceUnitServiceHandler.undeploy(context); // always uninstall persistent unit services from here
+    }
+
+    private static boolean deploymentHasPersistenceProvider(DeploymentUnit deploymentUnit) {
+        deploymentUnit = DeploymentUtils.getTopDeploymentUnit(deploymentUnit);
+        PersistenceProviderDeploymentHolder persistenceProviderDeploymentHolder =  deploymentUnit.getAttachment(JpaAttachments.DEPLOYED_PERSISTENCE_PROVIDER);
+        return (persistenceProviderDeploymentHolder != null && persistenceProviderDeploymentHolder.getProvider() != null ? persistenceProviderDeploymentHolder.getProvider().size() > 0: false);
+    }
+
+}

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
@@ -30,13 +30,13 @@ import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.jpa.persistenceprovider.PersistenceProviderResolverImpl;
-import org.jboss.as.jpa.processor.JPAAnnotationParseProcessor;
+import org.jboss.as.jpa.processor.JPAAnnotationProcessor;
 import org.jboss.as.jpa.processor.JPAClassFileTransformerProcessor;
 import org.jboss.as.jpa.processor.JPADependencyProcessor;
 import org.jboss.as.jpa.processor.JPAInterceptorProcessor;
-import org.jboss.as.jpa.processor.PersistenceProviderProcessor;
+import org.jboss.as.jpa.processor.PersistenceBeginInstallProcessor;
+import org.jboss.as.jpa.processor.PersistenceCompleteInstallProcessor;
 import org.jboss.as.jpa.processor.PersistenceRefProcessor;
-import org.jboss.as.jpa.processor.PersistenceUnitDeploymentProcessor;
 import org.jboss.as.jpa.processor.PersistenceUnitParseProcessor;
 import org.jboss.as.jpa.service.JPAService;
 import org.jboss.as.jpa.service.JPAUserTransactionListenerService;
@@ -46,8 +46,6 @@ import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 
 
 /**
@@ -86,20 +84,25 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler {
 
                 // handles parsing of persistence.xml
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_PERSISTENCE_UNIT, new PersistenceUnitParseProcessor());
+
                 // handles persistence unit / context annotations in components
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_PERSISTENCE_ANNOTATION, new JPAAnnotationParseProcessor());
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_PERSISTENCE_ANNOTATION, new JPAAnnotationProcessor());
                 // injects JPA dependencies into an application
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JPA, new JPADependencyProcessor());
+
+                // handle ClassFileTransformer
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.FIRST_MODULE_USE, Phase.FIRST_MODULE_USE_PERSISTENCE_CLASS_FILE_TRANSFORMER, new JPAClassFileTransformerProcessor());
+                // registers listeners/interceptors on session beans
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.FIRST_MODULE_USE, Phase.FIRST_MODULE_USE_INTERCEPTORS, new JPAInterceptorProcessor());
+                // begin pu service install and deploying a persistence provider
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.FIRST_MODULE_USE, Phase.FIRST_MODULE_USE_PERSISTENCE_PREPARE, new PersistenceBeginInstallProcessor());
+
                 // handles persistence unit / context references from deployment descriptors
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_PERSISTENCE_REF, new PersistenceRefProcessor());
-                // handle ClassFileTransformer
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_PERSISTENCE_CLASS_FILE_TRANSFORMER, new JPAClassFileTransformerProcessor());
-                // registers listeners/interceptors on session beans
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JPA_INTERCEPTORS, new JPAInterceptorProcessor());
-                // handles deploying a persistence provider
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_PERSISTENCE_PROVIDER, new PersistenceProviderProcessor());
-                // handles pu deployment (starts pu service)
-                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_PERSISTENTUNIT, new PersistenceUnitDeploymentProcessor(PersistenceUnitRegistryImpl.INSTANCE));
+
+                // handles pu deployment (completes pu service installation)
+                processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_PERSISTENTUNIT, new PersistenceCompleteInstallProcessor());
+
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/jpa/hibernate4/src/main/java/org/jboss/as/jpa/hibernate4/HibernateAnnotationScanner.java
+++ b/jpa/hibernate4/src/main/java/org/jboss/as/jpa/hibernate4/HibernateAnnotationScanner.java
@@ -168,9 +168,7 @@ public class HibernateAnnotationScanner implements Scanner {
                 for (ClassInfo classInfo : allClasses) {
                     String className = classInfo.name().toString();
                     try {
-                        resultClasses.add(pu.getClassLoader().loadClass(className));
-                        // TODO:  fix temp classloader (get CFNE on entity class)
-                        //result.add(pu.getNewTempClassLoader().loadClass(className));
+                        resultClasses.add(pu.getNewTempClassLoader().loadClass(className));
                     } catch (ClassNotFoundException e) {
                         throw MESSAGES.cannotLoadEntityClass(e, className);
                     }
@@ -236,11 +234,9 @@ public class HibernateAnnotationScanner implements Scanner {
                         String className = annotationInstance.target().toString();
                         try {
                             JPA_LOGGER.tracef("getClassesInJar found class %s with annotation %s", className, annClass.getName());
-                            Class<?> clazz = pu.getClassLoader().loadClass(className);
+                            Class<?> clazz = pu.getNewTempClassLoader().loadClass(className);
                             result.add(clazz);
                             classesForAnnotation.add(clazz);
-                            // TODO:  fix temp classloader (get CFNE on entity class)
-                            //result.add(pu.getNewTempClassLoader().loadClass(className));
                         } catch (ClassNotFoundException e) {
                             throw MESSAGES.cannotLoadEntityClass(e, className);
                         }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -266,7 +266,7 @@ public final class ServerService extends AbstractControllerService {
             DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.CONFIGURE_MODULE, Phase.CONFIGURE_MODULE_SPEC, new ModuleSpecProcessor());
             DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.POST_MODULE, Phase.POST_MODULE_INSTALL_EXTENSION, new ModuleExtensionNameProcessor());
             DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.POST_MODULE, Phase.POST_MODULE_REFLECTION_INDEX, new InstallReflectionIndexProcessor());
-            DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.POST_MODULE, Phase.POST_MODULE_TRANSFORMER, new ClassFileTransformerProcessor());
+            DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.FIRST_MODULE_USE, Phase.FIRST_MODULE_USE_TRANSFORMER, new ClassFileTransformerProcessor());
             DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.INSTALL, Phase.INSTALL_SERVICE_ACTIVATOR, new ServiceActivatorProcessor());
             DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.CLEANUP, Phase.CLEANUP_REFLECTION_INDEX, new CleanupReflectionIndexProcessor());
             DeployerChainAddHandler.addDeploymentProcessor(SERVER_NAME, Phase.CLEANUP, Phase.CLEANUP_ANNOTATION_INDEX, new CleanupAnnotationIndexProcessor());

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -141,30 +141,10 @@ public enum Phase {
      */
     DEPENDENCIES(null),
     CONFIGURE_MODULE(null),
+
     /**
-     * Processors that need to start/complete before the deployment classloader is used to load application classes, belong here.
-     *
-     * Upon entry, this phase performs the following actions:
-     * <ul>
-     * <li></li>
-     * </ul>
-     * <p>
-     * Processors in this phase have access to the following phase attachments:
-     * <ul>
-     * <li>{@link Attachments#BLAH} - description here</li>
-     * </ul>
-     * <p>
-     * Processors in this phase have access to the following deployment unit attachments, in addition to those defined
-     * for the previous phase:
-     * <ul>
-     * <li>{@link Attachments#BLAH} - description here</li>
-     * </ul>
-     * <p>
-     * In this phase, these phase attachments may be modified:
-     * <ul>
-     * <li>{@link Attachments#BLAH} - description here</li>
-     * </ul>
-     * <p>
+     * Processors that need to start/complete before the deployment classloader is used to load application classes,
+     * belong in the FIRST_MODULE_USE phase.
      */
     FIRST_MODULE_USE(null),
     POST_MODULE(null),
@@ -357,12 +337,12 @@ public enum Phase {
     public static final int CONFIGURE_RESOLVE_SUB_BUNDLE                = 0x0300;
 
     // FIRST_MODULE_USE
-    public static final int FIRST_MODULE_USE_PERSISTENCE_CLASS_FILE_TRANSFORMER = 0x050; // need to be before POST_MODULE_REFLECTION_INDEX
+    public static final int FIRST_MODULE_USE_PERSISTENCE_CLASS_FILE_TRANSFORMER = 0x0100; // need to be before POST_MODULE_REFLECTION_INDEX
                                                                                          // and anything that could load class definitions
-    public static final int FIRST_MODULE_USE_INTERCEPTORS               = 0x0110;
-    public static final int FIRST_MODULE_USE_PERSISTENCE_PREPARE        = 0x0115;
-    public static final int FIRST_MODULE_USE_DSXML_DEPLOYMENT           = 0x0120;
-    public static final int FIRST_MODULE_USE_TRANSFORMER                = 0x0130;
+    public static final int FIRST_MODULE_USE_INTERCEPTORS               = 0x0200;
+    public static final int FIRST_MODULE_USE_PERSISTENCE_PREPARE        = 0x0300;
+    public static final int FIRST_MODULE_USE_DSXML_DEPLOYMENT           = 0x0400;
+    public static final int FIRST_MODULE_USE_TRANSFORMER                = 0x0500;
 
 
     // POST_MODULE

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -141,6 +141,32 @@ public enum Phase {
      */
     DEPENDENCIES(null),
     CONFIGURE_MODULE(null),
+    /**
+     * Processors that need to start/complete before the deployment classloader is used to load application classes, belong here.
+     *
+     * Upon entry, this phase performs the following actions:
+     * <ul>
+     * <li></li>
+     * </ul>
+     * <p>
+     * Processors in this phase have access to the following phase attachments:
+     * <ul>
+     * <li>{@link Attachments#BLAH} - description here</li>
+     * </ul>
+     * <p>
+     * Processors in this phase have access to the following deployment unit attachments, in addition to those defined
+     * for the previous phase:
+     * <ul>
+     * <li>{@link Attachments#BLAH} - description here</li>
+     * </ul>
+     * <p>
+     * In this phase, these phase attachments may be modified:
+     * <ul>
+     * <li>{@link Attachments#BLAH} - description here</li>
+     * </ul>
+     * <p>
+     */
+    FIRST_MODULE_USE(null),
     POST_MODULE(null),
     INSTALL(null),
     CLEANUP(null),
@@ -330,10 +356,19 @@ public enum Phase {
     public static final int CONFIGURE_MODULE_SPEC                       = 0x0200;
     public static final int CONFIGURE_RESOLVE_SUB_BUNDLE                = 0x0300;
 
+    // FIRST_MODULE_USE
+    public static final int FIRST_MODULE_USE_PERSISTENCE_CLASS_FILE_TRANSFORMER = 0x050; // need to be before POST_MODULE_REFLECTION_INDEX
+                                                                                         // and anything that could load class definitions
+    public static final int FIRST_MODULE_USE_INTERCEPTORS               = 0x0110;
+    public static final int FIRST_MODULE_USE_PERSISTENCE_PREPARE        = 0x0115;
+    public static final int FIRST_MODULE_USE_DSXML_DEPLOYMENT           = 0x0120;
+    public static final int FIRST_MODULE_USE_TRANSFORMER                = 0x0130;
+
+
     // POST_MODULE
     public static final int POST_MODULE_INJECTION_ANNOTATION            = 0x0100;
     public static final int POST_MODULE_REFLECTION_INDEX                = 0x0200;
-    public static final int POST_MODULE_TRANSFORMER                     = 0x0201;
+
     public static final int POST_MODULE_JSF_MANAGED_BEANS               = 0x0300;
     public static final int POST_MODULE_INTERCEPTOR_ANNOTATIONS         = 0x0301;
     public static final int POST_MODULE_EJB_BUSINESS_VIEW_ANNOTATION    = 0x0400;
@@ -379,7 +414,6 @@ public enum Phase {
     public static final int POST_MODULE_ENV_ENTRY                       = 0x1400;
     public static final int POST_MODULE_EJB_REF                         = 0x1500;
     public static final int POST_MODULE_PERSISTENCE_REF                 = 0x1600;
-    public static final int POST_MODULE_PERSISTENCE_CLASS_FILE_TRANSFORMER = 0x1620;
     public static final int POST_MODULE_DATASOURCE_REF                  = 0x1700;
     public static final int POST_MODULE_WS_REF_DESCRIPTOR               = 0x1800;
     public static final int POST_MODULE_WS_REF_ANNOTATION               = 0x1801;
@@ -403,7 +437,6 @@ public enum Phase {
 
     // INSTALL
     public static final int INSTALL_JNDI_DEPENDENCY_SETUP               = 0x0100;
-    public static final int INSTALL_JPA_INTERCEPTORS                    = 0x0200;
     public static final int INSTALL_JACC_POLICY                         = 0x0350;
     public static final int INSTALL_COMPONENT_AGGREGATION               = 0x0400;
     public static final int INSTALL_RESOLVE_MESSAGE_DESTINATIONS        = 0x0403;
@@ -419,7 +452,7 @@ public enum Phase {
     public static final int INSTALL_EE_MODULE_CONFIG                    = 0x1101;
     public static final int INSTALL_MODULE_JNDI_BINDINGS                = 0x1200;
     public static final int INSTALL_DEPENDS_ON_ANNOTATION               = 0x1210;
-    public static final int INSTALL_PERSISTENCE_PROVIDER                = 0x1215;   // before INSTALL_PERSISTENTUNIT
+
     public static final int INSTALL_PERSISTENTUNIT                      = 0x1220;
     public static final int INSTALL_EE_COMPONENT                        = 0x1230;
     public static final int INSTALL_SERVLET_INIT_DEPLOYMENT             = 0x1300;
@@ -439,7 +472,6 @@ public enum Phase {
     public static final int INSTALL_DEPLOYMENT_REPOSITORY               = 0x1F00;
     public static final int INSTALL_EJB_MANAGEMENT_RESOURCES            = 0x2000;
     public static final int INSTALL_APPLICATION_CLIENT                  = 0x2010;
-    public static final int INSTALL_DSXML_DEPLOYMENT                    = 0x2020;
     public static final int INSTALL_MESSAGING_XML_RESOURCES             = 0x2030;
     public static final int INSTALL_BUNDLE_ACTIVATE                     = 0x2040;
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/cfgfile/CfgFileTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/cfgfile/CfgFileTestCase.java
@@ -49,19 +49,7 @@ public class CfgFileTestCase {
 
     private static final String ARCHIVE_NAME = "jpa_cfgfile";
 
-    private static final String persistence_xml =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
-            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
-            "  <persistence-unit name=\"mypc\">" +
-            "    <description>Persistence Unit." +
-            "    </description>" +
-            "		<properties> " +
-            "			<property name=\"hibernate.ejb.cfgfile\" value=\"hibernate.cfg.xml\"/>" +
-            "		</properties>" +
-            "  </persistence-unit>" +
-            "</persistence>"; 
-
-  private static final String hibernate_cfg_xml =
+    private static final String hibernate_cfg_xml =
 		"<?xml version='1.0' encoding='utf-8'?>\n " +
 		  "<!DOCTYPE hibernate-configuration PUBLIC\n" +
 		  "\"-//Hibernate/Hibernate Configuration DTD 3.0//EN\"\n" +
@@ -75,6 +63,7 @@ public class CfgFileTestCase {
 		  	"  </session-factory>" +
 		  "</hibernate-configuration>";
     
+
     @Deployment
     public static Archive<?> deploy() {
 
@@ -83,7 +72,7 @@ public class CfgFileTestCase {
             Employee.class,
             SFSB1.class
         );
-        jar.addAsResource(new StringAsset(persistence_xml), "META-INF/persistence.xml");
+        jar.addAsManifestResource(CfgFileTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         jar.addAsResource(new StringAsset(hibernate_cfg_xml), "hibernate.cfg.xml");
         return jar; 
     

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/cfgfile/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/cfgfile/persistence.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">
     <persistence-unit name="mypc">
-        <jta-data-source>java:app/DataSource</jta-data-source>
         <properties>
-            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.ejb.cfgfile" value="hibernate.cfg.xml"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/datasourcedefinition/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/datasourcedefinition/persistence.xml
@@ -4,6 +4,7 @@
         <jta-data-source>java:app/DataSource</jta-data-source>
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="jboss.as.jpa.classtransformer" value="false"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/ClassFileTransformerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/ClassFileTransformerTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.naming.InitialContext;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Hibernate "hibernate.ejb.use_class_enhancer" test that causes hibernate to add a
+ * javax.persistence.spi.ClassTransformer to the pu.
+ *
+ * @author Scott Marlow
+ */
+@RunWith(Arquillian.class)
+public class ClassFileTransformerTestCase {
+
+    private static final String ARCHIVE_NAME = "jpa_classTransformerTestWithMockProvider";
+
+    private static final String persistence_xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+            "  <persistence-unit name=\"mypc\">" +
+            "    <description>Persistence Unit." +
+            "    </description>" +
+            " <provider>org.jboss.as.test.integration.jpa.mockprovider.classtransformer.TestPersistenceProvider</provider>" +
+            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+            "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+            "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
+            "<property name=\"hibernate.ejb.use_class_enhancer\" value=\"true\"/>" +
+            "</properties>" +
+            "  </persistence-unit>" +
+            "</persistence>";
+
+    @Deployment
+    public static Archive<?> deploy() {
+        JavaArchive persistenceProvider = ShrinkWrap.create(JavaArchive.class, "testpersistenceprovider.jar");
+        persistenceProvider.addClasses(
+                    TestClassTransformer.class,
+                    TestEntityManagerFactory.class,
+                    TestPersistenceProvider.class
+                );
+
+        // META-INF/services/javax.persistence.spi.PersistenceProvider
+        persistenceProvider.addAsResource(new StringAsset("org.jboss.as.test.integration.jpa.mockprovider.classtransformer.TestPersistenceProvider"),
+                "META-INF/services/javax.persistence.spi.PersistenceProvider");
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
+
+        JavaArchive ejbjar = ShrinkWrap.create(JavaArchive.class, "ejbjar.jar");
+        ejbjar.addAsManifestResource(emptyEjbJar(), "ejb-jar.xml");
+        ejbjar.addClasses(ClassFileTransformerTestCase.class,
+                SFSB1.class
+        );
+        ejbjar.addAsManifestResource(new StringAsset(persistence_xml), "persistence.xml");
+
+        ear.addAsModule(ejbjar);        // add ejbjar to root of ear
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "lib.jar");
+        lib.addClasses(Employee.class, ClassFileTransformerTestCase.class);
+        ear.addAsLibraries(lib, persistenceProvider);
+        return ear;
+
+    }
+
+    private static StringAsset emptyEjbJar() {
+        return new StringAsset(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<ejb-jar xmlns=\"http://java.sun.com/xml/ns/javaee\" \n" +
+                "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \n" +
+                "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd\"\n" +
+                "         version=\"3.0\">\n" +
+                "   \n" +
+                "</ejb-jar>");
+    }
+
+    @ArquillianResource
+    private InitialContext iniCtx;
+
+    @Test
+    public void test_use_class_enhancer() throws Exception {
+        try {
+            assertTrue("entity classes are enhanced", TestClassTransformer.getTransformedClasses().size() > 0 );
+        } finally {
+            TestClassTransformer.clearTransformedClasses();
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/Employee.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee  {
+
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/SFSB1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/SFSB1.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
+
+import javax.ejb.Stateful;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceUnit;
+
+/**
+ * stateful session bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+public class SFSB1 {
+    @PersistenceUnit
+    EntityManagerFactory emf;
+
+    public void createEmployee(String name, String address, int id) {
+        Employee emp = new Employee();
+        emp.setId(id);
+        emp.setAddress(address);
+        emp.setName(name);
+        emf.createEntityManager().persist(emp);
+    }
+
+    public Employee getEmployeeNoTX(int id) {
+        return emf.createEntityManager().find(Employee.class, id, LockModeType.NONE);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestClassTransformer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestClassTransformer.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
+
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.persistence.spi.ClassTransformer;
+
+/**
+ * TestClassTransformer
+ *
+ * @author Scott Marlow
+ */
+public class TestClassTransformer implements ClassTransformer {
+
+    // track class names that would of been transformed of this class was capable of doing so.
+    private static final List<String> transformedClasses = Collections.synchronizedList(new ArrayList<String>());
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+        transformedClasses.add(className);
+        System.out.println("TestClassTransformer: enhancing class " + className);
+        return classfileBuffer;
+    }
+
+    public static Collection getTransformedClasses() {
+        return transformedClasses;
+    }
+
+    public static void clearTransformedClasses() {
+        transformedClasses.clear();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestEntityManagerFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestEntityManagerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * TestEntityManagerFactory
+ *
+ * @author Scott Marlow
+ */
+public class TestEntityManagerFactory implements InvocationHandler {
+
+    private static final List<String> invocations =Collections.synchronizedList(new ArrayList<String>());
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+        invocations.add(method.getName());
+        System.out.println("TestEntityManagerFactory method=" + method.getName() + " is returning null");
+        return null;
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestPersistenceProvider.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestPersistenceProvider.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
+
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.spi.PersistenceProvider;
+import javax.persistence.spi.PersistenceUnitInfo;
+import javax.persistence.spi.ProviderUtil;
+
+import org.jboss.as.jpa.container.EntityManagerUnwrappedTargetInvocationHandler;
+
+/**
+ * TestPersistenceProvider
+ *
+ * @author Scott Marlow
+ */
+public class TestPersistenceProvider implements PersistenceProvider {
+
+    @Override
+    public EntityManagerFactory createEntityManagerFactory(String emName, Map map) {
+        return null;
+    }
+
+    @Override
+    public EntityManagerFactory createContainerEntityManagerFactory(PersistenceUnitInfo info, Map map) {
+
+        TestClassTransformer testClassTransformer = new TestClassTransformer();
+        info.addTransformer(testClassTransformer);
+
+        TestEntityManagerFactory testEntityManagerFactory =
+            new TestEntityManagerFactory();
+        Class[] targetInterfaces = javax.persistence.EntityManagerFactory.class.getInterfaces();
+        Class[] proxyInterfaces = new Class[targetInterfaces.length + 1];  // include extra element for extensionClass
+        boolean alreadyHasInterfaceClass = false;
+        for (int interfaceIndex = 0; interfaceIndex < targetInterfaces.length; interfaceIndex++) {
+            Class interfaceClass =  targetInterfaces[interfaceIndex];
+            if (interfaceClass.equals(javax.persistence.EntityManagerFactory.class)) {
+                proxyInterfaces = targetInterfaces;                     // targetInterfaces already has all interfaces
+                alreadyHasInterfaceClass = true;
+                break;
+            }
+            proxyInterfaces[1 + interfaceIndex] = interfaceClass;
+        }
+        if (!alreadyHasInterfaceClass) {
+            proxyInterfaces[0] = javax.persistence.EntityManagerFactory.class;
+        }
+
+        EntityManagerFactory proxyEntityManagerFactory = (EntityManagerFactory)Proxy.newProxyInstance(
+                testEntityManagerFactory.getClass().getClassLoader(), //use the target classloader so the proxy has the same scope
+                proxyInterfaces,
+                testEntityManagerFactory
+        );
+
+        System.out.println("TestPersistenceProvider.createContainerEntityManagerFactory() is returning " + proxyEntityManagerFactory);
+        return proxyEntityManagerFactory;
+    }
+
+    @Override
+    public ProviderUtil getProviderUtil() {
+        return null;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourcelocal/ResourceLocalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourcelocal/ResourceLocalTestCase.java
@@ -55,7 +55,6 @@ public class ResourceLocalTestCase {
                     "    </description>" +
                     "  <non-jta-data-source>java:app/DataSource</non-jta-data-source>" +
                     "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
-                    "<property name=\"jboss.as.jpa.classtransformer\" value=\"false\"/>" +
                     "</properties>" +
                     "  </persistence-unit>" +
                     "</persistence>";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourcelocal/ResourceLocalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourcelocal/ResourceLocalTestCase.java
@@ -55,6 +55,7 @@ public class ResourceLocalTestCase {
                     "    </description>" +
                     "  <non-jta-data-source>java:app/DataSource</non-jta-data-source>" +
                     "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+                    "<property name=\"jboss.as.jpa.classtransformer\" value=\"false\"/>" +
                     "</properties>" +
                     "  </persistence-unit>" +
                     "</persistence>";


### PR DESCRIPTION
1. moved DsXmlDeploymentInstallProcessor() from Phase.INSTALL to occur before POST_MODULE (Phase.FIRST_MODULE_USE) phase.  DsXmlDeploymentParsingProcessor (Phase.PARSE) will still be called before DsXmlDeploymentInstallProcessor (Phase.FIRST_MODULE_USE).
2. Combined processors for deploying a persistence provider with starting a persistence unit.
3. Added two DUP (Phase.FIRST_MODULE_USE,  Phase.INSTALL) for starting/finishing persistence provider/persistence unit deployment that deals with different deployment situations.  If pu property "jboss.as.jpa.classtransformer" is set to false, the persistence unit will not be deployed until Phase.INSTALL.
4.  Also proposed a longer term change to the JPA specification (http://java.net/projects/jpa-spec/lists/jsr338-experts/archive/2012-07/message/15) but I don't expect that to help immediately.  We may come up with a Hibernate extension that uses a two phase approach to handle the PersistenceProvder.createContainerEntityManagerFactory() but that might not be enough initially (it will be hard to restrict DataSource use to the second phase).
5. Applications that use @DataSourceDefinition should also set the pu flag "jboss.as.jpa.classtransformer" to false (since the DataSource will not be available until the Install phase).
6.  Also moved ClassFileTransformerProcessor from POST_MODULE to FIRST_MODULE_USE phase.
