### PR TITLE
[master] Make web subsystem operation transformers fail on the way out

### DIFF
--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -476,9 +476,6 @@ public abstract class AbstractSubsystemTest {
      * @return the whole model of the legacy controller
      */
     protected ModelNode checkSubsystemModelTransformation(KernelServices kernelServices, ModelVersion modelVersion) throws IOException {
-        System.out.println(kernelServices.readWholeModel());
-
-
         KernelServices legacy = kernelServices.getLegacyServices(modelVersion);
         ModelNode legacyModel = legacy.readWholeModel();
         ModelNode legacySubsystem = legacyModel.require(SUBSYSTEM);

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/KernelServices.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/KernelServices.java
@@ -64,12 +64,15 @@ public class KernelServices {
     private final Map<ModelVersion, KernelServices> legacyServices;
     private final ExtensionRegistry extensionRegistry;
     private final ModelVersion legacyModelVersion;
+    private final boolean successfulBoot;
+    private final Throwable bootError;
+
 
     private static final AtomicInteger counter = new AtomicInteger();
 
 
     private KernelServices(ServiceContainer container, ModelController controller, StringConfigurationPersister persister, ManagementResourceRegistration rootRegistration,
-            OperationValidator operationValidator, String mainSubsystemName, ExtensionRegistry extensionRegistry, ModelVersion legacyModelVersion) {
+            OperationValidator operationValidator, String mainSubsystemName, ExtensionRegistry extensionRegistry, ModelVersion legacyModelVersion, boolean successfulBoot, Throwable bootError) {
         this.container = container;
         this.controller = controller;
         this.persister = persister;
@@ -79,6 +82,8 @@ public class KernelServices {
         this.legacyServices = legacyModelVersion != null ? null : new HashMap<ModelVersion, KernelServices>();
         this.extensionRegistry = extensionRegistry;
         this.legacyModelVersion = legacyModelVersion;
+        this.successfulBoot = successfulBoot;
+        this.bootError = bootError;
     }
 
     static KernelServices create(String mainSubsystemName, AdditionalInitialization additionalInit,
@@ -119,9 +124,26 @@ public class KernelServices {
         processState.setRunning();
 
         KernelServices kernelServices = new KernelServices(container, controller, persister, svc.getRootRegistration(),
-                new OperationValidator(svc.getRootRegistration()), mainSubsystemName, controllerExtensionRegistry, legacyModelVersion);
+                new OperationValidator(svc.getRootRegistration()), mainSubsystemName, controllerExtensionRegistry, legacyModelVersion, svc.isSuccessfulBoot(), svc.getBootError());
 
         return kernelServices;
+    }
+
+
+    /**
+     * Get whether the controller booted successfully
+     * @return true if the controller booted successfully
+     */
+    public boolean isSuccessfulBoot() {
+        return successfulBoot;
+    }
+
+    /**
+     * Get any errors thrown on boot
+     * @return the boot error
+     */
+    public Throwable getBootError() {
+        return bootError;
     }
 
     /**

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -73,6 +73,7 @@ class TestModelControllerService extends AbstractControllerService {
     private final boolean validateOps;
     private volatile ManagementResourceRegistration rootRegistration;
     private volatile Exception error;
+    private volatile boolean bootSuccess;
 
     TestModelControllerService(final Extension mainExtension, final ControllerInitializer controllerInitializer,
                            final AdditionalInitialization additionalPreStep, final ExtensionRegistry extensionRegistry,
@@ -123,7 +124,8 @@ class TestModelControllerService extends AbstractControllerService {
             if (validateOps) {
                 new OperationValidator(rootRegistration).validateOperations(bootOperations);
             }
-            return super.boot(persister.getBootOperations(), rollbackOnRuntimeFailure);
+            bootSuccess = super.boot(persister.getBootOperations(), rollbackOnRuntimeFailure);
+            return bootSuccess;
         } catch (Exception e) {
             error = e;
         } catch (Throwable t) {
@@ -133,6 +135,14 @@ class TestModelControllerService extends AbstractControllerService {
             latch.countDown();
         }
         return false;
+    }
+
+    protected boolean isSuccessfulBoot() {
+        return bootSuccess;
+    }
+
+    public Throwable getBootError() {
+        return error;
     }
 
     @Override

--- a/web/src/main/java/org/jboss/as/web/WebMessages.java
+++ b/web/src/main/java/org/jboss/as/web/WebMessages.java
@@ -24,7 +24,6 @@ package org.jboss.as.web;
 
 import java.util.concurrent.TimeoutException;
 
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Cause;
@@ -352,5 +351,5 @@ public interface WebMessages {
     TimeoutException timeoutContextActivation(ServiceName service);
 
     @Message(id = 18101, value = "Version 1.1.0 of the web subsystem had a bug meaning referencing virtual-server from connector is not supported. See https://issues.jboss.org/browse/JBPAPP-9314")
-    OperationFailedException transformationVersion_1_1_0_JBPAPP_9314();
+    String transformationVersion_1_1_0_JBPAPP_9314();
 }


### PR DESCRIPTION
They previously failed fast, which from discussions sounds like the wrong thing to do.
Now instead they fail on return.
