### PR TITLE
[7.1 branch] Bug fix for AS7-5432 

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/EjbExceptionTransformingInterceptorFactories.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/EjbExceptionTransformingInterceptorFactories.java
@@ -64,13 +64,21 @@ public class EjbExceptionTransformingInterceptorFactories {
             try {
                 return context.proceed();
             } catch (EJBTransactionRequiredException e) {
-                throw new TransactionRequiredException(e.getMessage());
+                final TransactionRequiredException tre = new TransactionRequiredException(e.getMessage());
+                tre.initCause(e);
+                throw tre;
             } catch (EJBTransactionRolledbackException e) {
-                throw new TransactionRolledbackException(e.getMessage());
+                final TransactionRolledbackException trbe = new TransactionRolledbackException(e.getMessage());
+                trbe.initCause(e);
+                throw trbe;
             } catch (NoSuchEJBException e) {
-                throw new NoSuchObjectException(e.getMessage());
+                final NoSuchObjectException nsoe = new NoSuchObjectException(e.getMessage());
+                nsoe.initCause(e);
+                throw nsoe;
             } catch (NoSuchEntityException e) {
-                throw new NoSuchObjectException(e.getMessage());
+                final NoSuchObjectException nsee = new NoSuchObjectException(e.getMessage());
+                nsee.initCause(e);
+                throw nsee;
             } catch (EJBException e) {
                 //as the create exception is not propagated the init method interceptor just stashes it in a ThreadLocal
                 CreateException createException = popCreateException();
@@ -88,13 +96,21 @@ public class EjbExceptionTransformingInterceptorFactories {
             try {
                 return context.proceed();
             } catch (EJBTransactionRequiredException e) {
-                throw new TransactionRequiredLocalException(e.getMessage());
+                final TransactionRequiredLocalException trle = new TransactionRequiredLocalException(e.getMessage());
+                trle.initCause(e);
+                throw trle;
             } catch (EJBTransactionRolledbackException e) {
-                throw new TransactionRolledbackLocalException(e.getMessage());
+                final TransactionRolledbackLocalException trble = new TransactionRolledbackLocalException(e.getMessage());
+                trble.initCause(e);
+                throw trble;
             } catch (NoSuchEJBException e) {
-                throw new NoSuchObjectLocalException(e.getMessage());
+                final NoSuchObjectLocalException nsole = new NoSuchObjectLocalException(e.getMessage());
+                nsole.initCause(e);
+                throw nsole;
             } catch (NoSuchEntityException e) {
-                throw new NoSuchObjectLocalException(e.getMessage());
+                final NoSuchObjectLocalException nsole = new NoSuchObjectLocalException(e.getMessage());
+                nsole.initCause(e);
+                throw nsole;
             } catch (EJBException e) {
                 CreateException createException = popCreateException();
                 if (createException != null) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/CustomRuntimeException.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/CustomRuntimeException.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.exception;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class CustomRuntimeException extends RuntimeException {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/ExceptionPropagationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/ExceptionPropagationTestCase.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.exception;
+
+import junit.framework.Assert;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ejb.EJBException;
+import javax.naming.InitialContext;
+
+/**
+ * Tests that invocations on EJB2.x beans which result in exceptions, have the original cause available
+ * in the propagated exception
+ *
+ * @author Jaikiran Pai
+ * @see https://issues.jboss.org/browse/AS7-5432
+ */
+@RunWith(Arquillian.class)
+public class ExceptionPropagationTestCase {
+
+    private static final Logger logger = Logger.getLogger(ExceptionPropagationTestCase.class);
+
+    private static final String MODULE_NAME = "exception-propagation-ejb2x";
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        ejbJar.addPackage(ExceptionPropagationTestCase.class.getPackage());
+        ejbJar.addAsManifestResource(ExceptionPropagationTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        return ejbJar;
+    }
+
+    /**
+     * Tests that when an invocation on an EJB 2.x bean throws a runtime exception which triggers {@link javax.ejb.TransactionRolledbackLocalException}
+     * then the original cause is retained in the exception that's returned back to the client
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testExceptionPropagation() throws Exception {
+        final Session21LocalHome localHome = InitialContext.doLookup("java:module/" + Session21Bean.class.getSimpleName() + "!" + Session21LocalHome.class.getName());
+        final Session21Local localEjb2xBean = localHome.create();
+        try {
+            localEjb2xBean.invokeOnSelfToThrowCustomRuntimeException();
+            Assert.fail("Expected the invocation on the EJB 2.x bean to intentionally fail with exception, but it didn't");
+        } catch (EJBException ejbex) {
+            boolean foundExpectedException = false;
+            Throwable cause = ejbex.getCause();
+            Assert.assertNotNull("The underlying cause of the EJBException was expected to be non-null");
+            while (cause != null) {
+                if (cause instanceof CustomRuntimeException) {
+                    foundExpectedException = true;
+                    break;
+                }
+                cause = cause.getCause();
+            }
+            Assert.assertTrue("Did not find the expected " + CustomRuntimeException.class.getName() + " in the exception stacktrace", foundExpectedException);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/Session21Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/Session21Bean.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.exception;
+
+import org.jboss.as.test.integration.ejb.ejb2.reference.global.Session30RemoteBusiness;
+import org.jboss.logging.Logger;
+
+import javax.ejb.EJBException;
+import javax.ejb.EJBLocalHome;
+import javax.ejb.EJBLocalObject;
+import javax.ejb.RemoveException;
+import javax.ejb.SessionContext;
+import javax.naming.InitialContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class Session21Bean implements javax.ejb.SessionBean {
+    private static final long serialVersionUID = 1L;
+    private static final Logger log = Logger.getLogger(Session21Bean.class);
+
+    private SessionContext sessionContext;
+
+    public void ejbCreate() {
+
+    }
+
+    public void ejbActivate() {
+
+    }
+
+    public void ejbPassivate() {
+
+    }
+
+    public void ejbRemove() {
+
+    }
+
+    public void setSessionContext(SessionContext context) {
+        this.sessionContext = context;
+    }
+
+    public void invokeOnSelfToThrowCustomRuntimeException() {
+        // use a "self" local object so that the subsequent invocation which is expected to
+        // throw a runtime exception, triggers a TransactionRolledbackLocalException
+        // @see https://issues.jboss.org/browse/AS7-5432
+        final Session21Local localObject = (Session21Local) sessionContext.getEJBLocalObject();
+        localObject.throwCustomRuntimeException();
+    }
+
+    public void throwCustomRuntimeException() {
+        throw new CustomRuntimeException();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/Session21Local.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/Session21Local.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.exception;
+
+import javax.ejb.EJBLocalObject;
+import java.rmi.RemoteException;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface Session21Local extends EJBLocalObject {
+
+    void throwCustomRuntimeException();
+
+    void invokeOnSelfToThrowCustomRuntimeException();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/Session21LocalHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/Session21LocalHome.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.exception;
+
+import javax.ejb.EJBHome;
+import javax.ejb.EJBLocalHome;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface Session21LocalHome extends EJBLocalHome {
+
+    public Session21Local create() throws javax.ejb.CreateException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/exception/ejb-jar.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN"
+        "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<ejb-jar>
+    <enterprise-beans>
+        <session>
+            <ejb-name>Session21Bean</ejb-name>
+            <local-home>org.jboss.as.test.integration.ejb.exception.Session21LocalHome</local-home>
+            <local>org.jboss.as.test.integration.ejb.exception.Session21Local</local>
+            <ejb-class>org.jboss.as.test.integration.ejb.exception.Session21Bean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Container</transaction-type>
+        </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-5432 where for certain exceptions thrown during an EJB 2.x invocation would not contain the original cause. This commit includes a testcase too.
