### PR TITLE
AS7-5369 Updated to reflect actual permitted parameter content.

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-pojo_7_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-pojo_7_0.xsd
@@ -27,7 +27,7 @@
             xmlns="urn:jboss:pojo:7.0"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
-            version="1.0">
+            version="1.1">
 
     <xs:complexType name="deployment">
         <xs:sequence>
@@ -179,7 +179,10 @@
         <xs:attribute name="trim" type="xs:boolean" use="optional"/>
     </xs:complexType>
 
-    <xs:complexType name="parameter">
+    <xs:complexType name="parameter" mixed="true">
+        <xs:sequence>
+            <xs:element name="value" type="value" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
         <xs:attribute name="class" type="xs:string" use="optional"/>
     </xs:complexType>
 


### PR DESCRIPTION
jboss-pojo_7_0.xsd hadn't been updated to reflect the parser change. Not sure if version should become 1.1 or file should become 7_1.xsd…
Also, the associated tests reference a non-existing jboss-mc_7_0.xsd when they probably should be using jboss-pojo instead…
