### PR TITLE
[AS7-5678] [master-only] Honor the directory grouping by-type for domain servers

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
@@ -300,7 +300,16 @@ class ManagedServerBootCmdFactory implements ManagedServerBootConfiguration {
             }
             properties.put(propertyName, result);
         } else {
-            result = new File(value).getAbsolutePath();
+            final File dir = new File(value);
+            switch (directoryGrouping) {
+                case BY_TYPE:
+                    result = getAbsolutePath(dir, "servers", serverName);
+                    break;
+                case BY_SERVER:
+                default:
+                    result = dir.getAbsolutePath();
+                    break;
+            }
         }
         command.add(String.format("-D%s=%s", propertyName, result));
         return result;


### PR DESCRIPTION
Currently if one of the directories (jboss.server.log.dir, jboss.server.tmp.dir or jboss.server.data.dir) are overridden the directory grouping is ignored. This honors the `by-type` directory listing.

```
 ${JBOSS_HOME}/bin/domain.sh -Djboss.server.log.dir=/var/log/
```

host.xml

``` xml
<host name="master" xmlns="urn:jboss:domain:1.3">
    ...
    <servers directory-grouping="by-type">
        <server name="server-one" group="main-server-group">
        </server>
        <server name="server-two" group="main-server-group" auto-start="true">
            <!-- server-two avoids port conflicts by incrementing the ports in
                 the default socket-group declared in the server-group -->
            <socket-bindings port-offset="150"/>
        </server>
        <server name="server-three" group="other-server-group" auto-start="false">
            <!-- server-three avoids port conflicts by incrementing the ports in
                 the default socket-group declared in the server-group -->
            <socket-bindings port-offset="250"/>
        </server>
    </servers>
</host>
```

Should result in a log directory for `server-one` of `/var/log/servers/server-one/`.
