### PR TITLE
[AS7-5744] Attempt to discover if the logging.properties is a J.U.L. config

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
@@ -132,4 +132,14 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11509, value = "Logging profile '%s' was specified for deployment '%s' but was not found. Using system logging configuration.")
     void loggingProfileNotFound(String loggingProfile, ResourceRoot deployment);
+
+    /**
+     * Logs a warning message indicating the configuration file found appears to be a {@link
+     * java.util.logging.LogManager J.U.L.} configuration file and the log manager does not allow this configuration.
+     *
+     * @param fileName the configuration file name
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11510, value = "The configuration file in '%s' appears to be a J.U.L. configuration file. The log manager does not allow this type of configuration file.")
+    void julConfigurationFileFound(String fileName);
 }

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/ConfigurationPersistence.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/ConfigurationPersistence.java
@@ -511,7 +511,7 @@ public final class ConfigurationPersistence implements Configurator {
      *
      * @throws IOException if an error occurs
      */
-    private void configure(final Properties properties) throws IOException {
+    public void configure(final Properties properties) throws IOException {
         synchronized (config) {
             try {
                 // Start with the list of loggers to configure.  The root logger is always on the list.


### PR DESCRIPTION
Make a best guess attempt to see if the logging.properties in the deployment is a J.U.L. configuration file. Logs a warning messages if it's a J.U.L. configuration file, otherwise attempts to load the configuration.
