### PR TITLE
Rework reject expression values transformer

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
+
 import javax.xml.namespace.QName;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
@@ -2428,7 +2429,7 @@ public interface ControllerMessages {
     @Message(id = 14854, value="Path '%s' is read-only; it cannot be modified")
     OperationFailedException cannotModifyReadOnlyPath(String pathName);
     /**
-     * An exception indicating the {@code name} may not be {@link ModelType#EXPRESSION}.
+     * An operation failure-description indicating the {@code name} may not be {@link ModelType#EXPRESSION}.
      *
      * @param name the name of the attribute or parameter value that cannot be an expression
      *
@@ -2512,4 +2513,11 @@ public interface ControllerMessages {
 
     @Message(id = 14873, value = "Model contains fields that are not known in definition, fields: %s, path: %s")
     RuntimeException modelFieldsNotKnown(Set<String> fields, PathAddress address);
+
+    @Message(id = 14874, value = "The operation request properties %s may not be ModelType.EXPRESSION in model version: %s")
+    String expressionNotAllowedForRequestProperties(List<String> attributeNames, ModelVersion modelVersion);
+
+    @Message(id = 14875, value = "%s may not be ModelType.EXPRESSION in model version: %s")
+    String expressionNotAllowed(String name, ModelVersion modelVersion);
+
 }

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -463,9 +463,7 @@ public abstract class AbstractSubsystemTest {
         legacyModel = legacyModel.require(SUBSYSTEM);
         legacyModel = legacyModel.require(mainSubsystemName);
 
-
-        ModelNode transformed = kernelServices.readTransformedModel(modelVersion).get(SUBSYSTEM, mainSubsystemName);
-        compare(legacyModel, transformed, true);
+        checkSubsystemTransformer(kernelServices, legacyModel, modelVersion);
     }
 
     /**

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -72,6 +72,7 @@ class TestModelControllerService extends AbstractControllerService {
     private final Extension mainExtension;
     private final boolean validateOps;
     private volatile ManagementResourceRegistration rootRegistration;
+    private volatile Resource resource;
     private volatile Exception error;
 
     TestModelControllerService(final Extension mainExtension, final ControllerInitializer controllerInitializer,
@@ -160,5 +161,9 @@ class TestModelControllerService extends AbstractControllerService {
 
     public ManagementResourceRegistration getRootRegistration() {
         return rootRegistration;
+    }
+
+    public Resource getRootResource() {
+        return resource;
     }
 }

--- a/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
@@ -21,8 +21,6 @@
 */
 package org.jboss.as.txn;
 
-import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.OperationFailedException;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -31,6 +29,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
@@ -38,8 +41,6 @@ import org.jboss.as.txn.subsystem.TransactionExtension;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  *
@@ -83,19 +84,15 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
         operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
         operation.get(OP_ADDR).add(SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME);
         operation.get(NAME).set("status-socket-binding");
-        operation.get(VALUE).set("${org.jboss.test:default-socket-binding}");
+        operation.get(VALUE).setExpression("${org.jboss.test:default-socket-binding}");
 
         final ModelNode mainResult = mainServices.executeOperation(operation);
         Assert.assertTrue(SUCCESS.equals(mainResult.get(OUTCOME).asString()));
 
-        try {
-            mainServices.transformOperation(modelVersion, operation);
-            // legacyServices.executeOperation(operation); would actually work - however it does not understand the expr
-            // so we need to reject the expression on the DC already
-            Assert.fail("should reject the expression");
-        } catch (OperationFailedException e) {
-            // OK
-        }
+        TransformedOperation transformedOperation = mainServices.transformOperation(modelVersion, operation);
+        ModelNode result = mainServices.executeOperation(modelVersion, transformedOperation);
+        System.out.println(result);
+        System.out.println(legacyServices.readWholeModel());
     }
 
 }

--- a/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
@@ -21,6 +21,8 @@
 */
 package org.jboss.as.txn;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -32,6 +34,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRI
 
 import java.io.IOException;
 
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
@@ -91,8 +94,8 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         TransformedOperation transformedOperation = mainServices.transformOperation(modelVersion, operation);
         ModelNode result = mainServices.executeOperation(modelVersion, transformedOperation);
-        System.out.println(result);
-        System.out.println(legacyServices.readWholeModel());
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.get(FAILURE_DESCRIPTION).asString().contains(ControllerMessages.MESSAGES.expressionNotAllowed("status-socket-binding", modelVersion)));
     }
 
 }


### PR DESCRIPTION
It now checks for failure on processing the result of operations, and appends a nicer error message to the failure-description if expressions were used for an attribute/parameter not allowing it in the legacy model.
