### PR TITLE
AS7-2217 & AS7-5347: adding 2 new extensions of ManagedReferenceFactory,...

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceReferenceFactoryService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceReferenceFactoryService.java
@@ -23,6 +23,9 @@
 package org.jboss.as.connector.subsystems.datasources;
 
 import javax.sql.DataSource;
+
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
@@ -40,7 +43,7 @@ import org.jboss.msc.value.InjectedValue;
  *
  * @author John Bailey
  */
-public class DataSourceReferenceFactoryService implements Service<ManagedReferenceFactory>, ManagedReferenceFactory {
+public class DataSourceReferenceFactoryService implements Service<ManagedReferenceFactory>, ContextListAndJndiViewManagedReferenceFactory {
     public static final ServiceName SERVICE_NAME_BASE = AbstractDataSourceService.SERVICE_NAME_BASE.append("reference-factory");
     private final InjectedValue<DataSource> dataSourceValue = new InjectedValue<DataSource>();
 
@@ -64,5 +67,17 @@ public class DataSourceReferenceFactoryService implements Service<ManagedReferen
 
     public Injector<DataSource> getDataSourceInjector() {
         return dataSourceValue; // TODO: Should we use unique references
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        final Object value = reference != null ? reference.getInstance() : null;
+        return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        final Object value = reference != null ? reference.getInstance() : null;
+        return String.valueOf(value);
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/beanvalidation/ValidatorJndiInjectable.java
+++ b/ee/src/main/java/org/jboss/as/ee/beanvalidation/ValidatorJndiInjectable.java
@@ -1,16 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.ee.beanvalidation;
 
 import javax.validation.ValidatorFactory;
 
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
 import org.jboss.msc.value.ImmediateValue;
 
 /**
 * @author Stuart Douglas
+* @author Eduardo Martins
 */
-final class ValidatorJndiInjectable implements ManagedReferenceFactory {
+final class ValidatorJndiInjectable implements ContextListAndJndiViewManagedReferenceFactory {
     private final ValidatorFactory factory;
 
     public ValidatorJndiInjectable(ValidatorFactory factory) {
@@ -20,5 +43,39 @@ final class ValidatorJndiInjectable implements ManagedReferenceFactory {
     @Override
     public ManagedReference getReference() {
         return new ValueManagedReference(new ImmediateValue<Object>(factory.getValidator()));
+    }
+
+    private Object getInstanceSafely() {
+        final ClassLoader cl = SecurityActions.getContextClassLoader();
+        try {
+            SecurityActions.setContextClassLoader(factory.getClass().getClassLoader());
+            return factory.getValidator();
+        } finally {
+            SecurityActions.setContextClassLoader(cl);
+        }
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        final Object instance = getInstanceSafely();
+        if (instance == null) {
+            return ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+        }
+        return instance.getClass().getName();
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        final Object instance = getInstanceSafely();
+        if (instance == null) {
+            return "null";
+        }
+        final ClassLoader cl = SecurityActions.getContextClassLoader();
+        try {
+            SecurityActions.setContextClassLoader(instance.getClass().getClassLoader());
+            return instance.toString();
+        } finally {
+            SecurityActions.setContextClassLoader(cl);
+        }
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/OptionalLookupInjectionSource.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/OptionalLookupInjectionSource.java
@@ -27,6 +27,8 @@ import static org.jboss.as.ee.EeMessages.MESSAGES;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
@@ -97,7 +99,7 @@ public final class OptionalLookupInjectionSource extends InjectionSource {
         return lookupName.hashCode();
     }
 
-    private static class OptionalLookupManagedReferenceFactory implements ManagedReferenceFactory {
+    private static class OptionalLookupManagedReferenceFactory implements ContextListAndJndiViewManagedReferenceFactory {
         private final String lookupName;
 
         public OptionalLookupManagedReferenceFactory(final String lookupName) {
@@ -112,6 +114,17 @@ public final class OptionalLookupInjectionSource extends InjectionSource {
             } catch (NamingException e) {
                 return null;
             }
+        }
+
+        @Override
+        public String getInstanceClassName() {
+            final Object value = getReference().getInstance();
+            return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+        }
+
+        @Override
+        public String getJndiViewInstanceValue() {
+            return String.valueOf(getReference().getInstance());
         }
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/ViewManagedReferenceFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ViewManagedReferenceFactory.java
@@ -23,6 +23,7 @@
 package org.jboss.as.ee.component;
 
 import org.jboss.as.ee.EeMessages;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.msc.inject.InjectionException;
@@ -32,7 +33,7 @@ import org.jboss.msc.inject.InjectionException;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-public final class ViewManagedReferenceFactory implements ManagedReferenceFactory {
+public final class ViewManagedReferenceFactory implements ContextListManagedReferenceFactory {
     private final ComponentView view;
 
     /**
@@ -42,6 +43,11 @@ public final class ViewManagedReferenceFactory implements ManagedReferenceFactor
      */
     public ViewManagedReferenceFactory(final ComponentView view) {
         this.view = view;
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        return view.getComponent().getComponentClass().getName();
     }
 
     /** {@inheritDoc} */

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbContextJndiBindingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbContextJndiBindingProcessor.java
@@ -39,6 +39,7 @@ import org.jboss.as.ee.component.deployers.EEResourceReferenceProcessorRegistry;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
 import org.jboss.as.ejb3.context.CurrentInvocationContext;
 import org.jboss.as.ejb3.context.EjbContextResourceReferenceProcessor;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -121,9 +122,15 @@ public class EjbContextJndiBindingProcessor implements DeploymentUnitProcessor {
         }
     };
 
-    private static final ManagedReferenceFactory ejbContextManagedReferenceFactory = new ManagedReferenceFactory() {
+    private static final ManagedReferenceFactory ejbContextManagedReferenceFactory = new ContextListManagedReferenceFactory() {
+
         public ManagedReference getReference() {
             return ejbContextManagedReference;
+        }
+
+        @Override
+        public String getInstanceClassName() {
+            return EJBContext.class.getName();
         }
     };
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemoteViewManagedReferenceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemoteViewManagedReferenceFactory.java
@@ -21,20 +21,21 @@
  */
 package org.jboss.as.ejb3.remote;
 
+import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+
+import javax.ejb.EJBHome;
+import javax.ejb.EJBLocalHome;
+
 import org.jboss.as.ejb3.EjbMessages;
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.JndiViewManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
 import org.jboss.ejb.client.EJBClient;
 import org.jboss.ejb.client.EJBHomeLocator;
 import org.jboss.ejb.client.EJBLocator;
 import org.jboss.ejb.client.StatelessEJBLocator;
 import org.jboss.msc.value.ImmediateValue;
-
-import javax.ejb.EJBHome;
-import javax.ejb.EJBLocalHome;
-
-import static org.jboss.as.ejb3.EjbMessages.*;
 import org.jboss.msc.value.Value;
 
 
@@ -42,8 +43,9 @@ import org.jboss.msc.value.Value;
  * Managed reference factory for remote EJB views that are bound to java: JNDI locations
  *
  * @author Stuart Douglas
+ * @author Eduardo Martins
  */
-public class RemoteViewManagedReferenceFactory implements ManagedReferenceFactory {
+public class RemoteViewManagedReferenceFactory implements ContextListAndJndiViewManagedReferenceFactory {
 
     private final String appName;
     private final String moduleName;
@@ -65,6 +67,17 @@ public class RemoteViewManagedReferenceFactory implements ManagedReferenceFactor
         this.viewClass = viewClass;
         this.stateful = stateful;
         this.viewClassLoader = viewClassLoader;
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        return viewClass;
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        return stateful ? JndiViewManagedReferenceFactory.DEFAULT_JNDI_VIEW_INSTANCE_VALUE : String.valueOf(getReference()
+                .getInstance());
     }
 
     @Override

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSessionAdd.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSessionAdd.java
@@ -6,6 +6,8 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ServiceBasedNamingStore;
@@ -88,7 +90,18 @@ public class MailSessionAdd extends AbstractAddStepHandler {
         addOutboundSocketDependency(service, mailSessionBuilder, config.getPop3Server());
         addOutboundSocketDependency(service, mailSessionBuilder, config.getSmtpServer());
 
-        final ManagedReferenceFactory valueManagedReferenceFactory = new ManagedReferenceFactory() {
+        final ManagedReferenceFactory valueManagedReferenceFactory = new ContextListAndJndiViewManagedReferenceFactory() {
+
+            @Override
+            public String getJndiViewInstanceValue() {
+                return String.valueOf(getReference().getInstance());
+            }
+
+            @Override
+            public String getInstanceClassName() {
+                final Object value = getReference().getInstance();
+                return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+            }
 
             @Override
             public ManagedReference getReference() {

--- a/naming/src/main/java/org/jboss/as/naming/ContextListAndJndiViewManagedReferenceFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ContextListAndJndiViewManagedReferenceFactory.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+import javax.naming.Context;
+
+/**
+ * A {@link ManagedReferenceFactory} which properly supports {@link Context} list operations, and JNDI View lookups.
+ *
+ * @author Eduardo Martins
+ *
+ */
+public interface ContextListAndJndiViewManagedReferenceFactory extends ContextListManagedReferenceFactory,
+        JndiViewManagedReferenceFactory {
+
+}

--- a/naming/src/main/java/org/jboss/as/naming/ContextListManagedReferenceFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ContextListManagedReferenceFactory.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+import javax.naming.Context;
+
+/**
+ * A {@link ManagedReferenceFactory} which knows the class name of its {@link ManagedReference} object instance. This type of
+ * {@link ManagedReferenceFactory} should be used for JNDI bindings, the {@link ServiceBasedNamingStore} relies on it to provide
+ * proper support for {@link Context} list operations.
+ *
+ * @author Eduardo Martins
+ *
+ */
+public interface ContextListManagedReferenceFactory extends ManagedReferenceFactory {
+
+    String DEFAULT_INSTANCE_CLASS_NAME = Object.class.getName();
+
+    /**
+     * Retrieves the reference's object instance class name.
+     *
+     * If it's impossible to obtain such data, the factory should return the static attribute DEFAULT_INSTANCE_CLASS_NAME,
+     * exposed by this interface.
+     *
+     * @return
+     */
+    String getInstanceClassName();
+}

--- a/naming/src/main/java/org/jboss/as/naming/ContextManagedReferenceFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ContextManagedReferenceFactory.java
@@ -10,8 +10,9 @@ import org.jboss.msc.value.InjectedValue;
  * Managed reference factory used for binding a context.
  *
  * @author Stuart Douglas
+ * @author Eduardo Martins
  */
-public class ContextManagedReferenceFactory implements ManagedReferenceFactory {
+public class ContextManagedReferenceFactory implements ContextListAndJndiViewManagedReferenceFactory {
 
     private final String name;
     private final InjectedValue<NamingStore> namingStoreInjectedValue = new InjectedValue<NamingStore>();
@@ -44,5 +45,15 @@ public class ContextManagedReferenceFactory implements ManagedReferenceFactory {
 
     public InjectedValue<NamingStore> getNamingStoreInjectedValue() {
         return namingStoreInjectedValue;
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        return NamingContext.class.getName();
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        return name;
     }
 }

--- a/naming/src/main/java/org/jboss/as/naming/InMemoryNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/InMemoryNamingStore.java
@@ -22,7 +22,23 @@
 
 package org.jboss.as.naming;
 
+import static org.jboss.as.naming.util.NamingUtils.cannotProceedException;
+import static org.jboss.as.naming.util.NamingUtils.emptyNameException;
+import static org.jboss.as.naming.util.NamingUtils.getLastComponent;
+import static org.jboss.as.naming.util.NamingUtils.isEmpty;
+import static org.jboss.as.naming.util.NamingUtils.isLastComponentEmpty;
+import static org.jboss.as.naming.util.NamingUtils.nameAlreadyBoundException;
+import static org.jboss.as.naming.util.NamingUtils.nameNotFoundException;
+import static org.jboss.as.naming.util.NamingUtils.notAContextException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.ReentrantLock;
+
 import javax.naming.Binding;
 import javax.naming.CannotProceedException;
 import javax.naming.CompositeName;
@@ -36,20 +52,6 @@ import javax.naming.event.EventContext;
 import javax.naming.event.NamingEvent;
 import javax.naming.event.NamingListener;
 import javax.naming.spi.ResolveResult;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import static org.jboss.as.naming.util.NamingUtils.cannotProceedException;
-import static org.jboss.as.naming.util.NamingUtils.emptyNameException;
-import static org.jboss.as.naming.util.NamingUtils.getLastComponent;
-import static org.jboss.as.naming.util.NamingUtils.isEmpty;
-import static org.jboss.as.naming.util.NamingUtils.isLastComponentEmpty;
-import static org.jboss.as.naming.util.NamingUtils.nameAlreadyBoundException;
-import static org.jboss.as.naming.util.NamingUtils.nameNotFoundException;
-import static org.jboss.as.naming.util.NamingUtils.notAContextException;
 
 
 /**
@@ -160,6 +162,12 @@ public class InMemoryNamingStore implements WritableNamingStore {
         }
         checkPermissions(name, JndiPermission.Action.LOOKUP);
         return root.accept(new LookupVisitor(name));
+    }
+
+    @Override
+    public Object lookup(Name name, boolean dereference) throws NamingException {
+        // ignoring dereference arg, it's not relevant to this store impl
+        return lookup(name);
     }
 
     /**

--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -86,7 +86,7 @@ public class InitialContext extends NamingContext {
         super(environment);
     }
 
-    public Object lookup(final Name name) throws NamingException {
+    public Object lookup(final Name name, boolean dereference) throws NamingException {
         final ParsedName parsedName = parse(name);
         if (parsedName.namespace() == null) {
             //TODO: this is a bit of a hack, there should be a better way to handle this
@@ -117,7 +117,7 @@ public class InitialContext extends NamingContext {
         }
         final Context namespaceContext = findContext(name, parsedName);
         if (namespaceContext == null)
-            return super.lookup(parsedName.remaining());
+            return super.lookup(parsedName.remaining(),dereference);
         else
             return namespaceContext.lookup(parsedName.remaining());
     }

--- a/naming/src/main/java/org/jboss/as/naming/JndiViewManagedReferenceFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/JndiViewManagedReferenceFactory.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.naming;
+
+/**
+ * A {@link ManagedReferenceFactory} which supports JNDI View lookups, which are done without the proper invocation context set.
+ *
+ * @author Eduardo Martins
+ *
+ */
+public interface JndiViewManagedReferenceFactory extends ManagedReferenceFactory {
+
+    String DEFAULT_JNDI_VIEW_INSTANCE_VALUE = "?";
+
+    /**
+     * Retrieves the reference's object instance JNDI View value.
+     *
+     * If it's not possible to obtain such data, the factory should return the static attribute
+     * DEFAULT_JNDI_VIEW_INSTANCE_VALUE, exposed by this interface.
+     *
+     * @return
+     */
+    String getJndiViewInstanceValue();
+
+}

--- a/naming/src/main/java/org/jboss/as/naming/NamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingStore.java
@@ -22,18 +22,20 @@
 
 package org.jboss.as.naming;
 
+import java.util.List;
+
 import javax.naming.Binding;
 import javax.naming.Name;
 import javax.naming.NameClassPair;
 import javax.naming.NamingException;
 import javax.naming.event.NamingListener;
-import java.util.List;
 
 /**
  * Interface to layout a contract for naming entry back-end storage.  This will be used by {@code NamingContext} instances
  * to manage naming entries.
  *
  * @author John E. Bailey
+ * @author Eduardo Martins
  */
 public interface NamingStore {
 
@@ -45,6 +47,16 @@ public interface NamingStore {
      * @throws NamingException If any errors occur.
      */
     Object lookup(Name name) throws NamingException;
+
+    /**
+     * Look up an object from the naming store.  An entry for this name must already exist.
+     *
+     * @param name The entry name
+     * @param dereference if true indicates that managed references should retrieve the instance.
+     * @return The object from the store.
+     * @throws NamingException If any errors occur.
+     */
+    Object lookup(Name name, boolean dereference) throws NamingException;
 
     /**
      * List the NameClassPair instances for the provided name.  An entry for this name must already exist and be bound

--- a/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
+++ b/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
@@ -56,4 +56,40 @@ final class SecurityActions {
         }
     }
 
+    /**
+     * Gets context classloader.
+     *
+     * @return the current context classloader
+     */
+    static ClassLoader getContextClassLoader() {
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                public ClassLoader run() {
+                    return Thread.currentThread().getContextClassLoader();
+                }
+            });
+        }
+    }
+
+    /**
+     * Sets context classloader.
+     *
+     * @param classLoader
+     *            the classloader
+     */
+    static void setContextClassLoader(final ClassLoader classLoader) {
+        if (System.getSecurityManager() == null) {
+            Thread.currentThread().setContextClassLoader(classLoader);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                public Object run() {
+                    Thread.currentThread().setContextClassLoader(classLoader);
+                    return null;
+                }
+            });
+        }
+    }
+
 }

--- a/naming/src/main/java/org/jboss/as/naming/StaticManagedObject.java
+++ b/naming/src/main/java/org/jboss/as/naming/StaticManagedObject.java
@@ -26,8 +26,9 @@ package org.jboss.as.naming;
  * A JNDI injectable which returns a static object and takes no action when the value is returned.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author Eduardo Martins
  */
-public final class StaticManagedObject implements ManagedReferenceFactory {
+public final class StaticManagedObject implements ContextListManagedReferenceFactory,JndiViewManagedReferenceFactory {
     private final Object value;
 
     /**
@@ -52,6 +53,25 @@ public final class StaticManagedObject implements ManagedReferenceFactory {
                 return value;
             }
         };
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        if (value == null) {
+            return "null";
+        }
+        final ClassLoader cl = SecurityActions.getContextClassLoader();
+        try {
+            SecurityActions.setContextClassLoader(value.getClass().getClassLoader());
+            return value.toString();
+        } finally {
+            SecurityActions.setContextClassLoader(cl);
+        }
     }
 
 }

--- a/naming/src/main/java/org/jboss/as/naming/ValueManagedReferenceFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ValueManagedReferenceFactory.java
@@ -31,8 +31,9 @@ import org.jboss.msc.value.Value;
  * to fetch the injected value, and takes no action when the value is returned.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author Eduardo Martins
  */
-public final class ValueManagedReferenceFactory implements ManagedReferenceFactory {
+public final class ValueManagedReferenceFactory implements ContextListAndJndiViewManagedReferenceFactory {
     private final Value<?> value;
 
     /**
@@ -47,6 +48,30 @@ public final class ValueManagedReferenceFactory implements ManagedReferenceFacto
     @Override
     public ManagedReference getReference() {
         return new ValueManagedReference(value.getValue());
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        final Object instance = value != null ? value.getValue() : null;
+        if(instance == null) {
+            return ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+        }
+        return instance.getClass().getName();
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        final Object instance = value != null ? value.getValue() : null;
+        if (instance == null) {
+            return "null";
+        }
+        final ClassLoader cl = SecurityActions.getContextClassLoader();
+        try {
+            SecurityActions.setContextClassLoader(instance.getClass().getClassLoader());
+            return instance.toString();
+        } finally {
+            SecurityActions.setContextClassLoader(cl);
+        }
     }
 
     public static class ValueManagedReference implements ManagedReference, Serializable {

--- a/naming/src/main/java/org/jboss/as/naming/management/JndiViewOperation.java
+++ b/naming/src/main/java/org/jboss/as/naming/management/JndiViewOperation.java
@@ -22,22 +22,25 @@
 
 package org.jboss.as.naming.management;
 
+import static org.jboss.as.naming.NamingMessages.MESSAGES;
+
 import javax.naming.Context;
 import javax.naming.NameClassPair;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.Reference;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.naming.JndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.NamingContext;
 import org.jboss.as.naming.NamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistry;
-
-import static org.jboss.as.naming.NamingMessages.MESSAGES;
 
 /**
  * @author John Bailey
@@ -121,17 +124,32 @@ public class JndiViewOperation implements OperationStepHandler {
         final NamingEnumeration<NameClassPair> entries = context.list("");
         while (entries.hasMore()) {
             final NameClassPair pair = entries.next();
-
             final ModelNode node = current.get(pair.getName());
             node.get("class-name").set(pair.getClassName());
             try {
-                final Object value = context.lookup(pair.getName());
+                final Object value;
+                if(context instanceof NamingContext) {
+                    value = ((NamingContext)context).lookup(pair.getName(), false);
+                } else {
+                    value = context.lookup(pair.getName());
+                }
                 if (value instanceof Context) {
                     addEntries(node.get("children"), Context.class.cast(value));
                 } else if (value instanceof Reference) {
                     //node.get("value").set(value.toString());
                 } else {
-                    node.get("value").set(value.toString());
+                    final String jndiViewValue;
+                    if (value instanceof JndiViewManagedReferenceFactory) {
+                        jndiViewValue = JndiViewManagedReferenceFactory.class.cast(value)
+                                .getJndiViewInstanceValue();
+                    } else {
+                        if (value instanceof ManagedReferenceFactory) {
+                            jndiViewValue = JndiViewManagedReferenceFactory.DEFAULT_JNDI_VIEW_INSTANCE_VALUE;
+                        } else {
+                            jndiViewValue = String.valueOf(value);
+                        }
+                    }
+                    node.get("value").set(jndiViewValue);
                 }
             } catch (NamingException e) {
                 // Ignore for now..

--- a/security/src/main/java/org/jboss/as/security/context/SecurityDomainJndiInjectable.java
+++ b/security/src/main/java/org/jboss/as/security/context/SecurityDomainJndiInjectable.java
@@ -36,8 +36,8 @@ import javax.naming.NameClassPair;
 import javax.naming.NameParser;
 import javax.naming.NamingEnumeration;
 
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
 import org.jboss.as.security.SecurityMessages;
 import org.jboss.as.security.plugins.DefaultAuthenticationCacheFactory;
@@ -55,9 +55,19 @@ import org.jboss.security.SecurityConstants;
  *
  * @author <a href="mailto:mmoyses@redhat.com">Marcus Moyses</a>
  */
-public class SecurityDomainJndiInjectable implements InvocationHandler, ManagedReferenceFactory {
+public class SecurityDomainJndiInjectable implements InvocationHandler, ContextListAndJndiViewManagedReferenceFactory {
 
     private final InjectedValue<ISecurityManagement> securityManagementValue = new InjectedValue<ISecurityManagement>();
+
+    @Override
+    public String getInstanceClassName() {
+        return getReference().getInstance().getClass().getName();
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        return String.valueOf(getReference().getInstance());
+    }
 
     /**
      * {@inheritDoc}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/injection/SimpleServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/injection/SimpleServlet.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.Writer;
 
 import javax.ejb.EJB;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -33,17 +35,30 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
+ * @author Eduardo Martins
  */
-@WebServlet(name="SimpleServlet", urlPatterns={"/simple"})
+@WebServlet(name = "SimpleServlet", urlPatterns = { "/simple" })
 public class SimpleServlet extends HttpServlet {
     @EJB
     private SimpleStatelessSessionBean bean;
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String msg = req.getParameter("input");
 
+        testAS7_5347(resp);
+
+        String msg = req.getParameter("input");
         Writer writer = resp.getWriter();
         writer.write(bean.echo(msg));
+    }
+
+    private void testAS7_5347(HttpServletResponse resp) throws IOException {
+        // java:module includes child EJBContext, which can't be looked up on a servlet, yet list() on this context must not
+        // fail, more info at AS7-5347
+        try {
+            new InitialContext().list("java:module");
+        } catch (NamingException e) {
+            resp.getWriter().write("AS7-5347 solution check failed");
+        }
     }
 }


### PR DESCRIPTION
... which provide support for Context#list operations and JndiView management op. The naming subsystem was changed so default safe values are returned if a factory does not implements such extensions.

updating 3 more factories, which are predefined in standalone

master PR: #3137
