### PR TITLE
Configadmin transformers

### DIFF
--- a/configadmin/src/main/java/org/jboss/as/configadmin/ConfigAdminMessages.java
+++ b/configadmin/src/main/java/org/jboss/as/configadmin/ConfigAdminMessages.java
@@ -38,5 +38,4 @@ import org.jboss.logging.Messages;
 public interface ConfigAdminMessages {
 
     ConfigAdminMessages MESSAGES = Messages.getBundle(ConfigAdminMessages.class);
-
 }


### PR DESCRIPTION
Add missing transformers for configadmin from current 1.0.1 to 1.0.0 used in 7.1.2.Final.
The model is the same but 1.0.1 adds an 'update' operation, make the transformers throw an error if that is attempted used for 1.0.1
