### PR TITLE
[master only] Minor optimization to AS7-5581 feature

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -66,6 +66,15 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
         }
         final DeploymentReflectionIndex deploymentReflectionIndex = context.getDeploymentUnit().getAttachment(org.jboss.as.server.deployment.Attachments.REFLECTION_INDEX);
         final EJBComponentDescription ejbComponentDescription = (EJBComponentDescription) componentConfiguration.getComponentDescription();
+        // The getSecurityDomain() will return a null value if neither an explicit security domain is configured
+        // for the bean nor there's any default security domain that's configured at EJB3 subsystem level.
+        // In such cases, we do *not* apply any security interceptors
+        if (ejbComponentDescription.getSecurityDomain() == null) {
+            ROOT_LOGGER.debug("Security is *not* enabled on EJB: " + ejbComponentDescription.getEJBName() +
+                    ", since no explicit security domain is configured for the bean, nor is there any default security domain configured in the EJB3 subsystem");
+            return;
+        }
+
         final String viewClassName = viewDescription.getViewClassName();
         final EJBViewDescription ejbViewDescription = (EJBViewDescription) viewDescription;
 


### PR DESCRIPTION
As part of https://issues.jboss.org/browse/AS7-5581 we introduced the feature where the absence of an explicit @SecurityDomain on the bean would cause the EJB3 subsystem to fall back on an (optional) default security domain configured in the EJB3 subsystem. The commit here adds an optimization to skip applying the security interceptors on the beans if there's neither an explicit nor a default security domain configured.
