### PR TITLE
[master] Fix AS7-5751 by properly reporting module load failures for JDBC drivers

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
@@ -124,8 +124,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
             moduleId = ModuleIdentifier.create(moduleName, slot);
             module = Module.getCallerModuleLoader().loadModule(moduleId);
         } catch (ModuleLoadException e) {
-            context.getFailureDescription().set(MESSAGES.failedToLoadModuleDriver(moduleName));
-            return;
+            throw new OperationFailedException(MESSAGES.failedToLoadModuleDriver(moduleName), e);
         }
 
         if (driverClassName == null) {


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-5751 where the module load failures during a JDBC driver add operation weren't being reported correctly. As a result, users have a hard time trying to figure out why the JDBC driver service wasn't installed.
