### PR TITLE
[AS7-5598] relax cluster-connection constraints

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AlternativeAttributeCheckHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AlternativeAttributeCheckHandler.java
@@ -42,10 +42,10 @@ public final class AlternativeAttributeCheckHandler implements OperationStepHand
         context.completeStep();
     }
 
-    public static void checkAlternatives(ModelNode operation, String attr1, String attr2) throws OperationFailedException {
+    public static void checkAlternatives(ModelNode operation, String attr1, String attr2, boolean acceptNone) throws OperationFailedException {
         boolean hasAttr1 = operation.hasDefined(attr1);
         boolean hasAttr2 = operation.hasDefined(attr2);
-        if (!hasAttr1 && !hasAttr2) {
+        if (!hasAttr1 && !hasAttr2 && !acceptNone) {
             throw new OperationFailedException(new ModelNode().set(MESSAGES.invalidOperationParameters(attr1, attr2)));
         } else if (hasAttr1 && hasAttr2) {
             throw new OperationFailedException(new ModelNode().set(MESSAGES.cannotIncludeOperationParameters(attr1, attr2)));

--- a/messaging/src/main/java/org/jboss/as/messaging/BridgeAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BridgeAdd.java
@@ -62,7 +62,7 @@ public class BridgeAdd extends AbstractAddStepHandler {
 
         model.setEmptyObject();
 
-        AlternativeAttributeCheckHandler.checkAlternatives(operation, CONNECTOR_REFS.getName(), DISCOVERY_GROUP_NAME.getName());
+        AlternativeAttributeCheckHandler.checkAlternatives(operation, CONNECTOR_REFS.getName(), DISCOVERY_GROUP_NAME.getName(), false);
 
         for (final AttributeDefinition attributeDefinition : BridgeDefinition.ATTRIBUTES) {
             attributeDefinition.validateAndSet(operation, model);

--- a/messaging/src/main/java/org/jboss/as/messaging/ClusterConnectionAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ClusterConnectionAdd.java
@@ -60,7 +60,7 @@ public class ClusterConnectionAdd extends AbstractAddStepHandler {
 
         model.setEmptyObject();
 
-        AlternativeAttributeCheckHandler.checkAlternatives(operation, CONNECTOR_REFS.getName(), (DISCOVERY_GROUP_NAME.getName()));
+        AlternativeAttributeCheckHandler.checkAlternatives(operation, CONNECTOR_REFS.getName(), (DISCOVERY_GROUP_NAME.getName()), true);
 
         for (final AttributeDefinition attributeDefinition : ClusterConnectionDefinition.ATTRIBUTES) {
             attributeDefinition.validateAndSet(operation, model);

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging12SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging12SubsystemParser.java
@@ -319,12 +319,16 @@ public class Messaging12SubsystemParser extends MessagingSubsystemParser {
             }
         }
 
-        checkOnlyOneOfElements(reader, seen, Element.STATIC_CONNECTORS, Element.DISCOVERY_GROUP_REF);
+        checkClusterConnectionConstraints(reader, seen);
 
         if(!required.isEmpty()) {
             missingRequired(reader, required);
         }
 
         updates.add(clusterConnectionAdd);
+    }
+
+    protected void checkClusterConnectionConstraints(XMLExtendedStreamReader reader, Set<Element> seen) throws XMLStreamException {
+        checkOnlyOneOfElements(reader, seen, Element.STATIC_CONNECTORS, Element.DISCOVERY_GROUP_REF);
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
@@ -33,6 +33,9 @@ import static org.jboss.as.messaging.CommonAttributes.CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.DEFAULT;
 import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
 import static org.jboss.as.messaging.CommonAttributes.SELECTOR;
+import static org.jboss.as.messaging.Element.DISCOVERY_GROUP_REF;
+import static org.jboss.as.messaging.Element.STATIC_CONNECTORS;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -67,6 +70,15 @@ public class Messaging13SubsystemParser extends Messaging12SubsystemParser {
     }
 
     protected Messaging13SubsystemParser() {
+    }
+
+    @Override
+    protected void checkClusterConnectionConstraints(XMLExtendedStreamReader reader, Set<Element> seen) throws XMLStreamException {
+        // AS7-5598 relax constraints on the cluster-connection to accept one without static-connectors or discovery-group-ref
+        // howver it is still not valid to have both
+        if (seen.contains(STATIC_CONNECTORS) && seen.contains(DISCOVERY_GROUP_REF)) {
+            throw new XMLStreamException(MESSAGES.onlyOneRequired(STATIC_CONNECTORS.getLocalName(), DISCOVERY_GROUP_REF.getLocalName()), reader.getLocation());
+        }
     }
 
     protected ModelNode createConnectionFactory(XMLExtendedStreamReader reader, ModelNode connectionFactory, boolean pooled) throws XMLStreamException

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -1625,7 +1625,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
     /**
      * Check one and only one of the 2 elements has been defined
      */
-    protected void checkOnlyOneOfElements(XMLExtendedStreamReader reader, Set<Element> seen, Element element1, Element element2) throws XMLStreamException {
+    protected static void checkOnlyOneOfElements(XMLExtendedStreamReader reader, Set<Element> seen, Element element1, Element element2) throws XMLStreamException {
         if (!seen.contains(element1) && !seen.contains(element2)) {
             throw new XMLStreamException(MESSAGES.required(element1.getLocalName(), element2.getLocalName()), reader.getLocation());
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAdd.java
@@ -67,7 +67,7 @@ public class ConnectionFactoryAdd extends AbstractAddStepHandler {
 
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
 
-        AlternativeAttributeCheckHandler.checkAlternatives(operation, Common.CONNECTOR.getName(), Common.DISCOVERY_GROUP_NAME.getName());
+        AlternativeAttributeCheckHandler.checkAlternatives(operation, Common.CONNECTOR.getName(), Common.DISCOVERY_GROUP_NAME.getName(), false);
 
         for (final AttributeDefinition attribute : ConnectionFactoryDefinition.ATTRIBUTES) {
             attribute.validateAndSet(operation, model);

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
@@ -66,7 +66,7 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler implement
 
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
 
-        AlternativeAttributeCheckHandler.checkAlternatives(operation, Common.CONNECTOR.getName(), Common.DISCOVERY_GROUP_NAME.getName());
+        AlternativeAttributeCheckHandler.checkAlternatives(operation, Common.CONNECTOR.getName(), Common.DISCOVERY_GROUP_NAME.getName(), false);
 
         for(final AttributeDefinition attribute : getDefinitions(PooledConnectionFactoryDefinition.ATTRIBUTES)) {
             attribute.validateAndSet(operation, model);

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
@@ -172,6 +172,15 @@
                         <connector-ref>netty</connector-ref>
                     </static-connectors>
                 </cluster-connection>
+                <!--  it is valid to have a cluster connection without
+                      a static-connector or discovery-group-ref when the node
+                      must accept connections from other cluster nodes but
+                      not connect to any other nodes.
+                 -->
+                <cluster-connection name="cc5">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                </cluster-connection>
             </cluster-connections>
             <grouping-handler name="grouping-handler">
                 <type>LOCAL</type>


### PR DESCRIPTION
AS7-5107 added a constraint to the cluster-connection to have
either a static-connectors or a discovery-group-ref defined.

However there is 1 case where it is valid to define a cluster-connection
without static-connectors or discovery-group-ref: when it is part of a
cluster and it accepts connections from other nodes but does not connect
to any other node.
This is a edge case but a valid one.

This commits relaxes the constraints and accepts a cluster-connection
without one of these attributes
