### PR TITLE
[7.1][AS7-5767] marshall empty messaging subsystem

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -1388,14 +1388,16 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         context.startSubsystemElement(getExpectedNamespace().getUriString(), false);
         final ModelNode node = context.getModelNode();
 
-        final ModelNode servers = node.require(HORNETQ_SERVER);
-        boolean first = true;
-        for (Property prop : servers.asPropertyList()) {
-            writeHornetQServer(writer, prop.getName(), prop.getValue());
-            if (!first) {
-                writeNewLine(writer);
-            } else {
-                first = false;
+        if (node.hasDefined(HORNETQ_SERVER)) {
+            final ModelNode servers = node.get(HORNETQ_SERVER);
+            boolean first = true;
+            for (Property prop : servers.asPropertyList()) {
+                writeHornetQServer(writer, prop.getName(), prop.getValue());
+                if (!first) {
+                    writeNewLine(writer);
+                } else {
+                    first = false;
+                }
             }
         }
 


### PR DESCRIPTION
check whether the messaging subsystem has defined any hornetq-server
before marshalling them

the bug does not occur in AS7 master branch since https://github.com/jbossas/jboss-as/commit/d6c93c2e5a4677a15ecc5de72010f4e1e9fc722a
