### PR TITLE
[AS7-5600] Messaging: handle absolute paths

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
@@ -116,6 +116,7 @@ import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.as.security.service.SecurityDomainService;
+import org.jboss.as.server.ServerEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceBuilder;
@@ -135,7 +136,7 @@ import org.jboss.msc.service.ServiceTarget;
 class HornetQServerAdd implements OperationStepHandler {
 
     private static final String DEFAULT_PATH = "messaging";
-    private static final String DEFAULT_RELATIVE_TO = "jboss.server.data.dir";
+    static final String DEFAULT_RELATIVE_TO = ServerEnvironment.SERVER_DATA_DIR;
     static final String PATH_BASE = "paths";
 
     static final String DEFAULT_BINDINGS_DIR = "bindings";

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -21,6 +21,7 @@ import org.hornetq.core.journal.impl.AIOSequentialFileFactory;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.JournalType;
 import org.hornetq.core.server.impl.HornetQServerImpl;
+import org.jboss.as.controller.services.path.AbsolutePathService;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
@@ -289,7 +290,10 @@ class HornetQService implements Service<HornetQServer> {
         }
 
         String resolve(PathManager pathManager, String path, String relativeToPath) {
-            return pathManager.resolveRelativePathEntry(path, relativeToPath);
+            // discard the relativeToPath if the path is absolute and must not be resolved according
+            // to the default relativeToPath value
+            String relativeTo = AbsolutePathService.isAbsoluteUnixOrWindowsPath(path) ? null : relativeToPath;
+            return pathManager.resolveRelativePathEntry(path, relativeTo);
         }
 
         synchronized void registerCallbacks(PathManager pathManager) {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingPathHandlers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingPathHandlers.java
@@ -92,15 +92,6 @@ class MessagingPathHandlers {
         }
     }
 
-    static ModelNode createAddOperation(final ModelNode address, final ModelNode subModel) {
-        final ModelNode operation = new ModelNode();
-        operation.get(OP).set(ADD);
-        operation.get(OP_ADDR).set(address);
-        operation.get(RELATIVE_TO).set(subModel.get(RELATIVE_TO));
-        operation.get(PATH).set(subModel.require(PATH));
-        return operation;
-    }
-
     static void reloadRequiredStep(final OperationContext context) {
         if(context.isNormalServer()) {
             context.addStep(new OperationStepHandler() {

--- a/messaging/src/test/java/org/jboss/as/messaging/MessagingPathsTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/MessagingPathsTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.messaging;
+
+import static org.jboss.as.messaging.HornetQServerAdd.DEFAULT_LARGE_MESSAGE_DIR;
+import static org.jboss.as.messaging.HornetQServerAdd.DEFAULT_PAGING_DIR;
+import static org.jboss.as.messaging.HornetQServerAdd.DEFAULT_RELATIVE_TO;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.services.path.PathManagerService;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.msc.service.ServiceContainer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
+ */
+public class MessagingPathsTestCase {
+
+    private static final String MY_SERVER_DATA_DIR = "/my/server/data/dir/";
+    private static final String MY_RELATIVE_JOURNAL_DIR = "my-relative-journal";
+    private static final String MY_ABSOLUTE_BINDINGS_DIR = "/my/absolute/bindings/dir";
+    private static final String MY_PAGING_RELATIVE_TO = "paging.relative-to.dir";
+    private static final String MY_PAGING_RELATIVE_TO_DIR = "/another/dir/for/paging/";
+
+    private ServiceContainer container;
+
+    @Before
+    public void setupContainer() {
+        container = ServiceContainer.Factory.create("test");
+    }
+
+    @After
+    public void shutdownContainer() {
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+    }
+
+    @Test
+    public void testAddPath() throws Exception {
+
+        PathManagerService pathManagerService = new PathManagerService() {
+            {
+                // define the standard server data dir that is the default relative-to for messaging paths
+                super.addHardcodedAbsolutePath(container, ServerEnvironment.SERVER_DATA_DIR, MY_SERVER_DATA_DIR);
+                // define another related-to specific for paging directory
+                super.addHardcodedAbsolutePath(container, MY_PAGING_RELATIVE_TO, MY_PAGING_RELATIVE_TO_DIR);
+            }
+        };
+
+
+        HornetQService.PathConfig pathConfig = new HornetQService.PathConfig(
+                MY_ABSOLUTE_BINDINGS_DIR, DEFAULT_RELATIVE_TO,  // => binding dir is absolute
+                MY_RELATIVE_JOURNAL_DIR, DEFAULT_RELATIVE_TO,   // => specific journal dir is relative to default relative-to
+                DEFAULT_LARGE_MESSAGE_DIR, DEFAULT_RELATIVE_TO, // => default largeMessage is relative to default relative-to
+                DEFAULT_PAGING_DIR, MY_PAGING_RELATIVE_TO);     // => paging is relative to specific relative-to
+
+
+        String resolvedJournalPath = pathConfig.resolveJournalPath(pathManagerService);
+        assertTrue("the specific relative path is prepended by the resolved default relative-to", resolvedJournalPath.startsWith(MY_SERVER_DATA_DIR));
+        assertTrue(resolvedJournalPath.endsWith(MY_RELATIVE_JOURNAL_DIR));
+
+        String resolvedBindingsPath = pathConfig.resolveBindingsPath(pathManagerService);
+        assertEquals("the speficic absolute path is not prepended by the resolved default relative-to", MY_ABSOLUTE_BINDINGS_DIR, resolvedBindingsPath);
+
+        String resolvedPagingPath = pathConfig.resolvePagingPath(pathManagerService);
+        assertTrue("the default path is prepended by the resolved specific relative-to", resolvedPagingPath.startsWith(MY_PAGING_RELATIVE_TO_DIR));
+        assertTrue(resolvedPagingPath.endsWith(DEFAULT_PAGING_DIR));
+
+        String resolvedLargeMessagePath = pathConfig.resolveLargeMessagePath(pathManagerService);
+        assertTrue("by default, the default path is prepended by the resolved default relative-to", resolvedLargeMessagePath.startsWith(MY_SERVER_DATA_DIR));
+        assertTrue(resolvedLargeMessagePath.endsWith(DEFAULT_LARGE_MESSAGE_DIR));
+    }
+}


### PR DESCRIPTION
fix regression which prevents to use absolute paths by discarding the
relativeTo path (which has default values) if the given path is
detected as absolute
