### PR TITLE
AS7-5395: adds support for CREATE TABLE IF NOT EXISTS, as solution to co...

### DIFF
--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc/SQLUtil.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc/SQLUtil.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.cmp.jdbc;
 
+import static org.jboss.as.cmp.CmpMessages.MESSAGES;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -29,11 +31,11 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Vector;
 import java.util.zip.CRC32;
+
 import javax.sql.DataSource;
 
 import org.jboss.as.cmp.CmpLogger;
 import org.jboss.as.cmp.CmpMessages;
-import static org.jboss.as.cmp.CmpMessages.MESSAGES;
 import org.jboss.as.cmp.jdbc.bridge.JDBCAbstractCMRFieldBridge;
 import org.jboss.as.cmp.jdbc.bridge.JDBCAbstractEntityBridge;
 import org.jboss.as.cmp.jdbc.bridge.JDBCEntityBridge;
@@ -68,6 +70,7 @@ public final class SQLUtil {
     public static final String ON = " ON ";
     public static final String NOT_EQUAL = "<>";
     public static final String CREATE_TABLE = "CREATE TABLE ";
+    public static final String CREATE_TABLE_IF_NOT_EXISTS = "CREATE TABLE IF NOT EXISTS ";
     public static final String DROP_TABLE = "DROP TABLE ";
     public static final String CREATE_INDEX = "CREATE INDEX ";
     public static final String NULL = "NULL";

--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/JDBCEntityMetaData.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/JDBCEntityMetaData.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.cmp.jdbc.metadata;
 
+import static org.jboss.as.cmp.CmpMessages.MESSAGES;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,8 +30,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jboss.as.cmp.CmpMessages;
-import static org.jboss.as.cmp.CmpMessages.MESSAGES;
 import org.jboss.as.cmp.jdbc.metadata.parser.ParsedCmpField;
 import org.jboss.as.cmp.jdbc.metadata.parser.ParsedEntity;
 import org.jboss.as.cmp.jdbc.metadata.parser.ParsedQuery;
@@ -112,6 +114,11 @@ public final class JDBCEntityMetaData {
      * Should we try and create the table when deployed?
      */
     private final boolean createTable;
+
+    /**
+     * indicates if CREATE TABLE IF NOT EXISTS sql dialect is supported
+     */
+    private final boolean createTableIfNotExistsSupported;
 
     /**
      * Should we drop the table when undeployed?
@@ -259,6 +266,7 @@ public final class JDBCEntityMetaData {
         dataSourceMappingName = null;
         tableName = null;
         createTable = false;
+        createTableIfNotExistsSupported = false;
         removeTable = false;
         alterTable = false;
         readOnly = false;
@@ -360,6 +368,7 @@ public final class JDBCEntityMetaData {
         dataSourceName = null;
         dataSourceMappingName = null;
         createTable = false;
+        createTableIfNotExistsSupported = false;
         removeTable = false;
         alterTable = false;
         rowLocking = false;
@@ -417,6 +426,7 @@ public final class JDBCEntityMetaData {
         dataSourceMappingName = defaultValues.dataSourceMappingName;
         tableName = defaultValues.tableName;
         createTable = defaultValues.createTable;
+        createTableIfNotExistsSupported = defaultValues.createTableIfNotExistsSupported;
         removeTable = defaultValues.removeTable;
         alterTable = defaultValues.alterTable;
         tablePostCreateCmd.addAll(defaultValues.tablePostCreateCmd);
@@ -499,6 +509,12 @@ public final class JDBCEntityMetaData {
             createTable = parsed.getCreateTable();
         } else {
             createTable = defaultValues.getCreateTable();
+        }
+
+        if (parsed.getCreateTableIfNotExistsSupported() != null) {
+            createTableIfNotExistsSupported = parsed.getCreateTableIfNotExistsSupported();
+        } else {
+            createTableIfNotExistsSupported = defaultValues.getCreateTableIfNotExistsSupported();
         }
 
         // remove table?  If not provided, keep default.
@@ -920,6 +936,14 @@ public final class JDBCEntityMetaData {
      */
     public boolean getCreateTable() {
         return createTable;
+    }
+
+    /**
+     * Gets the flag, which indicates that CREATE TABLE IF NOT EXISTS sql dialect is supported
+     * @return
+     */
+    public boolean getCreateTableIfNotExistsSupported() {
+        return createTableIfNotExistsSupported;
     }
 
     /**

--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/Element.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/Element.java
@@ -50,6 +50,7 @@ enum Element {
     CMR_FIELD("cmr-field-name"),
     COLUMN_NAME("column-name"),
     CREATE_TABLE("create-table"),
+    CREATE_TABLE_IF_NOT_EXISTS_SUPPORTED("create-table-if-not-exists-supported"),
     CREATED_BY("created-by"),
     CREATED_TIME("created-time"),
     DATASOURCE("datasource"),

--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/JDBCMetaDataParser.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/JDBCMetaDataParser.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.cmp.jdbc.metadata.parser;
 
+import static org.jboss.as.cmp.CmpMessages.MESSAGES;
+
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,7 +34,6 @@ import java.util.Map;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import static org.jboss.as.cmp.CmpMessages.MESSAGES;
 import org.jboss.as.cmp.jdbc.SQLUtil;
 import org.jboss.as.cmp.jdbc.metadata.JDBCApplicationMetaData;
 import org.jboss.as.cmp.jdbc.metadata.JDBCCMPFieldPropertyMetaData;
@@ -739,6 +740,10 @@ public class JDBCMetaDataParser extends MetaDataElementParser {
                 }
                 case CREATE_TABLE: {
                     metaData.createTable = Boolean.parseBoolean(getElementText(reader));
+                    break;
+                }
+                case CREATE_TABLE_IF_NOT_EXISTS_SUPPORTED: {
+                    metaData.createTableIfNotExistsSupported = Boolean.parseBoolean(getElementText(reader));
                     break;
                 }
                 case REMOVE_TABLE: {

--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/ParsedEntity.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc/metadata/parser/ParsedEntity.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.jboss.as.cmp.jdbc.metadata.JDBCEntityCommandMetaData;
 
 /**
@@ -37,6 +38,7 @@ public class ParsedEntity {
     String entityName;
     String tableName;
     Boolean createTable;
+    Boolean createTableIfNotExistsSupported;
     Boolean removeTable;
     Boolean alterTable;
     List<String> tablePostCreateCmd = new ArrayList<String>();
@@ -79,6 +81,10 @@ public class ParsedEntity {
 
     public Boolean getCreateTable() {
         return createTable;
+    }
+
+    public Boolean getCreateTableIfNotExistsSupported() {
+        return createTableIfNotExistsSupported;
     }
 
     public Boolean getRemoveTable() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/cmp/relationship/manyToManyBidirectional/CmpRelMTMBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/cmp/relationship/manyToManyBidirectional/CmpRelMTMBTestCase.java
@@ -36,16 +36,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(CmpTestRunner.class)
-public class ABTestCase extends AbstractCmpTest {
+public class CmpRelMTMBTestCase extends AbstractCmpTest {
 
-    static org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(ABTestCase.class);
+    static org.jboss.logging.Logger log = org.jboss.logging.Logger.getLogger(CmpRelMTMBTestCase.class);
 
     @Deployment
     public static Archive<?> deploy() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "mtom-bi-cmp-relationship.jar");
-        jar.addPackage(ABTestCase.class.getPackage());
-        jar.addAsManifestResource(ABTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
-        jar.addAsManifestResource(ABTestCase.class.getPackage(), "jbosscmp-jdbc.xml", "jbosscmp-jdbc.xml");
+        jar.addPackage(CmpRelMTMBTestCase.class.getPackage());
+        jar.addAsManifestResource(CmpRelMTMBTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        jar.addAsManifestResource(CmpRelMTMBTestCase.class.getPackage(), "jbosscmp-jdbc.xml", "jbosscmp-jdbc.xml");
         AbstractCmpTest.addDeploymentAssets(jar);
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/cmp/relationship/manyToManyBidirectional/jbosscmp-jdbc.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/cmp/relationship/manyToManyBidirectional/jbosscmp-jdbc.xml
@@ -6,21 +6,25 @@
 
 <jbosscmp-jdbc>
 
-   <defaults>
-      <create-table>true</create-table>
-      <remove-table>true</remove-table>
-      <pk-constraint>true</pk-constraint>
-      <read-ahead><strategy>on-find</strategy></read-ahead>
-   </defaults>
+	<defaults>
+		<create-table>true</create-table>
+		<create-table-if-not-exists-supported>true</create-table-if-not-exists-supported>
+		<remove-table>true</remove-table>
+		<pk-constraint>true</pk-constraint>
+		<read-ahead>
+			<strategy>on-find</strategy>
+		</read-ahead>
 
-   <relationships>
-      
-      <ejb-relation>
-         <ejb-relation-name>AB_ManyToMany_Bi</ejb-relation-name>
-         <relation-table-mapping>
-            <table-name>AB_ManyToManyBi</table-name>
-         </relation-table-mapping>
-      </ejb-relation>
-      
-   </relationships>
+	</defaults>
+
+	<relationships>
+
+		<ejb-relation>
+			<ejb-relation-name>AB_ManyToMany_Bi</ejb-relation-name>
+			<relation-table-mapping>
+				<table-name>AB_ManyToManyBi</table-name>
+			</relation-table-mapping>
+		</ejb-relation>
+
+	</relationships>
 </jbosscmp-jdbc>


### PR DESCRIPTION
...ncurrent CMP relation table creation. If the datasource does not supports it, that can be indicated through jboss-cmp xml, in such case the deployment unit catalog instance, will be used to sync CMP relation table creation logic.

Master PR: #3033
