### PR TITLE
AS7-5403

### DIFF
--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigAttributeDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigAttributeDefinition.java
@@ -1,0 +1,111 @@
+package org.jboss.as.modcluster;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.operations.validation.ParametersOfValidator;
+import org.jboss.as.controller.operations.validation.ParametersValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+public class ModClusterConfigAttributeDefinition extends ListAttributeDefinition {
+
+    public static final ParameterValidator validator;
+    public static final ParameterValidator fieldValidator;
+
+    static {
+        final ParametersValidator delegate = new ParametersValidator();
+
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            SimpleAttributeDefinition attribute = ModClusterConfigResourceDefinition.ATTRIBUTES[i];
+
+            switch(attribute.getType()){
+                case STRING:
+                    delegate.registerValidator(attribute.getName(), new ModelTypeValidator(ModelType.STRING, attribute.isAllowNull(), attribute.isAllowExpression()));
+                break;
+                case INT:
+                    delegate.registerValidator(attribute.getName(), new ModelTypeValidator(ModelType.INT, attribute.isAllowNull(), attribute.isAllowExpression()));
+                    break;
+                case BOOLEAN:
+                    delegate.registerValidator(attribute.getName(), new ModelTypeValidator(ModelType.BOOLEAN, attribute.isAllowNull(), attribute.isAllowExpression()));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        validator = new ParametersOfValidator(delegate);
+        fieldValidator = delegate;
+    }
+
+    public ModClusterConfigAttributeDefinition(String name, String xmlName) {
+        super(name, xmlName, true, 1, Integer.MAX_VALUE, validator, null, null, AttributeAccess.Flag.RESTART_ALL_SERVICES);
+    }
+
+    @Override
+    protected void addValueTypeDescription(ModelNode node, ResourceBundle bundle) {
+        // This method being used indicates a misuse of this class
+        // throw ModClusterMessages.MESSAGES.unsupportedOperationExceptionUseResourceDesc();
+
+    }
+
+    @Override
+    protected void addAttributeValueTypeDescription(ModelNode node, ResourceDescriptionResolver resolver, Locale locale,
+            ResourceBundle bundle) {
+        final ModelNode valueType = getNoTextValueTypeDescription(node);
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            String name = ModClusterConfigResourceDefinition.ATTRIBUTES[i].getName();
+
+            valueType.get(name, DESCRIPTION).set(
+                    resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, name));
+
+        }
+
+    }
+
+    @Override
+    protected void addOperationParameterValueTypeDescription(ModelNode node, String operationName,
+            ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
+        final ModelNode valueType = getNoTextValueTypeDescription(node);
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            String name = ModClusterConfigResourceDefinition.ATTRIBUTES[i].getName();
+
+            valueType.get(name, DESCRIPTION).set(
+                    resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle,
+                            name));
+        }
+
+    }
+
+    private ModelNode getNoTextValueTypeDescription(final ModelNode parent) {
+        final ModelNode valueType = parent.get(VALUE_TYPE);
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            String name = ModClusterConfigResourceDefinition.ATTRIBUTES[i].getName();
+
+            ModelNode advertiseSocket = valueType.get(name);
+            advertiseSocket.get(DESCRIPTION);
+            advertiseSocket.get(TYPE).set(ModClusterConfigResourceDefinition.ATTRIBUTES[i].getType());
+            boolean allowNull = ModClusterConfigResourceDefinition.ATTRIBUTES[i].isAllowNull();
+            advertiseSocket.get(NILLABLE).set(allowNull);
+
+        }
+
+        return valueType;
+    }
+
+}

--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigResourceDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.jboss.as.modcluster;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.ResourceDefinition;
@@ -281,4 +282,17 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
         final DescriptionProvider removeCustomMetric = new DefaultOperationDescriptionProvider(CommonAttributes.REMOVE_CUSTOM_METRIC, rootResolver, CustomLoadMetricDefinition.CLASS);
         resourceRegistration.registerOperationHandler(CommonAttributes.REMOVE_CUSTOM_METRIC, ModClusterRemoveCustomMetric.INSTANCE, removeCustomMetric, false, runtimeOnlyFlags);
     }
+
+
+    public static final ModClusterConfigAttributeDefinition CONFIG_ATTRIBUTE_DEFINITION = new ModClusterConfigAttributeDefinition(
+            CommonAttributes.CONFIGURATION, CommonAttributes.MOD_CLUSTER_CONFIG);
+
+    public static AttributeDefinition getThisAttributeDefinition(){
+        return CONFIG_ATTRIBUTE_DEFINITION;
+    }
+
+    public static OperationStepHandler getThisAttributeHandler(){
+        return new ReloadRequiredWriteAttributeHandler(CONFIG_ATTRIBUTE_DEFINITION);
+    }
+
 }

--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterDefinition.java
@@ -69,6 +69,10 @@ public class ModClusterDefinition extends SimpleResourceDefinition {
 
     }
 
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registration) {
+        registration.registerReadWriteAttribute(ModClusterConfigResourceDefinition.getThisAttributeDefinition(), null, ModClusterConfigResourceDefinition.getThisAttributeHandler());
+    }
 
     public void registerRuntimeOperations(ManagementResourceRegistration registration) {
         EnumSet<OperationEntry.Flag> runtimeOnlyFlags = EnumSet.of(OperationEntry.Flag.RUNTIME_ONLY);


### PR DESCRIPTION
Added a ModClusterConfigAttributeDefinition attribute to the
ModClusterDefinition so that the configuration could be manipulated
during the ./subsystem=modcluster:add() command.

The attribute mimics the ModClusterConfigResourceDefinition in the
attribute format.

Added functionality to catch the new attribute in the
ModClusterSubsystemAdd and validate the input.
