### PR TITLE
AS7-5038 JPA is missing a dependency on javax.servlet, which is referenced from org.jboss.as.jpa.interceptor.WebNonTxEmCloserValve.

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/jpa/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jpa/main/module.xml
@@ -37,6 +37,7 @@
         <module name="javax.ejb.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.resource.api"/>
+        <module name="javax.servlet.api" optional="true"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
         <module name="org.apache.commons.collections"/>


### PR DESCRIPTION
I'll submit a 7.1 merge in a minute
