### PR TITLE
security role attributes have no default value

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/SecurityRoleDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/SecurityRoleDefinition.java
@@ -62,7 +62,6 @@ public class SecurityRoleDefinition extends SimpleResourceDefinition {
     private static SimpleAttributeDefinition create(final String name, final String xmlName) {
         return SimpleAttributeDefinitionBuilder.create(name, BOOLEAN)
                 .setXmlName(xmlName)
-                .setDefaultValue(new ModelNode().set(false))
                 .setFlags(RESTART_NONE)
                 .build();
     }


### PR DESCRIPTION
I added a default value to them when I converted the messaging subsystem
resources but they don't have default value (as they are not nillable)
