### PR TITLE
JBPAPP-9094 fix for branch 7.1

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/EeMessages.java
+++ b/ee/src/main/java/org/jboss/as/ee/EeMessages.java
@@ -875,4 +875,10 @@ public interface EeMessages {
 
     @Message(id = 16700, value = "Failed to load jboss.properties")
     DeploymentUnitProcessingException failedToLoadJbossProperties(@Cause IOException e);
+
+    @Message(id = 16702, value = "library-directory of value / is not supported")
+    DeploymentUnitProcessingException rootAsLibraryDirectory();
+
+    @Message(id = 16703, value = "Module may not be a child of the EAR's library directory. Library directory: %s, module file name: %s")
+    DeploymentUnitProcessingException earModuleChildOfLibraryDirectory(String libraryDirectory, String moduleFileName);
 }

--- a/ee/src/main/java/org/jboss/as/ee/structure/EarStructureProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EarStructureProcessor.java
@@ -102,6 +102,9 @@ public class EarStructureProcessor implements DeploymentUnitProcessor {
         if (earMetaData != null) {
             final String xmlLibDirName = earMetaData.getLibraryDirectory();
             if (xmlLibDirName != null) {
+                if (xmlLibDirName.length() == 1 && xmlLibDirName.charAt(0) == '/') {
+                    throw MESSAGES.rootAsLibraryDirectory();
+                }
                 libDirName = xmlLibDirName;
             }
         }
@@ -168,6 +171,14 @@ public class EarStructureProcessor implements DeploymentUnitProcessor {
                         throw MESSAGES.cannotProcessEarModule(virtualFile, module.getFileName());
                     }
 
+                    if (libDir != null) {
+                        VirtualFile moduleParentFile = moduleFile.getParent();
+                        if (moduleParentFile != null) {
+                            if (libDir.equals(moduleParentFile)) {
+                                throw MESSAGES.earModuleChildOfLibraryDirectory(libDirName, module.getFileName());
+                            }
+                        }
+                    }
 
                     // maintain this in a collection of subdeployment virtual files, to be used later
                     subDeploymentFiles.add(moduleFile);


### PR DESCRIPTION
Throws deployment errors if library-directory value is not supported, and/or has modules as childs.
