### PR TITLE
[AS7-4925] - Allow log4j appenders to be used as custom handlers.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -349,7 +349,7 @@ public interface LoggingMessages {
     /**
      * A message indicating the handler is attached to the loggers.
      *
-     * @param handlerName the name of the attached handler.
+     * @param handlerName the name of tha attached handler.
      * @param loggers     a collection of the logger names.
      *
      * @return the message.
@@ -366,4 +366,23 @@ public interface LoggingMessages {
      */
     @Message(id = 11559, value = "Cannot add handler (%s) to itself")
     String cannotAddHandlerToSelf(String handlerName);
+
+    /**
+     * An exception indicating a handlers properties cannot be retrieved if it has been closed.
+     *
+     * @return an {@link IllegalStateException} for the error
+     */
+    @Message(id = 11560, value = "Cannot find properties on closed handler.")
+    IllegalStateException handlerClosed();
+
+    /**
+     * An exception indicating a property cannot be set on a closed handler.
+     *
+     * @param name  the name of the property
+     * @param value the value of the property
+     *
+     * @return an {@link IllegalStateException} for the error
+     */
+    @Message(id = Message.INHERIT, value = "Cannot set property '%s' on a closed handler with value '%s'.")
+    IllegalStateException handlerClosed(String name, String value);
 }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerService.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/custom/CustomHandlerService.java
@@ -29,6 +29,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.logging.Handler;
 
+import org.apache.log4j.Appender;
+import org.apache.log4j.WriterAppender;
 import org.jboss.as.logging.handlers.HandlerService;
 import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
@@ -66,12 +68,14 @@ public final class CustomHandlerService extends HandlerService<Handler> {
     @Override
     protected Handler createHandler() throws StartException {
         final Handler handler;
-        final ModuleLoader moduleLoader = Module.forClass(CustomHandlerService.class).getModuleLoader();
+        final ModuleLoader moduleLoader = ModuleLoader.forClass(CustomHandlerService.class);
         final ModuleIdentifier id = ModuleIdentifier.create(moduleName);
         try {
             final Class<?> handlerClass = Class.forName(className, false, moduleLoader.loadModule(id).getClassLoader());
             if (Handler.class.isAssignableFrom(handlerClass)) {
                 handler = (Handler) handlerClass.newInstance();
+            } else if (Appender.class.isAssignableFrom(handlerClass)) {
+                handler = new Log4jAppenderHandler((Appender) handlerClass.newInstance(), true);
             } else {
                 throw MESSAGES.invalidType(className, Handler.class);
             }

--- a/logging/src/main/java/org/jboss/as/logging/handlers/custom/Log4jAppenderHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/custom/Log4jAppenderHandler.java
@@ -1,0 +1,198 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.handlers.custom;
+
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.logging.Formatter;
+
+import org.apache.log4j.Appender;
+import org.apache.log4j.Category;
+import org.apache.log4j.JBossLevelMapping;
+import org.apache.log4j.Layout;
+import org.apache.log4j.spi.LocationInfo;
+import org.apache.log4j.spi.LoggingEvent;
+import org.jboss.logmanager.ExtHandler;
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * Wraps a {@link Appender log4j appender} to a {@link ExtHandler handler}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class Log4jAppenderHandler extends ExtHandler {
+    private volatile Appender appender = null;
+    private final boolean applyLayout;
+
+    private static final AtomicReferenceFieldUpdater<Log4jAppenderHandler, Appender> appenderUpdater = AtomicReferenceFieldUpdater.newUpdater(Log4jAppenderHandler.class, Appender.class, "appender");
+
+    /**
+     * Construct a new instance.
+     *
+     * @param appender the appender to delegate to
+     */
+    public Log4jAppenderHandler(final Appender appender) {
+        this(appender, false);
+    }
+
+    /**
+     * Construct a new instance, possibly applying a {@code Layout} to the given appender instance.
+     *
+     * @param appender    the appender to delegate to
+     * @param applyLayout {@code true} to apply an emulated layout, {@code false} otherwise
+     */
+    public Log4jAppenderHandler(final Appender appender, final boolean applyLayout) {
+        this.applyLayout = applyLayout;
+        if (applyLayout) {
+            appender.setLayout(null);
+        }
+        appenderUpdater.set(this, appender);
+    }
+
+    /**
+     * Get the log4j appender.
+     *
+     * @return the log4j appender
+     */
+    public Appender getAppender() {
+        return appender;
+    }
+
+    /**
+     * Set the Log4j appender.
+     *
+     * @param appender the log4j appender
+     */
+    public void setAppender(final Appender appender) {
+        checkAccess(this);
+        if (applyLayout && appender != null) {
+            final Formatter formatter = getFormatter();
+            appender.setLayout(formatter == null ? null : new FormatterLayout(formatter));
+        }
+        appenderUpdater.set(this, appender);
+    }
+
+    @Override
+    public void setFormatter(final Formatter newFormatter) throws SecurityException {
+        if (applyLayout) {
+            final Appender appender = this.appender;
+            if (appender != null) {
+                appender.setLayout(new FormatterLayout(newFormatter));
+            }
+        }
+        super.setFormatter(newFormatter);
+    }
+
+    @Override
+    protected void doPublish(final ExtLogRecord record) {
+        final Appender appender = this.appender;
+        if (appender == null) {
+            throw new IllegalStateException("Appender is closed");
+        }
+        final LoggingEvent event = new LoggingEvent(record, DummyCategory.of(record.getLoggerName()));
+        appender.doAppend(event);
+        super.doPublish(record);
+    }
+
+    @Override
+    public void flush() {
+        // Do nothing (there is no equivalent method on log4j appenders).
+    }
+
+    @Override
+    public void close() throws SecurityException {
+        checkAccess(this);
+        final Appender appender = appenderUpdater.getAndSet(this, null);
+        if (appender != null) {
+            appender.close();
+        }
+    }
+
+    static ExtLogRecord getLogRecordFor(LoggingEvent event) {
+        final ExtLogRecord rec = (ExtLogRecord) event.getProperties().get("org.jboss.logmanager.record");
+        if (rec != null) {
+            return rec;
+        }
+        final ExtLogRecord newRecord = new ExtLogRecord(JBossLevelMapping.getLevelFor(event.getLevel()), (String) event.getMessage(), event.getFQNOfLoggerClass());
+        newRecord.setLoggerName(event.getLoggerName());
+        newRecord.setMillis(event.getTimeStamp());
+        newRecord.setThreadName(event.getThreadName());
+        newRecord.setThrown(event.getThrowableInformation().getThrowable());
+        newRecord.setNdc(event.getNDC());
+        if (event.locationInformationExists()) {
+            final LocationInfo locationInfo = event.getLocationInformation();
+            newRecord.setSourceClassName(locationInfo.getClassName());
+            newRecord.setSourceFileName(locationInfo.getFileName());
+            newRecord.setSourceLineNumber(Integer.parseInt(locationInfo.getLineNumber()));
+            newRecord.setSourceMethodName(locationInfo.getMethodName());
+        }
+        return newRecord;
+    }
+
+    /**
+     * Dummy category for the logging event
+     */
+    private static final class DummyCategory extends Category {
+
+        static DummyCategory of(final String name) {
+            return new DummyCategory(name);
+        }
+
+        protected DummyCategory(String name) {
+            super(name);
+        }
+    }
+
+    /**
+     * An emulator for log4j {@code Layout}s.
+     *
+     * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+     */
+    public final class FormatterLayout extends Layout {
+        private final Formatter formatter;
+
+        /**
+         * Construct a new instance.
+         *
+         * @param formatter the formatter to delegate to
+         */
+        public FormatterLayout(final Formatter formatter) {
+            this.formatter = formatter;
+        }
+
+        @Override
+        public String format(final LoggingEvent event) {
+            return formatter.format(getLogRecordFor(event));
+        }
+
+        @Override
+        public boolean ignoresThrowable() {
+            // just be safe
+            return false;
+        }
+
+        @Override
+        public void activateOptions() {
+            // options are always activated already
+        }
+    }
+}

--- a/logging/src/test/java/org/jboss/as/logging/handlers/custom/Log4jAppenderTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/handlers/custom/Log4jAppenderTestCase.java
@@ -1,0 +1,132 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.handlers.custom;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Layout;
+import org.apache.log4j.spi.LoggingEvent;
+import org.jboss.logging.Logger;
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Log4jAppenderTestCase {
+
+    private static final String CATEGORY = Log4jAppenderTestCase.class.getPackage().getName();
+    private static final String DFT_MESSAGE = "This is a test message";
+
+    private final TestAppender appender = TestAppender.INSTANCE;
+    private final Log4jAppenderHandler handler = new Log4jAppenderHandler(appender, true);
+    private final org.jboss.logmanager.Logger lmLogger = org.jboss.logmanager.Logger.getLogger(CATEGORY);
+    private final Logger logger = Logger.getLogger(CATEGORY);
+
+    @Before
+    public void setUp() {
+        handler.setAppender(appender);
+        handler.setLevel(Level.INFO);
+        lmLogger.addHandler(handler);
+        lmLogger.setLevel(Level.INFO);
+    }
+
+    @After
+    public void tearDown() {
+        appender.close();
+        handler.close();
+        lmLogger.removeHandler(handler);
+    }
+
+
+    @Test
+    public void formatTest() throws Exception {
+        final String pattern = "fmt: %s";
+        final PatternFormatter formatter = new PatternFormatter(pattern);
+        handler.setFormatter(formatter);
+        logger.info(DFT_MESSAGE);
+        Assert.assertEquals(String.format(pattern, DFT_MESSAGE), appender.messages.get(0));
+    }
+
+    @Test
+    public void levelTest() throws Exception {
+        lmLogger.setLevel(Level.ALL);
+
+        // Should be 3 messages
+        handler.setLevel(Level.ALL);
+        logger.info(DFT_MESSAGE);
+        logger.error(DFT_MESSAGE);
+        logger.trace(DFT_MESSAGE);
+        Assert.assertEquals(3, appender.counter);
+
+        // Should be 2 messages
+        appender.close();
+        handler.setLevel(Level.INFO);
+        logger.info(DFT_MESSAGE);
+        logger.error(DFT_MESSAGE);
+        logger.trace(DFT_MESSAGE);
+        Assert.assertEquals(2, appender.counter);
+
+        // Should be 0 messages
+        appender.close();
+        handler.setLevel(Level.OFF);
+        logger.info(DFT_MESSAGE);
+        logger.error(DFT_MESSAGE);
+        logger.trace(DFT_MESSAGE);
+        Assert.assertEquals(0, appender.counter);
+    }
+
+    static class TestAppender extends AppenderSkeleton {
+        static TestAppender INSTANCE = new TestAppender();
+        int counter = 0;
+        final List<String> messages = new ArrayList<String>();
+
+        @Override
+        protected void append(final LoggingEvent event) {
+            counter++;
+            final Layout layout = getLayout();
+            if (layout != null) {
+                messages.add(layout.format(event));
+            } else {
+                messages.add(event.getLogRecord().getFormattedMessage());
+            }
+        }
+
+        @Override
+        public void close() {
+            counter = 0;
+            messages.clear();
+        }
+
+        @Override
+        public boolean requiresLayout() {
+            return false;
+        }
+    }
+}

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -59,6 +59,12 @@
         </properties>
     </custom-handler>
 
+    <custom-handler name="log4jAppender" module="org.apache.log4j" class="org.apache.log4j.ConsoleAppender">
+        <properties>
+            <property name="target" value="System.out"/>
+        </properties>
+    </custom-handler>
+
     <periodic-rotating-file-handler name="FILE">
         <encoding value="UTF-8" />
         <filter>


### PR DESCRIPTION
Allows log4j appenders to be used as custom handlers. A separate pull request for 7.2.x will be done with some other logging changes.
