### PR TITLE
[AS7-4057] Add logging profiles to the logging subsystem. [master only]

### DIFF
--- a/build/src/main/resources/appclient/configuration/appclient.xml
+++ b/build/src/main/resources/appclient/configuration/appclient.xml
@@ -37,7 +37,7 @@
     </extensions>
 
     <profile>
-        <subsystem xmlns="urn:jboss:domain:logging:1.1">
+        <subsystem xmlns="urn:jboss:domain:logging:1.2">
             <console-handler name="CONSOLE">
                 <level name="INFO"/>
                 <formatter>

--- a/build/src/main/resources/configuration/subsystems/logging.xml
+++ b/build/src/main/resources/configuration/subsystems/logging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.logging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:logging:1.1">
+   <subsystem xmlns="urn:jboss:domain:logging:1.2">
        <console-handler name="CONSOLE">
            <level name="INFO"/>
            <formatter>

--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_2.xsd
@@ -1,0 +1,430 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:logging:1.2"
+            xmlns="urn:jboss:domain:logging:1.2"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.2">
+
+    <!-- The logging subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the logging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType" />
+            <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profilesType">
+        <xs:annotation>
+            <xs:documentation>
+                Contains a list of profiles available for use in deployments
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="logging-profile" type="logging-profileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profileType">
+        <xs:annotation>
+            <xs:documentation>
+                A logging profile that can be used in a deployment for a custom logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="refType">
+        <xs:annotation>
+            <xs:documentation>
+                A named reference to another object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlersType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of handlers to apply to the enclosing object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="handler" type="refType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="rootLoggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines the root logger for this log context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all minOccurs="1" maxOccurs="1">
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="handlers" type="handlersType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="loggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a logger category.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="rootLoggerType">
+                <xs:attribute name="use-parent-handlers" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="consoleHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the console.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
+            <xs:element name="target" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="name" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="System.out"/>
+                                <xs:enumeration value="System.err"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="fileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType" minOccurs="1"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a time period derived from the given
+                suffix string, which should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+        <xs:complexType name="sizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a the size of the file grows beyond a
+                certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="asyncHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the sub-handlers in an asynchronous thread.  Used for handlers which
+                introduce a substantial amount of lag.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
+            <xs:element name="subhandlers" type="handlersType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="customHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a custom handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter" type="filterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="queueLengthType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                    <xs:minExclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="overflowActionType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="block"/>
+                    <xs:enumeration value="discard"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="positiveIntType">
+        <xs:attribute name="value" use="required" type="xs:positiveInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanValueType">
+        <xs:attribute name="value" use="required" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="valueType">
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="relative-to" use="optional" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeType">
+        <xs:attribute name="value">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <!-- XSD doesn't allow ^ or $ so ^[0-9]+[bkmgtp]?$ is invalid -->
+                    <xs:pattern value="[0-9]+[bkmgtp]"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="filterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a simple filter type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="simpleFilterGroup"/>
+    </xs:complexType>
+
+    <xs:complexType name="multiFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a composite filter type.  The "any" filter will return true of any of its constituent filters
+                returns true; the "all" filter will return false if any of its constituent filters returns false.  Both
+                composite filter types are short-circuiting, meaning that if the result can be determined with an earlier
+                filter, later filters are not run.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="simpleFilterGroup" maxOccurs="unbounded"/>
+    </xs:complexType>
+
+    <xs:group name="simpleFilterGroup">
+        <xs:choice>
+            <xs:element name="all" type="multiFilterType"/>
+            <xs:element name="any" type="multiFilterType"/>
+            <xs:element name="accept"/>
+            <xs:element name="deny"/>
+            <xs:element name="not" type="filterType"/>
+            <xs:element name="match" type="regexFilterType"/>
+            <xs:element name="replace" type="replaceFilterType"/>
+            <xs:element name="level" type="levelFilterType"/>
+            <xs:element name="level-range" type="levelRangeFilterType"/>
+            <xs:element name="change-level" type="levelChangeFilterType"/>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="regexFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                A regular expression-based filter.  The filter returns true if the pattern matches.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="replaceFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                A regular expression substitution filter.  This filter modifies the log message and always returns true.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+        <xs:attribute name="replacement" type="xs:string" use="required"/>
+        <xs:attribute name="replace-all" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="levelFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                A level filter.  This filter returns true if the log message level matches the parameter.  It is a
+                numerical match; two differently-named levels with the same numeric value will be considered equal.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="levelRangeFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                A level range filter.  This filter returns true if the log message level matches the range specified
+                by the parameters.  It is a
+                numerical match; two differently-named levels with the same numeric value will be considered equal.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="min-level" type="xs:string" use="required"/>
+        <xs:attribute name="min-inclusive" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="max-level" type="xs:string" use="required"/>
+        <xs:attribute name="max-inclusive" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="levelChangeFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                A level change filter.  This filter modifies the log message and always returns true.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="new-level" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <!-- Formatters -->
+
+    <xs:complexType name="formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="patternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter.  See the documentation for org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/config-assembly/src/test/resources/org/jboss/as/config/assembly/logging.xml
+++ b/config-assembly/src/test/resources/org/jboss/as/config/assembly/logging.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <config>
    <extension-module>org.jboss.as.logging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:logging:1.1">
+   <subsystem xmlns="urn:jboss:domain:logging:1.2">
 	    <console-handler name="CONSOLE">
 	        <level name="INFO"/>
 	        <formatter>

--- a/logging/src/main/java/org/jboss/as/logging/Attribute.java
+++ b/logging/src/main/java/org/jboss/as/logging/Attribute.java
@@ -22,10 +22,10 @@
 
 package org.jboss.as.logging;
 
-import org.jboss.as.controller.AttributeDefinition;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jboss.as.controller.AttributeDefinition;
 
 /**
  *

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -112,6 +112,10 @@ public interface CommonAttributes {
 
     String LOGGER = "logger";
 
+    String LOGGING_PROFILE = "logging-profile";
+
+    String LOGGING_PROFILES = "logging-profiles";
+
     SimpleAttributeDefinition MATCH = SimpleAttributeDefinitionBuilder.create("match", ModelType.STRING, true).build();
 
     PropertyAttributeDefinition MAX_BACKUP_INDEX = PropertyAttributeDefinition.Builder.of("max-backup-index", ModelType.INT, true).

--- a/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
@@ -25,9 +25,6 @@ package org.jboss.as.logging;
 import static org.jboss.as.logging.CommonAttributes.CLASS;
 import static org.jboss.as.logging.CommonAttributes.MODULE;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 

--- a/logging/src/main/java/org/jboss/as/logging/Element.java
+++ b/logging/src/main/java/org/jboss/as/logging/Element.java
@@ -22,10 +22,10 @@
 
 package org.jboss.as.logging;
 
-import org.jboss.as.controller.AttributeDefinition;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jboss.as.controller.AttributeDefinition;
 
 /**
  *
@@ -53,6 +53,8 @@ enum Element {
     LEVEL(CommonAttributes.LEVEL),
     LEVEL_RANGE(CommonAttributes.LEVEL_RANGE),
     LOGGER(CommonAttributes.LOGGER),
+    LOGGING_PROFILE(CommonAttributes.LOGGING_PROFILE),
+    LOGGING_PROFILES(CommonAttributes.LOGGING_PROFILES),
     MATCH(CommonAttributes.MATCH),
     MAX_BACKUP_INDEX(CommonAttributes.MAX_BACKUP_INDEX),
     NOT(CommonAttributes.NOT),

--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -27,9 +27,9 @@ import static org.jboss.as.logging.CommonAttributes.ENCODING;
 import static org.jboss.as.logging.CommonAttributes.FILE;
 import static org.jboss.as.logging.CommonAttributes.FILTER;
 import static org.jboss.as.logging.CommonAttributes.FORMATTER;
+import static org.jboss.as.logging.CommonAttributes.HANDLER_NAME;
 import static org.jboss.as.logging.CommonAttributes.LEVEL;
 import static org.jboss.as.logging.CommonAttributes.MODULE;
-import static org.jboss.as.logging.CommonAttributes.HANDLER_NAME;
 import static org.jboss.as.logging.CommonAttributes.PROPERTIES;
 import static org.jboss.as.logging.CommonAttributes.SUBHANDLERS;
 import static org.jboss.as.logging.LoggerOperations.ADD_HANDLER;
@@ -58,7 +58,6 @@ import org.jboss.logmanager.Logger.AttachmentKey;
 import org.jboss.logmanager.config.FormatterConfiguration;
 import org.jboss.logmanager.config.HandlerConfiguration;
 import org.jboss.logmanager.config.LogContextConfiguration;
-import org.jboss.logmanager.config.LoggerConfiguration;
 import org.jboss.logmanager.formatters.PatternFormatter;
 
 /**
@@ -285,27 +284,10 @@ final class HandlerOperations {
 
         @Override
         public void performRuntime(final OperationContext context, final ModelNode operation, final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) throws OperationFailedException {
-            // Check to see if the handler is assigned to a logger
-            final List<String> attached = new ArrayList<String>();
-            for (String loggerName : logContextConfiguration.getLoggerNames()) {
-                final LoggerConfiguration loggerConfig = logContextConfiguration.getLoggerConfiguration(loggerName);
-                if (loggerConfig.getHandlerNames().contains(name)) {
-                    attached.add(loggerName);
-                }
-            }
-            if (!attached.isEmpty()) {
-                throw createOperationFailure(LoggingMessages.MESSAGES.handlerAttachedToLoggers(name, attached));
-            }
-            // Check to see if the handler is assigned to another handler
-            for (String handlerName : logContextConfiguration.getHandlerNames()) {
-                final HandlerConfiguration handlerConfig = logContextConfiguration.getHandlerConfiguration(handlerName);
-                if (handlerConfig.getHandlerNames().contains(name)) {
-                    attached.add(handlerName);
-                }
-            }
-            if (!attached.isEmpty()) {
-                throw createOperationFailure(LoggingMessages.MESSAGES.handlerAttachedToHandlers(name, attached));
-            }
+            // Validating wouldn't work until the LogContextConfiguration.commit() happens as handlers could still be
+            // named as attached removed the check for this reason.
+
+            // Remove the handler
             logContextConfiguration.removeHandlerConfiguration(name);
             // Remove the formatter if there is one
             if (logContextConfiguration.getFormatterNames().contains(name)) {

--- a/logging/src/main/java/org/jboss/as/logging/LoggerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggerOperations.java
@@ -24,8 +24,8 @@ package org.jboss.as.logging;
 
 import static org.jboss.as.logging.CommonAttributes.FILTER;
 import static org.jboss.as.logging.CommonAttributes.HANDLERS;
-import static org.jboss.as.logging.CommonAttributes.LEVEL;
 import static org.jboss.as.logging.CommonAttributes.HANDLER_NAME;
+import static org.jboss.as.logging.CommonAttributes.LEVEL;
 import static org.jboss.as.logging.CommonAttributes.ROOT_LOGGER_ATTRIBUTE_NAME;
 import static org.jboss.as.logging.CommonAttributes.ROOT_LOGGER_NAME;
 import static org.jboss.as.logging.CommonAttributes.USE_PARENT_HANDLERS;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
@@ -27,10 +27,11 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.Closeable;
 
+import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
-import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -120,4 +121,15 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11508, value = "Filters are not currently supported for log4j appenders.")
     void filterNotSupported();
+
+    /**
+     * Logs a warning message indicating the deployment specified a logging profile, but the logging profile was not
+     * found.
+     *
+     * @param loggingProfile the logging profile that was not found
+     * @param deployment     the deployment that specified the logging profile
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11509, value = "Logging profile '%s' was specified for deployment '%s' but was not found. Using system logging configuration.")
+    void loggingProfileNotFound(String loggingProfile, ResourceRoot deployment);
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -28,10 +28,10 @@ import java.util.EnumSet;
 import java.util.logging.Handler;
 
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
-import org.jboss.logging.Messages;
 
 /**
  * This module is using message IDs in the range 11500-11599.

--- a/logging/src/main/java/org/jboss/as/logging/LoggingProfileContextSelector.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingProfileContextSelector.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging;
+
+import java.util.concurrent.ConcurrentMap;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.util.collection.ConcurrentSkipListMap;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+final class LoggingProfileContextSelector {
+    private static final LoggingProfileContextSelector INSTANCE = new LoggingProfileContextSelector();
+
+    private final ConcurrentMap<String, LogContext> profileContexts = new ConcurrentSkipListMap<String, LogContext>();
+
+    private LoggingProfileContextSelector() {
+
+    }
+
+    public static LoggingProfileContextSelector getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Get or create the log context based on the logging profile.
+     *
+     * @param loggingProfile the logging profile to get or create the log context for
+     *
+     * @return the log context that was found or a new log context
+     */
+    public LogContext getOrCreate(final String loggingProfile) {
+        LogContext result = profileContexts.get(loggingProfile);
+        if (result == null) {
+            result = LogContext.create();
+            final LogContext current = profileContexts.putIfAbsent(loggingProfile, result);
+            if (current != null) {
+                result = current;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the log context associated with the logging profile or {@code null} if the logging profile does not have
+     * an associated log context.
+     *
+     * @param loggingProfile the logging profile associated with the log context
+     *
+     * @return the log context or {@code null} if the logging profile is not associated with a log context
+     */
+    public LogContext get(final String loggingProfile) {
+        return profileContexts.get(loggingProfile);
+    }
+
+    /**
+     * Checks to see if the logging profile has a log context associated with it.
+     *
+     * @param loggingProfile the logging profile to check
+     *
+     * @return {@code true} if the logging profile has an associated log context, otherwise {@code false}
+     */
+    public boolean exists(final String loggingProfile) {
+        return profileContexts.containsKey(loggingProfile);
+    }
+
+    /**
+     * Removes the associated log context from the logging profile.
+     *
+     * @param loggingProfile the logging profile associated with the log context
+     *
+     * @return the log context that was removed or {@code null} if there was no log context associated
+     */
+    public LogContext remove(final String loggingProfile) {
+        return profileContexts.remove(loggingProfile);
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggingProfileOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingProfileOperations.java
@@ -1,0 +1,127 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.logging.logmanager.ConfigurationPersistence;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.config.LogContextConfiguration;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingProfileOperations {
+
+
+    static OperationStepHandler ADD_PROFILE = new AbstractAddStepHandler() {
+        @Override
+        protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            model.setEmptyObject();
+        }
+    };
+
+    static OperationStepHandler REMOVE_PROFILE = new AbstractRemoveStepHandler() {
+
+        @Override
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            // Get the address and the name of the logger or handler
+            final PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
+            // Get the logging profile
+            final String loggingProfile = getLoggingProfileName(address);
+            final LogContext logContext = LoggingProfileContextSelector.getInstance().remove(loggingProfile);
+            if (logContext != null) {
+                final ConfigurationPersistence configuration = ConfigurationPersistence.getConfigurationPersistence(logContext);
+                if (configuration != null) {
+                    final LogContextConfiguration logContextConfiguration = configuration.getLogContextConfiguration();
+                    try {
+                        // Remove all loggers
+                        for (String loggerName : logContextConfiguration.getLoggerNames()) {
+                            logContextConfiguration.removeLoggerConfiguration(loggerName);
+                        }
+                        // Remove all the handlers
+                        for (String handlerName : logContextConfiguration.getHandlerNames()) {
+                            logContextConfiguration.removeHandlerConfiguration(handlerName);
+                        }
+                        // Remove all the filters
+                        for (String filterName : logContextConfiguration.getFilterNames()) {
+                            logContextConfiguration.removeFilterConfiguration(filterName);
+                        }
+                        // Remove all the formatters
+                        for (String formatterName : logContextConfiguration.getFormatterNames()) {
+                            logContextConfiguration.removeFormatterConfiguration(formatterName);
+                        }
+                        // Remove all the error managers
+                        for (String errorManager : logContextConfiguration.getErrorManagerNames()) {
+                            logContextConfiguration.removeErrorManagerConfiguration(errorManager);
+                        }
+                        logContextConfiguration.commit();
+                        // Requires a reload
+                        context.reloadRequired();
+                    } finally {
+                        logContextConfiguration.forget();
+                    }
+                }
+            }
+        }
+
+        @Override
+        protected void recoverServices(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            // TODO (jrp) might need to find a way to add the profile back.
+        }
+    };
+
+    /**
+     * Checks if the address is a logging profile address.
+     *
+     * @param address the address to check for the logging profile
+     *
+     * @return {@code true} if the address is a logging profile address, otherwise {@code false}
+     */
+    static boolean isLoggingProfileAddress(final PathAddress address) {
+        return getLoggingProfileName(address) != null;
+    }
+
+    /**
+     * Gets the logging profile name. If the address is not in a logging profile path, {@code null} is returned.
+     *
+     * @param address the address to check for the logging profile name
+     *
+     * @return the logging profile name or {@code null}
+     */
+    static String getLoggingProfileName(final PathAddress address) {
+        for (PathElement pathElement : address) {
+            if (CommonAttributes.LOGGING_PROFILE.equals(pathElement.getKey())) {
+                return pathElement.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -41,10 +41,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.config.LogContextConfiguration;
 import org.jboss.msc.service.ServiceController;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
@@ -65,7 +61,7 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
         context.addStep(new AbstractDeploymentChainStep() {
             @Override
             protected void execute(final DeploymentProcessorTarget processorTarget) {
-                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG, LoggingConfigurationProcessor.INSTANCE);
+                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG, LoggingDeploymentUnitProcessor.INSTANCE);
             }
         }, Stage.RUNTIME);
 
@@ -108,12 +104,5 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
         } finally {
             logContextConfiguration.forget();
         }
-    }
-
-    static ModelNode createOperation(ModelNode address) {
-        final ModelNode subsystem = new ModelNode();
-        subsystem.get(OP).set(ADD);
-        subsystem.get(OP_ADDR).set(address);
-        return subsystem;
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -51,9 +51,12 @@ import static org.jboss.as.logging.CommonAttributes.FILE_HANDLER;
 import static org.jboss.as.logging.CommonAttributes.FILTER;
 import static org.jboss.as.logging.CommonAttributes.FORMATTER;
 import static org.jboss.as.logging.CommonAttributes.HANDLERS;
+import static org.jboss.as.logging.CommonAttributes.HANDLER_NAME;
 import static org.jboss.as.logging.CommonAttributes.LEVEL;
 import static org.jboss.as.logging.CommonAttributes.LEVEL_RANGE;
 import static org.jboss.as.logging.CommonAttributes.LOGGER;
+import static org.jboss.as.logging.CommonAttributes.LOGGING_PROFILE;
+import static org.jboss.as.logging.CommonAttributes.LOGGING_PROFILES;
 import static org.jboss.as.logging.CommonAttributes.MATCH;
 import static org.jboss.as.logging.CommonAttributes.MAX_BACKUP_INDEX;
 import static org.jboss.as.logging.CommonAttributes.MAX_INCLUSIVE;
@@ -61,7 +64,6 @@ import static org.jboss.as.logging.CommonAttributes.MAX_LEVEL;
 import static org.jboss.as.logging.CommonAttributes.MIN_INCLUSIVE;
 import static org.jboss.as.logging.CommonAttributes.MIN_LEVEL;
 import static org.jboss.as.logging.CommonAttributes.MODULE;
-import static org.jboss.as.logging.CommonAttributes.HANDLER_NAME;
 import static org.jboss.as.logging.CommonAttributes.NEW_LEVEL;
 import static org.jboss.as.logging.CommonAttributes.NOT;
 import static org.jboss.as.logging.CommonAttributes.OVERFLOW_ACTION;
@@ -94,7 +96,10 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -125,12 +130,9 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         if (reader.getAttributeCount() > 0) {
             throw unexpectedAttribute(reader, 0);
         }
+        final PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, LoggingExtension.SUBSYSTEM_NAME));
 
-        final ModelNode address = new ModelNode();
-        address.add(SUBSYSTEM, LoggingExtension.SUBSYSTEM_NAME);
-        address.protect();
-
-        list.add(LoggingSubsystemAdd.createOperation(address));
+        list.add(Util.createAddOperation(address));
 
         // Elements
         final Set<String> loggerNames = new HashSet<String>();
@@ -140,7 +142,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
             final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
             switch (namespace) {
                 case LOGGING_1_0:
-                case LOGGING_1_1: {
+                case LOGGING_1_1:
+                case LOGGING_1_2: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {
                         case LOGGER: {
@@ -181,6 +184,11 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                             parseAsyncHandlerElement(reader, address, list, handlerNames);
                             break;
                         }
+                        case LOGGING_PROFILES:
+                            if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1)
+                                throw unexpectedElement(reader);
+                            parseLoggingProfilesElement(reader, address, list);
+                            break;
                         default: {
                             reader.handleAny(list);
                             break;
@@ -196,8 +204,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
     }
 
 
-    static void parseLoggerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
-        final ModelNode node = new ModelNode();
+    static void parseLoggerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+        final ModelNode op = new ModelNode();
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.CATEGORY);
@@ -213,7 +221,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     break;
                 }
                 case USE_PARENT_HANDLERS: {
-                    USE_PARENT_HANDLERS.parseAndSetParameter(value, node, reader);
+                    USE_PARENT_HANDLERS.parseAndSetParameter(value, op, reader);
                     break;
                 }
                 default:
@@ -229,30 +237,31 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
 
         // Setup the operation
-        node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(LOGGER, name);
+        op.get(OP).set(ADD);
+        op.get(OP_ADDR).set(address.toModelNode()).add(LOGGER, name);
 
         // Element
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             switch (Namespace.forUri(reader.getNamespaceURI())) {
                 case LOGGING_1_0:
-                case LOGGING_1_1: {
+                case LOGGING_1_1:
+                case LOGGING_1_2: {
                     final Element element = Element.forName(reader.getLocalName());
                     if (!encountered.add(element)) {
                         throw duplicateNamedElement(reader, reader.getLocalName());
                     }
                     switch (element) {
                         case LEVEL: {
-                            LEVEL.parseAndSetParameter(readStringAttributeElement(reader, "name"), node, reader);
+                            LEVEL.parseAndSetParameter(readStringAttributeElement(reader, "name"), op, reader);
                             break;
                         }
                         case HANDLERS: {
-                            parseHandlersElement(node.get(HANDLERS.getName()), reader);
+                            parseHandlersElement(op.get(HANDLERS.getName()), reader);
                             break;
                         }
                         case FILTER: {
-                            parseFilter(node, reader);
+                            parseFilter(op, reader);
                             break;
                         }
                         default:
@@ -265,10 +274,10 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                 }
             }
         }
-        list.add(node);
+        list.add(op);
     }
 
-    static void parseAsyncHandlerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+    static void parseAsyncHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
         // Attributes
         String name = null;
@@ -297,7 +306,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Setup the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(ASYNC_HANDLER, name);
+        node.get(OP_ADDR).set(address.toModelNode()).add(ASYNC_HANDLER, name);
 
         // Elements
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
@@ -339,7 +348,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         list.add(node);
     }
 
-    static void parseRootLoggerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list) throws XMLStreamException {
+    static void parseRootLoggerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list) throws XMLStreamException {
         // No attributes
         if (reader.getAttributeCount() > 0) {
             throw unexpectedAttribute(reader, 0);
@@ -347,12 +356,13 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         final ModelNode node = new ModelNode();
         node.get(OP).set(RootLoggerResourceDefinition.ROOT_LOGGER_ADD_OPERATION_NAME);
-        node.get(OP_ADDR).set(address).add(ROOT_LOGGER, ROOT_LOGGER_ATTRIBUTE_NAME);
+        node.get(OP_ADDR).set(address.toModelNode()).add(ROOT_LOGGER, ROOT_LOGGER_ATTRIBUTE_NAME);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             switch (Namespace.forUri(reader.getNamespaceURI())) {
                 case LOGGING_1_0:
-                case LOGGING_1_1: {
+                case LOGGING_1_1:
+                case LOGGING_1_2: {
                     final Element element = Element.forName(reader.getLocalName());
                     if (encountered.contains(element)) {
                         throw duplicateNamedElement(reader, reader.getLocalName());
@@ -384,7 +394,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         list.add(node);
     }
 
-    static void parseConsoleHandlerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+    static void parseConsoleHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
         // Attributes
         String name = null;
@@ -417,7 +427,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Set-up the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(CONSOLE_HANDLER, name);
+        node.get(OP_ADDR).set(address.toModelNode()).add(CONSOLE_HANDLER, name);
 
         // Elements
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
@@ -459,7 +469,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         list.add(node);
     }
 
-    static void parseFileHandlerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+    static void parseFileHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
         // Attributes
         String name = null;
@@ -492,7 +502,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Setup the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(FILE_HANDLER, name);
+        node.get(OP_ADDR).set(address.toModelNode()).add(FILE_HANDLER, name);
 
         // Elements
         final EnumSet<Element> requiredElem = EnumSet.of(Element.FILE);
@@ -539,7 +549,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         list.add(node);
     }
 
-    static void parseCustomHandlerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+    static void parseCustomHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
         // Attributes
         String name = null;
@@ -575,7 +585,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
         // Setup the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(CUSTOM_HANDLER, name);
+        node.get(OP_ADDR).set(address.toModelNode()).add(CUSTOM_HANDLER, name);
 
 
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
@@ -613,7 +623,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         list.add(node);
     }
 
-    static void parsePeriodicRotatingFileHandlerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+    static void parsePeriodicRotatingFileHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
         // Attributes
         String name = null;
@@ -646,7 +656,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Setup the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(PERIODIC_ROTATING_FILE_HANDLER, name);
+        node.get(OP_ADDR).set(address.toModelNode()).add(PERIODIC_ROTATING_FILE_HANDLER, name);
 
         final EnumSet<Element> requiredElem = EnumSet.of(Element.FILE, Element.SUFFIX);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
@@ -696,7 +706,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         list.add(node);
     }
 
-    static void parseSizeRotatingHandlerElement(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
+    static void parseSizeRotatingHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
         // Attributes
         String name = null;
@@ -729,7 +739,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Setup the operation
         node.get(OP).set(ADD);
-        node.get(OP_ADDR).set(address).add(SIZE_ROTATING_FILE_HANDLER, name);
+        node.get(OP_ADDR).set(address.toModelNode()).add(SIZE_ROTATING_FILE_HANDLER, name);
 
         final EnumSet<Element> requiredElem = EnumSet.of(Element.FILE);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
@@ -815,7 +825,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
         switch (Namespace.forUri(reader.getNamespaceURI())) {
             case LOGGING_1_0:
-            case LOGGING_1_1: {
+            case LOGGING_1_1:
+            case LOGGING_1_2: {
                 final Element element = Element.forName(reader.getLocalName());
                 switch (element) {
                     case PATTERN_FORMATTER: {
@@ -905,7 +916,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             switch (Namespace.forUri(reader.getNamespaceURI())) {
                 case LOGGING_1_0:
-                case LOGGING_1_1: {
+                case LOGGING_1_1:
+                case LOGGING_1_2: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {
                         case HANDLER: {
@@ -919,6 +931,102 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                 }
                 default: {
                     throw unexpectedElement(reader);
+                }
+            }
+        }
+    }
+
+    static void parseLoggingProfilesElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list) throws XMLStreamException {
+        final Set<String> profileNames = new HashSet<String>();
+
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case LOGGING_PROFILE: {
+                    parseLoggingProfileElement(reader, address, list, profileNames);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+    }
+
+    static void parseLoggingProfileElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> profileNames) throws XMLStreamException {
+        // Attributes
+        String name = null;
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        if (!profileNames.add(name)) {
+            throw duplicateNamedElement(reader, name);
+        }
+        // Setup the address
+        final PathAddress profileAddress = address.append(LOGGING_PROFILE, name);
+        list.add(Util.createAddOperation(profileAddress));
+
+        final Set<String> loggerNames = new HashSet<String>();
+        final Set<String> handlerNames = new HashSet<String>();
+        boolean gotRoot = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case LOGGER: {
+                    parseLoggerElement(reader, profileAddress, list, loggerNames);
+                    break;
+                }
+                case ROOT_LOGGER: {
+                    if (gotRoot) {
+                        throw unexpectedElement(reader);
+                    }
+                    gotRoot = true;
+                    parseRootLoggerElement(reader, profileAddress, list);
+                    break;
+                }
+                case CONSOLE_HANDLER: {
+                    parseConsoleHandlerElement(reader, profileAddress, list, handlerNames);
+                    break;
+                }
+                case FILE_HANDLER: {
+                    parseFileHandlerElement(reader, profileAddress, list, handlerNames);
+                    break;
+                }
+                case CUSTOM_HANDLER: {
+                    parseCustomHandlerElement(reader, profileAddress, list, handlerNames);
+                    break;
+                }
+                case PERIODIC_ROTATING_FILE_HANDLER: {
+                    parsePeriodicRotatingFileHandlerElement(reader, profileAddress, list, handlerNames);
+                    break;
+                }
+                case SIZE_ROTATING_FILE_HANDLER: {
+                    parseSizeRotatingHandlerElement(reader, profileAddress, list, handlerNames);
+                    break;
+                }
+                case ASYNC_HANDLER: {
+                    parseAsyncHandlerElement(reader, profileAddress, list, handlerNames);
+                    break;
+                }
+                default: {
+                    reader.handleAny(list);
+                    break;
                 }
             }
         }
@@ -942,7 +1050,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             switch (Namespace.forUri(reader.getNamespaceURI())) {
                 case LOGGING_1_0:
-                case LOGGING_1_1: {
+                case LOGGING_1_1:
+                case LOGGING_1_2: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {
                         case ACCEPT: {
@@ -1023,14 +1132,32 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void writeContent(final XMLExtendedStreamWriter writer, final SubsystemMarshallingContext context) throws XMLStreamException {
         context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);
 
         ModelNode node = context.getModelNode();
+
+        writeContent(writer, node);
+
+        if (node.hasDefined(LOGGING_PROFILE)) {
+            final List<Property> profiles = node.get(LOGGING_PROFILE).asPropertyList();
+            if (!profiles.isEmpty()) {
+                writer.writeStartElement(LOGGING_PROFILES);
+                for (Property profile : profiles) {
+                    final String name = profile.getName();
+                    writer.writeStartElement(LOGGING_PROFILE);
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), name);
+                    writeContent(writer, profile.getValue());
+                    writer.writeEndElement();
+                }
+                writer.writeEndElement();
+            }
+        }
+        writer.writeEndElement();
+    }
+
+    public void writeContent(final XMLExtendedStreamWriter writer, final ModelNode node) throws XMLStreamException {
 
         if (node.hasDefined(ASYNC_HANDLER)) {
             final ModelNode handlers = node.get(ASYNC_HANDLER);
@@ -1112,7 +1239,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         if (node.hasDefined(ROOT_LOGGER)) {
             writeRootLogger(writer, node.get(ROOT_LOGGER, ROOT_LOGGER_ATTRIBUTE_NAME));
         }
-        writer.writeEndElement();
     }
 
     private void writeConsoleHandler(final XMLExtendedStreamWriter writer, final ModelNode node, final String name)

--- a/logging/src/main/java/org/jboss/as/logging/Namespace.java
+++ b/logging/src/main/java/org/jboss/as/logging/Namespace.java
@@ -24,7 +24,6 @@ package org.jboss.as.logging;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,12 +37,14 @@ public enum Namespace {
 
     LOGGING_1_0("urn:jboss:domain:logging:1.0"),
 
-    LOGGING_1_1("urn:jboss:domain:logging:1.1");
+    LOGGING_1_1("urn:jboss:domain:logging:1.1"),
+
+    LOGGING_1_2("urn:jboss:domain:logging:1.2");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = LOGGING_1_1;
+    public static final Namespace CURRENT = LOGGING_1_2;
 
     private final String name;
 

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/ConfigurationPersistence.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/ConfigurationPersistence.java
@@ -126,6 +126,18 @@ public final class ConfigurationPersistence implements Configurator {
         return result;
     }
 
+    /**
+     * Gets the property configurator. If the {@link ConfigurationPersistence} does not exist a {@code null} is
+     * returned.
+     *
+     * @param logContext the log context used to find the property configurator or to attach it to.
+     *
+     * @return the property configurator or {@code null}
+     */
+    public static ConfigurationPersistence getConfigurationPersistence(final LogContext logContext) {
+        return (ConfigurationPersistence) logContext.getAttachment(CommonAttributes.ROOT_LOGGER_NAME, Configurator.ATTACHMENT_KEY);
+    }
+
     @Override
     public void configure(final InputStream inputStream) throws IOException {
         final Properties properties = new Properties();
@@ -409,9 +421,9 @@ public final class ConfigurationPersistence implements Configurator {
     /**
      * Writes a property to the print stream.
      *
-     * @param out    the print stream to write to.
-     * @param name   the name of the property.
-     * @param value  the value of the property.
+     * @param out   the print stream to write to.
+     * @param name  the name of the property.
+     * @param value the value of the property.
      */
     private static void writeProperty(final PrintStream out, final String name, final String value) throws IOException {
         writeProperty(out, null, name, value);
@@ -693,7 +705,7 @@ public final class ConfigurationPersistence implements Configurator {
         for (int x = 0; x < string.length(); x++) {
             final char c = string.charAt(x);
             switch (c) {
-                case ' ' :
+                case ' ':
                     if (x == 0 || escapeSpaces)
                         out.append('\\');
                     out.append(c);

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/LoggerConfigurationImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/LoggerConfigurationImpl.java
@@ -67,7 +67,7 @@ final class LoggerConfigurationImpl extends AbstractBasicConfiguration<Logger, L
             }
 
             public void applyPostCreate(final ObjectProducer param) {
-                configuration.getHandlerRefs().get(getName()).setFilter((Filter) param.getObject());
+               configuration.getHandlerRefs().get(getName()).setFilter((Filter) param.getObject());
             }
 
             public void rollback() {

--- a/logging/src/main/java/org/jboss/as/logging/resolvers/LevelResolver.java
+++ b/logging/src/main/java/org/jboss/as/logging/resolvers/LevelResolver.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.logging.resolvers;
 
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import java.util.logging.Level;
 

--- a/logging/src/main/java/org/jboss/as/logging/resolvers/OverflowActionResolver.java
+++ b/logging/src/main/java/org/jboss/as/logging/resolvers/OverflowActionResolver.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.logging.resolvers;
 
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;

--- a/logging/src/main/java/org/jboss/as/logging/resolvers/SizeResolver.java
+++ b/logging/src/main/java/org/jboss/as/logging/resolvers/SizeResolver.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.logging.resolvers;
 
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/logging/src/main/java/org/jboss/as/logging/validators/FileValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/FileValidator.java
@@ -24,8 +24,8 @@ package org.jboss.as.logging.validators;
 
 import static org.jboss.as.logging.CommonAttributes.PATH;
 import static org.jboss.as.logging.CommonAttributes.RELATIVE_TO;
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;

--- a/logging/src/main/java/org/jboss/as/logging/validators/LogLevelValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/LogLevelValidator.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.logging.validators;
 
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/logging/src/main/java/org/jboss/as/logging/validators/SizeValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/SizeValidator.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.logging.validators;
 
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;

--- a/logging/src/main/java/org/jboss/as/logging/validators/SuffixValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/SuffixValidator.java
@@ -22,8 +22,8 @@
 
 package org.jboss.as.logging.validators;
 
-import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 import static org.jboss.as.logging.Logging.createOperationFailure;
+import static org.jboss.as.logging.LoggingMessages.MESSAGES;
 
 import java.text.SimpleDateFormat;
 

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -3,6 +3,11 @@ logging=The configuration of the logging subsystem.
 logging.add=Add the logging subsystem.
 logging.remove=Remove the logging subsystem.
 
+# Logging profiles
+logging.logging-profile=A profile that can be assigned to a deployment for it's logging configuration.
+logging.logging-profile.add=Adds a logging profile.
+logging.logging-profile.remove=Removes the logging profile and all associated loggers and handlers.
+
 # Root logger operations
 logging.root-logger=Defines the root logger for this log context.
 logging.root-logger.remove=Remove the root logger.

--- a/logging/src/test/java/org/jboss/as/logging/Operations.java
+++ b/logging/src/test/java/org/jboss/as/logging/Operations.java
@@ -1,0 +1,309 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Operations extends ClientConstants {
+
+    public static final String READ_ATTRIBUTE = ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+    public static final String READ_RESOURCE = ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+    public static final String RECURSIVE = ModelDescriptionConstants.RECURSIVE;
+    public static final String REMOVE = ModelDescriptionConstants.REMOVE;
+    public static final String VALUE = ModelDescriptionConstants.VALUE;
+    public static final String WRITE_ATTRIBUTE = ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+    /**
+     * Checks the result for a successful operation.
+     *
+     * @param result the result of executing an operation
+     *
+     * @return {@code true} if the operation was successful, otherwise {@code false}
+     */
+    public static boolean successful(final ModelNode result) {
+        return result.get(OUTCOME).asString().equals(SUCCESS);
+    }
+
+    /**
+     * Parses the result and returns the failure description. If the result was successful, an empty string is
+     * returned.
+     *
+     * @param result the result of executing an operation
+     *
+     * @return the failure message or an empty string
+     */
+    public static String getFailureDescription(final ModelNode result) {
+        if (successful(result)) {
+            return "";
+        }
+        final String msg;
+        if (result.hasDefined(FAILURE_DESCRIPTION)) {
+            if (result.hasDefined(OP)) {
+                msg = String.format("Operation '%s' at address '%s' failed: %s", result.get(OP), result.get(OP_ADDR), result.get(FAILURE_DESCRIPTION));
+            } else {
+                msg = String.format("Operation failed: %s", result.get(FAILURE_DESCRIPTION));
+            }
+        } else {
+            msg = String.format("An unexpected response was found. Result: %s", result);
+        }
+        return msg;
+    }
+
+    /**
+     * Creates an add operation.
+     *
+     * @param address the address for the operation
+     *
+     * @return the operation
+     */
+    public static ModelNode createAddOperation(final ModelNode address) {
+        return createOperation(ADD, address);
+    }
+
+    /**
+     * Creates a remove operation.
+     *
+     * @param address the address for the operation
+     *
+     * @return the operation
+     */
+    public static ModelNode createRemoveOperation(final ModelNode address, final boolean recursive) {
+        return createOperation(REMOVE, address, recursive);
+    }
+
+    /**
+     * Creates a composite operation with an empty address and empty steps that will rollback on a runtime failure.
+     *
+     * @return the operation
+     */
+    public static ModelNode createCompositeOperation() {
+        final ModelNode op = createOperation(COMPOSITE);
+        op.get(OP).set(COMPOSITE);
+        op.get(OP_ADDR).setEmptyList();
+        op.get(ROLLBACK_ON_RUNTIME_FAILURE).set(true);
+        op.get(STEPS).setEmptyList();
+        return op;
+    }
+
+    /**
+     * Creates an operation to read the attribute represented by the {@code attributeName} parameter.
+     *
+     * @param address   the address to create the write attribute for
+     * @param attribute the attribute to read
+     *
+     * @return the operation
+     */
+    public static ModelNode createReadAttributeOperation(final ModelNode address, final AttributeDefinition attribute) {
+        return createReadAttributeOperation(address, attribute.getName());
+    }
+
+    /**
+     * Creates an operation to read the attribute represented by the {@code attributeName} parameter.
+     *
+     * @param address       the address to create the write attribute for
+     * @param attributeName the name of the parameter to read
+     *
+     * @return the operation
+     */
+    public static ModelNode createReadAttributeOperation(final ModelNode address, final String attributeName) {
+        ModelNode op = new ModelNode();
+        op.get(OP_ADDR).set(address);
+        op.get(OP).set(READ_ATTRIBUTE);
+        op.get(NAME).set(attributeName);
+        return op;
+    }
+
+    /**
+     * Creates an operation to write an attribute value represented by the {@code attributeName} parameter.
+     *
+     * @param address   the address to create the write attribute for
+     * @param attribute the attribute to write
+     * @param value     the value to set the attribute to
+     *
+     * @return the operation
+     */
+    public static ModelNode createWriteAttributeOperation(final ModelNode address, final AttributeDefinition attribute, final String value) {
+        return createWriteAttributeOperation(address, attribute.getName(), value);
+    }
+
+    /**
+     * Creates an operation to write an attribute value represented by the {@code attributeName} parameter.
+     *
+     * @param address       the address to create the write attribute for
+     * @param attributeName the name of the attribute to write
+     * @param value         the value to set the attribute to
+     *
+     * @return the operation
+     */
+    public static ModelNode createWriteAttributeOperation(final ModelNode address, final String attributeName, final String value) {
+        ModelNode op = new ModelNode();
+        op.get(OP_ADDR).set(address);
+        op.get(OP).set(WRITE_ATTRIBUTE);
+        op.get(NAME).set(attributeName);
+        op.get(VALUE).set(value);
+        return op;
+    }
+
+    /**
+     * Creates a generic operation with no address.
+     *
+     * @param operation the operation to create
+     *
+     * @return the operation
+     */
+    public static ModelNode createOperation(final String operation) {
+        final ModelNode op = new ModelNode();
+        op.get(OP).set(operation);
+        op.get(OP_ADDR).setEmptyList();
+        return op;
+    }
+
+    /**
+     * Creates an operation.
+     *
+     * @param operation the operation name
+     * @param address   the address for the operation
+     *
+     * @return the operation
+     *
+     * @throws IllegalArgumentException if the address is not of type {@link org.jboss.dmr.ModelType#LIST}
+     */
+    public static ModelNode createOperation(final String operation, final ModelNode address) {
+        if (address.getType() != ModelType.LIST) {
+            throw new IllegalArgumentException("The address type must be a list.");
+        }
+        final ModelNode op = createOperation(operation);
+        op.get(OP_ADDR).set(address);
+        return op;
+    }
+
+    /**
+     * Creates an operation.
+     *
+     * @param operation the operation name
+     * @param address   the address for the operation
+     * @param recursive whether the operation is recursive or not
+     *
+     * @return the operation
+     *
+     * @throws IllegalArgumentException if the address is not of type {@link ModelType#LIST}
+     */
+    public static ModelNode createOperation(final String operation, final ModelNode address, final boolean recursive) {
+        final ModelNode op = createOperation(operation, address);
+        op.get(RECURSIVE).set(recursive);
+        return op;
+    }
+
+    /**
+     * Reads the result of an operation and returns the result as a string. If the operation does not have a {@link
+     * #RESULT} attribute and empty string is returned.
+     *
+     * @param result the result of executing an operation
+     *
+     * @return the result of the operation or an empty string
+     */
+    public static String readResultAsString(final ModelNode result) {
+        return (result.hasDefined(RESULT) ? result.get(RESULT).asString() : "");
+    }
+
+    /**
+     * Reads the result of an operation and returns the result as a list of strings. If the operation does not have a
+     * {@link #RESULT} attribute and empty list is returned.
+     *
+     * @param result the result of executing an operation
+     *
+     * @return the result of the operation or an empty list
+     */
+    public static List<String> readResultAsList(final ModelNode result) {
+        if (result.hasDefined(RESULT) && result.get(RESULT).getType() == ModelType.LIST) {
+            final List<String> list = new ArrayList<String>();
+            for (ModelNode n : result.get(RESULT).asList()) list.add(n.asString());
+            return list;
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * A builder for building composite operations.
+     * <p/>
+     *
+     * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+     */
+    public static class CompositeOperationBuilder {
+        private final ModelNode op;
+
+        private CompositeOperationBuilder(final ModelNode op) {
+            this.op = op;
+        }
+
+        /**
+         * Creates a new builder.
+         *
+         * @return a new builder
+         */
+        public static CompositeOperationBuilder create() {
+            return new CompositeOperationBuilder(createCompositeOperation());
+        }
+
+        /**
+         * Builds the operation.
+         *
+         * @return the built operation
+         */
+        public Operation build() {
+            return OperationBuilder.create(op).build();
+        }
+
+        /**
+         * Adds a new operation to the composite operation.
+         * <p/>
+         * Note that subsequent calls after a {@link #build() build} invocation will result the operation being
+         * appended to.
+         *
+         * @param op the operation to add
+         *
+         * @return the current builder
+         */
+        public CompositeOperationBuilder addStep(final ModelNode op) {
+            if (op.hasDefined(OP)) {
+                this.op.get(STEPS).add(op);
+            } else {
+                throw new IllegalArgumentException(String.format("Invalid operations: %s", op));
+            }
+            return this;
+        }
+    }
+}

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:1.1">
+<subsystem xmlns="urn:jboss:domain:logging:1.2">
     <async-handler name="async">
         <queue-length value="10"/>
         <overflow-action value="block"/>
@@ -134,4 +134,33 @@
             <handler name="FILE"/>
         </handlers>
     </root-logger>
+
+    <logging-profiles>
+        <logging-profile name="test-profile">
+
+            <console-handler name="CONSOLE">
+                <level name="ALL"/>
+                <filter>
+                    <level-range min-level="TRACE" max-level="WARN"/>
+                </filter>
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+            </console-handler>
+
+            <logger category="org.jboss.as.logging">
+                <level name="TRACE"/>
+                <filter>
+                    <level-range min-level="TRACE" max-level="ERROR" min-inclusive="true"/>
+                </filter>
+            </logger>
+
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                </handlers>
+            </root-logger>
+        </logging-profile>
+    </logging-profiles>
 </subsystem>

--- a/logging/src/test/resources/operations.xml
+++ b/logging/src/test/resources/operations.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:logging:1.1">
+<subsystem xmlns="urn:jboss:domain:logging:1.2">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>
@@ -20,4 +20,31 @@
             <handler name="FILE"/>
         </handlers>
     </root-logger>
+
+    <!-- Set-up a default logging profile -->
+    <logging-profiles>
+        <logging-profile name="testProfile">
+            <console-handler name="CONSOLE">
+                <level name="INFO"/>
+                <formatter>
+                    <pattern-formatter pattern="[profile] %d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+            </console-handler>
+            <periodic-rotating-file-handler name="FILE">
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="server-profile.log"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="true"/>
+            </periodic-rotating-file-handler>
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="FILE"/>
+                </handlers>
+            </root-logger>
+        </logging-profile>
+    </logging-profiles>
 </subsystem>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -39,7 +39,7 @@
 
         <profile name="default">
 
-            <subsystem xmlns="urn:jboss:domain:logging:1.1">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
                 <console-handler name="CONSOLE">
                     <level name="INFO"/>
                     <formatter>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -81,7 +81,7 @@
                </virtual-server>
              </subsystem>
 
-            <subsystem xmlns="urn:jboss:domain:logging:1.1">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
                 <console-handler name="CONSOLE">
                     <level name="INFO"/>
                     <formatter>
@@ -429,7 +429,7 @@
                </virtual-server>
              </subsystem>
 
-            <subsystem xmlns="urn:jboss:domain:logging:1.1">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
                 <console-handler name="CONSOLE">
                     <level name="INFO"/>
                     <formatter>
@@ -784,7 +784,7 @@
             <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
         </profile>
         <profile name="minimal">
-            <subsystem xmlns="urn:jboss:domain:logging:1.1">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
                 <console-handler name="CONSOLE">
                     <level name="INFO"/>
                     <formatter>


### PR DESCRIPTION
Allows for logging profiles to be configured. A logging profile can be attached to a deployment by specifying the Logging-Profile attribute in the MANIFEST.MF. This allows for runtime changes of application logging.

If a logging a profile was defined on a deployment, but the logging profile does not exist then a warning message is logged and logging falls back to the system configuration.
