### PR TITLE
[AS7-1459] Add debug flag in the --help output and make the standalone

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -3,14 +3,15 @@ rem -------------------------------------------------------------------------
 rem JBoss Bootstrap Script for Windows
 rem -------------------------------------------------------------------------
 
-rem Use --debug or -d to activate debug mode with an optional argument to specify the port
-rem Usage : standalone.bat -d
+rem Use --debug to activate debug mode with an optional argument to specify the port
+rem Usage : standalone.bat --debug
 rem         standalone.bat --debug 9797
 
 rem By default debug mode is disable.
 set DEBUG_MODE=false
 set DEBUG_PORT=8787
-set SERVER_OPTS=
+rem Set to all parameters by default
+set SERVER_OPTS=%*
 
 rem Get the program name before using shift as the command modify the variable ~nx0
 if "%OS%" == "Windows_NT" (
@@ -19,16 +20,24 @@ if "%OS%" == "Windows_NT" (
   set "PROGNAME=standalone.bat"
 )
 
+@if not "%ECHO%" == ""  echo %ECHO%
+@if "%OS%" == "Windows_NT" setlocal
+
+if "%OS%" == "Windows_NT" (
+  set "DIRNAME=%~dp0%"
+) else (
+  set DIRNAME=.\
+)
+
 rem Read command-line args.
 :READ-ARGS
 if "%1" == "" ( 
-   goto MAIN 
-) else if "%1" == "-d" (
-   goto READ-DEBUG-PORT
+   goto MAIN
 ) else if "%1" == "--debug" (
    goto READ-DEBUG-PORT
 ) else (
-   set SERVER_OPTS=%SERVER_OPTS% %1
+   rem This doesn't work as Windows splits on = and spaces by default
+   rem set SERVER_OPTS=%SERVER_OPTS% %1
    shift
    goto READ-ARGS
 )
@@ -47,14 +56,6 @@ if not "x%DEBUG_ARG" == "x" (
 
 :MAIN
 rem $Id$
-
-@if not "%ECHO%" == ""  echo %ECHO%
-@if "%OS%" == "Windows_NT" setlocal
-
-if "%OS%" == "Windows_NT" (
-  set "DIRNAME=%~dp0%"
-) else (
-  set DIRNAME=.\
 )
 
 if "%DEBUG_MODE%" == "true" (

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -10,21 +10,39 @@ rem         standalone.bat --debug 9797
 rem By default debug mode is disable.
 set DEBUG_MODE=false
 set DEBUG_PORT=8787
+set SERVER_OPTS=
+
+rem Get the program name before using shift as the command modify the variable ~nx0
+if "%OS%" == "Windows_NT" (
+  set "PROGNAME=%~nx0%"
+) else (
+  set "PROGNAME=standalone.bat"
+)
 
 rem Read command-line args.
 :READ-ARGS
 if "%1" == "" ( 
    goto MAIN 
-) else if "%1" == "--debug" or "%1" == "-d" (
-   set "DEBUG_MODE=true"
-   shift
+) else if "%1" == "-d" (
    goto READ-DEBUG-PORT
+) else if "%1" == "--debug" (
+   goto READ-DEBUG-PORT
+) else (
+   set SERVER_OPTS=%SERVER_OPTS% %1
+   shift
+   goto READ-ARGS
 )
 
 :READ-DEBUG-PORT
-if not "x%1" == "x" (
-   set "DEBUG_PORT=%1"
-   goto MAIN
+set "DEBUG_MODE=true"
+set DEBUG_ARG="%2"
+if not "x%DEBUG_ARG" == "x" (
+   if x%DEBUG_ARG:-=%==x%DEBUG_ARG% (
+      shift
+      set DEBUG_PORT=%DEBUG_ARG%
+   )
+   shift
+   goto READ-ARGS
 )
 
 :MAIN
@@ -77,12 +95,6 @@ if exist "%STANDALONE_CONF%" (
 )
 
 set DIRNAME=
-
-if "%OS%" == "Windows_NT" (
-  set "PROGNAME=%~nx0%"
-) else (
-  set "PROGNAME=standalone.bat"
-)
 
 rem Setup JBoss specific properties
 set JAVA_OPTS=-Dprogram.name=%PROGNAME% %JAVA_OPTS%
@@ -182,7 +194,7 @@ echo.
     -jaxpmodule "javax.xml.jaxp-provider" ^
      org.jboss.as.standalone ^
     -Djboss.home.dir="%JBOSS_HOME%" ^
-     %*
+     %SERVER_OPTS%
 
 if ERRORLEVEL 10 goto RESTART
 

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Use --debug or -d to activate debug mode with an optional argument to specify the port.
-# Usage : standalone.bat -d
+# Use --debug to activate debug mode with an optional argument to specify the port.
+# Usage : standalone.bat --debug
 #         standalone.bat --debug 9797
 
 # By default debug mode is disable.
@@ -11,7 +11,7 @@ SERVER_OPTS=""
 while [ "$#" -gt 0 ]
 do
     case "$1" in
-      -d|--debug)
+      --debug)
           DEBUG_MODE=true
           shift
           if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -7,21 +7,25 @@
 # By default debug mode is disable.
 DEBUG_MODE=false
 DEBUG_PORT="8787"
+SERVER_OPTS=""
 while [ "$#" -gt 0 ]
 do
     case "$1" in
       -d|--debug)
           DEBUG_MODE=true
           shift
-          if [ -n "$1" ]; then
+          if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then
               DEBUG_PORT=$1
+          else
+              SERVER_OPTS="$SERVER_OPTS $1"
           fi
           ;;
       --)
           shift 
           break;;
       *)
-          break;;
+          SERVER_OPTS="$SERVER_OPTS $1"
+          ;;
     esac
     shift
 done
@@ -148,9 +152,9 @@ fi
 
 if $linux; then
     # consolidate the server and command line opts
-    SERVER_OPTS="$JAVA_OPTS $@"
+    CONSOLIDATED_OPTS="$JAVA_OPTS $SERVER_OPTS"
     # process the standalone options
-    for var in $SERVER_OPTS
+    for var in $CONSOLIDATED_OPTS
     do
        case $var in
          -Djboss.server.base.dir=*)
@@ -214,7 +218,7 @@ while true; do
          org.jboss.as.standalone \
          -Djboss.home.dir=\"$JBOSS_HOME\" \
          -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
-         "$@"
+         "$SERVER_OPTS"
       JBOSS_STATUS=$?
    else
       # Execute the JVM in the background
@@ -227,7 +231,7 @@ while true; do
          org.jboss.as.standalone \
          -Djboss.home.dir=\"$JBOSS_HOME\" \
          -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
-         "$@" "&"
+         "$SERVER_OPTS" "&"
       JBOSS_PID=$!
       # Trap common signals and relay them to the jboss process
       trap "kill -HUP  $JBOSS_PID" HUP

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -43,7 +43,6 @@ public class CommandLineConstants {
 
     /** Debug flag */
     public static final String DEBUG = "--debug";
-    public static final String SHORT_DEBUG = "-d";
 
     /** Configure the file to be used to read properties */
     public static final String OLD_PROPERTIES = "-properties";

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -41,6 +41,10 @@ public class CommandLineConstants {
     public static final String SHORT_VERSION = "-v";
     public static final String OLD_SHORT_VERSION = "-V";
 
+    /** Debug flag */
+    public static final String DEBUG = "--debug";
+    public static final String SHORT_DEBUG = "-d";
+
     /** Configure the file to be used to read properties */
     public static final String OLD_PROPERTIES = "-properties";
     public static final String PROPERTIES = "--properties";

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
@@ -23,6 +23,9 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SHORT_SERVER_CONFIG + " <config>", CommandLineConstants.SHORT_SERVER_CONFIG + "=<config>");
         instructions.add(MESSAGES.argShortServerConfig());
 
+        addArguments(CommandLineConstants.DEBUG + " [<port>]");
+        instructions.add(MESSAGES.argDebugPort());
+
         addArguments(CommandLineConstants.SYS_PROP + "<name>[=<value>]");
         instructions.add(MESSAGES.argSystem());
 

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -225,6 +225,19 @@ public final class Main {
                     //Drop the first 2 characters
                     String token = arg.substring(2);
                     processSecurityProperties(token,systemProperties);
+                } else if (arg.equals(CommandLineConstants.DEBUG)) { // Need to process the debug options as they cannot be filtered out in Windows
+                    // The next option may or may not be a port. Assume if it's a number and doesn't start with a - it's the port
+                    final int next = i + 1;
+                    if (next < argsLength) {
+                        final String nextArg = args[next];
+                        if (!nextArg.startsWith("-")) {
+                            try {
+                                Integer.parseInt(nextArg);
+                                i++;
+                            } catch (NumberFormatException ignore) {
+                            }
+                        }
+                    }
                 } else {
                     System.err.printf(ServerMessages.MESSAGES.invalidCommandLineOption(arg));
                     usage();

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -187,7 +187,7 @@ public interface ServerMessages {
     String argAdminOnly();
 
     /**
-     * Instructions for the {@link org.jboss.as.server.CommandLineArgument#DEBUG} command line argument.
+     * Instructions for the {@link CommandLineConstants#DEBUG} command line argument.
      *
      * @return the message.
      */

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -187,6 +187,14 @@ public interface ServerMessages {
     String argAdminOnly();
 
     /**
+     * Instructions for the {@link org.jboss.as.server.CommandLineArgument#DEBUG} command line argument.
+     *
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Activate debug mode with an optional argument to specify the port. Only works if the launch script supports it.")
+    String argDebugPort();
+
+    /**
      * Creates an error message indicating a value was expected for the given command line option.
      *
      * @param option the name of the command line option


### PR DESCRIPTION
The --debug flag can be at any place in the list of arguments.
eg :

```
./standalone.sh -c=standalone-ha.xml --debug -b 0.0.0.0 # debug on port 8787
./standalone.bat -b 0.0.0.0 --debug 9797 # debug on port 9797
```

The debug flag is now removed from the command line arguments to send only the server arguments to the java main class.

As requested by Brian Stansberry the --help output now print for the debug flag :

```
--debug [<port>]                    Activate debug mode with an optional 
                                    argument to specify the port. Only 
                                    works if the launch script supports it.
```

Removed -d option and parameter parsing from batch script.
