### PR TITLE
AS7-5403 - Adding Modcluster from the Command Line Interface

### DIFF
--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigAttributeDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigAttributeDefinition.java
@@ -1,0 +1,111 @@
+package org.jboss.as.modcluster;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.operations.validation.ParametersOfValidator;
+import org.jboss.as.controller.operations.validation.ParametersValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+public class ModClusterConfigAttributeDefinition extends ListAttributeDefinition {
+
+    public static final ParameterValidator validator;
+    public static final ParameterValidator fieldValidator;
+
+    static {
+        final ParametersValidator delegate = new ParametersValidator();
+
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            SimpleAttributeDefinition attribute = ModClusterConfigResourceDefinition.ATTRIBUTES[i];
+
+            switch(attribute.getType()){
+                case STRING:
+                    delegate.registerValidator(attribute.getName(), new ModelTypeValidator(ModelType.STRING, attribute.isAllowNull(), attribute.isAllowExpression()));
+                break;
+                case INT:
+                    delegate.registerValidator(attribute.getName(), new ModelTypeValidator(ModelType.INT, attribute.isAllowNull(), attribute.isAllowExpression()));
+                    break;
+                case BOOLEAN:
+                    delegate.registerValidator(attribute.getName(), new ModelTypeValidator(ModelType.BOOLEAN, attribute.isAllowNull(), attribute.isAllowExpression()));
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        validator = new ParametersOfValidator(delegate);
+        fieldValidator = delegate;
+    }
+
+    public ModClusterConfigAttributeDefinition(String name, String xmlName) {
+        super(name, xmlName, true, 1, Integer.MAX_VALUE, validator, null, null, AttributeAccess.Flag.RESTART_ALL_SERVICES);
+    }
+
+    @Override
+    protected void addValueTypeDescription(ModelNode node, ResourceBundle bundle) {
+        // This method being used indicates a misuse of this class
+        // throw ModClusterMessages.MESSAGES.unsupportedOperationExceptionUseResourceDesc();
+
+    }
+
+    @Override
+    protected void addAttributeValueTypeDescription(ModelNode node, ResourceDescriptionResolver resolver, Locale locale,
+            ResourceBundle bundle) {
+        final ModelNode valueType = getNoTextValueTypeDescription(node);
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            String name = ModClusterConfigResourceDefinition.ATTRIBUTES[i].getName();
+
+            valueType.get(name, DESCRIPTION).set(
+                    resolver.getResourceAttributeValueTypeDescription(getName(), locale, bundle, name));
+
+        }
+
+    }
+
+    @Override
+    protected void addOperationParameterValueTypeDescription(ModelNode node, String operationName,
+            ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
+        final ModelNode valueType = getNoTextValueTypeDescription(node);
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            String name = ModClusterConfigResourceDefinition.ATTRIBUTES[i].getName();
+
+            valueType.get(name, DESCRIPTION).set(
+                    resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle,
+                            name));
+        }
+
+    }
+
+    private ModelNode getNoTextValueTypeDescription(final ModelNode parent) {
+        final ModelNode valueType = parent.get(VALUE_TYPE);
+
+        for(int i = 0; i < ModClusterConfigResourceDefinition.ATTRIBUTES.length; i++){
+            String name = ModClusterConfigResourceDefinition.ATTRIBUTES[i].getName();
+
+            ModelNode advertiseSocket = valueType.get(name);
+            advertiseSocket.get(DESCRIPTION);
+            advertiseSocket.get(TYPE).set(ModClusterConfigResourceDefinition.ATTRIBUTES[i].getType());
+            boolean allowNull = ModClusterConfigResourceDefinition.ATTRIBUTES[i].isAllowNull();
+            advertiseSocket.get(NILLABLE).set(allowNull);
+
+        }
+
+        return valueType;
+    }
+
+}

--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigResourceDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterConfigResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.jboss.as.modcluster;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.ResourceDefinition;
@@ -281,4 +282,17 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
         final DescriptionProvider removeCustomMetric = new DefaultOperationDescriptionProvider(CommonAttributes.REMOVE_CUSTOM_METRIC, rootResolver, CustomLoadMetricDefinition.CLASS);
         resourceRegistration.registerOperationHandler(CommonAttributes.REMOVE_CUSTOM_METRIC, ModClusterRemoveCustomMetric.INSTANCE, removeCustomMetric, false, runtimeOnlyFlags);
     }
+
+
+    public static final ModClusterConfigAttributeDefinition CONFIG_ATTRIBUTE_DEFINITION = new ModClusterConfigAttributeDefinition(
+            CommonAttributes.CONFIGURATION, CommonAttributes.MOD_CLUSTER_CONFIG);
+
+    public static AttributeDefinition getThisAttributeDefinition(){
+        return CONFIG_ATTRIBUTE_DEFINITION;
+    }
+
+    public static OperationStepHandler getThisAttributeHandler(){
+        return new ReloadRequiredWriteAttributeHandler(CONFIG_ATTRIBUTE_DEFINITION);
+    }
+
 }

--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterDefinition.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterDefinition.java
@@ -14,8 +14,6 @@ import org.jboss.dmr.ModelType;
 
 import java.util.EnumSet;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
-
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
@@ -69,6 +67,10 @@ public class ModClusterDefinition extends SimpleResourceDefinition {
 
     }
 
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registration) {
+        registration.registerReadWriteAttribute(ModClusterConfigResourceDefinition.getThisAttributeDefinition(), null, ModClusterConfigResourceDefinition.getThisAttributeHandler());
+    }
 
     public void registerRuntimeOperations(ManagementResourceRegistration registration) {
         EnumSet<OperationEntry.Flag> runtimeOnlyFlags = EnumSet.of(OperationEntry.Flag.RUNTIME_ONLY);

--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterSubsystemAdd.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterSubsystemAdd.java
@@ -78,7 +78,8 @@ class ModClusterSubsystemAdd extends AbstractAddStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model,
-                                  ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+            ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers)
+            throws OperationFailedException {
 
         final ModelNode fullModel = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
         final ModelNode modelConfig = fullModel.get(ModClusterExtension.CONFIGURATION_PATH.getKeyValuePair());
@@ -87,44 +88,79 @@ class ModClusterSubsystemAdd extends AbstractAddStepHandler {
         final String connector = CONNECTOR.resolveModelAttribute(context, modelConfig).asString();
         // Add mod_cluster service
         final ModClusterService service = new ModClusterService(config, loadProvider);
-        final ServiceBuilder<ModCluster> builder = AsynchronousService.addService(context.getServiceTarget(), ModClusterService.NAME, service, true, true)
+        final ServiceBuilder<ModCluster> builder = AsynchronousService
+                .addService(context.getServiceTarget(), ModClusterService.NAME, service, true, true)
                 .addDependency(WebSubsystemServices.JBOSS_WEB, WebServer.class, service.getWebServer())
-                .addDependency(SocketBindingManager.SOCKET_BINDING_MANAGER, SocketBindingManager.class, service.getBindingManager())
-                .addDependency(WebSubsystemServices.JBOSS_WEB_CONNECTOR.append(connector), Connector.class, service.getConnectorInjector())
-                .addListener(verificationHandler)
-                .setInitialMode(Mode.ACTIVE)
-        ;
+                .addDependency(SocketBindingManager.SOCKET_BINDING_MANAGER, SocketBindingManager.class,
+                        service.getBindingManager())
+                .addDependency(WebSubsystemServices.JBOSS_WEB_CONNECTOR.append(connector), Connector.class,
+                        service.getConnectorInjector()).addListener(verificationHandler).setInitialMode(Mode.ACTIVE);
         final ModelNode bindingRefNode = ADVERTISE_SOCKET.resolveModelAttribute(context, modelConfig);
         final String bindingRef = bindingRefNode.isDefined() ? bindingRefNode.asString() : null;
         if (bindingRef != null) {
-            builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(bindingRef), SocketBinding.class, service.getBinding());
+            builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(bindingRef), SocketBinding.class,
+                    service.getBinding());
         }
         newControllers.add(builder.install());
     }
 
     /*
-    this is here so legacy configuration can be supported
+     * this is here so legacy configuration can be supported
      */
     @Override
-    protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+    protected void populateModel(OperationContext context, ModelNode operation, Resource resource)
+            throws OperationFailedException {
+
         if (operation.hasDefined(CommonAttributes.MOD_CLUSTER_CONFIG)) {
             PathAddress opAddress = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
             PathAddress parent = opAddress.append(ModClusterExtension.CONFIGURATION_PATH);
             ModelNode targetOperation = Util.createAddOperation(parent);
+
             for (AttributeDefinition def : ModClusterConfigResourceDefinition.ATTRIBUTES) {
                 def.validateAndSet(operation, targetOperation);
             }
+
             context.addStep(targetOperation, ModClusterConfigAdd.INSTANCE, OperationContext.Stage.IMMEDIATE);
             context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+
+        }else if(operation.hasDefined(CommonAttributes.CONFIGURATION)){
+
+            // Populate the model using the list attribute validateAndSet
+            this.populateModel(operation,  resource.getModel());
+
+            // Get the map out of the resource
+            ModelNode node = resource.getModel();
+            ModelNode map = new ModelNode();
+            if(node != null && node.has(CommonAttributes.CONFIGURATION)){
+                ModelNode configuration = node.get(CommonAttributes.CONFIGURATION);
+                List<ModelNode> list = configuration.asList();
+                if( list.size() >= 1 ){
+                    map = list.get(0);
+                }
+            }
+
+            // Add the attributes to the context using the ModClusterConfigAdd
+            PathAddress opAddress = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
+            PathAddress parent = opAddress.append(ModClusterExtension.CONFIGURATION_PATH);
+            ModelNode targetOperation = Util.createAddOperation(parent);
+
+            for (AttributeDefinition def : ModClusterConfigResourceDefinition.ATTRIBUTES) {
+                def.validateAndSet(map, targetOperation);
+            }
+
+            context.addStep(targetOperation, ModClusterConfigAdd.INSTANCE, OperationContext.Stage.IMMEDIATE);
+            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+
         }
     }
 
     @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-
+        ModClusterConfigResourceDefinition.CONFIG_ATTRIBUTE_DEFINITION.validateAndSet(operation, model);
     }
 
-    private ModClusterConfig getModClusterConfig(final OperationContext context, ModelNode model) throws OperationFailedException {
+    private ModClusterConfig getModClusterConfig(final OperationContext context, ModelNode model)
+            throws OperationFailedException {
         ModClusterConfig config = new ModClusterConfig();
         config.setAdvertise(ADVERTISE.resolveModelAttribute(context, model).asBoolean());
 
@@ -169,7 +205,7 @@ class ModClusterSubsystemAdd extends AbstractAddStepHandler {
 
         config.setStopContextTimeout(STOP_CONTEXT_TIMEOUT.resolveModelAttribute(context, model).asInt());
         config.setStopContextTimeoutUnit(TimeUnit.valueOf(STOP_CONTEXT_TIMEOUT.getMeasurementUnit().getName()));
-        //config.setStopContextTimeoutUnit(TimeUnit.SECONDS); //todo use AttributeDefinition.getMeasurementUnit
+        // config.setStopContextTimeoutUnit(TimeUnit.SECONDS); //todo use AttributeDefinition.getMeasurementUnit
         // the default value is 20000 = 20 seconds.
         config.setSocketTimeout(SOCKET_TIMEOUT.resolveModelAttribute(context, model).asInt() * 1000);
         config.setStickySession(STICKY_SESSION.resolveModelAttribute(context, model).asBoolean());
@@ -193,7 +229,8 @@ class ModClusterSubsystemAdd extends AbstractAddStepHandler {
         return config;
     }
 
-    private LoadBalanceFactorProvider getModClusterLoadProvider(final OperationContext context, ModelNode model) throws OperationFailedException {
+    private LoadBalanceFactorProvider getModClusterLoadProvider(final OperationContext context, ModelNode model)
+            throws OperationFailedException {
         LoadBalanceFactorProvider load = null;
         if (model.hasDefined(CommonAttributes.SIMPLE_LOAD_PROVIDER_FACTOR)) {
             // TODO it seems we don't support that stuff.
@@ -231,8 +268,8 @@ class ModClusterSubsystemAdd extends AbstractAddStepHandler {
         return load;
     }
 
-
-    private void addLoadMetrics(Set<LoadMetric> metrics, ModelNode nodes, final OperationContext context) throws OperationFailedException {
+    private void addLoadMetrics(Set<LoadMetric> metrics, ModelNode nodes, final OperationContext context)
+            throws OperationFailedException {
         for (Property p : nodes.asPropertyList()) {
             ModelNode node = p.getValue();
             double capacity = CAPACITY.resolveModelAttribute(context, node).asDouble();


### PR DESCRIPTION
ModClusterDefinition so that the configuration could be manipulated
during the ./subsystem=modcluster:add() command.

The attribute mimics the ModClusterConfigResourceDefinition in the
attribute format.

Added functionality to catch the new attribute in the
ModClusterSubsystemAdd and validate the input.
