### PR TITLE
[7.1 branch] Fix for AS7-5368 and AS7-5331

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -46,6 +46,7 @@ public class InterceptorOrder {
         public static final int JPA_SESSION_BEAN_INTERCEPTOR = 0x600;
         public static final int SINGLETON_CONTAINER_MANAGED_CONCURRENCY_INTERCEPTOR = 0x700;
         public static final int CMP_RELATIONSHIP_INTERCEPTOR = 0x800;
+        public static final int USER_TX_ACCESS_PERMISSION_INTERCEPTOR = 0x801;
         // WS handlers, user and CDI interceptors plus the bean method are considered user execution time
         public static final int EJB_EXECUTION_TIME_INTERCEPTOR = 0x850;
         // JSR 109 - Version 1.3 - 6.2.2.4 Security
@@ -70,6 +71,7 @@ public class InterceptorOrder {
     public static final class ComponentPostConstruct {
 
         public static final int TCCL_INTERCEPTOR = 0x100;
+        public static final int USER_TX_ACCESS_PERMISSION_INTERCEPTOR = 0x101;
         public static final int EJB_SESSION_CONTEXT_INTERCEPTOR = 0x200;
         public static final int TRANSACTION_INTERCEPTOR = 0x300;
         public static final int JPA_SFSB_PRE_CREATE = 0x400;
@@ -93,6 +95,7 @@ public class InterceptorOrder {
     public static final class ComponentPreDestroy {
 
         public static final int TCCL_INTERCEPTOR = 0x100;
+        public static final int USER_TX_ACCESS_PERMISSION_INTERCEPTOR = 0x101;
         public static final int EJB_SESSION_CONTEXT_INTERCEPTOR = 0x200;
         public static final int TRANSACTION_INTERCEPTOR = 0x300;
         public static final int JNDI_NAMESPACE_INTERCEPTOR = 0x400;
@@ -111,6 +114,7 @@ public class InterceptorOrder {
     public static final class ComponentPassivation {
 
         public static final int TCCL_INTERCEPTOR = 0x100;
+        public static final int USER_TX_ACCESS_PERMISSION_INTERCEPTOR = 0x101;
         public static final int EJB_SESSION_CONTEXT_INTERCEPTOR = 0x200;
         public static final int TRANSACTION_INTERCEPTOR = 0x300;
         public static final int JNDI_NAMESPACE_INTERCEPTOR = 0x400;
@@ -134,6 +138,7 @@ public class InterceptorOrder {
         public static final int EJB_EXCEPTION_LOGGING_INTERCEPTOR = 0x210;
         public static final int SHUTDOWN_INTERCEPTOR = 0x220;
         public static final int INVALID_METHOD_EXCEPTION = 0x230;
+        public static final int USER_TX_ACCESS_PERMISSION_INTERCEPTOR = 0x240;
         public static final int SECURITY_CONTEXT = 0x250;
         public static final int EJB_SECURITY_AUTHORIZATION_INTERCEPTOR = 0x300;
         // after security we take note of the invocation

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -21,12 +21,29 @@
  */
 package org.jboss.as.ejb3.component;
 
-import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.Principal;
-import java.security.PrivilegedAction;
-import java.util.Collections;
-import java.util.Map;
+import org.jboss.as.controller.security.ServerSecurityManager;
+import org.jboss.as.ee.component.BasicComponent;
+import org.jboss.as.ee.component.ComponentView;
+import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
+import org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory;
+import org.jboss.as.ejb3.component.invocationmetrics.InvocationMetrics;
+import org.jboss.as.ejb3.context.CurrentInvocationContext;
+import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
+import org.jboss.as.ejb3.security.EJBSecurityMetaData;
+import org.jboss.as.ejb3.tx.ApplicationExceptionDetails;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.context.NamespaceContextSelector;
+import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.as.txn.service.UserTransactionAccessRightService;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBHomeLocator;
+import org.jboss.invocation.InterceptorContext;
+import org.jboss.invocation.InterceptorFactory;
+import org.jboss.invocation.proxy.MethodIdentifier;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 
 import javax.ejb.EJBHome;
 import javax.ejb.EJBLocalHome;
@@ -41,30 +58,12 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
-
-import org.jboss.as.controller.security.ServerSecurityManager;
-import org.jboss.as.ee.component.BasicComponent;
-import org.jboss.as.ee.component.ComponentView;
-import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
-import org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory;
-import org.jboss.as.ejb3.component.invocationmetrics.InvocationMetrics;
-import org.jboss.as.ejb3.context.CurrentInvocationContext;
-import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
-import org.jboss.as.ejb3.security.EJBSecurityMetaData;
-import org.jboss.as.ejb3.tx.ApplicationExceptionDetails;
-import org.jboss.as.naming.ManagedReference;
-import org.jboss.as.naming.context.NamespaceContextSelector;
-import org.jboss.as.server.CurrentServiceContainer;
-import org.jboss.ejb.client.EJBClient;
-import org.jboss.ejb.client.EJBHomeLocator;
-import org.jboss.invocation.InterceptorContext;
-import org.jboss.invocation.InterceptorFactory;
-import org.jboss.invocation.proxy.MethodIdentifier;
-import org.jboss.logging.Logger;
-import org.jboss.msc.service.ServiceContainer;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.StopContext;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.jboss.as.ejb3.EjbLogger.EJB3_LOGGER;
 import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
@@ -358,7 +357,7 @@ public abstract class EJBComponent extends BasicComponent {
         return utilities.getUserTransaction();
     }
 
-    private boolean isBeanManagedTransaction() {
+    boolean isBeanManagedTransaction() {
         return isBeanManagedTransaction;
     }
 
@@ -498,5 +497,9 @@ public abstract class EJBComponent extends BasicComponent {
 
     protected ShutDownInterceptorFactory getShutDownInterceptorFactory() {
         return shutDownInterceptorFactory;
+    }
+
+    UserTransactionAccessRightService getUserTransactionAccessRightService() {
+        return this.utilities.getUserTransactionAccessRightService();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -28,6 +28,7 @@ import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ee.component.ComponentConfigurator;
 import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.ComponentInterceptorFactory;
 import org.jboss.as.ee.component.ComponentNamingMode;
 import org.jboss.as.ee.component.ComponentStartService;
 import org.jboss.as.ee.component.ComponentView;
@@ -42,11 +43,14 @@ import org.jboss.as.ee.component.ViewService;
 import org.jboss.as.ee.component.interceptors.ComponentDispatcherInterceptor;
 import org.jboss.as.ee.component.interceptors.InterceptorOrder;
 import org.jboss.as.ee.naming.ContextInjectionSource;
+import org.jboss.as.ejb3.EjbLogger;
+import org.jboss.as.ejb3.component.entity.EntityBeanComponent;
 import org.jboss.as.ejb3.component.interceptors.AdditionalSetupInterceptor;
 import org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor;
 import org.jboss.as.ejb3.component.interceptors.EjbExceptionTransformingInterceptorFactories;
 import org.jboss.as.ejb3.component.interceptors.LoggingInterceptor;
 import org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory;
+import org.jboss.as.ejb3.component.interceptors.UserTransactionAccessRightInterceptor;
 import org.jboss.as.ejb3.component.invocationmetrics.ExecutionTimeInterceptor;
 import org.jboss.as.ejb3.deployment.ApplicableMethodInformation;
 import org.jboss.as.ejb3.deployment.ApplicationExceptions;
@@ -69,6 +73,7 @@ import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
+import org.jboss.invocation.InterceptorFactoryContext;
 import org.jboss.metadata.ejb.spec.EnterpriseBeanMetaData;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
 import org.jboss.msc.service.Service;
@@ -226,6 +231,8 @@ public abstract class EJBComponentDescription extends ComponentDescription {
         this.addCurrentInvocationContextFactory();
         // setup a dependency on EJB remote tx repository service, if this EJB exposes atleast one remote view
         this.addRemoteTransactionsRepositoryDependency();
+        // setup UserTransaction access permission interceptors
+        this.setupUserTxAccessPermissionInterceptors();
         this.transactionAttributes = new ApplicableMethodInformation<TransactionAttributeType>(componentName, TransactionAttributeType.REQUIRED);
         this.transactionTimeouts = new ApplicableMethodInformation<Integer>(componentName, null);
         this.descriptorMethodPermissions = new ApplicableMethodInformation<EJBMethodSecurityAttribute>(componentName, null);
@@ -445,6 +452,28 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                     }
                 }
                 return false;
+            }
+        });
+    }
+
+    /**
+     * Sets up component interceptors for the EJB component, which will set/reset the permission for accessing the
+     * {@link javax.transaction.UserTransaction} depending on whether the EJB is a BMT or a CMT
+     */
+    protected void setupUserTxAccessPermissionInterceptors() {
+
+        this.getConfigurators().add(new ComponentConfigurator() {
+            @Override
+            public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration componentConfiguration) throws DeploymentUnitProcessingException {
+                // setup the interceptors
+                componentConfiguration.addComponentInterceptor(UserTxAccessPermissionComponentInterceptorFactory.INSTANCE, InterceptorOrder.Component.USER_TX_ACCESS_PERMISSION_INTERCEPTOR, true);
+                componentConfiguration.addPostConstructInterceptor(UserTxAccessPermissionComponentInterceptorFactory.INSTANCE, InterceptorOrder.ComponentPostConstruct.USER_TX_ACCESS_PERMISSION_INTERCEPTOR);
+                componentConfiguration.addPreDestroyInterceptor(UserTxAccessPermissionComponentInterceptorFactory.INSTANCE, InterceptorOrder.ComponentPreDestroy.USER_TX_ACCESS_PERMISSION_INTERCEPTOR);
+                if (description.isPassivationApplicable()) {
+                    componentConfiguration.addPrePassivateInterceptor(UserTxAccessPermissionComponentInterceptorFactory.INSTANCE, InterceptorOrder.ComponentPassivation.USER_TX_ACCESS_PERMISSION_INTERCEPTOR);
+                    componentConfiguration.addPostActivateInterceptor(UserTxAccessPermissionComponentInterceptorFactory.INSTANCE, InterceptorOrder.ComponentPassivation.USER_TX_ACCESS_PERMISSION_INTERCEPTOR);
+                }
+                componentConfiguration.addTimeoutViewInterceptor(UserTxAccessPermissionComponentInterceptorFactory.INSTANCE, InterceptorOrder.View.USER_TX_ACCESS_PERMISSION_INTERCEPTOR);
             }
         });
     }
@@ -698,6 +727,26 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                 throw MESSAGES.componentViewNotAvailableInContext(context);
             }
             return "Proxy for view class: " + componentView.getViewClass().getName() + " of EJB: " + name;
+        }
+    }
+
+    /**
+     * A {@link ComponentInterceptorFactory} which sets up the {@link UserTransactionAccessRightInterceptor} for
+     * EJB components
+     */
+    private static class UserTxAccessPermissionComponentInterceptorFactory extends ComponentInterceptorFactory {
+        static final UserTxAccessPermissionComponentInterceptorFactory INSTANCE = new UserTxAccessPermissionComponentInterceptorFactory();
+
+        @Override
+        protected Interceptor create(final Component component, final InterceptorFactoryContext context) {
+            if (!(component instanceof EJBComponent)) {
+                throw EjbLogger.EJB3_LOGGER.notAnEJBComponent(component);
+            }
+            final EJBComponent ejbComponent = (EJBComponent) component;
+            // UserTransaction access is only allowed for BMT session and message driven beans. Entity beans
+            // and CMT beans are *not* allowed UserTransaction access
+            final boolean userTxAccessAllowed = ejbComponent.isBeanManagedTransaction() && !(ejbComponent instanceof EntityBeanComponent);
+            return new UserTransactionAccessRightInterceptor(ejbComponent.getUserTransactionAccessRightService(), userTxAccessAllowed);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -37,6 +37,8 @@ import javax.transaction.UserTransaction;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
+import org.jboss.as.txn.service.UserTransactionAccessRightService;
+import org.jboss.as.txn.service.UserTransactionService;
 import org.jboss.jca.core.spi.rar.Activation;
 import org.jboss.jca.core.spi.rar.Endpoint;
 import org.jboss.jca.core.spi.rar.MessageListener;
@@ -44,6 +46,7 @@ import org.jboss.jca.core.spi.rar.NotFoundException;
 import org.jboss.jca.core.spi.rar.ResourceAdapterRepository;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
@@ -70,6 +73,7 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
     private final InjectedValue<TransactionManager> transactionManagerValue = new InjectedValue<TransactionManager>();
     private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<UserTransaction> userTransactionValue = new InjectedValue<UserTransaction>();
+    private final InjectedValue<UserTransactionAccessRightService> userTxAccessRightService = new InjectedValue<UserTransactionAccessRightService>();
 
     private volatile boolean statisticsEnabled = false;
 
@@ -191,6 +195,14 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
 
     public Injector<UserTransaction> getUserTransactionInjector() {
         return userTransactionValue;
+    }
+
+    UserTransactionAccessRightService getUserTransactionAccessRightService() {
+        return this.userTxAccessRightService.getValue();
+    }
+
+    public Injector<UserTransactionAccessRightService> getUserTransactionAccessRightServiceInjector() {
+        return this.userTxAccessRightService;
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/UserTransactionAccessRightInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/UserTransactionAccessRightInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component.interceptors;
+
+import org.jboss.as.txn.service.UserTransactionAccessRightService;
+import org.jboss.invocation.InterceptorContext;
+
+/**
+ * An {@link org.jboss.invocation.Interceptor} which toggles access to {@link javax.transaction.UserTransaction}
+ * for EJB components based on the type of the EJB component and the transaction semantics of the EJB component
+ * This interceptor is here to take care of the EJB spec requirement that only BMT session and message driven beans
+ * are allowed access to {@link javax.transaction.UserTransaction} and CMT and entity beans aren't allowed access to it.
+ *
+ * @author Jaikiran Pai
+ */
+public class UserTransactionAccessRightInterceptor extends AbstractEJBInterceptor {
+
+    private final UserTransactionAccessRightService userTxAccessRightService;
+    private final boolean userTxAcessAllowed;
+
+    public UserTransactionAccessRightInterceptor(final UserTransactionAccessRightService userTxAccessRightService, final boolean userTxAcessAllowed) {
+        this.userTxAccessRightService = userTxAccessRightService;
+        this.userTxAcessAllowed = userTxAcessAllowed;
+    }
+
+
+    @Override
+    public Object processInvocation(final InterceptorContext context) throws Exception {
+        // Push the appropriate permission for UserTransaction access for the current thread
+        if (this.userTxAcessAllowed) {
+            this.userTxAccessRightService.pushAccessPermission(UserTransactionAccessRightService.UserTransactionAccessPermission.ALLOWED);
+        } else {
+            this.userTxAccessRightService.pushAccessPermission(UserTransactionAccessRightService.UserTransactionAccessPermission.DISALLOWED);
+        }
+        try {
+            return context.proceed();
+        } finally {
+            // done with the execution, so let's pop the current permission associated with this thread
+            this.userTxAccessRightService.popAccessPermission();
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -113,6 +113,7 @@ import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.txn.service.TxnServices;
+import org.jboss.as.txn.service.UserTransactionAccessRightService;
 import org.jboss.com.sun.corba.se.impl.javax.rmi.RemoteObjectSubstitutionManager;
 import org.jboss.dmr.ModelNode;
 import org.jboss.ejb.client.EJBClientContext;
@@ -304,6 +305,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, utilities.getTransactionManagerInjector())
                     .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, utilities.getTransactionSynchronizationRegistryInjector())
                     .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION, UserTransaction.class, utilities.getUserTransactionInjector())
+                    .addDependency(UserTransactionAccessRightService.SERVICE_NAME, UserTransactionAccessRightService.class, utilities.getUserTransactionAccessRightServiceInjector())
                     .addListener(verificationHandler)
                     .setInitialMode(ServiceController.Mode.ACTIVE)
                     .install());

--- a/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
@@ -128,8 +128,9 @@ public class ServiceBasedNamingStore implements NamingStore {
             try {
                 object = controller.getValue();
             } catch (IllegalStateException e) {
-                //occurs if the service is not actually up
-                throw new NameNotFoundException("Error looking up " + name + ", service " + lookupName + " is not started");
+                final NamingException namingException = new NamingException("Error looking up " + name + ", service " + lookupName);
+                namingException.setRootCause(e);
+                throw namingException;
             }
         } else {
             return null;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/resourceref/ejb-jar.xml
@@ -13,6 +13,7 @@
             <business-remote>org.jboss.as.test.integration.ee.injection.resource.resourceref.StatelessBeanRemote</business-remote>
             <ejb-class>org.jboss.as.test.integration.ee.injection.resource.resourceref.StatelessBean</ejb-class>
             <session-type>Stateless</session-type>
+            <transaction-type>Bean</transaction-type>
             
             <resource-env-ref>
                 <resource-env-ref-name>MyEJBContext</resource-env-ref-name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/packaging/war/namingcontext/War1Ejb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/packaging/war/namingcontext/War1Ejb.java
@@ -24,6 +24,8 @@ package org.jboss.as.test.integration.ejb.packaging.war.namingcontext;
 import javax.annotation.Resource;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.transaction.UserTransaction;
@@ -33,6 +35,7 @@ import javax.transaction.UserTransaction;
  */
 @Stateless
 @LocalBean
+@TransactionManagement(value = TransactionManagementType.BEAN)
 public class War1Ejb implements EjbInterface {
 
     @Resource

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/packaging/war/namingcontext/War2Ejb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/packaging/war/namingcontext/War2Ejb.java
@@ -24,6 +24,8 @@ package org.jboss.as.test.integration.ejb.packaging.war.namingcontext;
 import javax.annotation.Resource;
 import javax.ejb.LocalBean;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.transaction.UserTransaction;
@@ -33,6 +35,7 @@ import javax.transaction.UserTransaction;
  */
 @Stateless
 @LocalBean
+@TransactionManagement(value = TransactionManagementType.BEAN)
 public class War2Ejb implements EjbInterface {
 
     @Resource

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/usertransaction/BMTSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/usertransaction/BMTSLSB.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.usertransaction;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJBContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@TransactionManagement(value = TransactionManagementType.BEAN)
+public class BMTSLSB {
+
+    private static final Logger logger = Logger.getLogger(BMTSLSB.class);
+
+    @Resource
+    private EJBContext ejbContext;
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    @PostConstruct
+    void onConstruct() {
+        try {
+            this.checkUserTransactionAccess();
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void checkUserTransactionAvailability() {
+        try {
+            this.checkUserTransactionAccess();
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    private void checkUserTransactionAccess() throws NamingException {
+        if (userTransaction == null) {
+            throw new RuntimeException("UserTransaction injection in a BMT bean was expected to happen successfully, but it didn't!");
+        }
+        // (JBoss specific) java:jboss/UserTransaction lookup string
+        final String utJndiName = "java:jboss/UserTransaction";
+        final UserTransaction userTxInJBossNamespace = InitialContext.doLookup(utJndiName);
+        if (userTxInJBossNamespace == null) {
+            throw new RuntimeException("UserTransaction lookup at " + utJndiName + " returned null in a BMT bean");
+        }
+        // (spec mandated) java:comp/UserTransaction lookup string
+        final String utJavaCompJndiName = "java:comp/UserTransaction";
+        final UserTransaction userTxInJavaCompNamespace = InitialContext.doLookup(utJavaCompJndiName);
+        if (userTxInJavaCompNamespace == null) {
+            throw new RuntimeException("UserTransaction lookup at " + utJavaCompJndiName + " returned null in a BMT bean");
+        }
+        // try invoking EJBContext.getUserTransaction()
+        final UserTransaction ut = ejbContext.getUserTransaction();
+        if (ut == null) {
+            throw new RuntimeException("EJBContext.getUserTransaction() returned null in a BMT bean");
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/usertransaction/CMTSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/usertransaction/CMTSLSB.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.usertransaction;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.EJBContext;
+import javax.ejb.Stateless;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+public class CMTSLSB {
+
+    private static final Logger logger = Logger.getLogger(CMTSLSB.class);
+
+    @Resource
+    private EJBContext ejbContext;
+
+    @EJB
+    private BMTSLSB bmtSlsb;
+
+    @PostConstruct
+    void onConstruct() {
+        this.checkUserTransactionAccess();
+    }
+
+    public void checkUserTransactionAccessDenial() {
+        // check access to UserTransaction
+        this.checkUserTransactionAccess();
+        // now invoke a BMT SLSB and we expect that, that bean has access to the UserTransaction during the invocation
+        this.bmtSlsb.checkUserTransactionAvailability();
+        // now check UserTransaction access for ourselves (again) after the call to the BMT bean has completed
+        this.checkUserTransactionAccess();
+    }
+
+    private void checkUserTransactionAccess() {
+        // (JBoss specific) java:jboss/UserTransaction lookup string
+        try {
+            final String utJndiName = "java:jboss/UserTransaction";
+            final UserTransaction userTxInJBossNamespace = InitialContext.doLookup(utJndiName);
+            throw new RuntimeException("UserTransaction lookup at " + utJndiName + " was expected to fail in a CMT bean");
+        } catch (NamingException e) {
+            // expected since it's in CMT
+            logger.info("Got the expected exception while looking up UserTransaction in CMT bean", e);
+        }
+        // (spec mandated) java:comp/UserTransaction lookup string
+        try {
+            final String utJavaCompJndiName = "java:comp/UserTransaction";
+            final UserTransaction userTxInJavaCompNamespace = InitialContext.doLookup(utJavaCompJndiName);
+            throw new RuntimeException("UserTransaction lookup at " + utJavaCompJndiName + " was expected to fail in a CMT bean");
+        } catch (NamingException e) {
+            // expected since it's in CMT
+            logger.info("Got the expected exception while looking up UserTransaction in CMT bean", e);
+        }
+        // try invoking EJBContext.getUserTransaction()
+        try {
+            final UserTransaction ut = ejbContext.getUserTransaction();
+            throw new RuntimeException("EJBContext.getUserTransaction() was expected to throw an exception when invoked from a CMT bean, but it didn't!");
+        } catch (IllegalStateException ise) {
+            // expected since it's in CMT
+            logger.info("Got the expected exception while looking up EJBContext.getUserTransaction() in CMT bean", ise);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/usertransaction/UserTransactionAccessTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/usertransaction/UserTransactionAccessTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.usertransaction;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import java.io.File;
+
+/**
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class UserTransactionAccessTestCase {
+
+    private static final String MODULE_NAME = "user-transaction-access-test";
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(UserTransactionAccessTestCase.class.getPackage());
+        jar.as(ZipExporter.class).exportTo(new File(".", jar.getName()), true);
+        return jar;
+    }
+
+    @Test
+    public void testUserTransactionLookupInBMT() throws Exception {
+        final CMTSLSB cmtSlsb = InitialContext.doLookup("java:module/" + CMTSLSB.class.getSimpleName() + "!" + CMTSLSB.class.getName());
+        cmtSlsb.checkUserTransactionAccessDenial();
+
+        // test with a BMT bean now
+        final BMTSLSB bmtSlsb = InitialContext.doLookup("java:module/" + BMTSLSB.class.getSimpleName() + "!" + BMTSLSB.class.getName());
+        bmtSlsb.checkUserTransactionAvailability();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/EJBResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/integration/ejb/EJBResource.java
@@ -26,7 +26,7 @@ import javax.ejb.Stateless;
 import javax.interceptor.Interceptors;
 import javax.transaction.Status;
 import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
+import javax.transaction.TransactionSynchronizationRegistry;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -38,11 +38,11 @@ import javax.ws.rs.Produces;
 public class EJBResource implements EjbInterface {
 
     @Resource
-    private UserTransaction userTransaction;
+    private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
     @GET
     public String getMessage() throws SystemException {
-        if(userTransaction.getStatus() != Status.STATUS_ACTIVE) {
+        if(transactionSynchronizationRegistry.getTransactionStatus() != Status.STATUS_ACTIVE) {
             throw new RuntimeException("Transaction not active, not an EJB invocation");
         }
         return "Hello";

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/IIOPTransactionalStatelessBean.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/IIOPTransactionalStatelessBean.java
@@ -5,8 +5,7 @@ import javax.ejb.RemoteHome;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
+import javax.transaction.TransactionSynchronizationRegistry;
 
 /**
  * @author Stuart Douglas
@@ -16,15 +15,11 @@ import javax.transaction.UserTransaction;
 public class IIOPTransactionalStatelessBean {
 
     @Resource
-    private UserTransaction userTransaction;
+    private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
     @TransactionAttribute(TransactionAttributeType.SUPPORTS)
     public int transactionStatus() {
-        try {
-            return userTransaction.getStatus();
-        } catch (SystemException e) {
-            throw new RuntimeException(e);
-        }
+        return transactionSynchronizationRegistry.getTransactionStatus();
     }
 
 }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatelessBean.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionalStatelessBean.java
@@ -22,9 +22,11 @@
 package org.jboss.as.test.multinode.transaction;
 
 import javax.annotation.Resource;
-import javax.ejb.*;
-import javax.transaction.SystemException;
-import javax.transaction.UserTransaction;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.transaction.TransactionSynchronizationRegistry;
 
 /**
  * @author Stuart Douglas
@@ -35,15 +37,11 @@ import javax.transaction.UserTransaction;
 public class TransactionalStatelessBean implements TransactionalRemote {
 
     @Resource
-    private UserTransaction userTransaction;
+    private TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
     @TransactionAttribute(TransactionAttributeType.SUPPORTS)
     public int transactionStatus() {
-        try {
-            return userTransaction.getStatus();
-        } catch (SystemException e) {
-            throw new RuntimeException(e);
-        }
+        return transactionSynchronizationRegistry.getTransactionStatus();
     }
 
 }

--- a/transactions/src/main/java/org/jboss/as/txn/TransactionMessages.java
+++ b/transactions/src/main/java/org/jboss/as/txn/TransactionMessages.java
@@ -103,5 +103,8 @@ public interface TransactionMessages {
     @Message(id = 10106, value = "MBean Server service not installed, this functionality is not available if the JMX subsystem has not been installed.")
     RuntimeException jmxSubsystemNotInstalled();
 
+    @Message(id = 10107, value = "Access to javax.transaction.UserTransaction is not allowed")
+    IllegalStateException userTransactionAccessNotAllowed();
+
 
 }

--- a/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionJndiBindingProcessor.java
+++ b/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionJndiBindingProcessor.java
@@ -39,9 +39,12 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
+import org.jboss.as.txn.service.UserTransactionAccessRightService;
+import org.jboss.as.txn.service.UserTransactionBindingService;
 import org.jboss.as.txn.service.UserTransactionService;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
+
 
 /**
  * Processor responsible for binding transaction related resources to JNDI.
@@ -87,11 +90,12 @@ public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor 
     private void bindServices(DeploymentUnit deploymentUnit, ServiceTarget serviceTarget, EEModuleDescription description,String componentName,ServiceName contextServiceName) {
 
         final ServiceName userTransactionServiceName = contextServiceName.append("UserTransaction");
-        BinderService userTransactionBindingService = new BinderService("UserTransaction");
+        final UserTransactionBindingService userTransactionBindingService = new UserTransactionBindingService("UserTransaction");
         serviceTarget.addService(userTransactionServiceName, userTransactionBindingService)
             .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class,
                     new ManagedReferenceInjector<UserTransaction>(userTransactionBindingService.getManagedObjectInjector()))
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, userTransactionBindingService.getNamingStoreInjector())
+            .addDependency(UserTransactionAccessRightService.SERVICE_NAME, UserTransactionAccessRightService.class, userTransactionBindingService.getUserTransactionAccessRightServiceInjector())
             .install();
         deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES,userTransactionServiceName);
 
@@ -109,4 +113,5 @@ public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor 
     @Override
     public void undeploy(DeploymentUnit context) {
     }
+
 }

--- a/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionAccessRightService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionAccessRightService.java
@@ -28,7 +28,8 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * {@link UserTransactionAccessRightService} allows enabling/disabling access to the {@link javax.transaction.UserTransaction}
@@ -54,10 +55,10 @@ public class UserTransactionAccessRightService implements Service<UserTransactio
     }
 
     // The stack of current permissions associated with the thread
-    private final ThreadLocal<Stack<UserTransactionAccessPermission>> currentPermissions = new ThreadLocal<Stack<UserTransactionAccessPermission>>() {
+    private final ThreadLocal<Deque<UserTransactionAccessPermission>> currentPermissions = new ThreadLocal<Deque<UserTransactionAccessPermission>>() {
         @Override
-        protected Stack<UserTransactionAccessPermission> initialValue() {
-            return new Stack<UserTransactionAccessPermission>();
+        protected Deque<UserTransactionAccessPermission> initialValue() {
+            return new ArrayDeque<UserTransactionAccessPermission>();
         }
     };
 
@@ -82,7 +83,7 @@ public class UserTransactionAccessRightService implements Service<UserTransactio
      * @param permission
      */
     public void pushAccessPermission(final UserTransactionAccessPermission permission) {
-        final Stack<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
+        final Deque<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
         permissions.push(permission);
     }
 
@@ -92,7 +93,7 @@ public class UserTransactionAccessRightService implements Service<UserTransactio
      * @return
      */
     public UserTransactionAccessPermission popAccessPermission() {
-        final Stack<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
+        final Deque<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
         return permissions.pop();
     }
 
@@ -103,7 +104,7 @@ public class UserTransactionAccessRightService implements Service<UserTransactio
      * @return
      */
     public boolean isUserTransactionAccessDisAllowed() {
-        final Stack<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
+        final Deque<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
         if (permissions.isEmpty()) {
             return false;
         }

--- a/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionAccessRightService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionAccessRightService.java
@@ -1,0 +1,113 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.service;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+import java.util.Stack;
+
+/**
+ * {@link UserTransactionAccessRightService} allows enabling/disabling access to the {@link javax.transaction.UserTransaction}
+ * at runtime. Typically, components (like the EJB component), at runtime, based on a certain criteria decide whether or not
+ * access to the {@link javax.transaction.UserTransaction} is allowed during an invocation associated with a thread.
+ * The {@link UserTransactionService} and the {@link UserTransactionBindingService} which are responsible for handing
+ * out the {@link javax.transaction.UserTransaction} use this {@link UserTransactionAccessRightService} to decide whether
+ * or not they should hand out the {@link javax.transaction.UserTransaction}
+ *
+ * @author Jaikiran Pai
+ */
+public class UserTransactionAccessRightService implements Service<UserTransactionAccessRightService> {
+
+    public static final ServiceName SERVICE_NAME = TxnServices.JBOSS_TXN.append("UserTransactionAccessRightService");
+
+    /**
+     * Permissions for access to P{@link javax.transaction.UserTransaction}. {@link #ALLOWED} will
+     * allow access whereas {@link #DISALLOWED} will disallow access to {@link javax.transaction.UserTransaction}
+     */
+    public enum UserTransactionAccessPermission {
+        ALLOWED,
+        DISALLOWED
+    }
+
+    // The stack of current permissions associated with the thread
+    private final ThreadLocal<Stack<UserTransactionAccessPermission>> currentPermissions = new ThreadLocal<Stack<UserTransactionAccessPermission>>() {
+        @Override
+        protected Stack<UserTransactionAccessPermission> initialValue() {
+            return new Stack<UserTransactionAccessPermission>();
+        }
+    };
+
+    @Override
+    public void start(StartContext context) throws StartException {
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    @Override
+    public UserTransactionAccessRightService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    /**
+     * "Pushes" the passed {@link UserTransactionAccessPermission permission} on to a stack of permissions
+     * for the current thread. This permission will then be associated with this thread, until someone invokes
+     * this method again or invokes the {@link #popAccessPermission()} method to change the permission
+     *
+     * @param permission
+     */
+    public void pushAccessPermission(final UserTransactionAccessPermission permission) {
+        final Stack<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
+        permissions.push(permission);
+    }
+
+    /**
+     * "Pops" the current {@link UserTransactionAccessPermission permission} that's associated with the thread.
+     *
+     * @return
+     */
+    public UserTransactionAccessPermission popAccessPermission() {
+        final Stack<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
+        return permissions.pop();
+    }
+
+    /**
+     * Returns true if the current thread is associated with a {@link UserTransactionAccessPermission#DISALLOWED}
+     * permission. Else returns false in all other cases.
+     *
+     * @return
+     */
+    public boolean isUserTransactionAccessDisAllowed() {
+        final Stack<UserTransactionAccessPermission> permissions = this.currentPermissions.get();
+        if (permissions.isEmpty()) {
+            return false;
+        }
+        return permissions.peek() == UserTransactionAccessPermission.DISALLOWED;
+    }
+
+}

--- a/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionBindingService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionBindingService.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.service;
+
+import org.jboss.as.naming.ManagedReferenceFactory;
+import org.jboss.as.naming.service.BinderService;
+import org.jboss.as.txn.TransactionMessages;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.value.InjectedValue;
+
+/**
+ * A special type of {@link BinderService} used to bind {@link javax.transaction.UserTransaction} instances.
+ * This {@link UserTransactionBindingService} checks the
+ * {@link org.jboss.as.txn.service.UserTransactionAccessRightService#isUserTransactionAccessDisAllowed() permission to access the UserTransaction}
+ * before handing out the {@link javax.transaction.UserTransaction} instance from its {@link #getValue()} method.
+ * If the caller is {@link org.jboss.as.txn.service.UserTransactionAccessRightService.UserTransactionAccessPermission#DISALLOWED}
+ * access to the {@link javax.transaction.UserTransaction} when {@link #getValue()} is called, then this service throws
+ * an exception
+ *
+ * @author Jaikiran Pai
+ */
+public class UserTransactionBindingService extends BinderService {
+
+    private final InjectedValue<UserTransactionAccessRightService> userTxAccessRights = new InjectedValue<UserTransactionAccessRightService>();
+
+    public UserTransactionBindingService(final String name) {
+        super(name);
+    }
+
+    @Override
+    public synchronized ManagedReferenceFactory getValue() throws IllegalStateException {
+        // check if access to UserTransaction is disallowed. If so, throw an exception
+        final boolean accessDisallowed = userTxAccessRights.getValue().isUserTransactionAccessDisAllowed();
+        if (accessDisallowed) {
+            throw TransactionMessages.MESSAGES.userTransactionAccessNotAllowed();
+        }
+        return super.getValue();
+    }
+
+    public Injector<UserTransactionAccessRightService> getUserTransactionAccessRightServiceInjector() {
+        return this.userTxAccessRights;
+    }
+}


### PR DESCRIPTION
The commits in this PR fixes the issue where the UserTransaction was made available to CMT beans in violation to the EJB spec. The issue was reported in https://issues.jboss.org/browse/AS7-5368 and https://issues.jboss.org/browse/AS7-5331.

This has now been fixed and a testcase added to make sure that we no longer allow access to UserTransaction, wherever it isn't allowed. 

One of the commits here fixes a bunch of tests which were using UserTransaction in CMT beans.
