### PR TITLE
AS7-5254 - Upgrade infinispan to 5.2.0.ALPHA2

### DIFF
--- a/build/src/main/resources/modules/org/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/org/infinispan/main/module.xml
@@ -33,6 +33,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river"/>
+        <module name="org.jboss.staxmapper"/>
         <module name="org.jgroups"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <version.org.hibernate3>3.6.6.Final</version.org.hibernate3>
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
         <version.org.hornetq>2.2.18.Final</version.org.hornetq>
-        <version.org.infinispan>5.1.5.FINAL</version.org.infinispan>
+        <version.org.infinispan>5.2.0.ALPHA2</version.org.infinispan>
         <version.org.jacorb>2.3.2.jbossorg-0</version.org.jacorb>
         <version.org.javassist>3.15.0-GA</version.org.javassist>
         <version.org.jdom>1.1.2</version.org.jdom>


### PR DESCRIPTION
It is needed for Capedwarf
