### PR TITLE
cli fixes

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -31,35 +31,29 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executors;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
-import org.jboss.as.cli.batch.BatchManager;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.as.cli.operation.OperationFormatException;
 import org.jboss.as.cli.operation.ParsedCommandLine;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
-import org.jboss.as.cli.util.StrictSizeTable;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.jboss.vfs.TempFileProvider;
-import org.jboss.vfs.VFS;
 import org.jboss.vfs.spi.MountHandle;
 
 /**
  *
  * @author Alexey Loubyansky
  */
-public class DeployHandler extends BatchModeCommandHandler {
+public class DeployHandler extends DeploymentHandler {
 
     private final ArgumentWithoutValue force;
     private final ArgumentWithoutValue l;
@@ -71,8 +65,6 @@ public class DeployHandler extends BatchModeCommandHandler {
     private final ArgumentWithoutValue disabled;
     private final ArgumentWithoutValue unmanaged;
     private final ArgumentWithValue script;
-
-    private static final String CLI_ARCHIVE_SUFFIX = ".cli";
 
     public DeployHandler(CommandContext ctx) {
         super(ctx, "deploy", true);
@@ -734,102 +726,5 @@ public class DeployHandler extends BatchModeCommandHandler {
             StreamUtils.safeClose(is);
         }
         return bytes;
-    }
-
-    protected void listDeployments(CommandContext ctx, boolean l) throws CommandFormatException {
-        if(!l) {
-            printList(ctx, Util.getDeployments(ctx.getModelControllerClient()), l);
-            return;
-        }
-        final ModelControllerClient client = ctx.getModelControllerClient();
-        final List<String> names = Util.getDeployments(client);
-        if(names.isEmpty()) {
-            return;
-        }
-
-        final StrictSizeTable table = new StrictSizeTable(names.size());
-        final List<Property> descriptions = getDeploymentDescriptions(ctx, names).asPropertyList();
-        for(Property prop : descriptions) {
-            final ModelNode step = prop.getValue();
-            if(step.hasDefined(Util.RESULT)) {
-                final ModelNode result = step.get(Util.RESULT);
-                table.addCell(Util.NAME, result.get(Util.NAME).asString());
-                table.addCell(Util.RUNTIME_NAME, result.get(Util.RUNTIME_NAME).asString());
-                if(result.has(Util.ENABLED)) {
-                    table.addCell(Util.ENABLED, result.get(Util.ENABLED).asString());
-                }
-                if(result.has(Util.STATUS)) {
-                    table.addCell(Util.STATUS, result.get(Util.STATUS).asString());
-                }
-            }
-            if(!table.isAtLastRow()) {
-                table.nextRow();
-            }
-        }
-        throw new CommandFormatException(table.toString());
-    }
-
-    protected ModelNode getDeploymentDescriptions(CommandContext ctx, List<String> names) throws CommandFormatException {
-        final ModelNode composite = new ModelNode();
-        composite.get(Util.OPERATION).set(Util.COMPOSITE);
-        composite.get(Util.ADDRESS).setEmptyList();
-        final ModelNode steps = composite.get(Util.STEPS);
-        for(String name : names) {
-            final ModelNode deploymentResource = buildReadDeploymentResourceRequest(name);
-            if(deploymentResource != null) {
-                steps.add(deploymentResource);
-            }// else it's illegal state
-        }
-        ModelNode result;
-        try {
-            result = ctx.getModelControllerClient().execute(composite);
-        } catch (IOException e) {
-            throw new CommandFormatException("Failed to execute operation request.", e);
-        }
-        if (!result.hasDefined(Util.RESULT)) {
-            return null;
-        }
-        return result.get(Util.RESULT);
-    }
-
-    protected ModelNode buildReadDeploymentResourceRequest(String name) {
-        ModelNode request = new ModelNode();
-        ModelNode address = request.get(Util.ADDRESS);
-        address.add(Util.DEPLOYMENT, name);
-        request.get(Util.OPERATION).set(Util.READ_RESOURCE);
-        request.get(Util.INCLUDE_RUNTIME).set(true);
-        return request;
-    }
-
-    private MountHandle extractArchive(File archive) throws IOException {
-        return ((MountHandle)VFS.mountZipExpanded(archive, VFS.getChild("cli"),
-                TempFileProvider.create("cli", Executors.newSingleThreadScheduledExecutor())));
-    }
-
-    private String activateNewBatch(CommandContext ctx) {
-        String currentBatch = null;
-        BatchManager batchManager = ctx.getBatchManager();
-        if (batchManager.isBatchActive()) {
-            currentBatch = "batch" + System.currentTimeMillis();
-            batchManager.holdbackActiveBatch(currentBatch);
-        }
-        batchManager.activateNewBatch();
-        return currentBatch;
-    }
-
-    private void discardBatch(CommandContext ctx, String holdbackBatch) {
-        BatchManager batchManager = ctx.getBatchManager();
-        batchManager.discardActiveBatch();
-        if (holdbackBatch != null) {
-            batchManager.activateHeldbackBatch(holdbackBatch);
-        }
-    }
-
-    private boolean isCliArchive(File f) {
-        if (f == null || !f.getName().endsWith(CLI_ARCHIVE_SUFFIX)) {
-            return false;
-        } else {
-            return true;
-        }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentHandler.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.handlers;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.batch.BatchManager;
+import org.jboss.as.cli.util.StrictSizeTable;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.vfs.TempFileProvider;
+import org.jboss.vfs.VFS;
+import org.jboss.vfs.spi.MountHandle;
+
+
+/**
+ * Base class for deploy and undeploy handlers containing common code
+ * for these handlers.
+ *
+ * @author Alexey Loubyansky
+ */
+public abstract class DeploymentHandler extends BatchModeCommandHandler {
+
+    static final String CLI_ARCHIVE_SUFFIX = ".cli";
+
+    public DeploymentHandler(CommandContext ctx, String command, boolean connectionRequired) {
+        super(ctx, command, connectionRequired);
+    }
+
+    protected void listDeployments(CommandContext ctx, boolean l) throws CommandFormatException {
+        if(!l) {
+            printList(ctx, Util.getDeployments(ctx.getModelControllerClient()), l);
+            return;
+        }
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        final List<String> names = Util.getDeployments(client);
+        if(names.isEmpty()) {
+            return;
+        }
+
+        final StrictSizeTable table = new StrictSizeTable(names.size());
+        final List<Property> descriptions = getDeploymentDescriptions(ctx, names).asPropertyList();
+        for(Property prop : descriptions) {
+            final ModelNode step = prop.getValue();
+            if(step.hasDefined(Util.RESULT)) {
+                final ModelNode result = step.get(Util.RESULT);
+                table.addCell(Util.NAME, result.get(Util.NAME).asString());
+                table.addCell(Util.RUNTIME_NAME, result.get(Util.RUNTIME_NAME).asString());
+                if(result.has(Util.ENABLED)) {
+                    table.addCell(Util.ENABLED, result.get(Util.ENABLED).asString());
+                }
+                if(result.has(Util.STATUS)) {
+                    table.addCell(Util.STATUS, result.get(Util.STATUS).asString());
+                }
+            }
+            if(!table.isAtLastRow()) {
+                table.nextRow();
+            }
+        }
+        throw new CommandFormatException(table.toString());
+    }
+
+    protected ModelNode getDeploymentDescriptions(CommandContext ctx, List<String> names) throws CommandFormatException {
+        final ModelNode composite = new ModelNode();
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+        final ModelNode steps = composite.get(Util.STEPS);
+        for(String name : names) {
+            final ModelNode deploymentResource = buildReadDeploymentResourceRequest(name);
+            if(deploymentResource != null) {
+                steps.add(deploymentResource);
+            }// else it's illegal state
+        }
+        ModelNode result;
+        try {
+            result = ctx.getModelControllerClient().execute(composite);
+        } catch (IOException e) {
+            throw new CommandFormatException("Failed to execute operation request.", e);
+        }
+        if (!result.hasDefined(Util.RESULT)) {
+            return null;
+        }
+        return result.get(Util.RESULT);
+    }
+
+    protected ModelNode buildReadDeploymentResourceRequest(String name) {
+        ModelNode request = new ModelNode();
+        ModelNode address = request.get(Util.ADDRESS);
+        address.add(Util.DEPLOYMENT, name);
+        request.get(Util.OPERATION).set(Util.READ_RESOURCE);
+        request.get(Util.INCLUDE_RUNTIME).set(true);
+        return request;
+    }
+
+    protected MountHandle extractArchive(File archive) throws IOException {
+        return ((MountHandle)VFS.mountZipExpanded(archive, VFS.getChild("cli"),
+                TempFileProvider.create("cli", Executors.newSingleThreadScheduledExecutor())));
+    }
+
+    protected String activateNewBatch(CommandContext ctx) {
+        String currentBatch = null;
+        BatchManager batchManager = ctx.getBatchManager();
+        if (batchManager.isBatchActive()) {
+            currentBatch = "batch" + System.currentTimeMillis();
+            batchManager.holdbackActiveBatch(currentBatch);
+        }
+        batchManager.activateNewBatch();
+        return currentBatch;
+    }
+
+    protected void discardBatch(CommandContext ctx, String holdbackBatch) {
+        BatchManager batchManager = ctx.getBatchManager();
+        batchManager.discardActiveBatch();
+        if (holdbackBatch != null) {
+            batchManager.activateHeldbackBatch(holdbackBatch);
+        }
+    }
+
+    protected boolean isCliArchive(File f) {
+        if (f == null || f.isDirectory() || !f.getName().endsWith(CLI_ARCHIVE_SUFFIX)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
@@ -380,43 +380,40 @@ public class UndeployHandler extends DeploymentHandler {
             }
         }
 
-        if(ctx.isDomainMode()) {
-            List<String> serverGroups = Collections.emptyList();
-            if(allRelevantServerGroups) {
-                for(String deploymentName : deploymentNames) {
+        for(String deploymentName : deploymentNames) {
+
+            final List<String> serverGroups;
+            if(ctx.isDomainMode()) {
+                if(allRelevantServerGroups) {
                     if(keepContent) {
                         serverGroups = Util.getAllEnabledServerGroups(deploymentName, client);
                     } else {
                         serverGroups = Util.getAllReferencingServerGroups(deploymentName, client);
                     }
-                }
-            } else {
-                if(serverGroupsStr == null) {
-                    //throw new OperationFormatException("Either --all-relevant-server-groups or --server-groups must be specified.");
-                    serverGroups = Collections.emptyList();
                 } else {
-                    serverGroups = Arrays.asList(serverGroupsStr.split(","));
+                    if(serverGroupsStr == null) {
+                        //throw new OperationFormatException("Either --all-relevant-server-groups or --server-groups must be specified.");
+                        serverGroups = Collections.emptyList();
+                    } else {
+                        serverGroups = Arrays.asList(serverGroupsStr.split(","));
+                    }
                 }
-            }
 
-            if(serverGroups.isEmpty()) {
-                if(keepContent) {
-                    throw new OperationFormatException("None of the server groups is specified or references specified deployment.");
-                }
-            } else {
-                for(String deploymentName : deploymentNames) {
+                if(serverGroups.isEmpty()) {
+                    if(keepContent) {
+                        throw new OperationFormatException("None of the server groups is specified or references specified deployment.");
+                    }
+                } else {
                     for (String group : serverGroups){
                         ModelNode groupStep = Util.configureDeploymentOperation(Util.UNDEPLOY, deploymentName, group);
                         steps.add(groupStep);
-  //                      if(!keepContent) {
+//                      if(!keepContent) {
                             groupStep = Util.configureDeploymentOperation(Util.REMOVE, deploymentName, group);
                             steps.add(groupStep);
-//                        }
+//                      }
                     }
                 }
-            }
-        } else {
-            for(String deploymentName : deploymentNames) {
+            } else {
                 if(Util.isDeployedAndEnabledInStandalone(deploymentName, client)) {
                     builder = new DefaultOperationRequestBuilder();
                     builder.setOperationName(Util.UNDEPLOY);

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -331,7 +331,7 @@ class CommandContextImpl implements CommandContext {
         cmdRegistry.registerHandler(new CommandCommandHandler(cmdRegistry), "command");
         cmdRegistry.registerHandler(new ConnectHandler(), "connect");
         cmdRegistry.registerHandler(new EchoDMRHandler(), "echo-dmr");
-        cmdRegistry.registerHandler(new HelpHandler(), "help", "h");
+        cmdRegistry.registerHandler(new HelpHandler(cmdRegistry), "help", "h");
         cmdRegistry.registerHandler(new HistoryHandler(), "history");
         cmdRegistry.registerHandler(new LsHandler(), "ls");
         cmdRegistry.registerHandler(new ASModuleHandler(this), "module");

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -960,7 +960,9 @@ class CommandContextImpl implements CommandContext {
 
     @Override
     public void clearScreen() {
-        console.clearScreen();
+        if(console != null) {
+            console.clearScreen();
+        }
     }
 
     String promptConnectPart;
@@ -1006,6 +1008,13 @@ class CommandContextImpl implements CommandContext {
 
     @Override
     public CommandHistory getHistory() {
+        if(console == null) {
+            try {
+                initBasicConsole(null, null);
+            } catch (CliInitializationException e) {
+                throw new IllegalStateException("Failed to initialize console.", e);
+            }
+        }
         return console.getHistory();
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/UndeployWildcardDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/UndeployWildcardDomainTestCase.java
@@ -19,28 +19,23 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.management.cli;
+package org.jboss.as.test.integration.domain.management.cli;
 
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.net.URL;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.cli.CommandContext;
+import org.jboss.as.test.integration.domain.suites.CLITestSuite;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.SimpleServlet;
-import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
 import org.jboss.shrinkwrap.impl.base.path.BasicPath;
@@ -49,55 +44,48 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
+
 
 /**
  *
  * @author Alexey Loubyansky
  */
-@RunWith(Arquillian.class)
-@RunAsClient
-public class UndeployWildcardTestCase {
+public class UndeployWildcardDomainTestCase {
 
-    @ArquillianResource URL url;
+    private static File cliTestApp1War;
+    private static File cliTestApp2War;
+    private static File cliTestAnotherWar;
+    private static File cliTestAppEar;
 
-    private static File[] appFiles;
+    private static String sgOne;
+    private static String sgTwo;
 
     private CommandContext ctx;
-
-    @Deployment
-    public static Archive<?> getDeployment() {
-        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
-        ja.addClass(UndeployWildcardTestCase.class);
-        return ja;
-    }
 
     @BeforeClass
     public static void before() throws Exception {
         String tempDir = System.getProperty("java.io.tmpdir");
 
-        appFiles = new File[4];
-
         // deployment1
         WebArchive war = ShrinkWrap.create(WebArchive.class, "cli-test-app1.war");
         war.addClass(SimpleServlet.class);
         war.addAsWebResource(new StringAsset("Version0"), "page.html");
-        appFiles[0] = new File(tempDir + File.separator + war.getName());
-        new ZipExporterImpl(war).exportTo(appFiles[0], true);
+        cliTestApp1War = new File(tempDir + File.separator + war.getName());
+        new ZipExporterImpl(war).exportTo(cliTestApp1War, true);
 
         // deployment2
         war = ShrinkWrap.create(WebArchive.class, "cli-test-app2.war");
         war.addClass(SimpleServlet.class);
         war.addAsWebResource(new StringAsset("Version1"), "page.html");
-        appFiles[1] = new File(tempDir + File.separator + war.getName());
-        new ZipExporterImpl(war).exportTo(appFiles[1], true);
+        cliTestApp2War = new File(tempDir + File.separator + war.getName());
+        new ZipExporterImpl(war).exportTo(cliTestApp2War, true);
 
         // deployment3
         war = ShrinkWrap.create(WebArchive.class, "cli-test-another.war");
         war.addClass(SimpleServlet.class);
         war.addAsWebResource(new StringAsset("Version2"), "page.html");
-        appFiles[2] = new File(tempDir + File.separator + war.getName());
-        new ZipExporterImpl(war).exportTo(appFiles[2], true);
+        cliTestAnotherWar = new File(tempDir + File.separator + war.getName());
+        new ZipExporterImpl(war).exportTo(cliTestAnotherWar, true);
 
         // deployment4
         war = ShrinkWrap.create(WebArchive.class, "cli-test-app3.war");
@@ -105,15 +93,26 @@ public class UndeployWildcardTestCase {
         war.addAsWebResource(new StringAsset("Version3"), "page.html");
         final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "cli-test-app.ear");
         ear.add(war, new BasicPath("/"), ZipExporter.class);
-        appFiles[3] = new File(tempDir + File.separator + ear.getName());
-        new ZipExporterImpl(ear).exportTo(appFiles[3], true);
+        cliTestAppEar = new File(tempDir + File.separator + ear.getName());
+        new ZipExporterImpl(ear).exportTo(cliTestAppEar, true);
+
+        final Iterator<String> sgI = CLITestSuite.serverGroups.keySet().iterator();
+        if(!sgI.hasNext()) {
+            fail("Server groups aren't available.");
+        }
+        sgOne = sgI.next();
+        if(!sgI.hasNext()) {
+            fail("Second server groups isn't available.");
+        }
+        sgTwo = sgI.next();
     }
 
     @AfterClass
     public static void after() throws Exception {
-        for(File f : appFiles) {
-            f.delete();
-        }
+        cliTestApp1War.delete();
+        cliTestApp2War.delete();
+        cliTestAnotherWar.delete();
+        cliTestAppEar.delete();
     }
 
     private Set<String> afterTestDeployments;
@@ -122,29 +121,24 @@ public class UndeployWildcardTestCase {
     public void beforeTest() throws Exception {
         ctx = CLITestUtil.getCommandContext();
         ctx.connectController();
-        for(File f : appFiles) {
-            ctx.handle("deploy " + f.getAbsolutePath());
-        }
+
+        ctx.handle("deploy --server-groups=" + sgOne + ' ' + cliTestApp1War.getAbsolutePath());
+        ctx.handle("deploy --server-groups=" + sgOne + ' ' + cliTestAnotherWar.getAbsolutePath());
+
+        ctx.handle("deploy --server-groups=" + sgTwo + ' ' + cliTestApp2War.getAbsolutePath());
+        ctx.handle("deploy --server-groups=" + sgTwo + ',' + sgOne + ' ' + cliTestAppEar.getAbsolutePath());
+
         afterTestDeployments = new HashSet<String>();
     }
 
     @After
     public void afterTest() throws Exception {
-        StringBuilder buf = null;
-        for(File f : appFiles) {
-            ctx.handleSafe("undeploy " + f.getName());
-            if(ctx.getExitCode() == 0) {
-                if(!afterTestDeployments.remove(f.getName())) {
-                    if(buf == null) {
-                        buf = new StringBuilder();
-                        buf.append("Undeployed unexpected content: ");
-                        buf.append(f.getName());
-                    } else {
-                        buf.append(", ").append(f.getName());
-                    }
-                }
-            }
-        }
+
+        StringBuilder buf = undeploy(null, cliTestApp1War.getName(), sgOne);
+        buf = undeploy(buf, cliTestAnotherWar.getName(), sgOne);
+        buf = undeploy(buf, cliTestApp2War.getName(), sgTwo);
+        buf = undeploy(buf, cliTestAppEar.getName(), sgOne + ',' + sgTwo);
+
         ctx.terminateSession();
         if(buf != null) {
             fail(buf.toString());
@@ -154,33 +148,49 @@ public class UndeployWildcardTestCase {
         }
     }
 
+    protected StringBuilder undeploy(StringBuilder buf, String deployment, String sg) {
+        ctx.handleSafe("undeploy --server-groups=" + sg + ' ' + deployment);
+        if(ctx.getExitCode() == 0) {
+            if(!afterTestDeployments.remove(deployment)) {
+                if(buf == null) {
+                    buf = new StringBuilder();
+                    buf.append("Undeployed unexpected content: ");
+                    buf.append(deployment);
+                } else {
+                    buf.append(", ").append(deployment);
+                }
+            }
+        }
+        return buf;
+    }
+
     @Test
     public void testUndeployAllWars() throws Exception {
-        ctx.handle("undeploy *.war");
-        afterTestDeployments.add(appFiles[3].getName());
+        ctx.handle("undeploy *.war --all-relevant-server-groups");
+        afterTestDeployments.add(cliTestAppEar.getName());
     }
 
     @Test
     public void testUndeployCliTestApps() throws Exception {
-        ctx.handle("undeploy cli-test-app*");
-        afterTestDeployments.add(appFiles[2].getName());
+        ctx.handle("undeploy cli-test-app* --all-relevant-server-groups");
+        afterTestDeployments.add(cliTestAnotherWar.getName());
     }
 
 
     @Test
     public void testUndeployTestAps() throws Exception {
-        ctx.handle("undeploy *test-ap*");
-        afterTestDeployments.add(appFiles[2].getName());
+        ctx.handle("undeploy *test-ap* --all-relevant-server-groups");
+        afterTestDeployments.add(cliTestAnotherWar.getName());
     }
 
     @Test
     public void testUndeployTestAs() throws Exception {
-        ctx.handle("undeploy *test-a*");
+        ctx.handle("undeploy *test-a* --all-relevant-server-groups");
     }
 
     @Test
     public void testUndeployTestAWARs() throws Exception {
-        ctx.handle("undeploy *test-a*.war");
-        afterTestDeployments.add(appFiles[3].getName());
+        ctx.handle("undeploy *test-a*.war --all-relevant-server-groups");
+        afterTestDeployments.add(cliTestAppEar.getName());
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
@@ -34,6 +34,7 @@ import org.jboss.as.test.integration.domain.management.cli.DeployAllServerGroups
 import org.jboss.as.test.integration.domain.management.cli.DeploySingleServerGroupTestCase;
 import org.jboss.as.test.integration.domain.management.cli.JmsTestCase;
 import org.jboss.as.test.integration.domain.management.cli.RolloutPlanTestCase;
+import org.jboss.as.test.integration.domain.management.cli.UndeployWildcardDomainTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -48,6 +49,7 @@ import org.junit.runners.Suite;
     BasicOpsTestCase.class,
     DeployAllServerGroupsTestCase.class,
     DeploySingleServerGroupTestCase.class,
+    UndeployWildcardDomainTestCase.class,
     JmsTestCase.class,
     DataSourceTestCase.class,
     RolloutPlanTestCase.class

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/ArchiveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/ArchiveTestCase.java
@@ -36,7 +36,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
@@ -133,7 +132,7 @@ public class ArchiveTestCase {
             ctx.terminateSession();
         }
     }
-    
+
     @Test
     public void testUnDeployArchive() throws Exception {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/UndeployWildcardTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/UndeployWildcardTestCase.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.as.test.integration.management.util.SimpleServlet;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class UndeployWildcardTestCase {
+
+    @ArquillianResource URL url;
+
+    private static File[] appFiles;
+
+    private CommandContext ctx;
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
+        ja.addClass(UndeployWildcardTestCase.class);
+        return ja;
+    }
+
+    @BeforeClass
+    public static void before() throws Exception {
+        String tempDir = System.getProperty("java.io.tmpdir");
+
+        appFiles = new File[4];
+
+        // deployment1
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "cli-test-app1.war");
+        war.addClass(SimpleServlet.class);
+        war.addAsWebResource(new StringAsset("Version0"), "page.html");
+        appFiles[0] = new File(tempDir + File.separator + war.getName());
+        new ZipExporterImpl(war).exportTo(appFiles[0], true);
+
+        // deployment2
+        war = ShrinkWrap.create(WebArchive.class, "cli-test-app2.war");
+        war.addClass(SimpleServlet.class);
+        war.addAsWebResource(new StringAsset("Version1"), "page.html");
+        appFiles[1] = new File(tempDir + File.separator + war.getName());
+        new ZipExporterImpl(war).exportTo(appFiles[1], true);
+
+        // deployment3
+        war = ShrinkWrap.create(WebArchive.class, "cli-test-another.war");
+        war.addClass(SimpleServlet.class);
+        war.addAsWebResource(new StringAsset("Version2"), "page.html");
+        appFiles[2] = new File(tempDir + File.separator + war.getName());
+        new ZipExporterImpl(war).exportTo(appFiles[2], true);
+
+        // deployment4
+        war = ShrinkWrap.create(WebArchive.class, "cli-test-app3.war");
+        war.addClass(SimpleServlet.class);
+        war.addAsWebResource(new StringAsset("Version3"), "page.html");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "cli-test-app.ear");
+        ear.add(war, new BasicPath("/"), ZipExporter.class);
+        appFiles[3] = new File(tempDir + File.separator + ear.getName());
+        new ZipExporterImpl(ear).exportTo(appFiles[3], true);
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        for(File f : appFiles) {
+            f.delete();
+        }
+    }
+
+    private Set<String> afterTestDeployments;
+
+    @Before
+    public void beforeTest() throws Exception {
+        ctx = CLITestUtil.getCommandContext();
+        ctx.connectController();
+        for(File f : appFiles) {
+            ctx.handle("deploy " + f.getAbsolutePath());
+        }
+        afterTestDeployments = new HashSet<String>();
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        StringBuilder buf = null;
+        for(File f : appFiles) {
+            ctx.handleSafe("undeploy " + f.getName());
+            if(ctx.getExitCode() == 0) {
+                if(!afterTestDeployments.remove(f.getName())) {
+                    if(buf == null) {
+                        buf = new StringBuilder();
+                        buf.append("Undeployment unexpected content: ");
+                        buf.append(f.getName());
+                    } else {
+                        buf.append(", ").append(f.getName());
+                    }
+                }
+            }
+        }
+        ctx.terminateSession();
+        if(buf != null) {
+            fail(buf.toString());
+        }
+        if(afterTestDeployments.size() > 0) {
+            fail("Expected to undeploy but failed to: " + afterTestDeployments);
+        }
+    }
+
+    @Test
+    public void testUndeployAllWars() throws Exception {
+        ctx.handle("undeploy *.war");
+        afterTestDeployments.add(appFiles[3].getName());
+    }
+
+    @Test
+    public void testUndeployCliTestApps() throws Exception {
+        ctx.handle("undeploy cli-test-app*");
+        afterTestDeployments.add(appFiles[2].getName());
+    }
+
+
+    @Test
+    public void testUndeployTestAps() throws Exception {
+        ctx.handle("undeploy *test-ap*");
+        afterTestDeployments.add(appFiles[2].getName());
+    }
+
+    @Test
+    public void testUndeployTestAs() throws Exception {
+        ctx.handle("undeploy *test-a*");
+    }
+
+    @Test
+    public void testUndeployTestAWARs() throws Exception {
+        ctx.handle("undeploy *test-a*.war");
+        afterTestDeployments.add(appFiles[3].getName());
+    }
+}


### PR DESCRIPTION
Includes
- AS7-5138 Add ability to undeploy wildcarded deployments;
- AS7-5168 IllegalArgumentException when using tab-completion with a wildcard in the address;
- AS7-5414 cli help --commands doesn't list commands;
- AS7-5375 CLI: unify the format of -l output between the deploy and undeploy commands.

Thanks,
Alexey
