### PR TITLE
AS7-5584 Naming context read-only during SAR deployment

### DIFF
--- a/sar/src/main/java/org/jboss/as/service/AbstractService.java
+++ b/sar/src/main/java/org/jboss/as/service/AbstractService.java
@@ -25,7 +25,10 @@ package org.jboss.as.service;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.jboss.as.naming.WritableServiceBasedNamingStore;
+import org.jboss.msc.service.LifecycleContext;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceContainer;
 
 /**
  * Abstract service class.
@@ -45,13 +48,16 @@ abstract class AbstractService implements Service<Object> {
         return mBeanInstance;
     }
 
-    protected void invokeLifecycleMethod(final Method method) throws InvocationTargetException, IllegalAccessException {
+    protected void invokeLifecycleMethod(final Method method, final LifecycleContext context) throws InvocationTargetException, IllegalAccessException {
         if (method != null) {
+            final ServiceContainer container = context.getController().getServiceContainer();
+            WritableServiceBasedNamingStore.pushOwner(container.subTarget());
             final ClassLoader old = SecurityActions.setThreadContextClassLoader(mBeanInstance.getClass().getClassLoader());
             try {
                 method.invoke(mBeanInstance);
             } finally {
                 SecurityActions.resetThreadContextClassLoader(old);
+                WritableServiceBasedNamingStore.popOwner();
             }
         }
     }

--- a/sar/src/main/java/org/jboss/as/service/CreateDestroyService.java
+++ b/sar/src/main/java/org/jboss/as/service/CreateDestroyService.java
@@ -36,7 +36,7 @@ final class CreateDestroyService extends AbstractService {
             SarLogger.ROOT_LOGGER.tracef("Creating Service: %s", context.getController().getName());
         }
         try {
-            invokeLifecycleMethod(createMethod);
+            invokeLifecycleMethod(createMethod, context);
         } catch (final Exception e) {
             throw SarMessages.MESSAGES.failedExecutingLegacyMethod(e, "create()");
         }
@@ -54,7 +54,7 @@ final class CreateDestroyService extends AbstractService {
             managedReference.release();
         }
         try {
-            invokeLifecycleMethod(destroyMethod);
+            invokeLifecycleMethod(destroyMethod, context);
         } catch (final Exception e) {
             SarLogger.ROOT_LOGGER.failedExecutingLegacyMethod(e, "create()");
         }

--- a/sar/src/main/java/org/jboss/as/service/StartStopService.java
+++ b/sar/src/main/java/org/jboss/as/service/StartStopService.java
@@ -51,7 +51,7 @@ final class StartStopService extends AbstractService {
             SarLogger.ROOT_LOGGER.tracef("Starting Service: %s", context.getController().getName());
         }
         try {
-            invokeLifecycleMethod(startMethod);
+            invokeLifecycleMethod(startMethod, context);
         } catch (final Exception e) {
             throw SarMessages.MESSAGES.failedExecutingLegacyMethod(e, "start()");
         }
@@ -63,7 +63,7 @@ final class StartStopService extends AbstractService {
             SarLogger.ROOT_LOGGER.tracef("Stopping Service: %s", context.getController().getName());
         }
         try {
-            invokeLifecycleMethod(stopMethod);
+            invokeLifecycleMethod(stopMethod, context);
         } catch (final Exception e) {
             SarLogger.ROOT_LOGGER.failedExecutingLegacyMethod(e, "stop()");
         }


### PR DESCRIPTION
During the #start() #stop() method of a legacy SAR the naming context
is read only. The problem seems to be that
org.jboss.as.service.AbstractService.invokeLifecycleMethod(Method) only
sets the thread context class loader and does not do
WritableServiceBasedNamingStore.pushOwner.
- change AbstractService#invokeLifecycleMethod to take an additional
  LifecycleContext argument
- update CreateDestroyService to pass the context
- update StartStopService to pass the context

https://issues.jboss.org/browse/AS7-5584
