### PR TITLE
Speeding up clustering testsuite

### DIFF
--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -36,7 +36,7 @@
 
     <group qualifier="clustering-all">
 
-        <container qualifier="container-0" default="true" mode="manual" managed="false">
+        <container qualifier="container-0" mode="custom" managed="false" default="true">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-0</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
@@ -51,7 +51,7 @@
             </configuration>
         </container>
 
-        <container qualifier="container-1" mode="manual" managed="false">
+        <container qualifier="container-1" mode="custom" managed="false">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-1 -Djboss.node.name=node-1 -Djboss.port.offset=100</property>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
@@ -42,7 +42,7 @@ public class EJBClientContextSelector {
     }
     
     public static ContextSelector<EJBClientContext> setup(String file, Properties propertiesToReplace) throws IOException {
-        // setup the selector
+        // setUp the selector
         final InputStream inputStream = EJBClientContextSelector.class.getClassLoader().getResourceAsStream(file);
         if (inputStream == null) {
             throw new IllegalStateException("Could not find " + file + " in classpath");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -22,17 +22,33 @@
 package org.jboss.as.test.clustering;
 
 import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.test.api.ArquillianResource;
 
 /**
- * Helper class to start and stop container including a deployment.
+ * Utility class to start and stop containers and/or deployments.
  *
  * @author Radoslav Husar
+ * @version Oct 2012
  */
 public final class NodeUtil {
 
-    private NodeUtil() {
+    public static void deploy(Deployer deployer, String... deployments) {
+        for (int i = 0; i < deployments.length; i++) {
+            System.out.println(new Date() + " deploying deployment=" + deployments[i]);
+            deployer.deploy(deployments[i]);
+        }
+    }
+
+    public static void undeploy(Deployer deployer, String... deployments) {
+        for (int i = 0; i < deployments.length; i++) {
+            System.out.println(new Date() + " undeploying deployment=" + deployments[i]);
+            deployer.undeploy(deployments[i]);
+        }
     }
 
     public static void start(ContainerController controller, Deployer deployer, String container, String deployment) {
@@ -46,12 +62,36 @@ public final class NodeUtil {
         }
     }
 
+    public static void start(ContainerController controller, String[] containers) {
+        // TODO do this in parallel.
+        for (int i = 0; i < containers.length; i++) {
+            try {
+                System.out.println(new Date() + "starting deployment=NONE, container=" + containers[i]);
+                controller.start(containers[i]);
+            } catch (Throwable e) {
+                e.printStackTrace(System.err);
+            }
+        }
+    }
+
     public static void start(ContainerController controller, String container) {
         try {
             System.out.println(new Date() + "starting deployment=NONE, container=" + container);
             controller.start(container);
         } catch (Throwable e) {
             e.printStackTrace(System.err);
+        }
+    }
+
+    public static void stop(ContainerController controller, String[] containers) {
+        for (int i = 0; i < containers.length; i++) {
+            try {
+                System.out.println(new Date() + "stopping container=" + containers[i]);
+                controller.stop(containers[i]);
+                System.out.println(new Date() + "stopped container=" + containers[i]);
+            } catch (Throwable e) {
+                e.printStackTrace(System.err);
+            }
         }
     }
 
@@ -73,5 +113,8 @@ public final class NodeUtil {
         } catch (Throwable e) {
             e.printStackTrace(System.err);
         }
+    }
+
+    private NodeUtil() {
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
 
 /**
  * Utility class to start and stop containers and/or deployments.
@@ -37,28 +38,30 @@ import org.jboss.arquillian.test.api.ArquillianResource;
  */
 public final class NodeUtil {
 
+    private static final Logger log = Logger.getLogger(NodeUtil.class);
+
     public static void deploy(Deployer deployer, String... deployments) {
         for (int i = 0; i < deployments.length; i++) {
-            System.out.println(new Date() + " deploying deployment=" + deployments[i]);
+            log.info("Deploying deployment=" + deployments[i]);
             deployer.deploy(deployments[i]);
         }
     }
 
     public static void undeploy(Deployer deployer, String... deployments) {
         for (int i = 0; i < deployments.length; i++) {
-            System.out.println(new Date() + " undeploying deployment=" + deployments[i]);
+            log.info("Undeploying deployment=" + deployments[i]);
             deployer.undeploy(deployments[i]);
         }
     }
 
     public static void start(ContainerController controller, Deployer deployer, String container, String deployment) {
         try {
-            System.out.println(new Date() + "starting deployment=" + deployment + ", container=" + container);
+            log.info("Starting deployment=" + deployment + ", container=" + container);
             controller.start(container);
             deployer.deploy(deployment);
-            System.out.println(new Date() + "started deployment=" + deployment + ", container=" + container);
+            log.info("Started deployment=" + deployment + ", container=" + container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 
@@ -66,52 +69,52 @@ public final class NodeUtil {
         // TODO do this in parallel.
         for (int i = 0; i < containers.length; i++) {
             try {
-                System.out.println(new Date() + "starting deployment=NONE, container=" + containers[i]);
+                log.info("Starting deployment=NONE, container=" + containers[i]);
                 controller.start(containers[i]);
             } catch (Throwable e) {
-                e.printStackTrace(System.err);
+                log.error(e);
             }
         }
     }
 
     public static void start(ContainerController controller, String container) {
         try {
-            System.out.println(new Date() + "starting deployment=NONE, container=" + container);
+            log.info("Starting deployment=NONE, container=" + container);
             controller.start(container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 
     public static void stop(ContainerController controller, String[] containers) {
         for (int i = 0; i < containers.length; i++) {
             try {
-                System.out.println(new Date() + "stopping container=" + containers[i]);
+                log.info("Stopping container=" + containers[i]);
                 controller.stop(containers[i]);
-                System.out.println(new Date() + "stopped container=" + containers[i]);
+                log.info("Stopped container=" + containers[i]);
             } catch (Throwable e) {
-                e.printStackTrace(System.err);
+                log.error(e);
             }
         }
     }
 
     public static void stop(ContainerController controller, Deployer deployer, String container, String deployment) {
         try {
-            System.out.println(new Date() + "stopping deployment=" + deployment + ", container=" + container);
+            log.info("Stopping deployment=" + deployment + ", container=" + container);
             deployer.undeploy(deployment);
             controller.stop(container);
-            System.out.println(new Date() + "stopped deployment=" + deployment + ", container=" + container);
+            log.info("Stopped deployment=" + deployment + ", container=" + container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 
     public static void stop(ContainerController controller, String container) {
         try {
             controller.stop(container);
-            System.out.println(new Date() + "stopped deployment=NONE, container=" + container);
+            log.info("Stopped deployment=NONE, container=" + container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.arquillian;
+
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.Container.State;
+import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+import org.jboss.logging.Logger;
+
+/**
+ * Arquillian extension which stops custom containers after testsuite run.
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @author Radoslav Husar
+ * @version $Revision: $
+ */
+public class StopCustomContainersOnAfterSuiteExtension implements LoadableExtension {
+
+    private static final Logger log = Logger.getLogger(StopCustomContainersOnAfterSuiteExtension.class);
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(StopCustomContainers.class);
+    }
+
+    public static class StopCustomContainers {
+        public void close(@Observes AfterSuite event, ContainerRegistry registry) {
+            for (Container c : registry.getContainers()) {
+                if (c.getState() == State.STARTED && "custom".equalsIgnoreCase(c.getContainerConfiguration().getMode())) {
+                    try {
+                        c.stop();
+                        log.info("Stopped custom container: " + c.getName());
+                    } catch (Exception e) {
+                        log.error("Failed to stop custom container: " + c.getName(), e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.test.clustering.arquillian;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.Container.State;
 import org.jboss.arquillian.container.spi.ContainerRegistry;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -31,6 +31,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.logging.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -41,6 +42,8 @@ import org.junit.Test;
  * @version Oct 2012
  */
 public abstract class ClusterAbstractTestCase {
+
+    protected static final Logger log = Logger.getLogger(ClusterAbstractTestCase.class);
 
     @ArquillianResource
     protected ContainerController controller;
@@ -102,7 +105,7 @@ public abstract class ClusterAbstractTestCase {
     @BeforeClass
     public static void printSystemProperties() {
         Properties systemProperties = System.getProperties();
-        System.out.println("System properties:\n" + systemProperties);
+        log.info("System properties:\n" + systemProperties);
     }
 
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.cluster;
+
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINERS;
+
+import java.util.Properties;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.NodeUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Base cluster test that ensures the custom containers are already running.
+ *
+ * @author Radoslav Husar
+ * @version Oct 2012
+ */
+public abstract class ClusterAbstractTestCase {
+
+    @ArquillianResource
+    protected ContainerController controller;
+    @ArquillianResource
+    protected Deployer deployer;
+
+    /**
+     * Ensure the containers are running, otherwise start them.
+     */
+    @Test
+    @InSequence(-1)
+    @RunAsClient
+    public void testSetup() {
+        this.setUp();
+    }
+
+    /**
+     * Override this method for different behavior of the test.
+     */
+    protected void setUp() {
+        NodeUtil.start(controller, CONTAINERS);
+    }
+
+    protected void start(String container) {
+        NodeUtil.start(controller, container);
+    }
+
+    protected void start(String[] containers) {
+        NodeUtil.start(controller, containers);
+    }
+
+    protected void stop(String container) {
+        NodeUtil.stop(controller, container);
+    }
+
+    protected void stop(String[] containers) {
+        NodeUtil.stop(controller, containers);
+    }
+
+    protected void deploy(String deployment) {
+        NodeUtil.deploy(deployer, deployment);
+    }
+
+    protected void deploy(String[] deployments) {
+        NodeUtil.deploy(deployer, deployments);
+    }
+
+    protected void undeploy(String deployments) {
+        NodeUtil.undeploy(deployer, deployments);
+    }
+
+    protected void undeploy(String[] deployments) {
+        NodeUtil.undeploy(deployer, deployments);
+    }
+
+    /**
+     * Printout some debug info.
+     */
+    @BeforeClass
+    public static void printSystemProperties() {
+        Properties systemProperties = System.getProperties();
+        System.out.println("System properties:\n" + systemProperties);
+    }
+
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredBase.java
@@ -42,7 +42,7 @@ public class DisableClusteredBase implements java.io.Serializable, DisableCluste
     }
 
     public void setUpFailover(String failover) {
-        // To setup the failover property
+        // To setUp the failover property
         log.info("Setting up failover property: " + failover);
         System.setProperty("JBossCluster-DoFail", failover);
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/FailoverWithSecurityTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/FailoverWithSecurityTestCase.java
@@ -24,8 +24,6 @@ package org.jboss.as.test.clustering.cluster.ejb3.security;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -38,6 +36,7 @@ import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.NodeInfoServlet;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
@@ -51,35 +50,28 @@ import org.junit.runner.RunWith;
 
 /**
  * Test security login on failover.
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class FailoverWithSecurityTestCase {
+public class FailoverWithSecurityTestCase extends ClusterAbstractTestCase {
     private static Logger log = Logger.getLogger(FailoverWithSecurityTestCase.class);
 
     private static final String PROPERTIES_FILE = "cluster/ejb3/security/jboss-ejb-client.properties";
     private static final String ARCHIVE_NAME = "cluster-security-domain-test";
     private static RemoteEJBDirectory context;
 
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
-
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        Archive<?> archive = createDeployment();
-        return archive;
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        Archive<?> archive = createDeployment();
-        return archive;
+        return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
@@ -95,24 +87,20 @@ public class FailoverWithSecurityTestCase {
         context = new RemoteEJBDirectory(ARCHIVE_NAME);
     }
 
-    @Test
-    @InSequence(-1)
-    public void startServers() {
-        // Container is unmanaged, need to start manually.
-        // This is a little hacky @see https://community.jboss.org/thread/176096
-        controller.start(CONTAINER_1);
-        deployer.deploy(DEPLOYMENT_1);
-        controller.start(CONTAINER_2);
-        deployer.deploy(DEPLOYMENT_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     @Test
     @InSequence(1)
-    public void testDomainSecurityAnnotation(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
+    public void testDomainSecurityAnnotation(
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
-        
+
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(PROPERTIES_FILE);
-        
+
         try {
             BeanRemote statelessBean = context.lookupStateless(StatelessBean.class, BeanRemote.class);
             BeanRemote statefulBean = context.lookupStateful(StatefulBean.class, BeanRemote.class);
@@ -121,10 +109,10 @@ public class FailoverWithSecurityTestCase {
             String statefulNodeName = statefulBean.getNodeName();
             Assert.assertNotNull("No name was returned from SLSB ", statelessNodeName);
             Assert.assertNotNull("No name was returned from SFSB ", statefulNodeName);
-            
+
             String stoppedContainer = null;
             String runningNode = null;
-            if(NODE_1.equals(statefulNodeName)) {
+            if (NODE_1.equals(statefulNodeName)) {
                 stoppedContainer = CONTAINER_1;
                 runningNode = NODE_2;
             } else {
@@ -132,29 +120,29 @@ public class FailoverWithSecurityTestCase {
                 runningNode = NODE_1;
             }
             controller.stop(stoppedContainer);
-            
+
             statelessNodeName = statelessBean.getNodeName();
             statefulNodeName = statefulBean.getNodeName();
             Assert.assertEquals("SLSB has to return the only running node " + runningNode, runningNode, statelessNodeName);
             Assert.assertEquals("SFSB has to return the only running node " + runningNode, runningNode, statefulNodeName);
-            
-            if(CONTAINER_1.equals(stoppedContainer)) {
-                controller.start(CONTAINER_1);
-                deployer.undeploy(DEPLOYMENT_2);
-                controller.stop(CONTAINER_2);
+
+            if (CONTAINER_1.equals(stoppedContainer)) {
+                start(CONTAINER_1);
+                undeploy(DEPLOYMENT_2);
+                stop(CONTAINER_2);
                 runningNode = NODE_1;
             } else {
-                controller.start(CONTAINER_2);
-                deployer.undeploy(DEPLOYMENT_1);
-                controller.stop(CONTAINER_1);
+                start(CONTAINER_2);
+                undeploy(DEPLOYMENT_1);
+                stop(CONTAINER_1);
                 runningNode = NODE_2;
             }
-            
+
             statelessNodeName = statelessBean.getNodeName();
             statefulNodeName = statefulBean.getNodeName();
             Assert.assertEquals("SLSB has to return the only running node " + runningNode, runningNode, statelessNodeName);
             Assert.assertEquals("SFSB has to return the only running node " + runningNode, runningNode, statefulNodeName);
-            
+
         } finally {
             if (previousSelector != null) {
                 EJBClientContext.setSelector(previousSelector);
@@ -162,18 +150,4 @@ public class FailoverWithSecurityTestCase {
         }
     }
 
-    @Test
-    @InSequence(100)
-    public void stopServers(
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
-        if (client1.isServerInRunningState()) {
-            deployer.undeploy(DEPLOYMENT_1);
-            controller.stop(CONTAINER_1);
-        }
-        if (client2.isServerInRunningState()) {
-            deployer.undeploy(DEPLOYMENT_2);
-            controller.stop(CONTAINER_2);
-        }
-    }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
@@ -81,7 +81,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
                 "<interceptors><class>" + StatefulCDIInterceptor.class.getName() + "</class></interceptors>" +
                 "<decorators><class>" + CounterDecorator.class.getName() + "</class></decorators>" +
                 "</beans>"), "beans.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 
@@ -106,7 +106,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         String url1 = baseURL1.toString() + "count";
         String url2 = baseURL2.toString() + "count";
 
-        System.out.println("URLs are: " + url1 + ", " + url2);
+        log.info("URLs are: " + url1 + ", " + url2);
 
         try {
             assertQueryCount(20010101, client, url1);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
@@ -33,7 +33,10 @@ import javax.naming.NamingException;
 
 import junit.framework.Assert;
 
-import org.jboss.arquillian.container.test.api.*;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -44,6 +47,7 @@ import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeInfoServlet;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.dmr.ModelNode;
@@ -66,12 +70,12 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 /**
  * Clustering ejb passivation simple test.
  * Part of migration of tests from prior AS testsuites [JBQA-5855].
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class ClusterPassivationTestCase {
+public class ClusterPassivationTestCase extends ClusterAbstractTestCase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestCase.class);
     public static final String ARCHIVE_NAME = "cluster-passivation-test";
     public static final String ARCHIVE_NAME_HELPER = "cluster-passivation-test-helper";
@@ -79,18 +83,13 @@ public class ClusterPassivationTestCase {
     private static final String IDLE_TIMEOUT_ATTR = "idle-timeout";
     private static final String PASSIVATE_EVENTS_ON_REPLICATE_ATTR = "passivate-events-on-replicate";
     private static final String HELPER_DEPLOYMENT = "helper-";
-    
+
     private static EJBDirectory context;
-    
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         context = new RemoteEJBDirectory(ARCHIVE_NAME);
     }
-
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
 
     // Properties pass amongst tests
     private static ContextSelector<EJBClientContext> previousSelector;
@@ -99,11 +98,6 @@ public class ClusterPassivationTestCase {
     private static Map<String, String> container2node = new HashMap<String, String>();
     private static Map<String, ManagementClient> node2client = new HashMap<String, ManagementClient>();
 
-    @BeforeClass
-    public static void setUp() throws NamingException {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -118,15 +112,15 @@ public class ClusterPassivationTestCase {
         Archive<?> archive = createDeployment();
         return archive;
     }
-    
-    @Deployment(name = HELPER_DEPLOYMENT +  DEPLOYMENT_1, managed = true, testable = false)
+
+    @Deployment(name = DEPLOYMENT_1 + HELPER_DEPLOYMENT, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> helpDeployment0() {
         Archive<?> archive = createHelperDeployment();
         return archive;
     }
 
-    @Deployment(name = HELPER_DEPLOYMENT + DEPLOYMENT_2, managed = true, testable = false)
+    @Deployment(name = DEPLOYMENT_2 + HELPER_DEPLOYMENT, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> helpDeployment1() {
         Archive<?> archive = createHelperDeployment();
@@ -140,7 +134,7 @@ public class ClusterPassivationTestCase {
         log.info(war.toString(true));
         return war;
     }
-    
+
     private static Archive<?> createHelperDeployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME_HELPER + ".jar");
         jar.addClasses(StatefulBeanDeepNested.class, StatefulBeanDeepNestedRemote.class, StatefulBeanNestedParent.class, NodeNameGetter.class);
@@ -225,20 +219,22 @@ public class ClusterPassivationTestCase {
 
     /**
      * Start servers whether their are not started.
-     * 
+     *
      * @param client1 client for server1
      * @param client2 client for server2
      */
     private void startServers(ManagementClient client1, ManagementClient client2) {
         if (client1 == null || !client1.isServerInRunningState()) {
             log.info("Starting server: " + CONTAINER_1);
-            controller.start(CONTAINER_1);
-            deployer.deploy(DEPLOYMENT_1);
+            start(CONTAINER_1);
+            deploy(DEPLOYMENT_1 + HELPER_DEPLOYMENT);
+            deploy(DEPLOYMENT_1);
         }
         if (client2 == null || !client2.isServerInRunningState()) {
             log.info("Starting server: " + CONTAINER_2);
-            controller.start(CONTAINER_2);
-            deployer.deploy(DEPLOYMENT_2);
+            start(CONTAINER_2);
+            deploy(DEPLOYMENT_2 + HELPER_DEPLOYMENT);
+            deploy(DEPLOYMENT_2);
         }
     }
 
@@ -262,17 +258,16 @@ public class ClusterPassivationTestCase {
     @Test
     @InSequence(-2)
     public void arquillianStartServers() {
-        // Container is unmanaged, need to start manually.
-        // This is a little hacky - need for URL and client injection. @see https://community.jboss.org/thread/176096
         startServers(null, null);
     }
 
     /**
-     * Associtation of node names to deployment,container names and client context
+     * Association of node names to deployment,container names and client context
      */
     @Test
     @InSequence(-1)
-    public void defineMaps(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
+    public void defineMaps(
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
@@ -300,7 +295,7 @@ public class ClusterPassivationTestCase {
         // Loading context from file to get ejb:// remote context
         setupEJBClientContextSelector(); // setting context from .properties file
         final StatefulBeanRemote statefulBeanRemote = context.lookupStateful(StatefulBean.class, StatefulBeanRemote.class);
-        log.info("oochoaloup: Passivated (" + (isPassivation ? "TRUE" : "FALSE") + ") by on start: " + statefulBeanRemote.getPassivatedBy());
+        log.info("Passivated (" + (isPassivation ? "TRUE" : "FALSE") + ") by on start: " + statefulBeanRemote.getPassivatedBy());
 
         // Calling on server one
         int clientNumber = 40;
@@ -316,7 +311,7 @@ public class ClusterPassivationTestCase {
         // A small hack - deleting node (by name) from cluster which this client knows
         // It means that the next request (ejb call) will be passed to the server #2
         EJBClientContext.requireCurrent().getClusterContext(CLUSTER_NAME).removeClusterNode(calledNodeFirst);
-        
+
         if (isPassivation) {
             // this was redefined in @PrePassivate method on first server - checking whether second server knows about it
             Assert.assertEquals("Supposing to get passivation node which was set", calledNodeFirst, statefulBeanRemote.getPassivatedBy());
@@ -331,15 +326,15 @@ public class ClusterPassivationTestCase {
         } else {
             Assert.assertNull("We suppose that the passivation is not provided.", statefulBeanRemote.getPassivatedBy());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done", 0,  statefulBeanRemote.getNestedBeanActivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getNestedBeanActivatedCalled());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getDeepNestedBeanPassivatedCalled());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getDeepNestedBeanActivatedCalled());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanActivatedCalled());            
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanActivatedCalled());
         }
-        
+
         String calledNodeSecond = statefulBeanRemote.incrementNumber(); // 42
-        Assert.assertEquals("Nested bean has to be calledn on the same node as parent one", calledNodeSecond, statefulBeanRemote.getNestedBeanNodeName());
+        Assert.assertEquals("Nested bean has to be called on the same node as parent one", calledNodeSecond, statefulBeanRemote.getNestedBeanNodeName());
         statefulBeanRemote.setPassivationNode(calledNodeSecond);
         log.info("Called node name second: " + calledNodeSecond);
         Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
@@ -383,7 +378,7 @@ public class ClusterPassivationTestCase {
 
     @Test
     @InSequence(1)
-    @Ignore("AS7-4266")
+    @Ignore("https://issues.jboss.org/browse/AS7-4266")
     public void testPassivationOverNodesPassivated(
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
@@ -398,7 +393,7 @@ public class ClusterPassivationTestCase {
 
     @Test
     @InSequence(2)
-    @Ignore("AS7-4246")
+    @Ignore("https://issues.jboss.org/browse/AS7-4246")
     public void testPassivationOverNodesNotPassivated(
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
@@ -410,8 +405,8 @@ public class ClusterPassivationTestCase {
         runPassivation(isPassivated);
         startServers(client1, client2);
     }
-    
-  
+
+
     @Test
     @InSequence(3)
     /**
@@ -429,12 +424,12 @@ public class ClusterPassivationTestCase {
         setPassivationOnReplicate(client1.getControllerClient(), isPassivated);
         setPassivationIdleTimeout(client2.getControllerClient());
         setPassivationOnReplicate(client2.getControllerClient(), isPassivated);
-        
+
         log.info("Setting context selector...");
         setupEJBClientContextSelector();
-        
+
         final StatefulBeanChildRemote sb = context.lookupStateful(StatefulBeanChild.class, StatefulBeanChildRemote.class);
-        
+
         String stringData = "42";
         int intData = 42;
         String calledNodeName = sb.getNodeName();
@@ -442,7 +437,7 @@ public class ClusterPassivationTestCase {
         // redefine node2client maps
         node2client.put(container2node.get(CONTAINER_1), client1);
         node2client.put(container2node.get(CONTAINER_2), client2);
-        
+
         // 1. integer defined in sfsb bean
         sb.setInt(intData);
         // 2. DTO defined in sfsb
@@ -454,16 +449,16 @@ public class ClusterPassivationTestCase {
         // 4. DTO defined in parent of sfsb
         sb.setParentDTOStringData(stringData);
         sb.setParentDTOTransientStringData(stringData);
-                
+
         // waiting for passivation
         Thread.sleep(WAIT_FOR_PASSIVATION_MS);
-                
+
         // Stopping called node
         unsetPassivationAttributes(node2client.get(calledNodeName).getControllerClient());
-        deployer.undeploy(node2deployment.get(calledNodeName));
-        controller.stop(node2container.get(calledNodeName));
+        undeploy(node2deployment.get(calledNodeName));
+        stop(node2container.get(calledNodeName));
         log.info("Node " + calledNodeName + " was stopped.");
-        
+
         // checking data
         Assert.assertEquals("Int sfsb data wasn't passivated correctly", intData, sb.getInt());
         Assert.assertEquals("String data of dto defined in sfsb wasn't passivated correctly", stringData, sb.getDTOStringData());
@@ -489,13 +484,9 @@ public class ClusterPassivationTestCase {
         // unset & undeploy & stop
         if(client1.isServerInRunningState()) {
             unsetPassivationAttributes(client1.getControllerClient());
-            deployer.undeploy(DEPLOYMENT_1);
-            controller.stop(CONTAINER_1);
         }
         if(client2.isServerInRunningState()) {
             unsetPassivationAttributes(client2.getControllerClient());
-            deployer.undeploy(DEPLOYMENT_2);
-            controller.stop(CONTAINER_2);
         }
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
@@ -287,7 +287,7 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
             int frequency = Collections.frequency(results, entry);
             Assert.assertTrue(Integer.toString(frequency), frequency >= minCalls);
         }
-        System.out.println(String.format("All %d servers processed at least %f of calls", expectedServers, minCalls));
+        log.info(String.format("All %d servers processed at least %f of calls", expectedServers, minCalls));
     }
 
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
@@ -22,8 +22,10 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.xpc;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINERS;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENTS;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME;
@@ -32,14 +34,11 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Date;
-import java.util.Properties;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -48,28 +47,27 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.EJBDirectory;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb3.xpc.bean.StatefulBean;
 import org.jboss.as.test.http.util.HttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 /**
  * @author Paul Ferraro
  * @author Scott Marlow
- *
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore // AS7-5209 unstable test
-public class StatefulWithXPCFailoverTestCase {
+public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final String persistence_xml =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
@@ -86,19 +84,6 @@ public class StatefulWithXPCFailoverTestCase {
             "</properties>" +
             "  </persistence-unit>" +
             "</persistence>";
-
-    @ArquillianResource
-    ContainerController controller;
-    @ArquillianResource
-    Deployer deployer;
-
-
-
-    @BeforeClass
-    public static void printSysProps() {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -122,80 +107,10 @@ public class StatefulWithXPCFailoverTestCase {
         return war;
     }
 
-    @Test
-    @InSequence(1)
-    public void testArquillianWorkaroundSecond() {
-        // Container is unmanaged, need to start manually.
-        start(DEPLOYMENT_1, CONTAINER_1);
-
-        // TODO: This is nasty. I need to start it to be able to inject it later and then stop it again!
-        // https://community.jboss.org/thread/176096
-        start(DEPLOYMENT_2, CONTAINER_2);
-    }
-
-    @Test
-    @InSequence(2)
-    public void testBasicXPC(
-            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException, InterruptedException {
-
-        // TODO: This is nasty. I need to start it to be able to inject it later and then stop it again!
-        // https://community.jboss.org/thread/176096
-        stop(DEPLOYMENT_2, CONTAINER_2);
-
-        DefaultHttpClient client = HttpClientUtils.relaxedCookieHttpClient();
-
-        String xpc1_create_url = baseURL1 + "count?command=createEmployee";
-        String xpc1_get_url = baseURL1 + "count?command=getEmployee";
-        String xpc2_get_url = baseURL2 + "count?command=getEmployee";
-        String xpc1_getempsecond_url = baseURL1 + "count?command=getSecondBeanEmployee";
-        String xpc2_getempsecond_url = baseURL2 + "count?command=getSecondBeanEmployee";
-        String xpc2_getdestroy_url = baseURL2 + "count?command=destroy";
-
-        try {
-            // extended persistence context is available on node1
-
-            System.out.println(new Date() + "create employee entity ");
-            String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity that lives in the extended persistence context that this test will verify is always available");
-            assertEquals(employeeName, "Tom Brady");
-
-            System.out.println(new Date() + "1. about to read entity on node1");
-            // ensure that we can get it from node 1
-            employeeName = executeUrlWithAnswer(client, xpc1_get_url, "1. xpc on node1, node1 should be able to read entity on node1");
-            assertEquals(employeeName, "Tom Brady");
-            employeeName = executeUrlWithAnswer(client, xpc1_getempsecond_url, "1. xpc on node1, node1 should be able to read entity from second bean on node1");
-            assertEquals(employeeName, "Tom Brady");
-
-            start(DEPLOYMENT_2, CONTAINER_2);
-
-            System.out.println(new Date() + "2. started node2 + deployed, about to read entity on node1");
-
-            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "2. started node2, xpc on node1, node1 should be able to read entity on node1");
-            assertEquals(employeeName, "Tom Brady");
-            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "2. started node2, xpc on node1, node1 should be able to read entity from second bean on node1");
-            assertEquals(employeeName, "Tom Brady");
-
-            // failover to deployment2
-            stop(DEPLOYMENT_1, CONTAINER_1); // failover #1 to node 2
-
-            System.out.println(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
-
-            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc");
-            assertEquals(employeeName, "Tom Brady");
-            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc that is on node2 (second bean)");
-            assertEquals(employeeName, "Tom Brady");
-
-            String destroyed = executeUrlWithAnswer(client, xpc2_getdestroy_url, "4. destroy the bean on node2");
-            assertEquals(destroyed, "destroy");
-            System.out.println(new Date() + "4. test is done");
-
-        } finally {
-            client.getConnectionManager().shutdown();
-
-            stop(DEPLOYMENT_1, CONTAINER_1);
-            stop(DEPLOYMENT_2, CONTAINER_2);
-        }
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     /**
@@ -212,13 +127,11 @@ public class StatefulWithXPCFailoverTestCase {
      * @throws InterruptedException
      */
     @Test
-    @InSequence(3)
+    @InSequence(1)
     public void testSecondLevelCache(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
             throws IOException, InterruptedException {
-        start(DEPLOYMENT_1, CONTAINER_1);
-        start(DEPLOYMENT_2, CONTAINER_2);
 
         DefaultHttpClient client = new DefaultHttpClient();
 
@@ -277,7 +190,7 @@ public class StatefulWithXPCFailoverTestCase {
             employeesInCache = executeUrlWithAnswer(client,xpc1_secondLevelCacheEntries_url, "get number of elements in node1 second level cache (should be zero)");
             assertEquals(employeesInCache, "0");
 
-            employeesInCache = executeUrlWithAnswer(client,xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
+            employeesInCache = executeUrlWithAnswer(client, xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
             assertEquals(employeesInCache, "0");
 
             assertExecuteUrl(client, xpc1_delete_url);
@@ -287,10 +200,75 @@ public class StatefulWithXPCFailoverTestCase {
 
         } finally {
             client.getConnectionManager().shutdown();
-
-            stop(DEPLOYMENT_1, CONTAINER_1);
-            stop(DEPLOYMENT_2, CONTAINER_2);
         }
+    }
+
+    @Test
+    @InSequence(2)
+    public void testBasicXPC(
+            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
+            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
+            throws IOException, InterruptedException {
+
+        stop(CONTAINER_2);
+
+        DefaultHttpClient client = HttpClientUtils.relaxedCookieHttpClient();
+
+        String xpc1_create_url = baseURL1 + "count?command=createEmployee";
+        String xpc1_get_url = baseURL1 + "count?command=getEmployee";
+        String xpc2_get_url = baseURL2 + "count?command=getEmployee";
+        String xpc1_getempsecond_url = baseURL1 + "count?command=getSecondBeanEmployee";
+        String xpc2_getempsecond_url = baseURL2 + "count?command=getSecondBeanEmployee";
+        String xpc2_getdestroy_url = baseURL2 + "count?command=destroy";
+
+        try {
+            // extended persistence context is available on node1
+
+            System.out.println(new Date() + "create employee entity ");
+            String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity that lives in the extended persistence context that this test will verify is always available");
+            assertEquals(employeeName, "Tom Brady");
+
+            System.out.println(new Date() + "1. about to read entity on node1");
+            // ensure that we can get it from node 1
+            employeeName = executeUrlWithAnswer(client, xpc1_get_url, "1. xpc on node1, node1 should be able to read entity on node1");
+            assertEquals(employeeName, "Tom Brady");
+            employeeName = executeUrlWithAnswer(client, xpc1_getempsecond_url, "1. xpc on node1, node1 should be able to read entity from second bean on node1");
+            assertEquals(employeeName, "Tom Brady");
+
+            start(CONTAINER_2);
+
+            System.out.println(new Date() + "2. started node2 + deployed, about to read entity on node1");
+
+            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "2. started node2, xpc on node1, node1 should be able to read entity on node1");
+            assertEquals(employeeName, "Tom Brady");
+            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "2. started node2, xpc on node1, node1 should be able to read entity from second bean on node1");
+            assertEquals(employeeName, "Tom Brady");
+
+            // failover to deployment2
+            stop(CONTAINER_1); // failover #1 to node 2
+
+            System.out.println(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
+
+            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc");
+            assertEquals(employeeName, "Tom Brady");
+            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc that is on node2 (second bean)");
+            assertEquals(employeeName, "Tom Brady");
+
+            String destroyed = executeUrlWithAnswer(client, xpc2_getdestroy_url, "4. destroy the bean on node2");
+            assertEquals(destroyed, "destroy");
+            System.out.println(new Date() + "4. test is done");
+
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    @InSequence(99)
+    public void testCleanupStoppedDeployments() {
+        // A container is stopped even though the deployment remained deployed.
+        start(CONTAINERS);
+        undeploy(DEPLOYMENTS);
     }
 
     private String executeUrlWithAnswer(DefaultHttpClient client, String url, String message) throws IOException, InterruptedException {
@@ -332,28 +310,6 @@ public class StatefulWithXPCFailoverTestCase {
             Thread.sleep(100);
         }
         throw new AssertionError("assertExecuteUrl Timed out trying to execute url=" + url);
-    }
-
-    private void stop(String deployment, String container) {
-        try {
-            System.out.println(new Date() + "stopping deployment="+deployment+", container="+container);
-            deployer.undeploy(deployment);
-            controller.stop(container);
-            System.out.println(new Date() + "stopped deployment="+deployment+", container="+container);
-        } catch (Throwable e) {
-            e.printStackTrace(System.err);
-        }
-    }
-
-    private void start(String deployment, String container) {
-        try {
-            System.out.println(new Date() + "starting deployment="+deployment+", container="+ container);
-            controller.start(container);
-            deployer.deploy(deployment);
-            System.out.println(new Date() + "started deployment="+deployment+", container=" + container);
-        } catch (Throwable e) {
-            e.printStackTrace(System.err);
-        }
     }
 
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
@@ -103,7 +103,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         war.addPackage(EJBDirectory.class.getPackage());
         war.setWebXML(StatefulBean.class.getPackage(), "web.xml");
         war.addAsResource(new StringAsset(persistence_xml), "META-INF/persistence.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 
@@ -157,7 +157,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
             String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity in node1 in memory db");                           //
             assertEquals(employeeName, "Tom Brady");
-            System.out.println(new Date() + "about to read entity on node1 (from xpc queue)");
+            log.info(new Date() + "about to read entity on node1 (from xpc queue)");
 
             employeeName = executeUrlWithAnswer(client, xpc1_get_url, "on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
@@ -224,11 +224,11 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         try {
             // extended persistence context is available on node1
 
-            System.out.println(new Date() + "create employee entity ");
+            log.info(new Date() + "create employee entity ");
             String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity that lives in the extended persistence context that this test will verify is always available");
             assertEquals(employeeName, "Tom Brady");
 
-            System.out.println(new Date() + "1. about to read entity on node1");
+            log.info(new Date() + "1. about to read entity on node1");
             // ensure that we can get it from node 1
             employeeName = executeUrlWithAnswer(client, xpc1_get_url, "1. xpc on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
@@ -237,7 +237,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
             start(CONTAINER_2);
 
-            System.out.println(new Date() + "2. started node2 + deployed, about to read entity on node1");
+            log.info(new Date() + "2. started node2 + deployed, about to read entity on node1");
 
             employeeName = executeUrlWithAnswer(client, xpc2_get_url, "2. started node2, xpc on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
@@ -247,7 +247,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
             // failover to deployment2
             stop(CONTAINER_1); // failover #1 to node 2
 
-            System.out.println(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
+            log.info(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
 
             employeeName = executeUrlWithAnswer(client, xpc2_get_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc");
             assertEquals(employeeName, "Tom Brady");
@@ -256,7 +256,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
             String destroyed = executeUrlWithAnswer(client, xpc2_getdestroy_url, "4. destroy the bean on node2");
             assertEquals(destroyed, "destroy");
-            System.out.println(new Date() + "4. test is done");
+            log.info(new Date() + "4. test is done");
 
         } finally {
             client.getConnectionManager().shutdown();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
@@ -103,14 +103,14 @@ public class StatefulBean implements Stateful {
     }
 
     @Override
-        @TransactionAttribute(TransactionAttributeType.REQUIRED)
-        public void deleteEmployee(int id) {
-            Employee employee = em.find(Employee.class, id, LockModeType.NONE);
-            em.remove(employee);
-            logStats("deleteEmployee");
-            version = "deletedEmployee";
-            valueBag.put("version",version);
-        }
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public void deleteEmployee(int id) {
+        Employee employee = em.find(Employee.class, id, LockModeType.NONE);
+        em.remove(employee);
+        logStats("deleteEmployee");
+        version = "deletedEmployee";
+        valueBag.put("version", version);
+    }
 
 
     @Override

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
@@ -34,6 +34,7 @@ import javax.sql.DataSource;
 import org.hibernate.Session;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.logging.Logger;
 
 import java.sql.Connection;
 import java.util.HashMap;
@@ -46,6 +47,8 @@ import java.util.HashMap;
 @javax.ejb.Stateful(name = "StatefulBean")
 
 public class StatefulBean implements Stateful {
+
+    private static final Logger log = Logger.getLogger(StatefulBean.class);
 
     @PersistenceContext(unitName = "mypc", type = PersistenceContextType.EXTENDED)
     EntityManager em;
@@ -132,9 +135,9 @@ public class StatefulBean implements Stateful {
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     @Override
     public void echo(String message) {
-        System.out.println("echo entered for " + message);
+        log.info("echo entered for " + message);
         logStats("echo " + message);
-        System.out.println("echo completed for " + message);
+        log.info("echo completed for " + message);
     }
 
 
@@ -166,14 +169,14 @@ public class StatefulBean implements Stateful {
 
     private void logStats(String methodName) {
         Session session = em.unwrap(Session.class);
-        System.out.println(methodName + "(version="+version+", HashMap version="+valueBag.get("version")+") logging statistics for session = " + session);
+        log.info(methodName + "(version="+version+", HashMap version="+valueBag.get("version")+") logging statistics for session = " + session);
         session.getSessionFactory().getStatistics().setStatisticsEnabled(true);
         session.getSessionFactory().getStatistics().logSummary();
         String entityRegionNames[] =  session.getSessionFactory().getStatistics().getSecondLevelCacheRegionNames();
         for (String name: entityRegionNames) {
-            System.out.println("cache entity region name = " + name);
+            log.info("cache entity region name = " + name);
             SecondLevelCacheStatistics stats = session.getSessionFactory().getStatistics().getSecondLevelCacheStatistics(name);
-            System.out.println("2lc for " + name+ ": " + stats.toString());
+            log.info("2lc for " + name+ ": " + stats.toString());
 
         }
         // we will want to return the SecondLevelCacheStatistics for Employee

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulServlet.java
@@ -38,6 +38,7 @@ import javax.sql.DataSource;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.test.clustering.LocalEJBDirectory;
+import org.jboss.logging.Logger;
 
 /**
  * @author Paul Ferraro
@@ -46,6 +47,8 @@ import org.jboss.as.test.clustering.LocalEJBDirectory;
 @WebServlet(urlPatterns = { "/count" })
 public class StatefulServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
+
+    private static final Logger log = Logger.getLogger(StatefulServlet.class);
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -60,7 +63,7 @@ public class StatefulServlet extends HttpServlet {
         }
 
         String command = req.getParameter("command");
-        System.out.println(StatefulServlet.class.getName() + ": command = " + command);
+        log.info(StatefulServlet.class.getName() + ": command = " + command);
         String answer = null;
 
         if("createEmployee".equals(command)) {
@@ -118,6 +121,6 @@ public class StatefulServlet extends HttpServlet {
         }
         resp.getWriter().write("Success");
         session.setAttribute("bean", bean);
-        System.out.println(StatefulServlet.class.getName() + ": command = " + command + " finished");
+        log.info(StatefulServlet.class.getName() + ": command = " + command + " finished");
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -228,7 +228,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         String url1 = baseURL1.toString() + "home.jsf";
         String url2 = baseURL2.toString() + "home.jsf";
 
-        System.out.println("URLs are: " + url1 + ", " + url2);
+        log.info("URLs are: " + url1 + ", " + url2);
 
         try {
             HttpResponse response;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/management/CacheTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/management/CacheTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.clustering.cluster.management;
 
 import java.net.URL;
+
 import junit.framework.Assert;
 import org.jboss.arquillian.container.test.api.*;
 import org.jboss.arquillian.junit.Arquillian;
@@ -32,19 +33,22 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.common.JndiServlet;
 import org.jboss.as.test.integration.management.util.ModelUtil;
+
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+
 import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 
 /**
- *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
 @RunWith(Arquillian.class)
@@ -101,11 +105,12 @@ public class CacheTestCase extends AbstractMgmtTestBase {
 
         NodeUtil.stop(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
     }
+
     @Test
     public void testLocalCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/local-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/local-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("jndi-name").set("java:jboss/caches/TestCache");
@@ -121,7 +126,7 @@ public class CacheTestCase extends AbstractMgmtTestBase {
                     ModelDescriptionConstants.REMOVE);
             executeOperation(op);
         }
-        
+
         // check that it is unregistered
         String jndiClass = JndiServlet.lookup(url.toString(), "java:jboss/caches/TestCache");
         Assert.assertEquals(JndiServlet.NOT_FOUND, jndiClass);
@@ -129,10 +134,10 @@ public class CacheTestCase extends AbstractMgmtTestBase {
 
 
     @Test
-    public void testDistributedCache(@ArquillianResource ManagementClient managementClient,  @ArquillianResource URL url) throws Exception {
+    public void testDistributedCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/distributed-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/distributed-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("mode").set("ASYNC");
@@ -149,17 +154,17 @@ public class CacheTestCase extends AbstractMgmtTestBase {
                     ModelDescriptionConstants.REMOVE);
             executeOperation(op);
         }
-        
+
         // check that it is unregistered
         String jndiClass = JndiServlet.lookup(url.toString(), "java:jboss/caches/TestCache");
         Assert.assertEquals(JndiServlet.NOT_FOUND, jndiClass);
     }
 
     @Test
-    public void testReplicatedCache(@ArquillianResource ManagementClient managementClient,  @ArquillianResource URL url) throws Exception {
+    public void testReplicatedCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/replicated-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/replicated-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("mode").set("ASYNC");
@@ -183,10 +188,10 @@ public class CacheTestCase extends AbstractMgmtTestBase {
     }
 
     @Test
-    public void testInvalidationCache(@ArquillianResource ManagementClient managementClient,  @ArquillianResource URL url) throws Exception {
+    public void testInvalidationCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/invalidation-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/invalidation-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("mode").set("ASYNC");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
@@ -94,7 +94,7 @@ public class SingletonTestCase extends ClusterAbstractTestCase {
         String url1 = baseURL1.toString() + "service";
         String url2 = baseURL2.toString() + "service";
 
-        System.out.println("URLs are: " + url1 + ", " + url2);
+        log.info("URLs are: " + url1 + ", " + url2);
 
         try {
             HttpResponse response = client.execute(new HttpGet(url1));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceContextListener.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceContextListener.java
@@ -34,12 +34,15 @@ import org.jboss.as.clustering.singleton.election.PreferredSingletonElectionPoli
 import org.jboss.as.clustering.singleton.election.SimpleSingletonElectionPolicy;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
+import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 
 @WebListener
 public class MyServiceContextListener implements ServletContextListener {
+
+    private static final Logger log = Logger.getLogger(MyServiceContextListener.class);
 
     public static final String PREFERRED_NODE = NODE_2;
 
@@ -62,9 +65,9 @@ public class MyServiceContextListener implements ServletContextListener {
 
     @Override
     public void contextDestroyed(ServletContextEvent event) {
-        System.out.println(String.format("Initiating removal of %s", MyService.SERVICE_NAME.getCanonicalName()));
+        log.info(String.format("Initiating removal of %s", MyService.SERVICE_NAME.getCanonicalName()));
         ServiceContainerHelper.remove(ServiceContainerHelper.getCurrentServiceContainer().getRequiredService(MyService.SERVICE_NAME));
-        System.out.println(String.format("Removal of %s complete", MyService.SERVICE_NAME.getCanonicalName()));
+        log.info(String.format("Removal of %s complete", MyService.SERVICE_NAME.getCanonicalName()));
         this.verifyRemoved(MyService.SERVICE_NAME.append("service"));
         this.verifyRemoved(MyService.SERVICE_NAME.append("singleton"));
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -97,14 +97,14 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
         try {
             HttpResponse response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
             // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
@@ -114,14 +114,14 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             // Now check on the 2nd server
             response = tryGet(client, url2);
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
             // Let's do one more check.
             response = client.execute(new HttpGet(url2));
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
@@ -131,14 +131,14 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Lets wait for the cluster to update membership and state transfer.
 
             response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
             // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
@@ -176,14 +176,14 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
         try {
             HttpResponse response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
@@ -196,14 +196,14 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Note that this DOES rely on the fact that both servers are running on the "same" domain,
             // which is '127.0.0.1'. Otherwise you will have to spoof cookies. @Rado
             response = tryGet(client, url2);
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
             // Lets do one more check.
             response = tryGet(client, url2);
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
@@ -212,14 +212,14 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             deploy(DEPLOYMENT_1);
 
             response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+            log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -38,6 +38,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.as.test.http.util.HttpClientUtils;
 import org.junit.Assert;
@@ -45,45 +46,28 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.clustering.ClusterHttpClientUtil.tryGet;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENTS;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO_MEMBERSHIP_CHANGE;
 
 /**
- * Test that failover and undeploy works.
+ * Test that HTTP session failover on shutdown and undeploy works.
  *
  * @author Radoslav Husar
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public abstract class ClusteredWebFailoverAbstractCase {
+public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTestCase {
 
-    /** Controller for testing failover and undeploy **/
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
-
-    @BeforeClass
-    public static void printSysProps() {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
-
-    /**
-     * Workaround for Arquillian so that you can use "@ArquillianResource(C.class) @OperateOnDeployment(D)" because the
-     * containers need to be started beforehand.
-     */
-    @Test
-    @InSequence(1)
-    public void testStartContainersAndDeployments() {
-        // Container is unmanaged, need to start manually.
-        controller.start(CONTAINER_1);
-        deployer.deploy(DEPLOYMENT_1);
-        controller.start(CONTAINER_2);
-        deployer.deploy(DEPLOYMENT_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     /**
@@ -100,7 +84,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
      * @throws InterruptedException
      */
     @Test
-    @InSequence(2)
+    @InSequence(1)
     public void testGracefulSimpleFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -118,7 +102,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
-            // Lets do this twice to have more debug info if failover is slow.
+            // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -126,29 +110,25 @@ public abstract class ClusteredWebFailoverAbstractCase {
             response.getEntity().getContent().close();
 
             // Gracefully shutdown the 1st container.
-            controller.stop(CONTAINER_1);
+            stop(CONTAINER_1);
 
             // Now check on the 2nd server
-
-            // Note that this DOES rely on the fact that both servers are running on the "same" domain,
-            // which is '127.0.0.0'. Otherwise you will have to spoof cookies. @Rado
-
             response = tryGet(client, url2);
             System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
-            // Lets do one more check.
+            // Let's do one more check.
             response = client.execute(new HttpGet(url2));
             System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
-            controller.start(CONTAINER_1);
+            start(CONTAINER_1);
 
-            // Lets wait for the cluster to update membership and tranfer state.
+            // Lets wait for the cluster to update membership and state transfer.
 
             response = tryGet(client, url1);
             System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -156,7 +136,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
             response.getEntity().getContent().close();
 
-            // Lets do this twice to have more debug info if failover is slow.
+            // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -166,24 +146,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             client.getConnectionManager().shutdown();
         }
 
-        // Is would be done automatically, keep for 2nd test is added
-        deployer.undeploy(DEPLOYMENT_1);
-        controller.stop(CONTAINER_1);
-        deployer.undeploy(DEPLOYMENT_2);
-        controller.stop(CONTAINER_2);
-
         // Assert.fail("Show me the logs please!");
-    }
-
-    @Test
-    @InSequence(3)
-    public void testStartContainersAndDeploymentsForUndeployFailover() {
-        // Container is unmanaged, need to start manually.
-        controller.start(CONTAINER_1);
-        deployer.deploy(DEPLOYMENT_1);
-
-        controller.start(CONTAINER_2);
-        deployer.deploy(DEPLOYMENT_2);
     }
 
     /**
@@ -200,7 +163,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
      * @throws InterruptedException
      */
     @Test
-    @InSequence(4)
+    @InSequence(2)
     public void testGracefulUndeployFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -226,7 +189,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             response.getEntity().getContent().close();
 
             // Gracefully undeploy from the 1st container.
-            deployer.undeploy(DEPLOYMENT_1);
+            undeploy(DEPLOYMENT_1);
 
             // Now check on the 2nd server
 
@@ -246,7 +209,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             response.getEntity().getContent().close();
 
             // Redeploy
-            deployer.deploy(DEPLOYMENT_1);
+            deploy(DEPLOYMENT_1);
 
             response = tryGet(client, url1);
             System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -264,22 +227,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             client.getConnectionManager().shutdown();
         }
 
-        // Is would be done automatically, keep for when 3nd test is added
-        deployer.undeploy(DEPLOYMENT_1);
-        controller.stop(CONTAINER_1);
-        deployer.undeploy(DEPLOYMENT_2);
-        controller.stop(CONTAINER_2);
-
         // Assert.fail("Show me the logs please!");
     }
 
-    private HttpResponse tryGet(final DefaultHttpClient client, final String url1) throws IOException {
-        final long startTime;
-        HttpResponse response = client.execute(new HttpGet(url1));
-        startTime = System.currentTimeMillis();
-        while(response.getStatusLine().getStatusCode() != HttpServletResponse.SC_OK && startTime + GRACE_TIME_TO_MEMBERSHIP_CHANGE > System.currentTimeMillis()) {
-            response = client.execute(new HttpGet(url1));
-        }
-        return response;
-    }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
@@ -94,7 +94,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 
@@ -111,7 +111,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
 
         // returns the URL of the deployment (http://127.0.0.1:8180/distributable)
         String url = baseURL.toString();
-        System.out.println("URL = " + url);
+        log.info("URL = " + url);
 
         try {
             HttpResponse response = client.execute(new HttpGet(url + "simple"));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
@@ -47,6 +47,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.as.test.http.util.HttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
@@ -60,6 +61,7 @@ import org.junit.runner.RunWith;
 import static org.jboss.as.test.clustering.ClusterTestUtil.waitForReplication;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENTS;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO_REPLICATE;
@@ -72,33 +74,23 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class ClusteredWebSimpleTestCase {
+public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
 
     private static final int REQUEST_DURATION = 10000;
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
-
-    @BeforeClass
-    public static void printSysProps() {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
-        war.addClass(SimpleServlet.class);
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
-        return war;
+        return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
@@ -106,18 +98,10 @@ public class ClusteredWebSimpleTestCase {
         return war;
     }
 
-    @Test
-    @InSequence(-1)
-    public void testStartContainers() {
-        NodeUtil.start(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.start(controller, deployer, CONTAINER_2, DEPLOYMENT_2);
-    }
-
-    @Test
-    @InSequence(1)
-    public void testStopContainers() {
-        NodeUtil.stop(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.stop(controller, deployer, CONTAINER_2, DEPLOYMENT_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     @Test
@@ -233,10 +217,10 @@ public class ClusteredWebSimpleTestCase {
 
         if (undeployOnly) {
             // Undeploy the app only.
-            deployer.undeploy(DEPLOYMENT_1);
+            undeploy(DEPLOYMENT_1);
         } else {
             // Shutdown server.
-            controller.stop(CONTAINER_1);
+            stop(CONTAINER_1);
         }
 
         // Get result of long request
@@ -262,10 +246,10 @@ public class ClusteredWebSimpleTestCase {
         // Cleanup after test.
         if (undeployOnly) {
             // Redeploy the app only.
-            deployer.deploy(DEPLOYMENT_1);
+            deploy(DEPLOYMENT_1);
         } else {
             // Startup server.
-            controller.start(CONTAINER_1);
+            start(CONTAINER_1);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
@@ -52,7 +52,7 @@ public class DistributionWebFailoverTestCase extends ClusteredWebFailoverAbstrac
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
@@ -21,6 +21,11 @@
  */
 package org.jboss.as.test.clustering.cluster.web;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
@@ -28,25 +33,21 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
 public class DistributionWebFailoverTestCase extends ClusteredWebFailoverAbstractCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
-        war.addClass(SimpleServlet.class);
-        // Take web.xml from the managed test.
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
-        return war;
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -54,7 +54,7 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -39,20 +39,19 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "granular-distributable.war");
-        war.addClass(SimpleServlet.class);
-        // Take web.xml from the managed test.
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
-        return war;
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "granular-distributable.war");
         war.addClass(SimpleServlet.class);
+        // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
         System.out.println(war.toString(true));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
@@ -49,7 +49,7 @@ public class ReplicationWebFailoverTestCase extends ClusteredWebFailoverAbstract
         war.addClass(SimpleServlet.class);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
@@ -35,19 +35,19 @@ public class ReplicationWebFailoverTestCase extends ClusteredWebFailoverAbstract
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
-        war.addClass(SimpleServlet.class);
-        // Take web.xml from the managed test.
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
-        return war;
+        return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
+        // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         System.out.println(war.toString(true));
         return war;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
@@ -29,28 +29,26 @@ import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 
 /**
  * @author Radoslav Husar
  * @version April 2012
  */
-@Ignore // AS7-5279
 public class AttributeBasedSessionPassivationTestCase extends SessionPassivationAbstractCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        return getDeployment();
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        return getDeployment();
+        return createDeployment();
     }
 
-    private static Archive<?> getDeployment() {
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "passivating-attribute.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
@@ -53,7 +53,7 @@ public class AttributeBasedSessionPassivationTestCase extends SessionPassivation
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(SessionPassivationAbstractCase.class.getPackage(), "jboss-web_passivation_attribute.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
@@ -53,7 +53,7 @@ public class SessionBasedSessionPassivationTestCase extends SessionPassivationAb
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(SessionPassivationAbstractCase.class.getPackage(), "jboss-web_passivation_session.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
@@ -29,28 +29,26 @@ import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 
 /**
  * @author Radoslav Husar
  * @version April 2012
  */
-@Ignore // AS7-5279
 public class SessionBasedSessionPassivationTestCase extends SessionPassivationAbstractCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        return getDeployment();
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        return getDeployment();
+        return createDeployment();
     }
 
-    private static Archive<?> getDeployment() {
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "passivating-session.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalJdbcStoreTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalJdbcStoreTestCase.java
@@ -44,6 +44,7 @@ import javax.naming.NamingException;
  * @author Martin Gencur
  */
 @RunWith(Arquillian.class)
+@Ignore("https://issues.jboss.org/browse/ISPN-604")
 public class TransactionalJdbcStoreTestCase {
 
     @Deployment
@@ -55,37 +56,31 @@ public class TransactionalJdbcStoreTestCase {
         return war;
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxPutCommit() throws Exception {
         getIspnBeanFromJndi().testTxPutCommit();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxPutRollback() throws Exception {
         getIspnBeanFromJndi().testTxPutRollback();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxRemoveCommit() throws Exception {
         getIspnBeanFromJndi().testTxRemoveCommit();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxRemoveRollback() throws Exception {
         getIspnBeanFromJndi().testTxRemoveRollback();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxAlterCommit() throws Exception {
         getIspnBeanFromJndi().testTxAlterCommit();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxAlterRollback() throws Exception {
         getIspnBeanFromJndi().testTxAlterRollback();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -51,12 +52,14 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class SimpleWebTestCase {
 
+    private static final Logger log = Logger.getLogger(SimpleWebTestCase.class);
+
     @Deployment(name = "deployment-single")
     public static Archive<?> deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(SimpleWebTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 

--- a/testsuite/integration/clust/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/integration/clust/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.as.test.clustering.arquillian.StopCustomContainersOnAfterSuiteExtension

--- a/testsuite/integration/clust/src/test/resources/logging.properties
+++ b/testsuite/integration/clust/src/test/resources/logging.properties
@@ -21,7 +21,8 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.ejb.client
+loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.ejb.client,org.jboss.arquillian
+logger.org.jboss.arquillian.level=INFO
 logger.org.jboss.shrinkwrap.level=INFO
 logger.org.jboss.ejb.client.level=DEBUG
 logger.sun.rmi.level=WARNING


### PR DESCRIPTION
Features
- 2x speed up -> clustering ts now runs in ~8 minutes
- introduced abstract cluster test significantly reducing repetitive code
- leveraging ARQ custom container mode
- no more starting and stopping on every test
- replaced system outs with logger
- less intermittent issues
- reenabled most tests
- disabled consistently failing tests
