### PR TITLE
Upgrade Remoting to 3.2.12.GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.org.jboss.osgi.spi>3.1.1.CR8</version.org.jboss.osgi.spi>
         <version.org.jboss.osgi.vfs>1.1.2.CR1</version.org.jboss.osgi.vfs>
         <version.org.jboss.remote-naming>1.0.4.Final</version.org.jboss.remote-naming>
-        <version.org.jboss.remoting3>3.2.11.GA</version.org.jboss.remoting3>
+        <version.org.jboss.remoting3>3.2.12.GA</version.org.jboss.remoting3>
         <version.org.jboss.remotingjmx.remoting-jmx>1.1.0.Beta1</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.resteasy>2.3.3.Final</version.org.jboss.resteasy>
         <version.org.jboss.sasl>1.0.3.Final</version.org.jboss.sasl>


### PR DESCRIPTION
Just one fix - a hang can occur if the sender fills the window (e.g. a large invocation or invocation response) and a slow client hangs up the message while the window is full.  The server never gets the hangup, which can result in a failure to shut down the server later on.
