### PR TITLE
[master only] AS7-5581 - Enable security on beans if any security metadata is configured but security domain isn't

### DIFF
--- a/build/src/main/resources/configuration/subsystems/ejb3.xml
+++ b/build/src/main/resources/configuration/subsystems/ejb3.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.ejb3</extension-module>
-   <subsystem xmlns="urn:jboss:domain:ejb3:1.3">
+   <subsystem xmlns="urn:jboss:domain:ejb3:1.4">
        <session-bean>
            <stateless>
                <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
@@ -10,6 +10,7 @@
            <?STATEFUL-BEAN?>
            <singleton default-access-timeout="5000"/>
        </session-bean>
+       <default-security-domain value="other"/>
        <?MDB?>
        <pools>
            <bean-instance-pools>

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_4.xsd
@@ -1,0 +1,342 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:ejb3:1.4"
+           xmlns="urn:jboss:domain:ejb3:1.4"
+           xmlns:threads="urn:jboss:domain:threads:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.4">
+
+    <xs:import namespace="urn:jboss:domain:threads:1.1" schemaLocation="jboss-as-threads_1_1.xsd"/>
+
+    <!-- The ejb3 subsystem root element -->
+    <xs:element name="subsystem" type="ejb3-subsystemType"/>
+
+    <xs:complexType name="ejb3-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                EJB3 subsystem configurations
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="session-bean" type="session-beanType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="mdb" type="mdbType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="entity-bean" type="entityType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="pools" type="poolsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="caches" type="cachesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="passivation-stores" type="passivation-storesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="async" type="asyncType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="timer-service" type="timerServiceType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="remote" type="remoteType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="thread-pools" type="threadPoolsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="iiop" type="iiopType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="in-vm-remote-interface-invocation" type="in-vm-remote-interface-invocationType"
+                        minOccurs="0" maxOccurs="1"/>
+            <xs:element name="default-distinct-name" type="default-distinct-nameType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="default-security-domain" type="default-security-domainType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="statistics" type="statisticsType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="mdbType">
+        <xs:all>
+            <xs:element name="resource-adapter-ref" type="resource-adapter-refType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="bean-instance-pool-ref" type="bean-instance-pool-refType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="entityType">
+        <xs:all>
+            <xs:element name="bean-instance-pool-ref" type="bean-instance-pool-refType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="optimistic-locking" type="optimistic-lockingType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="optimistic-lockingType">
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="remoteType">
+        <xs:all>
+            <xs:element name="channel-creation-options" type="channel-creation-optionsType" minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="connector-ref" type="xs:string" use="required"/>
+        <xs:attribute name="thread-pool-name" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="asyncType">
+        <xs:attribute name="thread-pool-name" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="session-beanType">
+        <xs:all>
+            <xs:element name="stateless" type="stateless-beanType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="stateful" type="stateful-beanType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="singleton" type="singleton-beanType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="stateless-beanType">
+        <xs:all>
+            <xs:element name="bean-instance-pool-ref" type="bean-instance-pool-refType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="stateful-beanType">
+        <xs:attribute name="default-access-timeout" type="xs:positiveInteger" default="5000" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The default access timeout, for stateful session beans, in milliseconds
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cache-ref" type="xs:string"/>
+        <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="singleton-beanType">
+        <xs:attribute name="default-access-timeout" type="xs:positiveInteger" default="5000" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The default access timeout, for singleton beans, in milliseconds
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="resource-adapter-refType">
+        <xs:attribute name="resource-adapter-name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="bean-instance-pool-refType">
+        <xs:attribute name="pool-name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="poolsType">
+        <xs:all>
+            <xs:element name="bean-instance-pools" type="bean-instance-poolsType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="bean-instance-poolsType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="strict-max-pool" type="strict-max-poolType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="strict-max-poolType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="max-pool-size" type="xs:positiveInteger" default="20" use="optional"/>
+        <xs:attribute name="instance-acquisition-timeout" type="xs:positiveInteger" default="5" use="optional"/>
+        <xs:attribute name="instance-acquisition-timeout-unit" type="timeout-unitType"
+                      default="MINUTES" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="cachesType">
+        <xs:sequence>
+            <xs:element name="cache" type="cacheType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="cacheType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="passivation-store-ref" type="xs:string"/>
+        <xs:attribute name="aliases" type="aliases"/>
+    </xs:complexType>
+
+    <xs:complexType name="passivation-storesType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="file-passivation-store" type="file-passivation-storeType"/>
+            <xs:element name="cluster-passivation-store" type="cluster-passivation-storeType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:attributeGroup name="passivation-common">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="idle-timeout" type="xs:positiveInteger" default="300"/>
+        <xs:attribute name="idle-timeout-unit" type="timeout-unitType" default="SECONDS"/>
+    </xs:attributeGroup>
+
+    <xs:complexType name="file-passivation-storeType">
+        <xs:attributeGroup ref="passivation-common"/>
+        <xs:attribute name="max-size" type="xs:positiveInteger" default="100000"/>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir"/>
+        <xs:attribute name="sessions-path" type="xs:string" default="ejb3/sessions"/>
+        <xs:attribute name="groups-path" type="xs:string" default="ejb3/groups"/>
+        <xs:attribute name="subdirectory-count" type="xs:positiveInteger" default="100"/>
+    </xs:complexType>
+
+    <xs:complexType name="cluster-passivation-storeType">
+        <xs:attributeGroup ref="passivation-common"/>
+        <xs:attribute name="max-size" type="xs:positiveInteger" default="10000"/>
+        <xs:attribute name="passivate-events-on-replicate" type="xs:boolean" default="true"/>
+        <xs:attribute name="cache-container" type="xs:string" default="ejb"/>
+        <xs:attribute name="bean-cache" type="xs:string"/>
+        <xs:attribute name="client-mappings-cache" type="xs:string" default="remote-connector-client-mappings"/>
+    </xs:complexType>
+
+    <xs:simpleType name="aliases">
+        <xs:annotation>
+            <xs:documentation>A list of aliases.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="timeout-unitType">
+        <xs:annotation>
+            <xs:documentation>
+                TimeUnit that are allowed for instance-acquisition-timeout on a pool
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="DAYS"/>
+            <xs:enumeration value="HOURS"/>
+            <xs:enumeration value="MINUTES"/>
+            <xs:enumeration value="SECONDS"/>
+            <xs:enumeration value="MILLISECONDS"/>
+            <xs:enumeration value="MICROSECONDS"/>
+            <xs:enumeration value="NANOSECONDS"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="timerServiceType">
+        <xs:sequence>
+            <xs:element name="data-store" type="dataStoreType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="thread-pool-name" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="threadPoolsType">
+        <xs:sequence>
+            <xs:element name="thread-pool" type="threadPoolType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="threadPoolType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no
+                upper bound.  When a task is submitted, if the number of running threads is less than the core size,
+                a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be
+                submitted to this type of executor, an out of memory condition may occur.
+
+                The "name" attribute is the name of the created executor.
+
+                The "max-threads" attribute must be used to specify the thread pool size.  The nested
+                "keepalive-time" element may used to specify the amount of time that pool threads should
+                be kept running when idle; if not specified, threads will run until the executor is shut down.
+                The "thread-factory" element specifies the bean name of a specific threads subsystem thread factory to
+                use to create worker threads. Usually it will not be set for an EJB3 thread pool and an appropriate
+                default thread factory will be used.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-threads" type="threads:countType"/>
+            <xs:element name="keepalive-time" type="threads:time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="threads:ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="dataStoreType">
+        <xs:attribute name="path" type="xs:string"/>
+        <xs:attribute name="relative-to" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="iiopType">
+        <xs:attribute name="enable-by-default" type="xs:boolean" use="required"/>
+        <xs:attribute name="use-qualified-name" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="in-vm-remote-interface-invocationType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The EJB3 spec mandates that the invocations on remote interfaces of a EJB, use pass-by-value
+                semantics for parameters (i.e. parameter values are serialized/deserialized) during invocation.
+                The pass-by-value attribute of this element can be used to switch that behaviour to pass the parameters
+                by reference (and skip the serialization/deserialization step). Setting the pass-by-value to false will
+                return in pass-by-reference semantics.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pass-by-value" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="default-distinct-nameType">
+        <xs:attribute name="value" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="default-security-domainType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The default security domain name that will be used for EJBs in the absence of any explicitly configured
+                security domain name for the bean
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="statisticsType">
+        <xs:attribute name="enabled" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="channel-creation-optionsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The options that will be used while creating the channel for EJB remote invocation communication
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="option" type="optionType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="optionType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The "name" attribute specifies the name of the option being configured.
+
+                The "value" attribute is the value that's going to be set for the option.
+
+                The "type" attribute value can either be "xnio" or "remoting". If it's "xnio", then the option
+                being configured will be looked up against the org.xnio.Options class. If it's "remoting" then
+                the option will be looked up against the org.xnio.Option.RemotingOptions class.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string"/>
+        <xs:attribute name="type" type="xs:string" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -113,6 +113,11 @@ public abstract class EJBComponentDescription extends ComponentDescription {
     private String securityDomain;
 
     /**
+     * The default security domain to use if no explicit security domain is configured for this bean
+     */
+    private String defaultSecurityDomain;
+
+    /**
      * The @DeclareRoles (a.k.a security-role-ref) for the bean
      */
     private final Set<String> declaredRoles = new HashSet<String>();
@@ -532,8 +537,31 @@ public abstract class EJBComponentDescription extends ComponentDescription {
         this.securityDomain = securityDomain;
     }
 
+    public void setDefaultSecurityDomain(final String defaultSecurityDomain) {
+        this.defaultSecurityDomain = defaultSecurityDomain;
+    }
+
+    /**
+     * Returns the security domain that is applicable for this bean. In the absence of any explicit
+     * configuration of a security domain for this bean, this method returns the default security domain
+     * (if any) that's configured for all beans in the EJB3 subsystem
+     * @return
+     */
     public String getSecurityDomain() {
+        if (this.securityDomain == null) {
+            return this.defaultSecurityDomain;
+        }
         return this.securityDomain;
+    }
+
+    /**
+     * Returns true if this bean has been explicitly configured with a security domain via the
+     * {@link org.jboss.ejb3.annotation.SecurityDomain} annotation or via the jboss-ejb3.xml deployment descriptor.
+     * Else returns false.
+     * @return
+     */
+    public boolean isExplicitSecurityDomainConfigured() {
+        return this.securityDomain != null;
     }
 
     public SecurityRolesMetaData getSecurityRoles() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.deployment.processors;
+
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+
+import java.util.Collection;
+
+import static org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION;
+
+/**
+ * A {@link DeploymentUnitProcessor} which looks for {@link EJBComponentDescription}s in the deployment
+ * unit and sets the default security domain name, that's configured at the EJB subsystem level, to each of the EJB
+ * component descriptions
+ * <p/>
+ * Note that this processor is expected to run *before* the annotation and deployment descriptor parsers for
+ * the security domain configuration are run on the deployment. That way, those processors can override this
+ * default global value that's set by this processor on the EJB components
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcessor {
+
+    private volatile String defaultSecurityDomainName;
+
+    public EJBDefaultSecurityDomainProcessor(final String defaultSecurityDomainName) {
+        this.defaultSecurityDomainName = defaultSecurityDomainName;
+    }
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(EE_MODULE_DESCRIPTION);
+        if (eeModuleDescription == null) {
+            return;
+        }
+        final Collection<ComponentDescription> componentDescriptions = eeModuleDescription.getComponentDescriptions();
+        if (componentDescriptions == null || componentDescriptions.isEmpty()) {
+            return;
+        }
+        for (ComponentDescription componentDescription : componentDescriptions) {
+            if (componentDescription instanceof EJBComponentDescription) {
+                ((EJBComponentDescription) componentDescription).setSecurityDomain(this.defaultSecurityDomainName);
+            }
+        }
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+    /**
+     * Sets the default security domain name to be used for EJB components, if no explicit security domain
+     * is configured for the bean.
+     *
+     * @param securityDomainName The security domain name. Can be null.
+     */
+    public void setDefaultSecurityDomainName(final String securityDomainName) {
+        this.defaultSecurityDomainName = securityDomainName;
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
@@ -36,12 +36,8 @@ import static org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION;
 
 /**
  * A {@link DeploymentUnitProcessor} which looks for {@link EJBComponentDescription}s in the deployment
- * unit and sets the default security domain name, that's configured at the EJB subsystem level, to each of the EJB
- * component descriptions
- * <p/>
- * Note that this processor is expected to run *before* the annotation and deployment descriptor parsers for
- * the security domain configuration are run on the deployment. That way, those processors can override this
- * default global value that's set by this processor on the EJB components
+ * unit and sets the default security domain name, that's configured at the EJB subsystem level,
+ * {@link EJBComponentDescription#setDefaultSecurityDomain(String) to each of the EJB component descriptions}.
  *
  * @author Jaikiran Pai
  */
@@ -66,7 +62,7 @@ public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcesso
         }
         for (ComponentDescription componentDescription : componentDescriptions) {
             if (componentDescription instanceof EJBComponentDescription) {
-                ((EJBComponentDescription) componentDescription).setSecurityDomain(this.defaultSecurityDomainName);
+                ((EJBComponentDescription) componentDescription).setDefaultSecurityDomain(this.defaultSecurityDomainName);
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
@@ -59,6 +59,7 @@ public class EJB3Extension implements Extension {
     public static final String NAMESPACE_1_1 = EJB3SubsystemNamespace.EJB3_1_1.getUriString();
     public static final String NAMESPACE_1_2 = EJB3SubsystemNamespace.EJB3_1_2.getUriString();
     public static final String NAMESPACE_1_3 = EJB3SubsystemNamespace.EJB3_1_3.getUriString();
+    public static final String NAMESPACE_1_4 = EJB3SubsystemNamespace.EJB3_1_4.getUriString();
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
     private static final int MANAGEMENT_API_MINOR_VERSION = 1;
@@ -81,7 +82,7 @@ public class EJB3Extension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
 
-        subsystem.registerXMLElementWriter(EJB3Subsystem13Parser.INSTANCE);
+        subsystem.registerXMLElementWriter(EJB3Subsystem14Parser.INSTANCE);
 
         final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(EJB3SubsystemRootResourceDefinition.INSTANCE);
 
@@ -132,6 +133,7 @@ public class EJB3Extension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, EJB3Subsystem11Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, EJB3Subsystem12Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_3, EJB3Subsystem13Parser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_4, EJB3Subsystem14Parser.INSTANCE);
     }
 
     private static class EJB3ThreadFactoryResolver extends ThreadFactoryResolver.SimpleResolver {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem14Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem14Parser.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+import javax.xml.stream.XMLStreamException;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN;
+
+
+/**
+ */
+public class EJB3Subsystem14Parser extends EJB3Subsystem13Parser {
+
+    public static final EJB3Subsystem14Parser INSTANCE = new EJB3Subsystem14Parser();
+
+    protected EJB3Subsystem14Parser() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void writeElements(final XMLExtendedStreamWriter writer, final SubsystemMarshallingContext context) throws XMLStreamException {
+        super.writeElements(writer, context);
+
+        final ModelNode model = context.getModelNode();
+
+        // default-security-domain element
+        if (model.hasDefined(DEFAULT_SECURITY_DOMAIN)) {
+            writer.writeStartElement(EJB3SubsystemXMLElement.DEFAULT_SECURITY_DOMAIN.getLocalName());
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.VALUE.getLocalName(), model.get(DEFAULT_SECURITY_DOMAIN).asString());
+            writer.writeEndElement();
+        }
+    }
+
+    @Override
+    protected void readElement(final XMLExtendedStreamReader reader, final EJB3SubsystemXMLElement element, final List<ModelNode> operations, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+        switch (element) {
+            case DEFAULT_SECURITY_DOMAIN: {
+                parseDefaultSecurityDomain(reader, ejb3SubsystemAddOperation);
+                break;
+            }
+            default: {
+                super.readElement(reader, element, operations, ejb3SubsystemAddOperation);
+            }
+        }
+    }
+
+    @Override
+    protected EJB3SubsystemNamespace getExpectedNamespace() {
+        return EJB3SubsystemNamespace.EJB3_1_4;
+    }
+
+    private void parseDefaultSecurityDomain(final XMLExtendedStreamReader reader, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        final EnumSet<EJB3SubsystemXMLAttribute> missingRequiredAttributes = EnumSet.of(EJB3SubsystemXMLAttribute.VALUE);
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final EJB3SubsystemXMLAttribute attribute = EJB3SubsystemXMLAttribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case VALUE:
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    // found the mandatory attribute
+                    missingRequiredAttributes.remove(EJB3SubsystemXMLAttribute.VALUE);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        requireNoContent(reader);
+        if (!missingRequiredAttributes.isEmpty()) {
+            throw missingRequired(reader, missingRequiredAttributes);
+        }
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -41,6 +41,7 @@ public interface EJB3SubsystemModel {
     String IN_VM_REMOTE_INTERFACE_INVOCATION_PASS_BY_VALUE = "in-vm-remote-interface-invocation-pass-by-value";
 
     String DEFAULT_DISTINCT_NAME = "default-distinct-name";
+    String DEFAULT_SECURITY_DOMAIN = "default-security-domain";
     String DEFAULT_MDB_INSTANCE_POOL = "default-mdb-instance-pool";
     String DEFAULT_RESOURCE_ADAPTER_NAME = "default-resource-adapter-name";
     String DEFAULT_SFSB_CACHE = "default-sfsb-cache";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemNamespace.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemNamespace.java
@@ -38,6 +38,7 @@ public enum EJB3SubsystemNamespace {
     EJB3_1_1("urn:jboss:domain:ejb3:1.1"),
     EJB3_1_2("urn:jboss:domain:ejb3:1.2"),
     EJB3_1_3("urn:jboss:domain:ejb3:1.3"),
+    EJB3_1_4("urn:jboss:domain:ejb3:1.4")
     ;
 
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
@@ -43,6 +43,7 @@ public enum EJB3SubsystemXMLElement {
 
     DATA_STORE("data-store"),
     DEFAULT_DISTINCT_NAME("default-distinct-name"),
+    DEFAULT_SECURITY_DOMAIN("default-security-domain"),
 
     IIOP("iiop"),
     IN_VM_REMOTE_INTERFACE_INVOCATION("in-vm-remote-interface-invocation"),

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBDefaultSecurityDomainWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBDefaultSecurityDomainWriteHandler.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.ejb3.deployment.processors.EJBDefaultSecurityDomainProcessor;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Write handler for default security domain attribute of EJB3 subsystem
+ *
+ * @author Jaikiran Pai
+ */
+class EJBDefaultSecurityDomainWriteHandler extends AbstractWriteAttributeHandler<Void> {
+
+    private final AttributeDefinition attributeDefinition;
+    private final EJBDefaultSecurityDomainProcessor ejbDefaultSecurityDomainProcessor;
+
+    EJBDefaultSecurityDomainWriteHandler(final AttributeDefinition attributeDefinition, final EJBDefaultSecurityDomainProcessor ejbDefaultSecurityDomainProcessor) {
+        super(attributeDefinition);
+        this.attributeDefinition = attributeDefinition;
+        this.ejbDefaultSecurityDomainProcessor = ejbDefaultSecurityDomainProcessor;
+    }
+
+    @Override
+    protected void validateResolvedValue(String attributeName, ModelNode value) throws OperationFailedException {
+    }
+
+    @Override
+    protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName,
+                                           ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> handbackHolder) throws OperationFailedException {
+        final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+        updateDefaultSecurityDomainDeploymentProcessor(context, model);
+
+        return false;
+    }
+
+    @Override
+    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName,
+                                         ModelNode valueToRestore, ModelNode valueToRevert, Void handback) throws OperationFailedException {
+        final ModelNode restored = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().clone();
+        restored.get(attributeName).set(valueToRestore);
+        updateDefaultSecurityDomainDeploymentProcessor(context, restored);
+    }
+
+    private void updateDefaultSecurityDomainDeploymentProcessor(final OperationContext context, final ModelNode model) throws OperationFailedException {
+
+        if (this.ejbDefaultSecurityDomainProcessor == null) {
+            return;
+        }
+        final ModelNode defaultSecurityDomainModelNode = this.attributeDefinition.resolveModelAttribute(context, model);
+        final String defaultSecurityDomainName = defaultSecurityDomainModelNode.isDefined() ? defaultSecurityDomainModelNode.asString() : null;
+        this.ejbDefaultSecurityDomainProcessor.setDefaultSecurityDomainName(defaultSecurityDomainName);
+    }
+
+}

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -14,6 +14,7 @@ ejb3.default-stateful-bean-access-timeout=The default access timeout for statefu
 ejb3.default-singleton-bean-access-timeout=The default access timeout for singleton beans
 ejb3.in-vm-remote-interface-invocation-pass-by-value=If set to false, the parameters to invocations on remote interface of an EJB, will be passed by reference. Else, the parameters will be passed by value.
 ejb3.default-distinct-name=The default distinct name that is applied to every EJB deployed on this server
+ejb3.default-security-domain=The default security domain that will be used for EJBs if the bean doesn't explicitly specify one
 
 service=Centrally configurable services that are part of the EJB3 subsystem.
 

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -278,6 +278,7 @@ public enum Phase {
     public static final int PARSE_DATA_SOURCE_DEFINITION_ANNOTATION     = 0x2D00;
     public static final int PARSE_EJB_CONTEXT_BINDING                   = 0x2E00;
     public static final int PARSE_EJB_TIMERSERVICE_BINDING              = 0x2E01;
+    public static final int PARSE_EJB_DEFAULT_SECURITY_DOMAIN           = 0x2E02;
     public static final int PARSE_PERSISTENCE_UNIT                      = 0x2F00;
     public static final int PARSE_LIFECYCLE_ANNOTATION                  = 0x3200;
     public static final int PARSE_PASSIVATION_ANNOTATION                = 0x3250;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/BeanWithoutExplicitSecurityDomain.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/BeanWithoutExplicitSecurityDomain.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security;
+
+import javax.annotation.Resource;
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Local;
+import javax.ejb.LocalBean;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Local({Restriction.class, FullAccess.class})
+@LocalBean
+public class BeanWithoutExplicitSecurityDomain implements Restriction, FullAccess {
+
+    @Resource
+    private SessionContext sessionContext;
+
+    @Override
+    @DenyAll
+    public void restrictedMethod() {
+        throw new RuntimeException("No one was expected to be able to call this method");
+    }
+
+    @Override
+    @PermitAll
+    public void doAnything() {
+    }
+
+    @RolesAllowed("role2")
+    public void allowOnlyRoleTwoToAccess() {
+        if (!this.sessionContext.isCallerInRole("role2")) {
+            throw new RuntimeException("Only user(s) in role2 were expected to have access to this method");
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -22,24 +22,6 @@
 
 package org.jboss.as.test.integration.ejb.security.callerprincipal;
 
-import java.security.Principal;
-
-import javax.ejb.EJBHome;
-import javax.jms.DeliveryMode;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
-import javax.jms.ObjectMessage;
-import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
-import javax.jms.QueueSession;
-import javax.jms.Session;
-import javax.jms.TemporaryQueue;
-import javax.jms.TextMessage;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
 import junit.framework.Assert;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -63,15 +45,27 @@ import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.util.Base64;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.util.Base64;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import javax.ejb.EJBHome;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
+import javax.jms.TextMessage;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 /**
  * The Bean Provider can invoke the getCallerPrincipal and isCallerInRole methods only
@@ -225,26 +219,6 @@ public class GetCallerPrincipalTestCase {
         client.setSimple("user1", "password1");
         client.login();
         return client;
-    }
-
-
-    /*
-     * Tests
-     */
-    @Test
-    public void testUnauthenticatedNoSecurityDomain() throws Exception {
-        try {
-            ISLSBWithoutSecurityDomain bean = (ISLSBWithoutSecurityDomain) initialContext.lookup("ejb:/callerprincipal-test//" + SLSBWithoutSecurityDomain.class.getSimpleName() + "!" + ISLSBWithoutSecurityDomain.class.getName());
-            final Principal principal = bean.getCallerPrincipal();
-            assertNotNull("EJB 3.1 FR 17.6.5 The container must never return a null from the getCallerPrincipal method.",
-                    principal);
-            assertEquals(ANONYMOUS, principal.getName());
-        } catch (RuntimeException e) {
-            e.printStackTrace();
-            log.error(e.getStackTrace());
-            fail("EJB 3.1 FR 17.6.5 The EJB container must provide the caller’s security context information during the execution of a business method ("
-                    + e.getMessage() + ")");
-        }
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java
@@ -1,0 +1,159 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.callerprincipal;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.ejb3.subsystem.EJB3Extension;
+import org.jboss.as.ejb3.subsystem.EJB3SubsystemModel;
+import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
+import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.util.Base64;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import java.security.Principal;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that when the default security domain is disabled at EJB3 subsystem level then the security API
+ * invocations on the EJB work correctly
+ *
+ * @author Jaikiran Pai
+ * @see https://issues.jboss.org/browse/AS7-5581
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.DisableDefaultSecurityDomainSetupTask.class})
+public class GetCallerPrincipalWithNoDefaultSecurityDomainTestCase {
+
+    private static final Logger log = Logger.getLogger(GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.class);
+
+    private static final String ANONYMOUS = "anonymous"; //TODO: is this constant configured somewhere?
+
+    private static final String MODULE_NAME = "callerprincipal-without-default-security-domain";
+
+    /**
+     * Server setup task responsible for disabling (and then re-enabling) the default security domain
+     * that's configured at EJB3 subsystem level
+     */
+    static class DisableDefaultSecurityDomainSetupTask extends AbstractMgmtServerSetupTask {
+
+        private String defaultSecurityDomain;
+
+        @Override
+        protected void doSetup(final ManagementClient managementClient) throws Exception {
+            // first read the current value of the default-security-domain
+            final PathAddress ejb3SubsystemPathAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME));
+
+            final ModelNode defaultSecurityDomainAttr = new ModelNode();
+            defaultSecurityDomainAttr.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION);
+            defaultSecurityDomainAttr.get(NAME).set(EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN);
+            defaultSecurityDomainAttr.get(OP_ADDR).set(ejb3SubsystemPathAddress.toModelNode());
+
+            final ModelNode readResult = executeOperation(defaultSecurityDomainAttr);
+            this.defaultSecurityDomain = readResult.asString();
+            // remove the default security domain from EJB3 subsystem
+            final ModelNode disableDefaultSecurityDomain = new ModelNode();
+            disableDefaultSecurityDomain.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION);
+            disableDefaultSecurityDomain.get(NAME).set(EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN);
+            disableDefaultSecurityDomain.get(OP_ADDR).set(ejb3SubsystemPathAddress.toModelNode());
+
+            executeOperation(disableDefaultSecurityDomain);
+
+
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            final PathAddress ejb3SubsystemPathAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME));
+            final ModelNode defaultSecurityDomainAttr = new ModelNode();
+            defaultSecurityDomainAttr.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION);
+            defaultSecurityDomainAttr.get(NAME).set(EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN);
+            defaultSecurityDomainAttr.get(VALUE).set(this.defaultSecurityDomain);
+            defaultSecurityDomainAttr.get(OP_ADDR).set(ejb3SubsystemPathAddress.toModelNode());
+
+            executeOperation(defaultSecurityDomainAttr);
+        }
+
+    }
+
+    @ArquillianResource
+    private InitialContext initialContext;
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar")
+                .addClass(GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.class)
+                .addClass(Base64.class)
+                .addClass(SLSBWithoutSecurityDomain.class)
+                .addClass(ISLSBWithoutSecurityDomain.class)
+                .addClasses(DisableDefaultSecurityDomainSetupTask.class, AbstractMgmtTestBase.class)
+                .addPackage(AbstractMgmtTestBase.class.getPackage()).addClasses(MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class)
+                .addAsManifestResource(GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.class.getPackage(), "MANIFEST.MF-no-default-security-domain", "MANIFEST.MF");
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    /**
+     * Tests that the {@link javax.ejb.EJBContext#getCallerPrincipal()} works as expected in the absence of
+     * any default security domain at EJB3 susbsystem level and any explicit security domain on the bean
+     */
+    @Test
+    public void testUnauthenticatedNoSecurityDomain() throws Exception {
+        try {
+            ISLSBWithoutSecurityDomain bean = (ISLSBWithoutSecurityDomain) initialContext.lookup("ejb:/" + MODULE_NAME + "//" + SLSBWithoutSecurityDomain.class.getSimpleName() + "!" + ISLSBWithoutSecurityDomain.class.getName());
+            final Principal principal = bean.getCallerPrincipal();
+            assertNotNull("EJB 3.1 FR 17.6.5 The container must never return a null from the getCallerPrincipal method.",
+                    principal);
+            assertEquals(ANONYMOUS, principal.getName());
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            log.error(e.getStackTrace());
+            fail("EJB 3.1 FR 17.6.5 The EJB container must provide the caller’s security context information during the execution of a business method ("
+                    + e.getMessage() + ")");
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/MANIFEST.MF-no-default-security-domain
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/MANIFEST.MF-no-default-security-domain
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Dependencies: org.jboss.as.controller-client,org.jboss.as.controller,org.jboss.dmr

--- a/testsuite/integration/clust/src/test/resources/cluster/ejb3/security/jboss-ejb-client.properties
+++ b/testsuite/integration/clust/src/test/resources/cluster/ejb3/security/jboss-ejb-client.properties
@@ -35,3 +35,6 @@ remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHA
 remote.clusters=ejb
 remote.cluster.ejb.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
 remote.cluster.ejb.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+remote.cluster.ejb.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS=JBOSS-LOCAL-USER
+remote.cluster.ejb.username=user1
+remote.cluster.ejb.password=password1


### PR DESCRIPTION
The commit in this pull request implements the feature request https://issues.jboss.org/browse/AS7-5581:

Consider the following example:

```
@Stateless
public class SecureBean 
{

   @RolesAllowed("role1")
   public void restrictedRoles()
   {
    ...
   }

   @DenyAll
   public void denyEveryone()
   {
     ...
   }

}
```

Notice that the bean methods use EJB security annotations to restrict access however the bean doesn't have any explicit @SecurityDomain configured (not even in jboss-ejb3.xml). Right now, AS7 ignores the security restriction on that bean allows everyone to invoke on it, as if security wasn't configured for that bean. This has confused users who expect the invocations to fail since they have used the javax.ejb.\* security annotations to restrict access. Many users have asked for a feature where the security domain is defaulted (if not explicitly specified) in cases like this.

The commit here defaults the security domain for such beans to "other". The default security domain itself can be configured (or even removed) from the EJB3 subsystem:

```
<default-security-domain value="other"/>
```

The presence of this default security domain adds a dependency on the appropriate security domain service from the security subsystem. The default-security-domain element can be removed from the EJB3 subsystem if the users want to disable this feature. 
