### PR TITLE
[7.1 branch] Fix for AS7-5125

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.LongRangeValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
@@ -95,6 +96,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public static final SimpleAttributeDefinition DEFAULT_DISTINCT_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_DISTINCT_NAME, ModelType.STRING, true)
                     .setAllowExpression(true)
+                    .setValidator(new StringLengthValidator(0, true))
                     .build();
 
     public static final SimpleAttributeDefinition PASS_BY_VALUE =


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-5125 where an empty value for the default-distinct-name in the EJB3 subsystem wasn't being allowed by the management model.
