### PR TITLE
Fixed typo: get grouping handler config correctly

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerAdd.java
@@ -98,7 +98,7 @@ public class GroupingHandlerAdd implements OperationStepHandler, DescriptionProv
 
     static void addGroupingHandlerConfig(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
         if (model.hasDefined(CommonAttributes.GROUPING_HANDLER)) {
-            Property prop = model.get(CommonAttributes.BROADCAST_GROUP).asProperty();
+            Property prop = model.get(CommonAttributes.GROUPING_HANDLER).asProperty();
             configuration.setGroupingHandlerConfiguration(createGroupingHandlerConfiguration(context, prop.getName(), prop.getValue()));
         }
     }


### PR DESCRIPTION
Currently the broadcast group configuration is used for the grouping handler, causing an error that the "type" is not provided even though it is.
