### PR TITLE
[AS7-5232] Path read-only attribute model type

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathResourceDefinition.java
@@ -67,7 +67,7 @@ public abstract class PathResourceDefinition extends SimpleResourceDefinition {
                 .build();
 
     static final SimpleAttributeDefinition READ_ONLY =
-            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.READ_ONLY, ModelType.STRING, true)
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.READ_ONLY, ModelType.BOOLEAN, true)
                 .setDefaultValue(new ModelNode(false))
                 .setStorageRuntime()
                 .build();


### PR DESCRIPTION
- fix Path resource's read-only attribute to be a BOOLEAN (not a STRING)

I have not bumped up any management version for this model change. I don't know if any applies...
