### PR TITLE
[AS7-5269] HornetQ interceptors are not supported

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -310,6 +310,13 @@
     </xs:complexType>
 
     <xs:complexType name="remoting-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Remoting interceptors must be placed into a JBoss module and added as a dependency to org.jboss.as.messaging:main module.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
        <xs:sequence>
           <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
        </xs:sequence>


### PR DESCRIPTION
- set HornetQ remoting interceptors on HornetQ configuration
  before adding the server
- the subsystem expects the interceptors to be put into a
  JBoss Module that depends on org.hornetq:main and is added as
  a dependency of org.jboss.as.messaging:main
