### PR TITLE
AS7-5574 Switch to standard Java debug options -agentlib

### DIFF
--- a/build/src/main/resources/bin/add-user.sh
+++ b/build/src/main/resources/bin/add-user.sh
@@ -61,7 +61,7 @@ if $cygwin; then
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
 # Uncomment to override standalone and domain user location  
 #JAVA_OPTS="$JAVA_OPTS -Djboss.server.config.user.dir=../standalone/configuration -Djboss.domain.config.user.dir=../domain/configuration"
 

--- a/build/src/main/resources/bin/appclient.conf
+++ b/build/src/main/resources/bin/appclient.conf
@@ -47,10 +47,10 @@ if [ "x$JAVA_OPTS" = "x" ]; then
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging 
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_shmem,server=y,suspend=n,address=jboss"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
 
 # Allow JProfiler to find its classes
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=com.jprofiler"

--- a/build/src/main/resources/bin/appclient.conf.bat
+++ b/build/src/main/resources/bin/appclient.conf.bat
@@ -56,10 +56,10 @@ rem # This is necessary to inject Byteman rules into AS7 deployments
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=org.jboss.byteman"
 
 rem # Sample JPDA settings for remote socket debugging
-rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 rem # Sample JPDA settings for shared memory debugging
-rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
+rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"

--- a/build/src/main/resources/bin/domain.conf
+++ b/build/src/main/resources/bin/domain.conf
@@ -63,9 +63,9 @@ if [ "x$HOST_CONTROLLER_JAVA_OPTS" = "x" ]; then
 fi
 
 # Sample JPDA settings for remote socket debuging.
-#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8788,server=y,suspend=n"
-#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8788,server=y,suspend=n"
+#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -Xrunjdwp:transport=dt_shmem,server=y,suspend=n,address=jboss"
-#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -Xrunjdwp:transport=dt_shmem,server=y,suspend=n,address=jboss"
+#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"

--- a/build/src/main/resources/bin/domain.conf.bat
+++ b/build/src/main/resources/bin/domain.conf.bat
@@ -68,12 +68,12 @@ rem The HostController process uses its own set of java options
 set "HOST_CONTROLLER_JAVA_OPTS=%JAVA_OPTS%"
 
 rem # Sample JPDA settings for remote socket debugging
-rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=8788,server=y,suspend=n"
-rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8788,server=y,suspend=n"
+rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 rem # Sample JPDA settings for shared memory debugging
-rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
-rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
+rem set "PROCESS_CONTROLLER_JAVA_OPTS=%PROCESS_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
+rem set "HOST_CONTROLLER_JAVA_OPTS=%HOST_CONTROLLER_JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 :JAVA_OPTS_SET
 

--- a/build/src/main/resources/bin/jboss-cli.sh
+++ b/build/src/main/resources/bin/jboss-cli.sh
@@ -68,6 +68,6 @@ else
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 eval \"$JAVA\" $JAVA_OPTS \"-Dlogging.configuration=file:$JBOSS_HOME/bin/jboss-cli-logging.properties\" -jar \"$JBOSS_HOME/jboss-modules.jar\" -mp \"$JBOSS_HOME/modules\" org.jboss.as.cli '"$@"'

--- a/build/src/main/resources/bin/standalone.conf
+++ b/build/src/main/resources/bin/standalone.conf
@@ -55,10 +55,10 @@ else
 fi
 
 # Sample JPDA settings for remote socket debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 # Sample JPDA settings for shared memory debugging
-#JAVA_OPTS="$JAVA_OPTS -Xrunjdwp:transport=dt_shmem,server=y,suspend=n,address=jboss"
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
 
 # Uncomment to not use JBoss Modules lockless mode
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=false"

--- a/build/src/main/resources/bin/standalone.conf.bat
+++ b/build/src/main/resources/bin/standalone.conf.bat
@@ -62,10 +62,10 @@ rem # Set the default configuration file to use if -c or --server-config are not
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.default.config=standalone.xml"
 
 rem # Sample JPDA settings for remote socket debugging
-rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
+rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
 rem # Sample JPDA settings for shared memory debugging
-rem set "JAVA_OPTS=%JAVA_OPTS% -Xrunjdwp:transport=dt_shmem,address=jboss,server=y,suspend=n"
+rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,server=y,suspend=n"
 
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"

--- a/build/src/main/resources/bin/wsconsume.sh
+++ b/build/src/main/resources/bin/wsconsume.sh
@@ -55,7 +55,7 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 #JPDA options. Uncomment and modify as appropriate to enable remote debugging .
-#JAVA_OPTS="-classic -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y $JAVA_OPTS"
+#JAVA_OPTS="-classic -Xdebug -Xnoagent -Djava.compiler=NONE -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y $JAVA_OPTS"
 
 # Setup JBoss sepecific properties
 JAVA_OPTS="$JAVA_OPTS"

--- a/build/src/main/resources/bin/wsprovide.sh
+++ b/build/src/main/resources/bin/wsprovide.sh
@@ -55,7 +55,7 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 #JPDA options. Uncomment and modify as appropriate to enable remote debugging .
-#JAVA_OPTS="-classic -Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y $JAVA_OPTS"
+#JAVA_OPTS="-classic -Xdebug -Xnoagent -Djava.compiler=NONE -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y $JAVA_OPTS"
 
 # Setup JBoss sepecific properties
 JAVA_OPTS="$JAVA_OPTS"

--- a/build/src/main/resources/domain/configuration/host.xml
+++ b/build/src/main/resources/domain/configuration/host.xml
@@ -65,7 +65,7 @@
             <!-- Remote JPDA debugging for a specific server
             <jvm name="default">
               <jvm-options>
-                <option value="-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"/>
+                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
               </jvm-options>
            </jvm>
            -->

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmOptionsBuilderFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmOptionsBuilderFactory.java
@@ -111,13 +111,7 @@ public class JvmOptionsBuilderFactory {
                 command.add("-javaagent:" + jvmElement.getJavaagent());
             }
             if (jvmElement.isDebugEnabled() != null && jvmElement.isDebugEnabled() && jvmElement.getDebugOptions() != null) {
-                String debugOptions = jvmElement.getDebugOptions();
-                if(debugOptions != null) {
-                    if(! debugOptions.startsWith("-X")) {
-                        debugOptions = "-X" + debugOptions;
-                    }
-                    command.add(debugOptions);
-                }
+                command.add(jvmElement.getDebugOptions());
             }
             List<String> options = jvmElement.getJvmOptions().getOptions();
             if (options.size() > 0) {
@@ -131,6 +125,11 @@ public class JvmOptionsBuilderFactory {
                         continue;
                     }
                     if (!checkOption(jvmElement.getStack() != null && option.startsWith("-Xss"), jvmName, option, Element.STACK.toString())) {
+                        continue;
+                    }
+                    if (!checkOption(jvmElement.isDebugEnabled() != null && jvmElement.isDebugEnabled() && jvmElement.getDebugOptions() != null &&
+                            (option.startsWith("-Xrunjdwp") || option.startsWith("-agentlib:jdwp")),
+                            jvmName, option, Attribute.DEBUG_OPTIONS.toString())) {
                         continue;
                     }
                     if (!checkOption(jvmElement.getAgentPath() != null && option.startsWith("-agentpath:"), jvmName, option, Element.AGENT_PATH.toString())) {
@@ -149,11 +148,6 @@ public class JvmOptionsBuilderFactory {
                         continue;
                     }
                     if (!checkOption(jvmElement.getJavaagent() != null && option.startsWith("-XX:MaxPermSize"), jvmName, option, Element.PERMGEN.toString())) {
-                        continue;
-                    }
-                    if (!checkOption(jvmElement.isDebugEnabled() != null && jvmElement.isDebugEnabled()
-                            && jvmElement.getDebugOptions() != null && option.startsWith("-Xrunjdwp"), jvmName, option,
-                            Attribute.DEBUG_OPTIONS.toString())) {
                         continue;
                     }
                     command.add(option);

--- a/host-controller/src/test/java/org/jboss/as/host/controller/model/jvm/JvmOptionsBuilderUnitTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/model/jvm/JvmOptionsBuilderUnitTestCase.java
@@ -71,7 +71,7 @@ public class JvmOptionsBuilderUnitTestCase {
     private void testDebugOptionsNotEnabled(JvmType type) {
         JvmElement element = JvmElementTestUtils.create(type);
         JvmElementTestUtils.setDebugEnabled(element, false);
-        JvmElementTestUtils.setDebugOptions(element, "-Xrunjdwp:transport=dt_socket,server=y,suspend=n");
+        JvmElementTestUtils.setDebugOptions(element, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
 
         List<String> command = new ArrayList<String>();
         JvmOptionsBuilderFactory.getInstance().addOptions(element, command);
@@ -92,13 +92,13 @@ public class JvmOptionsBuilderUnitTestCase {
     private void testDebugOptionsAndEnabled(JvmType type) {
         JvmElement element = JvmElementTestUtils.create(type);
         JvmElementTestUtils.setDebugEnabled(element, true);
-        JvmElementTestUtils.setDebugOptions(element, "-Xrunjdwp:transport=dt_socket,server=y,suspend=n");
+        JvmElementTestUtils.setDebugOptions(element, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
 
         List<String> command = new ArrayList<String>();
         JvmOptionsBuilderFactory.getInstance().addOptions(element, command);
 
         Assert.assertEquals(1, command.size());
-        Assert.assertTrue(command.contains("-Xrunjdwp:transport=dt_socket,server=y,suspend=n"));
+        Assert.assertTrue(command.contains("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n"));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class JvmOptionsBuilderUnitTestCase {
 
         //Main schema
         JvmElementTestUtils.setDebugEnabled(element, true);
-        JvmElementTestUtils.setDebugOptions(element, "-Xrunjdwp:transport=dt_socket,server=y,suspend=n");
+        JvmElementTestUtils.setDebugOptions(element, "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
         JvmElementTestUtils.setHeapSize(element, "28M");
         JvmElementTestUtils.setMaxHeap(element, "96M");
         JvmElementTestUtils.setPermgenSize(element, "32M");
@@ -285,7 +285,7 @@ public class JvmOptionsBuilderUnitTestCase {
         JvmElementTestUtils.addJvmOption(element, "-Xblah1=yes");
         JvmElementTestUtils.addJvmOption(element, "-Xblah2=no");
         //Ignored options
-        JvmElementTestUtils.addJvmOption(element, "-Xrunjdwp:ignoreme");
+        JvmElementTestUtils.addJvmOption(element, "-agentlib:jdwp=ignoreme");
         JvmElementTestUtils.addJvmOption(element, "-Xms1024M");
         JvmElementTestUtils.addJvmOption(element, "-Xmx1024M");
         JvmElementTestUtils.addJvmOption(element, "-XX:PermSize=1024M");
@@ -298,7 +298,7 @@ public class JvmOptionsBuilderUnitTestCase {
         JvmOptionsBuilderFactory.getInstance().addOptions(element, command);
 
         Assert.assertEquals(type == JvmType.SUN ? 10 : 8, command.size());
-        Assert.assertTrue(command.contains("-Xrunjdwp:transport=dt_socket,server=y,suspend=n"));
+        Assert.assertTrue(command.contains("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n"));
         Assert.assertTrue(command.contains("-Xms28M"));
         Assert.assertTrue(command.contains("-Xmx96M"));
         if (type == JvmType.SUN) {

--- a/pom.xml
+++ b/pom.xml
@@ -6031,7 +6031,7 @@
                 </property>
             </activation>
             <properties>
-                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
+                <surefire.jpda.args>-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
 

--- a/process-controller/src/test/java/org/jboss/as/process/support/TestProcessUtils.java
+++ b/process-controller/src/test/java/org/jboss/as/process/support/TestProcessUtils.java
@@ -93,7 +93,7 @@ public abstract class TestProcessUtils {
         cmd.add(System.getProperty("java.class.path"));
 
         if (debugPort > 0)
-            cmd.add("-Xrunjdwp:transport=dt_socket,address=" + debugPort
+            cmd.add("-agentlib:jdwp=transport=dt_socket,address=" + debugPort
                     + ",server=y,suspend=" + (suspend ? "y" : "n"));
 
         cmd.add(classname);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/EPCPropagationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/EPCPropagationTestCase.java
@@ -41,7 +41,7 @@ import org.junit.runner.RunWith;
 
 /**
  * For managed debugging:
- * -Djboss.options="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y"
+ * -Djboss.options="-Djava.compiler=NONE -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=y"
  * <p/>
  * For embedded debugging:
  *  start AS standalone and attach debugger

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-0.xml
@@ -60,7 +60,7 @@
             <!-- Remote JPDA debugging for a specific server
             <jvm name="default">
               <jvm-options>
-                <option value="-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"/>
+                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
               </jvm-options>
            </jvm>
            -->

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-1.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-1.xml
@@ -60,7 +60,7 @@
             <!-- Remote JPDA debugging for a specific server
             <jvm name="default">
               <jvm-options>
-                <option value="-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"/>
+                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
               </jvm-options>
            </jvm>
            -->

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-2.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/7-1-2.xml
@@ -65,7 +65,7 @@
             <!-- Remote JPDA debugging for a specific server
             <jvm name="default">
               <jvm-options>
-                <option value="-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"/>
+                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
               </jvm-options>
            </jvm>
            -->

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -610,14 +610,14 @@
             <id>jpda.profile</id>
             <activation><property><name>jpda</name></property></activation>
             <properties>
-                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=${as.debug.port},server=y,suspend=y</surefire.jpda.args>
+                <surefire.jpda.args>-agentlib:jdwp=transport=dt_socket,address=${as.debug.port},server=y,suspend=y</surefire.jpda.args>
             </properties>
         </profile>
         <profile>
             <id>debug.profile</id>
             <activation><property><name>debug</name></property></activation>
             <properties>
-                <surefire.jpda.args>-Xrunjdwp:transport=dt_socket,address=${as.debug.port},server=y,suspend=n</surefire.jpda.args>
+                <surefire.jpda.args>-agentlib:jdwp=transport=dt_socket,address=${as.debug.port},server=y,suspend=n</surefire.jpda.args>
             </properties>
         </profile>
 


### PR DESCRIPTION
Replace the old, non-standard debug options (-Xrunjdwp) with the standard option (-agentlib:jdwp).
