### PR TITLE
Startup scripts ergonomics

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -39,17 +39,6 @@ if "%OS%" == "Windows_NT" (
   set DIRNAME=.\
 )
 
-rem Read an optional configuration file.
-if "x%STANDALONE_CONF%" == "x" (
-   set "STANDALONE_CONF=%DIRNAME%standalone.conf.bat"
-)
-if exist "%STANDALONE_CONF%" (
-   echo Calling "%STANDALONE_CONF%"
-   call "%STANDALONE_CONF%" %*
-) else (
-   echo Config file not found "%STANDALONE_CONF%"
-)
-
 if "%DEBUG_MODE%" == "true" (
    set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
 )
@@ -66,8 +55,25 @@ pushd "%JBOSS_HOME%"
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo             JBOSS_HOME: %JBOSS_HOME%
+   echo.
+   rem 2 seconds pause
+   ping 127.0.0.1 -n 3 > nul
+)
+
+rem Read an optional configuration file.
+if "x%STANDALONE_CONF%" == "x" (
+   set "STANDALONE_CONF=%DIRNAME%standalone.conf.bat"
+)
+if exist "%STANDALONE_CONF%" (
+   echo Calling "%STANDALONE_CONF%"
+   call "%STANDALONE_CONF%" %*
+) else (
+   echo Config file not found "%STANDALONE_CONF%"
 )
 
 set DIRNAME=

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -51,13 +51,6 @@ case "`uname`" in
         ;;
 esac
 
-# Read an optional running configuration file
-if [ "x$RUN_CONF" = "x" ]; then
-    RUN_CONF="$DIRNAME/standalone.conf"
-fi
-if [ -r "$RUN_CONF" ]; then
-    . "$RUN_CONF"
-fi
 
 if [ "$DEBUG_MODE" = "true" ]; then
     JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n"
@@ -81,11 +74,23 @@ if [ "x$JBOSS_HOME" = "x" ]; then
 else
  SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
  if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
+   echo "   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+   echo ""
+   echo "             JBOSS_HOME: $JBOSS_HOME"
+   echo ""
+   sleep 2s
  fi
 fi
 export JBOSS_HOME
+
+# Read an optional running configuration file
+if [ "x$RUN_CONF" = "x" ]; then
+    RUN_CONF="$DIRNAME/standalone.conf"
+fi
+if [ -r "$RUN_CONF" ]; then
+    . "$RUN_CONF"
+fi
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then


### PR DESCRIPTION
I propose slight modifications of startup scripts:
- Export JBOSS_HOME before including standalone.conf

This makes it possible to refer to $JBOSS_HOME within standalone.conf which is much better than referring to $PWD, as that requires always changing to correct directory before running a startup script.
For example: standalone.conf may refer to $PWD/extras presuming PWD is JBOSS_HOME. Or standalone.conf may refer to $PWD/../extras presuming PWD is JBOSS_HOME/bin.
- If a warning situation occurs, warning message should be more prominent

When JBOSS_HOME env variable is not equal to JBOSS_HOME corresponding to the location of the script (./.. since script is in $JBOSS_HOME/bin) there is a warning displayed as almost always such a situation is a usage error.

Currently this warning is so incospicuous that it's never noticed. With this patch I make it much more prominent, and it also pauses execution for 2 seconds.
