### PR TITLE
AS7-5561 incorrect command name in error message reported by scripts

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/CommandLineArgumentUsageImpl.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/CommandLineArgumentUsageImpl.java
@@ -34,6 +34,6 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
     public static void printUsage(final PrintStream out) {
         init();
-        out.print(usage());
+        out.print(usage("appclient"));
     }
 }

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsage.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsage.java
@@ -4,6 +4,7 @@ import static org.jboss.as.process.ProcessMessages.MESSAGES;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public abstract class CommandLineArgumentUsage {
 
@@ -113,11 +114,13 @@ public abstract class CommandLineArgumentUsage {
         }
     }
 
-    protected static String usage() {
+    protected static String usage(String executableBaseName) {
+        boolean isWindows = (SecurityActions.getSystemProperty("os.name")).toLowerCase(Locale.ENGLISH).contains("windows");
+        String executableName = isWindows ? executableBaseName : executableBaseName + ".sh";
+
         if (USAGE == null) {
             final StringBuilder sb = new StringBuilder();
-            sb.append(MESSAGES.argUsage()).append(NEW_LINE);
-
+            sb.append(NEW_LINE).append(MESSAGES.argUsage(executableName)).append(NEW_LINE);
 
             for (int i = 0; i < arguments.size(); i++) {
                 sb.append(getCommand(i)).append(NEW_LINE);

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsageImpl.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsageImpl.java
@@ -74,6 +74,6 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
     public static void printUsage(final PrintStream out) {
         init();
-        out.print(usage());
+        out.print(usage("domain"));
     }
 }

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessMessages.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessMessages.java
@@ -43,8 +43,8 @@ interface ProcessMessages {
      */
     ProcessMessages MESSAGES = Messages.getBundle(ProcessMessages.class);
 
-    @Message(id = Message.NONE, value = "Usage: ./domain.sh [args...]%nwhere args include:")
-    String argUsage();
+    @Message(id = Message.NONE, value = "Usage: %s [args...]%nwhere args include:")
+    String argUsage(String executableName);
 
     /**
      * Instructions for the {@link CommandLineConstants#BACKUP_DC} command line argument.

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
@@ -54,7 +54,7 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
     public static void printUsage(final PrintStream out) {
         init();
-        out.print(usage());
+        out.print(usage("standalone"));
     }
 
 }


### PR DESCRIPTION
parameterize the argUsage() message, and have standalone, domain, and appclient CommandLineArgumentUsageImpl classes pass in their respective executable base name.
