### PR TITLE
[master] AS7-5745 Increase connection timeout for a testcase

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/jboss-ejb-client.xml
@@ -26,7 +26,7 @@
         </ejb-receivers>
         <clusters>
             <cluster name="ejb" max-allowed-connected-nodes="20" cluster-node-selector="org.jboss.as.test.manualmode.ejb.client.cluster.ApplicationSpecificClusterNodeSelector"
-                     connect-timeout="5000" username="user1" security-realm="PasswordRealm">
+                     connect-timeout="15000" username="user1" security-realm="PasswordRealm">
                 <connection-creation-options>
                     <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
                     <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>


### PR DESCRIPTION
It looks like on a (probably) slow system the connection creation is timing out for a EJB cluster testcase. The issue is reported here https://issues.jboss.org/browse/AS7-5745. This commit just increases that configured timeout value for this specific testcase.
