### PR TITLE
[AS7-5648] Fix wrong merging of all defined resource adapter objects (in...

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
@@ -89,7 +89,7 @@ public final class ResourceAdapterXmlDeploymentService extends AbstractResourceA
             IronJacamar ijmd = mdr.getValue().getIronJacamar(deployment);
             File root = mdr.getValue().getRoot(deployment);
 
-            cmd = (new Merger()).mergeConnectorWithCommonIronJacamar(raxml, cmd);
+            cmd = (new Merger()).mergeConnectorWithCommonIronJacamar(ijmd, cmd);
 
             final ServiceContainer container = context.getController().getServiceContainer();
             final AS7RaXmlDeployer raDeployer = new AS7RaXmlDeployer(context.getChildTarget(), connectorXmlDescriptor.getUrl(),


### PR DESCRIPTION
...stead of IronJacamar object) with the connector object. This will lead to have some defaults in the connector based on the merge of all the values of the defined resource adapter's objects and so the user specified connection definitions and admin objects with unwanted default values for the not specified properties.
