### PR TITLE
Build fails on Spanish OS

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -61,6 +61,7 @@
                             <value>${test.level}</value>
                         </property>
                     </systemProperties>
+                    <argLine>-Duser.region=US -Duser.language=en</argLine>
                     <includes>
                         <include>**/*TestCase.java</include>
                     </includes>
@@ -132,7 +133,7 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
 
     </dependencies>
 

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -44,6 +44,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Duser.region=US -Duser.language=en</argLine>
                     <includes>
                         <include>**/*TestCase.java</include>
                     </includes>


### PR DESCRIPTION
Fixes for issue 2667: force language and region when running JUnit tests for controller and jmx modules. (Change necessary to support builds on Spanish systems).

Edit: newbie mistake on creating issue twice.
