### PR TITLE
[AS7-5349] Upgrade HornetQ to 2.2.19.Final

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServices.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServices.java
@@ -192,7 +192,7 @@ public class JMSServices {
         create(BLOCK_ON_ACK, "blockOnAcknowledge", true),
         create(BLOCK_ON_DURABLE_SEND, "blockOnDurableSend", true),
         create(BLOCK_ON_NON_DURABLE_SEND, "blockOnNonDurableSend", true),
-        create(CACHE_LARGE_MESSAGE_CLIENT, "cacheLargeMessageClient", false), // FIXME HORNETQ-948
+        create(CACHE_LARGE_MESSAGE_CLIENT, "cacheLargeMessagesClient", true),
         create(CALL_TIMEOUT, "callTimeout", true),
         create(CLIENT_FAILURE_CHECK_PERIOD, "clientFailureCheckPeriod", true),
         create(CLIENT_ID, "clientID", true),
@@ -203,17 +203,17 @@ public class JMSServices {
         create(DISCOVERY_GROUP_NAME, null, false),
         create(DISCOVERY_INITIAL_WAIT_TIMEOUT, null, false), // Not used since messaging 1.2, we keep it for compatibility sake
         create(DUPS_OK_BATCH_SIZE, "dupsOKBatchSize", true),
-        create(FAILOVER_ON_INITIAL_CONNECTION, "failoverOnInitialConnection", false), // FIXME HORNETQ-948
+        create(FAILOVER_ON_INITIAL_CONNECTION, "failoverOnInitialConnection", true),
         create(FAILOVER_ON_SERVER_SHUTDOWN, "failoverOnServerShutdown", false), // TODO HornetQResourceAdapter does not have this method
-        create(GROUP_ID, "groupID", false), // FIXME HORNETQ-948
+        create(GROUP_ID, "groupID", true),
         create(HA, "HA", true),
         create(LOAD_BALANCING_CLASS_NAME, "connectionLoadBalancingPolicyClassName", true),
-        create(MAX_RETRY_INTERVAL, "maxRetryInterval", false), // FIXME HORNETQ-948
+        create(MAX_RETRY_INTERVAL, "maxRetryInterval", true),
         create(MIN_LARGE_MESSAGE_SIZE, "minLargeMessageSize", true),
         create(PCF_PASSWORD, "password", true),
         create(PRE_ACK, "preAcknowledge", true),
         create(PRODUCER_MAX_RATE, "producerMaxRate", true),
-        create(PRODUCER_WINDOW_SIZE, "producerWindowSize", false),  // FIXME HORNETQ-948
+        create(PRODUCER_WINDOW_SIZE, "producerWindowSize", true),
         create(CONNECTION_FACTORY_RECONNECT_ATTEMPTS, RECONNECT_ATTEMPTS_PROP_NAME, true),
         create(RETRY_INTERVAL, "retryInterval", true),
         create(RETRY_INTERVAL_MULTIPLIER, "retryIntervalMultiplier", true),

--- a/messaging/src/test/java/org/jboss/as/messaging/jms/test/PooledConnectionFactoryAttributesTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/jms/test/PooledConnectionFactoryAttributesTestCase.java
@@ -34,7 +34,12 @@ public class PooledConnectionFactoryAttributesTestCase {
         UNSUPPORTED_HORNETQ_RA_PROPERTIES.add(PooledConnectionFactoryService.CONNECTOR_CLASSNAME);
         UNSUPPORTED_HORNETQ_RA_PROPERTIES.add(PooledConnectionFactoryService.TRANSACTION_MANAGER_LOCATOR_CLASS);
         UNSUPPORTED_HORNETQ_RA_PROPERTIES.add(PooledConnectionFactoryService.TRANSACTION_MANAGER_LOCATOR_METHOD);
+        UNSUPPORTED_HORNETQ_RA_PROPERTIES.add("compressLargeMessage");
+        UNSUPPORTED_HORNETQ_RA_PROPERTIES.add("initialConnectAttempts");
+        UNSUPPORTED_HORNETQ_RA_PROPERTIES.add("initialMessagePacketSize");
         UNSUPPORTED_HORNETQ_RA_PROPERTIES.add("managedConnectionFactory");
+        UNSUPPORTED_HORNETQ_RA_PROPERTIES.add("passwordCodec");
+        UNSUPPORTED_HORNETQ_RA_PROPERTIES.add("useMaskedPassword");
 
         KNOWN_ATTRIBUTES = new TreeSet<String>();
         // these are supported but it is not found by JavaBeans introspector because of the type

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         <version.org.hibernate3>3.6.6.Final</version.org.hibernate3>
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
-        <version.org.hornetq>2.2.18.Final</version.org.hornetq>
+        <version.org.hornetq>2.2.19.Final</version.org.hornetq>
         <version.org.infinispan>5.1.5.FINAL</version.org.infinispan>
         <version.org.jacorb>2.3.2.jbossorg-0</version.org.jacorb>
         <version.org.javassist>3.15.0-GA</version.org.javassist>


### PR DESCRIPTION
- add compress-large-messages attribute to pooled-connection-factory and connection-factory
  to be up to date with HornetQ configuration API

this PR does not handle resource transformation for this new attribute, I'll open another PR when https://github.com/jbossas/jboss-as/pull/2841 (which adds resource transformation to messaging subsystem) is merged.
