### PR TITLE
[master] AS7-4808 Add dependency on security domain service wherever applicable

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
@@ -32,7 +32,9 @@ import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
+import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.dmr.ModelNode;
+import org.jboss.jca.common.api.metadata.ds.DsSecurity;
 import org.jboss.jca.common.api.validator.ValidateException;
 import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.ServiceBuilder;
@@ -119,6 +121,14 @@ public class DataSourceEnable implements OperationStepHandler {
             if (verificationHandler != null) {
                 builder.addListener(verificationHandler);
             }
+            // add dependency on security domain service if applicable
+            final DsSecurity dsSecurityConfig = dataSourceConfig.getSecurity();
+            if (dsSecurityConfig != null) {
+                final String securityDomainName = dsSecurityConfig.getSecurityDomain();
+                if (securityDomainName != null) {
+                    builder.addDependency(SecurityDomainService.SERVICE_NAME.append(securityDomainName));
+                }
+            }
             int propertiesCount = 0;
             for (ServiceName name : serviceNames) {
                 if (xaDataSourceConfigServiceName.append("xa-datasource-properties").isParentOf(name)) {
@@ -160,7 +170,14 @@ public class DataSourceEnable implements OperationStepHandler {
             if (verificationHandler != null) {
                 builder.addListener(verificationHandler);
             }
-
+            // add dependency on security domain service if applicable
+            final DsSecurity dsSecurityConfig = dataSourceConfig.getSecurity();
+            if (dsSecurityConfig != null) {
+                final String securityDomainName = dsSecurityConfig.getSecurityDomain();
+                if (securityDomainName != null) {
+                    builder.addDependency(SecurityDomainService.SERVICE_NAME.append(securityDomainName));
+                }
+            }
             for (ServiceName name : serviceNames) {
                 if (dataSourceCongServiceName.append("connection-properties").isParentOf(name)) {
                     final ServiceController<?> dataSourceController = registry.getService(name);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -22,26 +22,9 @@
 package org.jboss.as.ejb3.component;
 
 
-import java.lang.reflect.Method;
-import java.rmi.Remote;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.ejb.EJBLocalObject;
-import javax.ejb.TimerService;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagementType;
-
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.BindingConfiguration;
+import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ee.component.ComponentConfigurator;
 import org.jboss.as.ee.component.ComponentDescription;
@@ -78,6 +61,7 @@ import org.jboss.as.ejb3.security.EJBSecurityViewConfigurator;
 import org.jboss.as.ejb3.security.SecurityContextInterceptorFactory;
 import org.jboss.as.ejb3.timerservice.AutoTimer;
 import org.jboss.as.ejb3.timerservice.NonFunctionalTimerService;
+import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -87,8 +71,26 @@ import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
 import org.jboss.metadata.ejb.spec.EnterpriseBeanMetaData;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
+import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
+
+import javax.ejb.EJBLocalObject;
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagementType;
+import java.lang.reflect.Method;
+import java.rmi.Remote;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 
@@ -221,6 +223,7 @@ public abstract class EJBComponentDescription extends ComponentDescription {
 
         getConfigurators().addFirst(new NamespaceConfigurator());
         getConfigurators().add(new EjbJarConfigurationConfigurator());
+        getConfigurators().add(new SecurityDomainDependencyConfigurator(this));
 
         // setup a dependency on the EJBUtilities service
         this.addDependency(EJBUtilities.SERVICE_NAME, ServiceBuilder.DependencyType.REQUIRED);
@@ -671,6 +674,33 @@ public abstract class EJBComponentDescription extends ComponentDescription {
             }
             final EJBComponentCreateServiceFactory ejbComponentCreateServiceFactory = (EJBComponentCreateServiceFactory) configuration.getComponentCreateServiceFactory();
             ejbComponentCreateServiceFactory.setEjbJarConfiguration(appExceptions);
+        }
+    }
+
+    /**
+     * Responsible for adding a dependency on the security domain service for the EJB component, if a security domain
+     * is applicable for the bean
+     */
+    private class SecurityDomainDependencyConfigurator implements ComponentConfigurator {
+
+        private final EJBComponentDescription ejbComponentDescription;
+
+        SecurityDomainDependencyConfigurator(final EJBComponentDescription ejbComponentDescription) {
+            this.ejbComponentDescription = ejbComponentDescription;
+        }
+
+        @Override
+        public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
+            configuration.getCreateDependencies().add(new DependencyConfigurator<Service<Component>>() {
+                @Override
+                public void configureDependency(ServiceBuilder<?> serviceBuilder, Service<Component> service) throws DeploymentUnitProcessingException {
+                    final String securityDomainName = SecurityDomainDependencyConfigurator.this.ejbComponentDescription.getSecurityDomain();
+                    if (securityDomainName != null) {
+                        final ServiceName securityDomainServiceName = SecurityDomainService.SERVICE_NAME.append(securityDomainName);
+                        serviceBuilder.addDependency(securityDomainServiceName);
+                    }
+                }
+            });
         }
     }
 

--- a/security/src/main/java/org/jboss/as/security/service/SecurityDomainService.java
+++ b/security/src/main/java/org/jboss/as/security/service/SecurityDomainService.java
@@ -113,6 +113,7 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
     /** {@inheritDoc} */
     @Override
     public void stop(StopContext context) {
+        log.debug("Stopping security domain service " + name);
         final JNDIBasedSecurityManagement securityManagement = (JNDIBasedSecurityManagement) securityManagementValue.getValue();
         securityManagement.removeSecurityDomain(name);
         // TODO clear auth cache?


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-4808 where the datasource if backed by a security domain would fail with NullPointerExceptions due to a missing dependency on the security domain service. A similar dependency was missing for EJB components too which has been fixed in this commit.
