### PR TITLE
Fix AS7-5492. Make JNDI listBindings() work with multiple NamingStores.

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
@@ -221,6 +221,16 @@ public class ServiceBasedNamingStore implements NamingStore {
                 break;
             }
         }
+
+        // add items from the service registry which aren't already there from boundServices
+        for (ServiceName next: serviceRegistry.getServiceNames()) {
+            if (name.isParentOf(next) && !name.equals(next)) {
+                if (!children.contains(next)) {
+                    children.add(next);
+                }
+            }
+        }
+
         return children;
     }
 


### PR DESCRIPTION
This is a small fix for AS7-5492, by making listChildren() return items from the ServiceRegistry too.

Potential performance concerns:
1) It iterates through the entire contents of the registry. I don't see a way of fixing that without adding additional ServiceRegistry API to either get partial contents or to notify the store of changes.
2) It checks whether entries are in the child list when adding which is O(n^2) in the number of items from the registry. It would be O(n) to use an IdentityHashMap as a set, but probably not worth it since the number of entries is likely to be small. Reversing the order of adding to be registry then boundServices may be better (though then n^2 in the number of boundServices matches)
