### PR TITLE
[7.1] [AS7-5499] upgrade HornetQ to 2.2.19.Final-build2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <version.org.hibernate.validator>4.2.0.Final</version.org.hibernate.validator>
         <version.org.hibernate3>3.6.6.Final</version.org.hibernate3>
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>
-        <version.org.hornetq>2.2.19.Final</version.org.hornetq>
+        <version.org.hornetq>2.2.19.Final-build2</version.org.hornetq>
         <version.org.infinispan>5.1.7.Final</version.org.infinispan>
         <version.org.jacorb>2.3.2.jbossorg-0</version.org.jacorb>
         <version.org.javassist>3.15.0-GA</version.org.javassist>


### PR DESCRIPTION
- this version of HornetQ depends on Netty 3.2.6.Final
