### PR TITLE
Fix security cache to use incoming principal as key. Handle groups in WebJASPIAuthenticator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <version.org.opensaml.opensaml>2.5.1-1</version.org.opensaml.opensaml>
         <version.org.opensaml.openws>1.4.2-1</version.org.opensaml.openws>
         <version.org.opensaml.xmltooling>1.3.2-1</version.org.opensaml.xmltooling>
-        <version.org.picketbox>4.0.13.Final</version.org.picketbox>
+        <version.org.picketbox>4.0.14.Final</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.1.4.Final</version.org.picketlink>
         <version.org.powermock>1.4.11</version.org.powermock>

--- a/web/src/main/java/org/jboss/as/web/security/JBossGenericPrincipal.java
+++ b/web/src/main/java/org/jboss/as/web/security/JBossGenericPrincipal.java
@@ -31,6 +31,7 @@ import javax.security.auth.login.LoginContext;
 import org.apache.catalina.Realm;
 import org.apache.catalina.realm.GenericPrincipal;
 import org.jboss.security.CacheableManager;
+import org.jboss.security.SimplePrincipal;
 
 /**
  *
@@ -89,8 +90,8 @@ public class JBossGenericPrincipal extends GenericPrincipal {
      */
     @Override
     public void logout() throws Exception {
-        if (cm != null && userPrincipal != null)
-            cm.flushCache(userPrincipal);
+        if (cm != null && super.name != null)
+            cm.flushCache(new SimplePrincipal(super.name));
         super.logout();
     }
 

--- a/web/src/main/java/org/jboss/as/web/security/JBossWebRealm.java
+++ b/web/src/main/java/org/jboss/as/web/security/JBossWebRealm.java
@@ -209,17 +209,18 @@ public class JBossWebRealm extends RealmBase {
         if (authorizationManager == null)
             throw new IllegalStateException("Authorization Manager has not been set");
 
-        Principal userPrincipal = getPrincipal(username);
+        Principal incomingPrincipal = getPrincipal(username);
+        Principal userPrincipal;
         Subject subject = new Subject();
         try {
-            boolean isValid = authenticationManager.isValid(userPrincipal, credentials, subject);
+            boolean isValid = authenticationManager.isValid(incomingPrincipal, credentials, subject);
             if (isValid) {
-                WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + userPrincipal + " is authenticated");
+                WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + incomingPrincipal + " is authenticated");
                 SecurityContext sc = SecurityActions.getSecurityContext();
                 if (sc == null)
                     throw new IllegalStateException("No SecurityContext found!");
+                sc.getUtil().createSubjectInfo(incomingPrincipal, credentials, subject);
                 userPrincipal = getPrincipal(subject);
-                sc.getUtil().createSubjectInfo(userPrincipal, credentials, subject);
                 SecurityContextCallbackHandler scb = new SecurityContextCallbackHandler(sc);
                 if (mappingManager != null) {
                     // if there are mapping modules let them handle the role mapping
@@ -246,12 +247,12 @@ public class JBossWebRealm extends RealmBase {
                 if (authenticationManager instanceof CacheableManager) {
                     @SuppressWarnings("unchecked")
                     CacheableManager<?, Principal> cm = (CacheableManager<?, Principal>) authenticationManager;
-                    userPrincipal = new JBossGenericPrincipal(this, userPrincipal.getName(), null, rolesAsStringList,
+                    userPrincipal = new JBossGenericPrincipal(this, incomingPrincipal.getName(), null, rolesAsStringList,
                             userPrincipal, null, credentials, cm, subject);
                     successAudit(userPrincipal, null);
                     return userPrincipal;
                 } else {
-                    userPrincipal = new JBossGenericPrincipal(this, userPrincipal.getName(), null, rolesAsStringList,
+                    userPrincipal = new JBossGenericPrincipal(this, incomingPrincipal.getName(), null, rolesAsStringList,
                             userPrincipal, null, credentials, null, subject);
                     successAudit(userPrincipal, null);
                     return userPrincipal;
@@ -281,18 +282,18 @@ public class JBossWebRealm extends RealmBase {
         if (authorizationManager == null)
             throw MESSAGES.noAuthorizationManager();
 
+        Principal incomingPrincipal = certMapping.toPrincipal(certs);
         Principal userPrincipal = null;
         try {
-            userPrincipal = certMapping.toPrincipal(certs);
             Subject subject = new Subject();
-            boolean isValid = authenticationManager.isValid(userPrincipal, certs, subject);
+            boolean isValid = authenticationManager.isValid(incomingPrincipal, certs, subject);
             if (isValid) {
-                WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + userPrincipal + " is authenticated");
+                WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + incomingPrincipal + " is authenticated");
                 SecurityContext sc = SecurityActions.getSecurityContext();
                 if (sc == null)
                     throw new IllegalStateException("No SecurityContext found!");
+                sc.getUtil().createSubjectInfo(incomingPrincipal, certs, subject);
                 userPrincipal = getPrincipal(subject);
-                sc.getUtil().createSubjectInfo(userPrincipal, certs, subject);
                 SecurityContextCallbackHandler scb = new SecurityContextCallbackHandler(sc);
                 if (mappingManager != null) {
                     // if there are mapping modules let them handle the role mapping
@@ -319,10 +320,10 @@ public class JBossWebRealm extends RealmBase {
                 if (authenticationManager instanceof CacheableManager) {
                     @SuppressWarnings("unchecked")
                     CacheableManager<?, Principal> cm = (CacheableManager<?, Principal>) authenticationManager;
-                    userPrincipal = new JBossGenericPrincipal(this, userPrincipal.getName(), null, rolesAsStringList,
+                    userPrincipal = new JBossGenericPrincipal(this, incomingPrincipal.getName(), null, rolesAsStringList,
                             userPrincipal, null, certs, cm, subject);
                 } else
-                    userPrincipal = new JBossGenericPrincipal(this, userPrincipal.getName(), null, rolesAsStringList,
+                    userPrincipal = new JBossGenericPrincipal(this, incomingPrincipal.getName(), null, rolesAsStringList,
                             userPrincipal, null, certs, null, subject);
             } else {
                 WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + userPrincipal + " is NOT authenticated");
@@ -352,6 +353,8 @@ public class JBossWebRealm extends RealmBase {
             throw MESSAGES.noAuthenticationManager();
         if (authorizationManager == null)
             throw MESSAGES.noAuthorizationManager();
+
+        Principal incomingPrincipal = getPrincipal(username);
         Principal userPrincipal = null;
         SecurityContext sc = SecurityActions.getSecurityContext();
         if (sc == null)
@@ -363,13 +366,12 @@ public class JBossWebRealm extends RealmBase {
         try {
             DigestCallbackHandler handler = new DigestCallbackHandler(username, nOnce, nc, cnonce, qop, realm, md5a2);
             CallbackHandlerPolicyContextHandler.setCallbackHandler(handler);
-            userPrincipal = getPrincipal(username);
             Subject subject = new Subject();
-            boolean isValid = authenticationManager.isValid(userPrincipal, clientDigest, subject);
+            boolean isValid = authenticationManager.isValid(incomingPrincipal, clientDigest, subject);
             if (isValid) {
-                WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + userPrincipal + " is authenticated");
+                WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + incomingPrincipal + " is authenticated");
+                sc.getUtil().createSubjectInfo(incomingPrincipal, clientDigest, subject);
                 userPrincipal = getPrincipal(subject);
-                sc.getUtil().createSubjectInfo(userPrincipal, clientDigest, subject);
                 SecurityContextCallbackHandler scb = new SecurityContextCallbackHandler(sc);
                 if (mappingManager != null) {
                     // if there are mapping modules let them handle the role mapping
@@ -396,10 +398,10 @@ public class JBossWebRealm extends RealmBase {
                 if (authenticationManager instanceof CacheableManager) {
                     @SuppressWarnings("unchecked")
                     CacheableManager<?, Principal> cm = (CacheableManager<?, Principal>) authenticationManager;
-                    userPrincipal = new JBossGenericPrincipal(this, userPrincipal.getName(), null, rolesAsStringList,
+                    userPrincipal = new JBossGenericPrincipal(this, incomingPrincipal.getName(), null, rolesAsStringList,
                             userPrincipal, null, clientDigest, cm, subject);
                 } else
-                    userPrincipal = new JBossGenericPrincipal(this, userPrincipal.getName(), null, rolesAsStringList,
+                    userPrincipal = new JBossGenericPrincipal(this, incomingPrincipal.getName(), null, rolesAsStringList,
                             userPrincipal, null, clientDigest, null, subject);
             } else {
                 WebLogger.WEB_SECURITY_LOGGER.tracef("User: " + userPrincipal + " is NOT authenticated");

--- a/web/src/main/java/org/jboss/as/web/security/SecurityContextAssociationValve.java
+++ b/web/src/main/java/org/jboss/as/web/security/SecurityContextAssociationValve.java
@@ -47,6 +47,7 @@ import org.jboss.security.SecurityConstants;
 import org.jboss.security.SecurityContext;
 import org.jboss.security.SecurityRolesAssociation;
 import org.jboss.security.SecurityUtil;
+import org.jboss.security.SimplePrincipal;
 
 /**
  * A {@code Valve} that creates a {@code SecurityContext} if one doesn't exist and sets the security information based on the
@@ -150,7 +151,7 @@ public class SecurityContextAssociationValve extends ValveBase {
                 if (principal != null) {
                     WebLogger.WEB_SECURITY_LOGGER.tracef("Restoring principal info from cache");
                     if (createdSecurityContext) {
-                        sc.getUtil().createSubjectInfo(principal.getUserPrincipal(), principal.getCredentials(),
+                        sc.getUtil().createSubjectInfo(new SimplePrincipal(principal.getName()), principal.getCredentials(),
                                 principal.getSubject());
                     }
                 }


### PR DESCRIPTION
AS7-5693 Use incoming principal when populating subject info / flushing cache. This aligns with changes made in PicketBox (JBossCachedAuthenticationManager now uses the incoming principal as cache key instead of the caller principal created by the login module).
AS7-5735 Handle GroupPrincipalCallback in the WebJASPIAuthenticator. Current code ignores any GroupPrincipalCallbacks and can also result in NPEs if the optional PasswordValidationCallback is null.
