### PR TITLE
Fix security cache to use incoming principal as key. Handle groups in WebJASPIAuthenticator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <version.org.jgroups>3.0.14.Final</version.org.jgroups>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.8.5</version.org.mockito>
-        <version.org.picketbox>4.0.13.Final</version.org.picketbox>
+        <version.org.picketbox>4.0.14.Final</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.1.4.Final</version.org.picketlink>
         <version.org.powermock>1.4.11</version.org.powermock>

--- a/web/src/main/java/org/jboss/as/web/security/JBossGenericPrincipal.java
+++ b/web/src/main/java/org/jboss/as/web/security/JBossGenericPrincipal.java
@@ -31,6 +31,7 @@ import javax.security.auth.login.LoginContext;
 import org.apache.catalina.Realm;
 import org.apache.catalina.realm.GenericPrincipal;
 import org.jboss.security.CacheableManager;
+import org.jboss.security.SimplePrincipal;
 
 /**
  *
@@ -89,8 +90,8 @@ public class JBossGenericPrincipal extends GenericPrincipal {
      */
     @Override
     public void logout() throws Exception {
-        if (cm != null && userPrincipal != null)
-            cm.flushCache(userPrincipal);
+        if (cm != null && super.name != null)
+            cm.flushCache(new SimplePrincipal(super.name));
         super.logout();
     }
 

--- a/web/src/main/java/org/jboss/as/web/security/SecurityContextAssociationValve.java
+++ b/web/src/main/java/org/jboss/as/web/security/SecurityContextAssociationValve.java
@@ -47,6 +47,7 @@ import org.jboss.security.SecurityConstants;
 import org.jboss.security.SecurityContext;
 import org.jboss.security.SecurityRolesAssociation;
 import org.jboss.security.SecurityUtil;
+import org.jboss.security.SimplePrincipal;
 
 /**
  * A {@code Valve} that creates a {@code SecurityContext} if one doesn't exist and sets the security information based on the
@@ -150,7 +151,7 @@ public class SecurityContextAssociationValve extends ValveBase {
                 if (principal != null) {
                     WebLogger.WEB_SECURITY_LOGGER.tracef("Restoring principal info from cache");
                     if (createdSecurityContext) {
-                        sc.getUtil().createSubjectInfo(principal.getUserPrincipal(), principal.getCredentials(),
+                        sc.getUtil().createSubjectInfo(new SimplePrincipal(principal.getName()), principal.getCredentials(),
                                 principal.getSubject());
                     }
                 }


### PR DESCRIPTION
AS7-5693 Use incoming principal when populating subject info / flushing cache. This aligns with changes made in PicketBox (JBossCachedAuthenticationManager now uses the incoming principal as cache key instead of the caller principal created by the login module).
AS7-5735 Handle GroupPrincipalCallback in the WebJASPIAuthenticator. Current code ignores any GroupPrincipalCallbacks and can also result in NPEs if the optional PasswordValidationCallback is null.
