### PR TITLE
AS7-5612 Add "Clear Cache" operation on cache container and cache

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanMessages.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanMessages.java
@@ -150,4 +150,23 @@ public interface InfinispanMessages {
     @Message(id = 10299, value = "Value for property with key %s is not defined")
     OperationFailedException propertyValueNotDefined(String propertyKey);
 
+    /**
+     * Creates an exception indicating that the cache container is not available because the cache container service is not up.
+     *
+     * @param cacheContainerName the name of the cache container which is not available.
+     *
+     * @return the String.
+     */
+    @Message(id = 10300, value = "Cache container %s is not available. Please start the cache container service before using any operation")
+    String cacheContainerNotAvailableForOperation(String cacheContainerName);
+
+    /**
+     * Creates an exception indicating that the cache container is not available because the cache service is not up.
+     *
+     * @param cacheName the name of the cache which is not available.
+     *
+     * @return the String.
+     */
+    @Message(id = 10301, value = "Cache %s is not available. Please start the cache service before using any operation")
+    String cacheNotAvailableForOperation(String cacheName);
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheOperations.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheOperations.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.infinispan.Cache;
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartException;
+
+/**
+ * @author Guillaume Grossetie
+ */
+public abstract class CacheOperations implements OperationStepHandler {
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        context.readResource(PathAddress.EMPTY_ADDRESS);
+        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+        context.addStep(new OperationStepHandler() {
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                final PathAddress containerAddress = address.subAddress(0, address.size() - 1);
+                String cacheName = address.getLastElement().getValue();
+                String containerName = containerAddress.getLastElement().getValue();
+                final ServiceName cacheServiceName = CacheService.getServiceName(containerName, cacheName);
+                final ServiceController<?> cacheService = context.getServiceRegistry(false).getService(cacheServiceName);
+                try {
+                    if (!ServiceController.State.UP.equals(cacheService.getState())) {
+                        cacheService.setMode(ServiceController.Mode.ACTIVE);
+                    }
+                    final Cache cache = ServiceContainerHelper.getValue(cacheService, Cache.class);
+                    ModelNode operationResult = invokeCommandOn(cache);
+                    if (operationResult != null) {
+                        context.getResult().set(operationResult);
+                    }
+                } catch (StartException e) {
+                    throw new OperationFailedException(e.getLocalizedMessage(), e);
+                }
+                context.completeStep();
+            }
+        }, OperationContext.Stage.RUNTIME);
+        context.completeStep();
+    }
+
+    protected abstract ModelNode invokeCommandOn(Cache cache);
+
+    public static class ClearCache extends CacheOperations {
+        public static ClearCache INSTANCE = new ClearCache();
+
+        @Override
+        protected ModelNode invokeCommandOn(Cache cache) {
+            cache.clear();
+            return null;
+        }
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EmbeddedCacheManagerOperations.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EmbeddedCacheManagerOperations.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartException;
+
+/**
+ * @author Guillaume Grossetie
+ */
+public abstract class EmbeddedCacheManagerOperations implements OperationStepHandler {
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        context.readResource(PathAddress.EMPTY_ADDRESS);
+        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+        context.addStep(new OperationStepHandler() {
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                final String containerName = address.getLastElement().getValue();
+                final ServiceName containerServiceName = EmbeddedCacheManagerService.getServiceName(containerName);
+                final ServiceController<?> containerService = context.getServiceRegistry(false).getService(containerServiceName);
+                try {
+                    if (!ServiceController.State.UP.equals(containerService.getState())) {
+                        containerService.setMode(ServiceController.Mode.ACTIVE);
+                    }
+                    final EmbeddedCacheManager embeddedCacheManager = ServiceContainerHelper.getValue(containerService, EmbeddedCacheManager.class);
+                    ModelNode operationResult = invokeCommandOn(embeddedCacheManager);
+                    if (operationResult != null) {
+                        context.getResult().set(operationResult);
+                    }
+                } catch (StartException e) {
+                    throw new OperationFailedException(e.getLocalizedMessage(), e);
+                }
+                context.completeStep();
+            }
+        }, OperationContext.Stage.RUNTIME);
+        context.completeStep();
+    }
+
+    protected abstract ModelNode invokeCommandOn(EmbeddedCacheManager embeddedCacheManager);
+
+    public static class ClearCachesInCacheManager extends EmbeddedCacheManagerOperations {
+        public static ClearCachesInCacheManager INSTANCE = new ClearCachesInCacheManager();
+
+        @Override
+        protected ModelNode invokeCommandOn(EmbeddedCacheManager embeddedCacheManager) {
+            for (String cacheName : embeddedCacheManager.getCacheNames()) {
+                embeddedCacheManager.getCache(cacheName).clear();
+            }
+            return null;
+        }
+    }
+}

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
@@ -290,6 +290,12 @@ public class InfinispanDescriptions {
         return op;
     }
 
+    static ModelNode getLocalCacheClearDescription(Locale locale) {
+        ResourceBundle resources = getResources(locale);
+        final ModelNode op = createOperationDescription("clear", resources, "infinispan.local-cache.clear");
+        return op;
+    }
+
     // cache container transport element
     static ModelNode getTransportDescription(Locale locale) {
         ResourceBundle resources = getResources(locale);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanDescriptions.java
@@ -124,12 +124,12 @@ public class InfinispanDescriptions {
         container.get(CHILDREN, ModelKeys.INVALIDATION_CACHE, MIN_OCCURS).set(0);
         container.get(CHILDREN, ModelKeys.INVALIDATION_CACHE, MAX_OCCURS).set(Integer.MAX_VALUE);
         container.get(CHILDREN, ModelKeys.INVALIDATION_CACHE, MODEL_DESCRIPTION);
-        // information about its child "local-cache"
+        // information about its child "replicated-cache"
         container.get(CHILDREN, ModelKeys.REPLICATED_CACHE, DESCRIPTION).set(resources.getString(keyPrefix + ".replicated-cache"));
         container.get(CHILDREN, ModelKeys.REPLICATED_CACHE, MIN_OCCURS).set(0);
         container.get(CHILDREN, ModelKeys.REPLICATED_CACHE, MAX_OCCURS).set(Integer.MAX_VALUE);
         container.get(CHILDREN, ModelKeys.REPLICATED_CACHE, MODEL_DESCRIPTION);
-        // information about its child "local-cache"
+        // information about its child "distributed-cache"
         container.get(CHILDREN, ModelKeys.DISTRIBUTED_CACHE, DESCRIPTION).set(resources.getString(keyPrefix + ".distributed-cache"));
         container.get(CHILDREN, ModelKeys.DISTRIBUTED_CACHE, MIN_OCCURS).set(0);
         container.get(CHILDREN, ModelKeys.DISTRIBUTED_CACHE, MAX_OCCURS).set(Integer.MAX_VALUE);
@@ -169,6 +169,11 @@ public class InfinispanDescriptions {
         return op;
     }
 
+    static ModelNode getCacheContainerClearCachesCommandDescription(Locale locale) {
+        ResourceBundle resources = getResources(locale);
+        final ModelNode op = createOperationDescription("clear-caches", resources, "infinispan.container.clear-caches");
+        return op;
+    }
 
     // local caches
     static ModelNode getLocalCacheDescription(Locale locale) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -119,6 +119,7 @@ public class InfinispanExtension implements Extension {
         ManagementResourceRegistration local = container.registerSubModel(localCachePath, InfinispanSubsystemProviders.LOCAL_CACHE);
         local.registerOperationHandler(ADD, LocalCacheAdd.INSTANCE, InfinispanSubsystemProviders.LOCAL_CACHE_ADD, false);
         local.registerOperationHandler(REMOVE, CacheRemove.INSTANCE, InfinispanSubsystemProviders.CACHE_REMOVE, false);
+        local.registerOperationHandler("clear", CacheOperations.ClearCache.INSTANCE, InfinispanSubsystemProviders.LOCAL_CACHE_CLEAR, false);
         registerCommonCacheAttributeHandlers(local);
 
         // add /subsystem=infinispan/cache-container=*/invalidation-cache=*

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -38,6 +38,7 @@ import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.OperationEntry.EntryType;
 import org.jboss.as.controller.transform.AbstractOperationTransformer;
 import org.jboss.as.controller.transform.TransformationContext;
@@ -54,6 +55,7 @@ import org.jboss.staxmapper.XMLElementReader;
 public class InfinispanExtension implements Extension {
 
     static final String SUBSYSTEM_NAME = "infinispan";
+    private static final EnumSet<OperationEntry.Flag> RUNTIME_ONLY_FLAG = EnumSet.of(OperationEntry.Flag.RUNTIME_ONLY);
 
     private static final PathElement containerPath = PathElement.pathElement(ModelKeys.CACHE_CONTAINER);
     private static final PathElement localCachePath = PathElement.pathElement(ModelKeys.LOCAL_CACHE);
@@ -86,6 +88,7 @@ public class InfinispanExtension implements Extension {
      */
     @Override
     public void initialize(ExtensionContext context) {
+        boolean registerRuntimeOnly = context.isRuntimeOnlyRegistrationValid();
         // IMPORTANT: Management API version != xsd version! Not all Management API changes result in XSD changes
         SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
@@ -101,6 +104,9 @@ public class InfinispanExtension implements Extension {
         container.registerOperationHandler(REMOVE, CacheContainerRemove.INSTANCE, InfinispanSubsystemProviders.CACHE_CONTAINER_REMOVE, false);
         container.registerOperationHandler("add-alias", AddAliasCommand.INSTANCE, InfinispanSubsystemProviders.ADD_ALIAS, false);
         container.registerOperationHandler("remove-alias", RemoveAliasCommand.INSTANCE, InfinispanSubsystemProviders.REMOVE_ALIAS, false);
+        if (registerRuntimeOnly) {
+            container.registerOperationHandler("clear-caches", EmbeddedCacheManagerOperations.ClearCachesInCacheManager.INSTANCE, InfinispanSubsystemProviders.CACHE_CONTAINER_CLEAR_CACHES, false, RUNTIME_ONLY_FLAG);
+        }
         CacheContainerWriteAttributeHandler.INSTANCE.registerAttributes(container);
 
         // add /subsystem=infinispan/cache-container=*/singleton=transport:write-attribute

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
@@ -66,6 +66,13 @@ public class InfinispanSubsystemProviders {
         }
     };
 
+    static final DescriptionProvider CACHE_CONTAINER_CLEAR_CACHES = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getCacheContainerClearCachesCommandDescription(locale);
+        }
+    };
+
     static final DescriptionProvider ADD_ALIAS = new DescriptionProvider() {
         @Override
         public ModelNode getModelDescription(Locale locale) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemProviders.java
@@ -143,6 +143,13 @@ public class InfinispanSubsystemProviders {
         }
     };
 
+    static final DescriptionProvider LOCAL_CACHE_CLEAR = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return InfinispanDescriptions.getLocalCacheClearDescription(locale);
+        }
+    };
+
     static final DescriptionProvider TRANSPORT = new DescriptionProvider() {
          @Override
         public ModelNode getModelDescription(Locale locale) {

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -158,6 +158,7 @@ infinispan.distributed-cache.owners=Number of cluster-wide replicas for each cac
 infinispan.distributed-cache.virtual-nodes=Controls the number of virtual nodes per "real" node. If numVirtualNodes is 1, then virtual nodes are disabled. The topology aware consistent hash must be used if you wish to take advantage of virtual nodes. A default of 1 is used.
 infinispan.distributed-cache.l1-lifespan=Maximum lifespan of an entry placed in the L1 cache. This element configures the L1 cache behavior in 'distributed' caches instances. In any other cache modes, this element is ignored.
 
+infinispan.local-cache.clear=Clear a local cache
 #infinispan.local-cache.add=Add a local cache to the Infinispan subsystem
 #infinispan.invalidation-cache.add=Add a invalidation cache to the Infinispan subsystem
 #infinispan.replicated-cache.add=Add a replicated cache to the Infinispan subsystem

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -6,6 +6,7 @@ infinispan.remove=Remove the infinispan subsystem
 infinispan.container=The configuration of an infinispan cache container
 infinispan.container.default-cache=The default infinispan cache
 infinispan.container.add=Add a cache container to the infinispan subsystem
+infinispan.container.clear-caches=Clear all the local caches of a cache container
 infinispan.container.remove=Remove a cache container from the infinispan subsystem
 infinispan.container.listener-executor=The executor used for the replication queue
 infinispan.container.eviction-executor=The scheduled executor used for eviction


### PR DESCRIPTION
I found useful having the ability to clear local cache (in-memory) without a server restart.
The clear operation calls the method #clear on the org.infinispan.Cache interface.

Here's the output with the jboss-cli.sh :

```
[standalone@localhost:9999 /] /subsystem=infinispan/cache-container=hibernate/local-cache=entity:read-operation-description(name=clear)
{
    "outcome" => "success",
    "result" => {
        "operation-name" => "clear",
        "description" => "Clear a local cache",
        "read-only" => false
    }
}
[standalone@localhost:9999 /] /subsystem=infinispan/cache-container=hibernate/local-cache=entity:clear
{"outcome" => "success"}
[standalone@localhost:9999 /] /subsystem=infinispan/cache-container=hibernate:read-operation-description(name=clear-caches)
{
    "outcome" => "success",
    "result" => {
        "operation-name" => "clear-caches",
        "description" => "Clear all the local caches of a cache container",
        "read-only" => false
    }
}
[standalone@localhost:9999 /] /subsystem=infinispan/cache-container=hibernate:clear-caches
{"outcome" => "success"}
```

I think it would be nice if we could add more runtime operations on cache and support clear on persistent/clustered caches.
