### PR TITLE
AS7-4837: Updated dependency of JBoss Common Beans to 1.1.0.Final

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.common-beans"/>
+	<module name="org.jboss.common-beans" services="export"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.jandex"/>

--- a/pojo/src/main/java/org/jboss/as/pojo/PojoExtension.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/PojoExtension.java
@@ -33,7 +33,6 @@ import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.common.beans.property.PropertyEditors;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
@@ -84,7 +83,6 @@ public class PojoExtension implements Extension {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(PojoResource.INSTANCE);
         registration.registerOperationHandler(DESCRIBE, GenericSubsystemDescribeHandler.INSTANCE, GenericSubsystemDescribeHandler.INSTANCE, false, OperationEntry.EntryType.PRIVATE);
         subsystem.registerXMLElementWriter(parser);
-        PropertyEditors.init();
     }
 
     /**

--- a/pojo/src/main/java/org/jboss/as/pojo/service/Configurator.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/service/Configurator.java
@@ -26,11 +26,11 @@ import org.jboss.as.pojo.PojoMessages;
 import org.jboss.as.pojo.descriptor.ValueConfig;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
-import org.jboss.common.beans.property.finder.PropertyEditorFinder;
 import org.jboss.common.beans.property.PropertiesValueResolver;
 import org.jboss.logging.Logger;
 
 import java.beans.PropertyEditor;
+import java.beans.PropertyEditorManager;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -111,7 +111,7 @@ public class Configurator {
 
         // Next look for a property editor
         if (valueClass == String.class) {
-            PropertyEditor editor = PropertyEditorFinder.getInstance().find(clazz);
+            PropertyEditor editor = PropertyEditorManager.findEditor(clazz);
             if (editor != null) {
                 editor.setAsText((String) value);
                 return editor.getValue();

--- a/pojo/src/main/java/org/jboss/as/pojo/service/Configurator.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/service/Configurator.java
@@ -26,11 +26,11 @@ import org.jboss.as.pojo.PojoMessages;
 import org.jboss.as.pojo.descriptor.ValueConfig;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.common.beans.property.finder.PropertyEditorFinder;
 import org.jboss.common.beans.property.PropertiesValueResolver;
 import org.jboss.logging.Logger;
 
 import java.beans.PropertyEditor;
-import java.beans.PropertyEditorManager;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -111,7 +111,7 @@ public class Configurator {
 
         // Next look for a property editor
         if (valueClass == String.class) {
-            PropertyEditor editor = PropertyEditorManager.findEditor(clazz);
+            PropertyEditor editor = PropertyEditorFinder.getInstance().find(clazz);
             if (editor != null) {
                 editor.setAsText((String) value);
                 return editor.getValue();

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <version.org.jboss.as.jbossweb-native>2.0.10.Final</version.org.jboss.as.jbossweb-native>
         <version.org.jboss.byteman>2.0.1</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.0.3.Final</version.org.jboss.classfilewriter>
-        <version.org.jboss.common.jboss-common-beans>1.0.0.Final</version.org.jboss.common.jboss-common-beans>
+        <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
         <version.org.jboss.ejb-client>1.0.11.Final</version.org.jboss.ejb-client>

--- a/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
+++ b/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
@@ -47,7 +47,7 @@ import org.jboss.as.service.descriptor.JBossServiceConstructorConfig;
 import org.jboss.as.service.descriptor.JBossServiceConstructorConfig.Argument;
 import org.jboss.as.service.descriptor.JBossServiceDependencyConfig;
 import org.jboss.as.service.descriptor.JBossServiceXmlDescriptor;
-import org.jboss.common.beans.property.PropertyEditors;
+import org.jboss.common.beans.property.finder.PropertyEditorFinder;
 import org.jboss.modules.Module;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.inject.MethodInjector;
@@ -212,7 +212,7 @@ public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor
     }
 
     private static Object newValue(final Class<?> type, final String value) {
-        final PropertyEditor editor = PropertyEditors.findEditor(type);
+        final PropertyEditor editor = PropertyEditorFinder.getInstance().find(type);
         if (editor == null) {
             SarLogger.DEPLOYMENT_SERVICE_LOGGER.propertyNotFound(type);
             return null;

--- a/sar/src/main/java/org/jboss/as/service/SarExtension.java
+++ b/sar/src/main/java/org/jboss/as/service/SarExtension.java
@@ -51,7 +51,6 @@ import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.common.beans.property.PropertyEditors;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
@@ -90,7 +89,6 @@ public class SarExtension implements Extension {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(RESOURCE_DEFINITION);
         registration.registerOperationHandler(DESCRIBE, SarDescribeHandler.INSTANCE, SarDescribeHandler.INSTANCE, false, OperationEntry.EntryType.PRIVATE);
         subsystem.registerXMLElementWriter(parser);
-        PropertyEditors.init();
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Updated relevant classes to use the new PropertyEditorFinder class. The use of PropertyEditorManagers was also removed and the use of the PropertyEditorFinder within JBoss Common Beans used. The failed test, JMXPropertyEditorsTestCase, that initially caused the bug now passes.
