### PR TITLE
[7.1] [AS7-1271] ObjectMessage ClassLoader isolation

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/MyPayload.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/MyPayload.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms.objectmessage;
+
+import java.io.Serializable;
+
+/**
+ * A simple class that is used as the ObjectMessage's payload.
+ * 
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
+ */
+public class MyPayload implements Serializable {
+
+    private static final long serialVersionUID = -8548845020077689464L;
+
+    private final String name;
+
+    public MyPayload(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "MyPayload[name=" + name + "]";
+    }
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/ObjectMessageMDB.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/ObjectMessageMDB.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms.objectmessage;
+
+import javax.annotation.Resource;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+
+/**
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
+ */
+@MessageDriven(name = "ObjectMessageMDB", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "queue/objectMessageQueue"),
+        @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge") })
+public class ObjectMessageMDB implements MessageListener {
+
+    @Resource(mappedName = "java:/ConnectionFactory")
+    private ConnectionFactory connectionFactory;
+
+    public void onMessage(Message rcvMessage) {
+        ObjectMessage msg = null;
+        try {
+            if (rcvMessage instanceof ObjectMessage) {
+                msg = (ObjectMessage) rcvMessage;
+                Object o = msg.getObject();
+                System.out.println("Received object: " + o);
+                MyPayload res = (MyPayload) msg.getObject();
+                System.out.println("Received my resource: " + res);
+
+                Destination replyTo = msg.getJMSReplyTo();
+                Connection connection = connectionFactory.createConnection();
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                MessageProducer producer = session.createProducer(replyTo);
+                producer.send(msg);
+                connection.close();
+            }
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/ObjectMessageServlet.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/ObjectMessageServlet.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms.objectmessage;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.annotation.Resource;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
+ */
+@WebServlet("/objectmessage")
+public class ObjectMessageServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -4858704774886318215L;
+
+    @Resource(mappedName = "java:/ConnectionFactory")
+    private ConnectionFactory connectionFactory;
+
+    @Resource(mappedName = "java:/queue/objectMessageQueue")
+    private Destination destination;
+
+    @Resource(mappedName = "java:/queue/replyToQueue")
+    private Destination replyTo;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        Connection connection = null;
+        resp.setContentType("text/plain");
+        PrintWriter out = resp.getWriter();
+        try {
+            connection = connectionFactory.createConnection();
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            MessageProducer producer = session.createProducer(destination);
+            ObjectMessage message = session.createObjectMessage();
+            MyPayload resource = new MyPayload("This is my payload");
+            message.setObject(resource);
+            message.setJMSReplyTo(replyTo);
+            producer.send(message);
+            out.write("OK");
+        } catch (JMSException e) {
+            e.printStackTrace(out);
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (JMSException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (out != null) {
+                out.close();
+            }
+        }
+    }
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/ObjectMessageTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/ObjectMessageTest.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms.objectmessage;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.naming.Context;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+public class ObjectMessageTest {
+
+    private static final Logger LOGGER = Logger.getLogger(ObjectMessageTest.class);
+
+    @Deployment(name = "ear")
+    public static EnterpriseArchive createArchive() {
+        // the MyPayLoad class that is used both by the servlet and the MDB
+        // is put in a common lib jar
+        JavaArchive commons = ShrinkWrap.create(JavaArchive.class, "objectmessage-commons.jar")
+                .addClass(MyPayload.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        LOGGER.info(commons.toString(true));
+        
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "objectmessage.war")
+                .addClass(ObjectMessageServlet.class)
+                .addAsWebInfResource(ObjectMessageTest.class.getPackage(), "hornetq-jms.xml", "hornetq-jms.xml");
+        LOGGER.info(war.toString(true));
+        
+        JavaArchive mdb = ShrinkWrap.create(JavaArchive.class, "objectmessage-ejb.jar")
+                .addClass(ObjectMessageMDB.class);
+        LOGGER.info(mdb.toString(true));
+        
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "objectmessage.ear")
+                .addAsLibraries(commons)
+                .addAsModules(war, mdb);
+        LOGGER.info(ear.toString(true));
+        return ear;
+    }
+    
+    @ContainerResource
+    private Context context;
+
+    @ArquillianResource
+    @OperateOnDeployment("ear")
+    private URL servletUrl;
+    
+    /**
+     * Validation test for https://issues.jboss.org/browse/AS7-1271
+     */
+    @Test
+    @RunAsClient
+    public void objectMessageWithCustomPayload() throws Exception {
+        invokeServlet();
+        checkMDBHasReplied();
+    }
+
+    /**
+     * If the MDB has received the ObjectMessage witht the payload, it has forwarded the message
+     * to the replyTo queue that we check.
+     */
+    private void checkMDBHasReplied() throws Exception {
+        ConnectionFactory cf = (ConnectionFactory) context.lookup("jms/RemoteConnectionFactory");
+        assertNotNull(cf);
+        Connection connection = null;
+        try {
+            connection = cf.createConnection("guest", "guest");
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Destination replyToQueue = (Destination) context.lookup("queue/replyToQueue");
+            MessageConsumer consumer = session.createConsumer(replyToQueue);
+            connection.start();
+            Message m = consumer.receive(SECONDS.toMillis(1));
+            assertNotNull(m);
+            ObjectMessage message = (ObjectMessage) m;
+            Object payload = message.getObject();
+            assertTrue(payload instanceof MyPayload);
+        } finally {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    private void invokeServlet() throws IOException, ExecutionException, TimeoutException {
+        String res = HttpRequest.get(servletUrl.toExternalForm() + "objectmessage", 4, SECONDS);
+        assertEquals("OK", res);
+    }
+
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/hornetq-jms.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/objectmessage/hornetq-jms.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<messaging-deployment xmlns="urn:jboss:messaging-deployment:1.0">
+    <hornetq-server>
+        <jms-destinations>
+            <jms-queue name="objectMessageQueue">
+                <entry name="/queue/objectMessageQueue"/>
+            </jms-queue>
+            <jms-queue name="replyToQueue">
+                <entry name="/queue/replyToQueue"/>
+                <entry name="java:jboss/exported/queue/replyToQueue"/>
+            </jms-queue>
+        </jms-destinations>
+    </hornetq-server>
+</messaging-deployment>


### PR DESCRIPTION
- add a test to check that a ObjectMessage with a custom serializable
  can properly be produced from a WAR and consumed by a MDB (provided
  the EAR is built appropriately)
