### PR TITLE
AS7-5176 Pass More Metadata from DMR to JMX

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -22,11 +22,9 @@
 package org.jboss.as.jmx.model;
 
 import static javax.management.JMX.DEFAULT_VALUE_FIELD;
-import static javax.management.JMX.LEGAL_VALUES_FIELD;
 import static javax.management.JMX.MAX_VALUE_FIELD;
 import static javax.management.JMX.MIN_VALUE_FIELD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
@@ -49,7 +47,6 @@ import static org.jboss.as.jmx.JmxMessages.MESSAGES;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -250,6 +247,7 @@ public class MBeanInfoFactory {
         }
         List<Property> propertyList = opNode.get(REQUEST_PROPERTIES).asPropertyList();
         List<OpenMBeanParameterInfo> params = new ArrayList<OpenMBeanParameterInfo>(propertyList.size());
+
         for (Property prop : propertyList) {
             ModelNode value = prop.getValue();
             String paramName = NameConverter.convertToCamelCase(prop.getName());
@@ -262,13 +260,8 @@ public class MBeanInfoFactory {
             if (!expressionsAllowed) {
                 Object defaultValue = getIfExists(value, DEFAULT);
                 descriptions.put(DEFAULT_VALUE_FIELD, defaultValue);
-                if (value.has(ALLOWED)) {
-                    List<ModelNode> allowed = value.get(ALLOWED).asList();
-                    descriptions.put(LEGAL_VALUES_FIELD, new HashSet<ModelNode>(allowed));
-                } else {
-                    descriptions.put(MIN_VALUE_FIELD, getIfExistsAsComparable(value, MIN));
-                    descriptions.put(MAX_VALUE_FIELD, getIfExistsAsComparable(value, MAX));
-                }
+                descriptions.put(MIN_VALUE_FIELD, getIfExistsAsComparable(value, MIN));
+                descriptions.put(MAX_VALUE_FIELD, getIfExistsAsComparable(value, MAX));
             }
 
             params.add(
@@ -291,12 +284,12 @@ public class MBeanInfoFactory {
         }
     }
 
-    private Comparable getIfExistsAsComparable(final ModelNode parentNode, final String name) {
+    private Comparable<?> getIfExistsAsComparable(final ModelNode parentNode, final String name) {
         if (parentNode.has(name)) {
             ModelNode defaultNode = parentNode.get(name);
             Object value = converters.fromModelNode(parentNode, defaultNode);
             if (value instanceof Comparable) {
-                return (Comparable) value;
+                return (Comparable<?>) value;
             }
         }
         return null;

--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -22,10 +22,14 @@
 package org.jboss.as.jmx.model;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
@@ -51,6 +55,7 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanNotificationInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.ObjectName;
+import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenMBeanAttributeInfo;
 import javax.management.openmbean.OpenMBeanAttributeInfoSupport;
 import javax.management.openmbean.OpenMBeanConstructorInfo;
@@ -253,8 +258,29 @@ public class MBeanInfoFactory {
                             getDescription(prop.getValue()),
                             converters.convertToMBeanType(value),
                             new ImmutableDescriptor(descriptions)));
+
         }
         return params.toArray(new OpenMBeanParameterInfo[params.size()]);
+    }
+
+    private Object getIfExists(final ModelNode parentNode, final String name) {
+        if (parentNode.has(DEFAULT)) {
+            ModelNode defaultNode = parentNode.get(DEFAULT);
+            return TypeConverter.fromModelNode(parentNode, defaultNode);
+        } else {
+            return null;
+        }
+    }
+
+    private Comparable getIfExistsAsComparable(final ModelNode parentNode, final String name) {
+        if (parentNode.has(name)) {
+            ModelNode defaultNode = parentNode.get(name);
+            Object value = TypeConverter.fromModelNode(parentNode, defaultNode);
+            if (value instanceof Comparable) {
+                return (Comparable) value;
+            }
+        }
+        return null;
     }
 
     private OpenType<?> getReturnType(ModelNode opNode) {

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -26,6 +26,14 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -38,9 +46,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -249,17 +259,35 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(IntOperationWithParams.OPERATION_JMX_NAME, op.getName());
         Assert.assertEquals("Test2", op.getDescription());
         Assert.assertEquals(String.class.getName(), op.getReturnType());
-        Assert.assertEquals(3, op.getSignature().length);
+        Assert.assertEquals(5, op.getSignature().length);
+
         Assert.assertEquals("param1", op.getSignature()[0].getName());
         Assert.assertEquals("Param1", op.getSignature()[0].getDescription());
         Assert.assertEquals(Long.class.getName(), op.getSignature()[0].getType());
+
         Assert.assertEquals("param2", op.getSignature()[1].getName());
         Assert.assertEquals("Param2", op.getSignature()[1].getDescription());
         Assert.assertEquals(String[].class.getName(), op.getSignature()[1].getType());
+
         Assert.assertEquals("param3", op.getSignature()[2].getName());
         Assert.assertEquals("Param3", op.getSignature()[2].getDescription());
         Assert.assertEquals(TabularData.class.getName(), op.getSignature()[2].getType());
         assertMapType(assertCast(OpenMBeanParameterInfo.class, op.getSignature()[2]).getOpenType(), SimpleType.STRING, SimpleType.INTEGER);
+
+        Assert.assertEquals("param4", op.getSignature()[3].getName());
+        Assert.assertEquals("Param4", op.getSignature()[3].getDescription());
+        Assert.assertEquals(Integer.class.getName(), op.getSignature()[3].getType());
+        OpenMBeanParameterInfo parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[3]);
+        Assert.assertEquals(6, parameterInfo.getDefaultValue());
+        Assert.assertEquals(5, parameterInfo.getMinValue());
+        Assert.assertEquals(10, parameterInfo.getMaxValue());
+
+        Assert.assertEquals("param5", op.getSignature()[4].getName());
+        Assert.assertEquals("Param5", op.getSignature()[4].getDescription());
+        Assert.assertEquals(Integer.class.getName(), op.getSignature()[4].getType());
+        parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertEquals(new HashSet<Object>(Arrays.asList(3, 5, 7)), parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());
@@ -792,8 +820,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         String result = assertCast(String.class, connection.invoke(
                 name,
                 IntOperationWithParams.OPERATION_JMX_NAME,
-                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3)},
-                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName()}));
+                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3), 5, 5},
+                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()}));
         Assert.assertEquals("A105", result);
         Assert.assertTrue(IntOperationWithParams.INSTANCE_NO_EXPRESSIONS.invoked);
 
@@ -1473,6 +1501,18 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
                 node.get(REQUEST_PROPERTIES, "param3", VALUE_TYPE).set(ModelType.INT);
                 node.get(REQUEST_PROPERTIES, "param3", DESCRIPTION).set("Param3");
                 node.get(REQUEST_PROPERTIES, "param3", EXPRESSIONS_ALLOWED).set(allowExpressions);
+                node.get(REQUEST_PROPERTIES, "param4", TYPE).set(ModelType.INT);
+                node.get(REQUEST_PROPERTIES, "param4", DESCRIPTION).set("Param4");
+                node.get(REQUEST_PROPERTIES, "param4", EXPRESSIONS_ALLOWED).set(allowExpressions);
+                node.get(REQUEST_PROPERTIES, "param4", DEFAULT).set(6);
+                node.get(REQUEST_PROPERTIES, "param4", MIN).set(5);
+                node.get(REQUEST_PROPERTIES, "param4", MAX).set(10);
+                node.get(REQUEST_PROPERTIES, "param5", TYPE).set(ModelType.INT);
+                node.get(REQUEST_PROPERTIES, "param5", DESCRIPTION).set("Param5");
+                node.get(REQUEST_PROPERTIES, "param5", EXPRESSIONS_ALLOWED).set(allowExpressions);
+                node.get(REQUEST_PROPERTIES, "param5", ALLOWED).add(3);
+                node.get(REQUEST_PROPERTIES, "param5", ALLOWED).add(5);
+                node.get(REQUEST_PROPERTIES, "param5", ALLOWED).add(7);
                 node.get(REPLY_PROPERTIES, TYPE).set(ModelType.STRING);
                 node.get(REPLY_PROPERTIES, DESCRIPTION).set("Return");
                 return node;

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -22,10 +22,6 @@
 package org.jboss.as.jmx;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
@@ -238,7 +234,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -319,7 +315,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -361,7 +357,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -382,17 +378,35 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(IntOperationWithParams.OPERATION_JMX_NAME, op.getName());
         Assert.assertEquals("Test2", op.getDescription());
         Assert.assertEquals(String.class.getName(), op.getReturnType());
-        Assert.assertEquals(3, op.getSignature().length);
+        Assert.assertEquals(5, op.getSignature().length);
+
         Assert.assertEquals("param1", op.getSignature()[0].getName());
         Assert.assertEquals("Param1", op.getSignature()[0].getDescription());
         Assert.assertEquals(String.class.getName(), op.getSignature()[0].getType());
+
         Assert.assertEquals("param2", op.getSignature()[1].getName());
         Assert.assertEquals("Param2", op.getSignature()[1].getDescription());
         Assert.assertEquals(String[].class.getName(), op.getSignature()[1].getType());
+
         Assert.assertEquals("param3", op.getSignature()[2].getName());
         Assert.assertEquals("Param3", op.getSignature()[2].getDescription());
         Assert.assertEquals(TabularData.class.getName(), op.getSignature()[2].getType());
         assertMapType(assertCast(OpenMBeanParameterInfo.class, op.getSignature()[2]).getOpenType(), SimpleType.STRING, SimpleType.STRING);
+
+        Assert.assertEquals("param4", op.getSignature()[3].getName());
+        Assert.assertEquals("Param4", op.getSignature()[3].getDescription());
+        Assert.assertEquals(String.class.getName(), op.getSignature()[3].getType());
+        OpenMBeanParameterInfo parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[3]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getMinValue());
+        Assert.assertNull(parameterInfo.getMaxValue());
+
+        Assert.assertEquals("param5", op.getSignature()[4].getName());
+        Assert.assertEquals("Param5", op.getSignature()[4].getDescription());
+        Assert.assertEquals(String.class.getName(), op.getSignature()[4].getType());
+        parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());
@@ -849,8 +863,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
             connection.invoke(
                 name,
                 IntOperationWithParams.OPERATION_JMX_NAME,
-                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3)},
-                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName()});
+                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3), 5, 5},
+                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()});
             Assert.fail("Should not have been able to invoke method");
         } catch (Exception expected) {
         }
@@ -870,8 +884,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         String result = assertCast(String.class, connection.invoke(
                 name,
                 IntOperationWithParams.OPERATION_JMX_NAME,
-                new Object[] {"${should.not.exist!!!!!:100}", new String[] {"${should.not.exist!!!!!:A}"}, Collections.singletonMap("test", "${should.not.exist!!!!!:3}")},
-                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName()}));
+                new Object[] {"${should.not.exist!!!!!:100}", new String[] {"${should.not.exist!!!!!:A}"}, Collections.singletonMap("test", "${should.not.exist!!!!!:3}"), "${should.not.exist!!!!!:5}", "${should.not.exist!!!!!:5}"},
+                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()}));
         Assert.assertEquals("A105", result);
         Assert.assertTrue(IntOperationWithParams.INSTANCE_EXPRESSIONS.invoked);
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -42,11 +42,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -283,7 +281,6 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(Integer.class.getName(), op.getSignature()[4].getType());
         parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
         Assert.assertNull(parameterInfo.getDefaultValue());
-        Assert.assertEquals(new HashSet<Object>(Arrays.asList(3, 5, 7)), parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -42,9 +42,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -232,7 +234,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -281,6 +283,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(Integer.class.getName(), op.getSignature()[4].getType());
         parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
         Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertEquals(new HashSet<Object>(Arrays.asList(3, 5, 7)), parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());
@@ -312,7 +316,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -354,7 +358,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -402,6 +406,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals("Param5", op.getSignature()[4].getDescription());
         Assert.assertEquals(String.class.getName(), op.getSignature()[4].getType());
         parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getLegalValues());
         Assert.assertNull(parameterInfo.getDefaultValue());
         Assert.assertNull(parameterInfo.getLegalValues());
 


### PR DESCRIPTION
In the DMR model there is a lot information that we could pass to
OpenMBeans but don't. This information includes  default value
(DEFAULT), min value (MIN), max value (MAX) and legal values (ALLOWED).

This change includes:
- pass the following information from DMR to JMX
  - default value
  - min value
  - max value
  - legal values
- add unit tests

https://issues.jboss.org/browse/AS7-5176
