### PR TITLE
[AS7-5419] Add jtype module to fix NoClassDefFoundError

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -328,6 +328,10 @@
             <maven-resource group="com.google.guava" artifact="guava" />
         </module-def>
 
+        <module-def name="com.googlecode.jtype">
+            <maven-resource group="com.googlecode.jtype" artifact="jtype" />
+        </module-def>
+
         <module-def name="com.h2database.h2">
             <maven-resource group="com.h2database" artifact="h2"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -233,6 +233,11 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>com.googlecode.jtype</groupId>
+                    <artifactId>jtype</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>com.sun.codemodel</groupId>
                     <artifactId>codemodel</artifactId>
                 </dependency>

--- a/build/src/main/resources/modules/com/googlecode/jtype/main/module.xml
+++ b/build/src/main/resources/modules/com/googlecode/jtype/main/module.xml
@@ -22,23 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.validator">
-  <resources>
-    <!-- Insert resources here -->
-  </resources>
+<module xmlns="urn:jboss:module:1.1" name="com.googlecode.jtype">
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
 
-  <dependencies>
-    <module name="com.googlecode.jtype"/>
-    <module name="javax.api"/>
-    <module name="javax.persistence.api"/>
-    <module name="javax.validation.api"/>
-    <module name="javax.persistence.api"/>
-    <module name="javax.xml.bind.api"/>
-    <module name="org.jboss.logging"/>
-    <module name="org.jboss.common-core"/>
-    <module name="org.joda.time"/>
-    <module name="org.slf4j"/>
-    <module name="org.apache.xerces" services="import"/>
-    <module name="sun.jdk" services="import"/>
-  </dependencies>
+    <dependencies>
+    </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <version.ch.qos.cal10n>0.7.3</version.ch.qos.cal10n>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>11.0.2</version.com.google.guava>
+        <version.com.googlecode.jtype>0.1.1</version.com.googlecode.jtype>
         <version.com.h2database>1.3.168</version.com.h2database>
         <version.com.sun.codemodel>2.6</version.com.sun.codemodel>
         <version.com.sun.faces>2.1.12-jbossorg-1</version.com.sun.faces>
@@ -1231,6 +1232,12 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.googlecode.jtype</groupId>
+                <artifactId>jtype</artifactId>
+                <version>${version.com.googlecode.jtype}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Add jtype dependency to hibernate-validator to fix the java.lang.NoClassDefFoundError: com/googlecode/jtype/TypeUtils exception.

Issue with description: https://issues.jboss.org/browse/AS7-5419
