### PR TITLE
AS7-5059 Deprecate/remove use of recursive context.completeStep() [1]

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AddAliasCommand.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AddAliasCommand.java
@@ -50,11 +50,11 @@ public class AddAliasCommand implements OperationStepHandler {
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                     context.reloadRequired();
-                    context.completeStep();
+                    context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
     /**

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigOperationHandlers.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigOperationHandlers.java
@@ -103,7 +103,7 @@ public class CacheConfigOperationHandlers {
         public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
             context.removeResource(PathAddress.EMPTY_ADDRESS);
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     };
 
@@ -114,7 +114,7 @@ public class CacheConfigOperationHandlers {
             final Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
             CommonAttributes.VALUE.validateAndSet(operation, resource.getModel());
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     };
 
@@ -124,7 +124,7 @@ public class CacheConfigOperationHandlers {
             final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
             CommonAttributes.VALUE.validateAndSet(operation, resource.getModel());
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     };
 
@@ -155,7 +155,7 @@ public class CacheConfigOperationHandlers {
 
             // This needs a reload
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
 
         void process(ModelNode subModel, ModelNode operation) {
@@ -480,9 +480,7 @@ public class CacheConfigOperationHandlers {
 //                        context.reloadRequired();
 //                    }
                     context.reloadRequired();
-                    if (context.completeStep() == OperationContext.ResultAction.ROLLBACK) {
-                        context.revertReloadRequired();
-                    }
+                    context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerReadAttributeHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerReadAttributeHandler.java
@@ -63,7 +63,7 @@ public class CacheContainerReadAttributeHandler implements OperationStepHandler 
         context.getResult().set(currentValue);
 
         // since we are not updating the model, there is no need for a RUNTIME step
-        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        context.stepCompleted();
     }
 
     public void registerAttributes(final ManagementResourceRegistration registry) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerWriteAttributeHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerWriteAttributeHandler.java
@@ -73,11 +73,11 @@ public class CacheContainerWriteAttributeHandler implements OperationStepHandler
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                     context.reloadRequired();
-                    context.completeStep();
+                    context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheReadAttributeHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheReadAttributeHandler.java
@@ -42,6 +42,6 @@ public class CacheReadAttributeHandler implements OperationStepHandler {
         context.getResult().set(currentValue);
 
         // since we are not updating the model, there is no need for a RUNTIME step
-        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        context.stepCompleted();
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheWriteAttributeHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheWriteAttributeHandler.java
@@ -79,13 +79,11 @@ public class CacheWriteAttributeHandler implements OperationStepHandler, SelfReg
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                     context.reloadRequired();
-                    if (context.completeStep() == OperationContext.ResultAction.ROLLBACK) {
-                        context.revertReloadRequired();
-                    }
+                    context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
      /**

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemDescribe.java
@@ -56,7 +56,7 @@ public class InfinispanSubsystemDescribe implements OperationStepHandler {
         // add operations to recreate the cache container ModelNodes in their current state
         addCacheContainerCommands(subsystemModel, rootAddress.toModelNode(), result);
 
-        context.completeStep();
+        context.stepCompleted();
     }
 
     /**

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoveAliasCommand.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoveAliasCommand.java
@@ -50,11 +50,11 @@ public class RemoveAliasCommand implements OperationStepHandler {
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                     context.reloadRequired();
-                    context.completeStep();
+                    context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
     /**

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemDescribe.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemDescribe.java
@@ -75,7 +75,7 @@ public class JGroupsSubsystemDescribe implements OperationStepHandler {
             }
         }
         context.getResult().set(result);
-        context.completeStep();
+        context.stepCompleted();
     }
 
     private void addProtocolPropertyCommands(ModelNode protocol, ModelNode address, ModelNode result) throws OperationFailedException {

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackConfigOperationHandlers.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackConfigOperationHandlers.java
@@ -57,7 +57,7 @@ public class StackConfigOperationHandlers {
         public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
             context.removeResource(PathAddress.EMPTY_ADDRESS);
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     };
 
@@ -67,7 +67,7 @@ public class StackConfigOperationHandlers {
             final Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
             CommonAttributes.VALUE.validateAndSet(operation, resource.getModel());
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     };
 
@@ -77,7 +77,7 @@ public class StackConfigOperationHandlers {
             final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
             CommonAttributes.VALUE.validateAndSet(operation, resource.getModel());
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     };
 
@@ -126,12 +126,12 @@ public class StackConfigOperationHandlers {
             }
             // This needs a reload
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
 
         void process(ModelNode subModel, ModelNode operation) {
             //
-        };
+        }
     }
 
     /**
@@ -200,12 +200,12 @@ public class StackConfigOperationHandlers {
             }
             // This needs a reload
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
 
         void process(ModelNode subModel, ModelNode operation) {
             //
-        };
+        }
     }
 
     /**
@@ -249,7 +249,7 @@ public class StackConfigOperationHandlers {
 
             // This needs a reload
             reloadRequiredStep(context);
-            context.completeStep();
+            context.stepCompleted();
         }
     }
 
@@ -281,7 +281,7 @@ public class StackConfigOperationHandlers {
                         ProtocolStack stack = new ProtocolStack();
                         stack.addProtocols(protocols);
                         context.getResult().set(stack.printProtocolSpecAsXML());
-                        context.completeStep();
+                        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                     } finally {
                         channel.close();
                     }
@@ -348,11 +348,7 @@ public class StackConfigOperationHandlers {
                     // add some condition here if reload needs to be conditional on context
                     // e.g. if a service is not installed, don't do a reload
                     context.reloadRequired();
-                    context.completeStep();
-
-                    if (context.completeStep() == OperationContext.ResultAction.ROLLBACK) {
-                        context.revertReloadRequired();
-                    }
+                    context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }

--- a/connector/src/main/java/org/jboss/as/connector/dynamicresource/operations/ClearStatisticsHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/dynamicresource/operations/ClearStatisticsHandler.java
@@ -53,11 +53,11 @@ public class ClearStatisticsHandler implements OperationStepHandler {
                     for (StatisticsPlugin statsPlugin : stats) {
                         statsPlugin.clear();
                     }
-                    context.completeStep();
+                    context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
@@ -83,7 +83,7 @@ public class PoolConfigurationRWHandler {
 
             context.getResult().set(currentValue);
 
-            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+            context.stepCompleted();
         }
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolMetrics.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolMetrics.java
@@ -66,12 +66,12 @@ public abstract class PoolMetrics implements OperationStepHandler {
                             throw new OperationFailedException(MESSAGES.failedToGetMetrics(e.getLocalizedMessage()));
                         }
                     }
-                   context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
         }
 
-        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        context.stepCompleted();
     }
 
     protected abstract List<StatisticsPlugin> getMatchingStats(String jndiName, ManagementRepository repository);
@@ -89,7 +89,6 @@ public abstract class PoolMetrics implements OperationStepHandler {
             if (context.isNormalServer()) {
                 context.addStep(new OperationStepHandler() {
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
                         final String attributeName = operation.require(NAME).asString();
 
                         final ServiceController<?> managementRepoService = context.getServiceRegistry(false).getService(
@@ -103,12 +102,12 @@ public abstract class PoolMetrics implements OperationStepHandler {
                                throw new OperationFailedException(MESSAGES.failedToGetMetrics(e.getLocalizedMessage()));
                             }
                         }
-                        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+                        context.stepCompleted();
                     }
                 }, OperationContext.Stage.RUNTIME);
             }
 
-            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+            context.stepCompleted();
 
         }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
@@ -67,11 +67,11 @@ public abstract class PoolOperations implements OperationStepHandler {
                             context.getResult().set(operationResult);
                         }
                     }
-                    context.completeStep();
+                    context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
     protected abstract ModelNode invokeCommandOn(Pool pool) throws Exception;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -95,7 +95,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        context.stepCompleted();
     }
 
     /**

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractXMLDataSourceRuntimeHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractXMLDataSourceRuntimeHandler.java
@@ -60,7 +60,7 @@ public abstract class AbstractXMLDataSourceRuntimeHandler<T> extends AbstractRun
         if (ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION.equals(opName)) {
             final String attributeName = operation.require(ModelDescriptionConstants.NAME).asString();
             executeReadAttribute(attributeName, context, dataSource, address);
-            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+            context.stepCompleted();
         } else {
             throw unknownOperation(opName);
         }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
@@ -160,10 +160,16 @@ public class DataSourceDisable implements OperationStepHandler {
                     }
                 }, OperationContext.Stage.RUNTIME);
             } else {
-                context.restartRequired();
+                context.addStep(new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        context.reloadRequired();
+                        context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
+                    }
+                }, OperationContext.Stage.RUNTIME);
             }
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
     public void reEnable(final OperationContext context, final ModelNode operation) throws OperationFailedException {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
@@ -90,11 +90,12 @@ public class DataSourceEnable implements OperationStepHandler {
                     ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
                     addServices(context, operation, verificationHandler, model, isXa());
                     context.addStep(verificationHandler, Stage.VERIFY);
-                    context.completeStep();
+                    // TODO AS7-5607 handle rollback
+                    context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
     static void addServices(OperationContext context, ModelNode operation, ServiceVerificationHandler verificationHandler, ModelNode model, boolean isXa) throws OperationFailedException {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
@@ -927,7 +927,7 @@ public class DataSourcesExtension implements Extension {
                 }
             }
 
-            context.completeStep();
+            context.stepCompleted();
         }
 
         @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
@@ -75,11 +75,11 @@ public class GetInstalledDriverOperationHandler implements OperationStepHandler 
                     result.add(driverNode);
 
                     context.getResult().set(result);
-                    context.completeStep();
+                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
         }
 
-        context.completeStep();
+        context.stepCompleted();
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/InstalledDriversListOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/InstalledDriversListOperationHandler.java
@@ -70,13 +70,13 @@ public class InstalledDriversListOperationHandler implements OperationStepHandle
                         driverNode.get(JDBC_COMPLIANT).set(driver.isJdbcCompliant());
                         result.add(driverNode);
                     }
-                    context.completeStep();
+                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
         } else {
             context.getResult().set(MESSAGES.noMetricsAvailable());
         }
 
-        context.completeStep();
+        context.stepCompleted();
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaActivate.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaActivate.java
@@ -53,12 +53,12 @@ public class RaActivate implements OperationStepHandler {
                     final String archiveName = model.get(ARCHIVE.getName()).asString();
 
                     RaOperationUtil.activate(context, raName, archiveName);
-
-                    context.completeStep();
+                    // TODO AS7-5608 handle rollback
+                    context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep();
+        context.stepCompleted();
     }
 
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaRemove.java
@@ -79,11 +79,14 @@ public class RaRemove extends RaOperationUtil implements OperationStepHandler {
 
                 }
                 context.removeService(raServiceName);
-                if (context.completeStep() == OperationContext.ResultAction.ROLLBACK) {
-                    // TODO:  RE-ADD SERVICES
-                }
+                context.completeStep(new OperationContext.RollbackHandler() {
+                    @Override
+                    public void handleRollback(OperationContext context, ModelNode operation) {
+                        // TODO:  AS7-5609 RE-ADD SERVICES
+                    }
+                });
             }
         }, OperationContext.Stage.RUNTIME);
-        context.completeStep();
+        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -234,6 +234,11 @@ abstract class AbstractOperationContext implements OperationContext {
         // we return and executeStep picks it up
     }
 
+    @Override
+    public final void stepCompleted() {
+        completeStep(RollbackHandler.NOOP_ROLLBACK_HANDLER);
+    }
+
     /**
      * Perform the work of completing a step.
      */

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -182,6 +182,7 @@ public interface OperationContext extends ExpressionResolver {
      * </p>
      *
      * @return the operation result action to take
+     *
      */
     ResultAction completeStep();
 
@@ -769,6 +770,25 @@ public interface OperationContext extends ExpressionResolver {
                 // no-op
             }
         };
+
+        /**
+         * A {@link RollbackHandler} that calls {@link OperationContext#revertReloadRequired()}. Intended for use by
+         * operation step handlers call {@link OperationContext#reloadRequired()} and perform no other actions
+         * that need to be rolled back.
+         */
+        RollbackHandler REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER = new RollbackHandler() {
+            /**
+             * Does nothing.
+             *
+             * @param context  ignored
+             * @param operation ignored
+             */
+            @Override
+            public void handleRollback(OperationContext context, ModelNode operation) {
+                context.revertReloadRequired();
+            }
+        };
+
 
         /**
          * Callback to an {@link OperationStepHandler} indicating that the overall operation is being

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -194,6 +194,22 @@ public interface OperationContext extends ExpressionResolver {
      * @param rollbackHandler the handler for any rollback notification. Cannot be {@code null}.
      */
     void completeStep(RollbackHandler rollbackHandler);
+
+    /**
+     * Called by an {@link OperationStepHandler} to indicate it has completed its handling of a step and is
+     * uninterested in the result of subsequent steps. This is a convenience method that is equivalent to a call to
+     * {@link #completeStep(RollbackHandler) completeStep(OperationContext.RollbackHandler.NO_OP_ROLLBACK_HANDLER)}.
+     * <p>
+     * A common user of this method would be a {@link Stage#MODEL} handler. Typically such a handler would not need
+     * to take any further action in the case of a {@link ResultAction#KEEP successful result} for the overall operation.
+     * If the operation result is a {@link ResultAction#ROLLBACK rollback}, the {@code OperationContext} itself
+     * will ensure any changes made to the model are discarded, again requiring no action on the part of the handler.
+     * So a {@link Stage#MODEL} handler typically can be uninterested in the result of the overall operation and can
+     * use this method.
+     * </p>
+     */
+    void stepCompleted();
+
     /**
      * Get the type of process in which this operation is executing.
      *

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -241,6 +241,10 @@ public abstract class AbstractOperationTestCase {
 
         }
 
+        public void stepCompleted() {
+            completeStep(RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        }
+
         public ModelNode getFailureDescription() {
             return null;
         }


### PR DESCRIPTION
This is the first of likely many PRs related to moving off the recursive OperationContext.completeStep() variant.

The plan is to submit various bite-sized PRs moving away from the recursive variant, and then at the end deprecate the method.

The first commit in this PR will show up in other similar PRs until the commit gets merged. It's infrastructure that will get reused as I switch the OSH impls.
