### PR TITLE
AS7-5649 Add dormant MyFaces annotation/lifecycle handlers

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/jsf-injection/1.2/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jsf-injection/1.2/module.xml
@@ -36,5 +36,6 @@
         <module name="javax.api"/>
         <module name="org.jboss.as.web"/>
         <module name="javax.servlet.api"/>
+        <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/org/jboss/as/jsf-injection/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jsf-injection/main/module.xml
@@ -36,5 +36,9 @@
         <module name="javax.api"/>
         <module name="org.jboss.as.web"/>
         <module name="javax.servlet.api"/>
+        <module name="org.jboss.logging"/>
+
+        <!-- added this for MyFacesAnnotationProvider -->
+        <module name="javax.faces.api"/>
     </dependencies>
 </module>

--- a/jsf/injection/pom.xml
+++ b/jsf/injection/pom.xml
@@ -43,5 +43,11 @@
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-jsf</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.myfaces.core</groupId>
+            <artifactId>myfaces-impl</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/JSFLogger.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/JSFLogger.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jsf;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.vfs.VirtualFile;
+
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.WARN;
+
+/**
+ * Date: 05.11.2011
+ *
+ *
+ * 12600-12649
+ *
+ * @author Stuart Douglas
+ */
+@MessageLogger(projectCode = "JBAS")
+public interface JSFLogger extends BasicLogger {
+
+    /**
+     * A logger with a category of the package name.
+     */
+    JSFLogger ROOT_LOGGER = Logger.getMessageLogger(JSFLogger.class, "org.jboss.as.jsf");
+
+    @LogMessage(level = ERROR)
+    @Message(id = 12600, value = "Could not load JSF managed bean class: %s")
+    void managedBeanLoadFail(String managedBean);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 12601, value = "JSF managed bean class %s has no default constructor")
+    void managedBeanNoDefaultConstructor(String managedBean);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 12602, value = "Failed to parse %s, managed beans defined in this file will not be available")
+    void managedBeansConfigParseFailed(VirtualFile facesConfig);
+
+    @LogMessage(level = WARN)
+    @Message(id = 12603, value = "Unknown JSF version %s %s will be used instead")
+    void unknownJSFVersion(String version, String referenceVersion);
+}

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/JSFMessages.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/JSFMessages.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jsf;
+
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
+import org.jboss.logging.Messages;
+
+/**
+ * Date: 05.11.2011
+ *
+ * 12650 - 12699
+ *
+ * @author Stuart Douglas
+ */
+@MessageBundle(projectCode = "JBAS")
+public interface JSFMessages {
+
+    /**
+     * The messages
+     */
+    JSFMessages MESSAGES = Messages.getBundle(JSFMessages.class);
+
+    @Message(id = 12650, value = "Failed to load annotated class: %s")
+    String classLoadingFailed(DotName clazz);
+
+    @Message(id = 12651, value = "Annotation %s in class %s is only allowed on classes")
+    String invalidAnnotationLocation(Object annotation, AnnotationTarget classInfo);
+
+    @Message(id = 12652, value = "Instance creation failed")
+    RuntimeException instanceCreationFailed(@Cause Throwable t);
+
+    @Message(id = 12653, value = "Instance destruction failed")
+    RuntimeException instanceDestructionFailed(@Cause Throwable t);
+
+    @Message(id = 12654, value = "Thread local injection container not set")
+    IllegalStateException noThreadLocalInjectionContainer();
+
+    @Message(id = 12655, value = "@ManagedBean is only allowed at class level %s")
+    String invalidManagedBeanAnnotation(AnnotationTarget target);
+}

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesAnnotationProvider.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesAnnotationProvider.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jsf.injection;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.net.URL;
+import java.util.Map;
+import java.util.Set;
+import javax.faces.context.ExternalContext;
+import org.apache.myfaces.spi.AnnotationProvider;
+import org.jboss.as.jsf.deployment.JSFAnnotationProcessor;
+
+/**
+ * {@link }AnnotationProvider} implementation which provides the JSF annotations which we parsed from from a
+ * Jandex index.
+ *
+ * @author Stan Silvert
+ */
+public class MyFacesAnnotationProvider extends AnnotationProvider {
+
+    /**
+     * @see JSFAnnotationProcessor#FACES_ANNOTATIONS_SC_ATTR
+     */
+    public static final String FACES_ANNOTATIONS_SC_ATTR =  "org.jboss.as.jsf.FACES_ANNOTATIONS";
+
+    @Override
+    public Map<Class<? extends Annotation>, Set<Class<?>>> getAnnotatedClasses(ExternalContext externalCtx) {
+        return (Map<Class<? extends Annotation>, Set<Class<?>>>)externalCtx.getApplicationMap().get(FACES_ANNOTATIONS_SC_ATTR);
+    }
+
+    @Override
+    public Set<URL> getBaseUrls() throws IOException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+}

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProvider.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProvider.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.jsf.injection;
+
+import org.apache.myfaces.config.annotation.LifecycleProvider2;
+import org.jboss.as.jsf.JSFMessages;
+import org.jboss.as.web.deployment.WebInjectionContainer;
+
+import javax.naming.NamingException;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class MyFacesLifecycleProvider implements LifecycleProvider2 {
+
+    private final WebInjectionContainer container;
+
+    public MyFacesLifecycleProvider() {
+        this.container = WebInjectionContainer.getCurrentInjectionContainer();
+        if (this.container == null) {
+            throw JSFMessages.MESSAGES.noThreadLocalInjectionContainer();
+        }
+    }
+
+    public Object newInstance(String className) throws ClassNotFoundException, IllegalAccessException, InstantiationException, NamingException, InvocationTargetException {
+        return container.newInstance(className);
+    }
+
+    public void postConstruct(Object obj) throws IllegalAccessException, InvocationTargetException {
+       // do nothing.  container.newInstance() took care of this.
+    }
+
+    public void destroyInstance(Object obj) throws IllegalAccessException, InvocationTargetException {
+        container.destroyInstance(obj);
+    }
+
+}

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProviderFactory.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/MyFacesLifecycleProviderFactory.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.jboss.as.jsf.injection;
+
+import javax.faces.context.ExternalContext;
+import org.apache.myfaces.config.annotation.LifecycleProvider;
+import org.apache.myfaces.config.annotation.LifecycleProviderFactory;
+
+/**
+ * Dispenses the MyFacesLifecycleProvder.
+ *
+ * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
+ */
+public class MyFacesLifecycleProviderFactory extends LifecycleProviderFactory {
+
+    private final LifecycleProvider provider;
+
+    public MyFacesLifecycleProviderFactory() {
+        provider = new MyFacesLifecycleProvider();
+    }
+
+    @Override
+    public LifecycleProvider getLifecycleProvider(ExternalContext ec) {
+        return provider;
+    }
+
+    @Override
+    public void release() {
+
+    }
+
+}

--- a/jsf/injection/src/main/resources/META-INF/services/org.apache.myfaces.config.annotation.LifecycleProviderFactory
+++ b/jsf/injection/src/main/resources/META-INF/services/org.apache.myfaces.config.annotation.LifecycleProviderFactory
@@ -1,0 +1,1 @@
+org.jboss.as.jsf.injection.MyFacesLifecycleProviderFactory

--- a/jsf/injection/src/main/resources/META-INF/services/org.apache.myfaces.spi.AnnotationProvider
+++ b/jsf/injection/src/main/resources/META-INF/services/org.apache.myfaces.spi.AnnotationProvider
@@ -1,0 +1,1 @@
+org.jboss.as.jsf.injection.MyFacesAnnotationProvider

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
@@ -31,6 +31,7 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.modules.LocalModuleLoader;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFSharedTldsProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFSharedTldsProcessor.java
@@ -49,7 +49,7 @@ import org.jboss.modules.ModuleLoadException;
  */
 public class JSFSharedTldsProcessor implements DeploymentUnitProcessor {
 
-    private static final String[] JSF_TAGLIBS = { "html_basic.tld", "jsf_core.tld", "mojarra_ext.tld" };
+    private static final String[] JSF_TAGLIBS = { "html_basic.tld", "jsf_core.tld", "mojarra_ext.tld", "myfaces_core.tld", "myfaces_html.tld" };
 
     private final ArrayList<TldMetaData> jsfTlds = new ArrayList<TldMetaData>();
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <version.org.apache.maven>3.0.3</version.org.apache.maven>
         <version.org.apache.maven.wagon>1.0-beta-7</version.org.apache.maven.wagon>
         <version.org.apache.maven.wagon.http-lightweight>1.0</version.org.apache.maven.wagon.http-lightweight>
+        <version.org.apache.myfaces.core>2.1.8</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.0.2</version.org.apache.neethi>
         <version.org.apache.openjpa>2.1.1</version.org.apache.openjpa>
         <version.org.apache.santuario>1.5.2</version.org.apache.santuario>
@@ -2997,6 +2998,46 @@
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-provider-api</artifactId>
                 <version>${version.org.apache.maven.wagon}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.myfaces.core</groupId>
+                <artifactId>myfaces-impl</artifactId>
+                <version>${version.org.apache.myfaces.core}</version>
+                <exclusions>
+                   <exclusion>
+                       <groupId>commons-logging</groupId>
+                       <artifactId>commons-logging</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>commons-collections</groupId>
+                       <artifactId>commons-logging</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>commons-collections</groupId>
+                       <artifactId>commons-collections</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>commons-codec</groupId>
+                       <artifactId>commons-codec</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>commons-beanutils</groupId>
+                       <artifactId>commons-beanutils</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>commons-digester</groupId>
+                       <artifactId>commons-digester</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>org.apache.myfaces.core</groupId>
+                       <artifactId>myfaces-api</artifactId>
+                   </exclusion>
+                   <exclusion>
+                       <groupId>javax.servlet</groupId>
+                       <artifactId>servlet-api</artifactId>
+                   </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Currently, the only way to use MyFaces with AS7 is to bundle it with the WAR and set WAR_BUNDLES_JSF_IMPL. This has disadvantages. One is that you must bundle MyFaces and its dependencies with each WAR.

The second disadvantage is that it will use the default MyFaces annotation and lifecycle handling. This is less efficient than using native AS7 processing via the SPI.

This feature creates a MyFacesAnnotationProvider and MyFacesLifecycleProvider that are only activated if Mojarra is replaced by MyFaces in the modules directory.

With this preliminary version of the feature, use of MyFaces will require a bit of "hacking" in the modules directory.  But it does get us a step closer to fully pluggable JSF. And in the mean time, those who want to do an apples to apples comparison of MyFaces and Mojarra can test their application unchanged against each implementation. Thus, the community can start to gather legitimate data about which implementation runs better under certain conditions.

See jira for MyFaces installation instructions.  https://issues.jboss.org/browse/AS7-5649
