### PR TITLE
[AS7-5720] jboss-client.jar is missing HornetQ classes

### DIFF
--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -46,6 +46,12 @@
 
     <dependencies>
 
+        <!-- required until HORNETQ-1053 is fixed -->
+        <dependency>
+            <groupId>org.hornetq</groupId>
+            <artifactId>hornetq-commons</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-core-client</artifactId>


### PR DESCRIPTION
HornetQ 2.3.0.BETA1 hornetq-core-client jar does not include all the
classes required to run HornetQ code on the client side. Until this is
fixed (HORNETQ-1053), add hornetq-commons.jar to the JMS client BOM
