### PR TITLE
Fix bug of print format output when a log4j appender is used as a custom handler

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/handlers/custom/Log4jAppenderHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/custom/Log4jAppenderHandler.java
@@ -27,9 +27,7 @@ import java.util.logging.Formatter;
 
 import org.apache.log4j.Appender;
 import org.apache.log4j.Category;
-import org.apache.log4j.JBossLevelMapping;
 import org.apache.log4j.Layout;
-import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
@@ -127,27 +125,6 @@ class Log4jAppenderHandler extends ExtHandler {
         }
     }
 
-    static ExtLogRecord getLogRecordFor(LoggingEvent event) {
-        final ExtLogRecord rec = (ExtLogRecord) event.getProperties().get("org.jboss.logmanager.record");
-        if (rec != null) {
-            return rec;
-        }
-        final ExtLogRecord newRecord = new ExtLogRecord(JBossLevelMapping.getLevelFor(event.getLevel()), (String) event.getMessage(), event.getFQNOfLoggerClass());
-        newRecord.setLoggerName(event.getLoggerName());
-        newRecord.setMillis(event.getTimeStamp());
-        newRecord.setThreadName(event.getThreadName());
-        newRecord.setThrown(event.getThrowableInformation().getThrowable());
-        newRecord.setNdc(event.getNDC());
-        if (event.locationInformationExists()) {
-            final LocationInfo locationInfo = event.getLocationInformation();
-            newRecord.setSourceClassName(locationInfo.getClassName());
-            newRecord.setSourceFileName(locationInfo.getFileName());
-            newRecord.setSourceLineNumber(Integer.parseInt(locationInfo.getLineNumber()));
-            newRecord.setSourceMethodName(locationInfo.getMethodName());
-        }
-        return newRecord;
-    }
-
     /**
      * Dummy category for the logging event
      */
@@ -181,7 +158,7 @@ class Log4jAppenderHandler extends ExtHandler {
 
         @Override
         public String format(final LoggingEvent event) {
-            return formatter.format(getLogRecordFor(event));
+            return formatter.format(event.getLogRecord());
         }
 
         @Override

--- a/logging/src/test/java/org/jboss/as/logging/handlers/custom/Log4jAppenderTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/handlers/custom/Log4jAppenderTestCase.java
@@ -72,6 +72,8 @@ public class Log4jAppenderTestCase {
         handler.setFormatter(formatter);
         logger.info(DFT_MESSAGE);
         Assert.assertEquals(String.format(pattern, DFT_MESSAGE), appender.messages.get(0));
+        logger.infof("%s", DFT_MESSAGE);
+        Assert.assertEquals(String.format(pattern, DFT_MESSAGE), appender.messages.get(1));
     }
 
     @Test


### PR DESCRIPTION
When a log record uses the PRINTF format and a new log record is created the message does not get properly formatted as MESSAGE_FORMAT is the default. This change uses the log record that is attached to the event from the custom log4j-jboss-logmanager.
