### PR TITLE
AS7-5764 add global JPA settings for VFS URLs and extended persistence context inheritance compatability.

### DIFF
--- a/build/src/main/resources/configuration/subsystems/jpa.xml
+++ b/build/src/main/resources/configuration/subsystems/jpa.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.jpa</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jpa:1.0">
-       <jpa default-datasource=""/>
+   <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+       <jpa default-datasource="" default-extended-persistence-inheritance="DEEP" default-vfs="true"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/docs/schema/jboss-as-jpa_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jpa_1_1.xsd
@@ -1,0 +1,60 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:jpa:1.1"
+            xmlns="urn:jboss:domain:jpa:1.1"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.1">
+
+    <!-- The managedbean subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+      <xs:sequence>
+          <xs:element name="jpa" type="jpa-config" />
+      </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jpa-config">
+        <xs:attribute name="default-datasource" use="optional" type="xs:string" default=""/>
+        <xs:attribute name="default-extended-persistence-inheritance" type="inheritance_type" use="optional" default="DEEP"/>
+        <xs:attribute name="default-vfs" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:simpleType name="inheritance_type">
+        <xs:annotation>
+            <xs:documentation>
+            Controls how JPA extended persistence context (XPC) inheritance is performed. 
+            DEEP - Extended persistence context is shared at top bean level with all sub-beans referencing the same named persistence context.
+            SHALLOW - Extended persistece context is only shared with the parent bean (never with sibling beans).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="DEEP"/>
+            <xs:enumeration value="SHALLOW"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>
+
+

--- a/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -217,4 +217,7 @@ public class Configuration {
         return providerClassToAdapterModuleName.get(providerClassName);
     }
 
+    public static String getDefaultProviderModuleName() {
+        return PROVIDER_MODULE_DEFAULT;
+    }
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -40,9 +40,9 @@ import org.jboss.as.jpa.container.EntityManagerUnwrappedTargetInvocationHandler;
 import org.jboss.as.jpa.container.ExtendedEntityManager;
 import org.jboss.as.jpa.container.ExtendedPersistenceDeepInheritance;
 import org.jboss.as.jpa.container.ExtendedPersistenceShallowInheritance;
-import org.jboss.as.jpa.container.SFSBCallStack;
 import org.jboss.as.jpa.container.TransactionScopedEntityManager;
 import org.jboss.as.jpa.processor.JpaAttachments;
+import org.jboss.as.jpa.service.JPAService;
 import org.jboss.as.jpa.service.PersistenceUnitServiceImpl;
 import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
 import org.jboss.as.naming.ManagedReference;
@@ -150,7 +150,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
                 if (JPA_LOGGER.isDebugEnabled())
                     JPA_LOGGER.debugf("created new TransactionScopedEntityManager for unit name=%s", unitName);
             } else {
-                boolean useDeepInheritance = true;      // ExtendedPersistenceInheritance.DEEP is enabled by default
+                boolean useDeepInheritance = !ExtendedPersistenceInheritance.SHALLOW.equals(JPAService.getDefaultExtendedPersistenceInheritance());
                                                         // get deployment settings from top level du (jboss-all.xml is only parsed at the top level).
                 JPADeploymentSettings jpaDeploymentSettings =
                         DeploymentUtils.getTopDeploymentUnit(deploymentUnit).getAttachment(JpaAttachments.DEPLOYMENT_SETTINGS_KEY);

--- a/jpa/core/src/main/java/org/jboss/as/jpa/persistenceprovider/PersistenceProviderLoader.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/persistenceprovider/PersistenceProviderLoader.java
@@ -27,6 +27,7 @@ import java.util.ServiceLoader;
 import javax.persistence.spi.PersistenceProvider;
 
 import org.jboss.as.jpa.config.Configuration;
+import org.jboss.as.jpa.service.JPAService;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
@@ -45,7 +46,8 @@ public class PersistenceProviderLoader {
      * @throws ModuleLoadException
      */
     public static void loadDefaultProvider() throws ModuleLoadException {
-        loadProviderModuleByName(Configuration.PROVIDER_MODULE_DEFAULT);
+        String defaultProviderModule = Configuration.getDefaultProviderModuleName();
+        loadProviderModuleByName(defaultProviderModule);
     }
 
     /**

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
@@ -133,9 +133,9 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
 
         // add dependencies for the default persistence provider module
         if (defaultProviderCount > 0) {
-            moduleDependencies.add(Configuration.PROVIDER_MODULE_DEFAULT);
+            moduleDependencies.add(Configuration.getDefaultProviderModuleName());
             ROOT_LOGGER.debugf("added (default provider) %s dependency to %s (since %d PU(s) didn't specify %s",
-                Configuration.PROVIDER_MODULE_DEFAULT, deploymentUnit.getName(),defaultProviderCount, Configuration.PROVIDER_MODULE + ")");
+                Configuration.getDefaultProviderModuleName(), deploymentUnit.getName(),defaultProviderCount, Configuration.PROVIDER_MODULE + ")");
             // only inject default envers for default Hibernate module
             addDependency(moduleSpecification, moduleLoader, deploymentUnit, HIBERNATE_ENVERS_ID);
         }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -29,6 +29,7 @@ import org.jboss.as.jpa.config.Configuration;
 import org.jboss.as.jpa.config.PersistenceUnitMetadataHolder;
 import org.jboss.as.jpa.config.PersistenceUnitsInApplication;
 import org.jboss.as.jpa.puparser.PersistenceUnitXmlParser;
+import org.jboss.as.jpa.service.JPAService;
 import org.jboss.as.jpa.spi.PersistenceUnitMetadata;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -237,7 +238,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
         final DeploymentUnit deploymentUnit ) {
 
         for (PersistenceUnitMetadata pu : puHolder.getPersistenceUnits()) {
-            boolean convertVFS = false; // convert VFS url to FILE based url if JPA_ENABLE_VFS_URLS == false
+            boolean convertVFS = (false == JPAService.isDefaultVFS()); // convert VFS url to FILE based url if JPA_ENABLE_VFS_URLS == false
             String enableVFS = pu.getProperties().getProperty(Configuration.JPA_ENABLE_VFS_URLS);
             if (enableVFS != null && Boolean.parseBoolean(enableVFS) == false) {
                 convertVFS = true;

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -422,7 +422,7 @@ public class PersistenceUnitServiceHandler {
 
         final Map<URL, Index> annotationIndexes = new HashMap<URL, Index>();
 
-        boolean convertVFS = false; // convert VFS url to FILE based url if JPA_ENABLE_VFS_URLS == false
+        boolean convertVFS = (false == JPAService.isDefaultVFS()); // convert VFS url to FILE based url if JPA_ENABLE_VFS_URLS == false
         for (PersistenceUnitMetadata pu : puHolder.getPersistenceUnits()) {
             String enableVFS = pu.getProperties().getProperty(Configuration.JPA_ENABLE_VFS_URLS);
             if (enableVFS != null && Boolean.parseBoolean(enableVFS) == false) {

--- a/jpa/core/src/main/java/org/jboss/as/jpa/service/JPAService.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/service/JPAService.java
@@ -22,9 +22,12 @@
 
 package org.jboss.as.jpa.service;
 
+import static org.jboss.as.jpa.JpaLogger.ROOT_LOGGER;
+
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
+import org.jboss.as.jpa.config.ExtendedPersistenceInheritance;
 import org.jboss.as.jpa.transaction.TransactionUtil;
 import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.as.txn.service.TransactionManagerService;
@@ -51,14 +54,49 @@ public class JPAService implements Service<Void> {
     public static final ServiceName SERVICE_NAME = JPAServiceNames.getJPAServiceName();
 
     private static volatile String defaultDataSourceName = null;
+    private static volatile ExtendedPersistenceInheritance defaultExtendedPersistenceInheritance = null;
+    private static volatile boolean defaultVFS = true;
 
     public static String getDefaultDataSourceName() {
+        ROOT_LOGGER.tracef("JPAService.getDefaultDataSourceName() == %s", JPAService.defaultDataSourceName);
         return defaultDataSourceName;
     }
 
-    public static ServiceController<?> addService(final ServiceTarget target, final String defaultDataSourceName, final ServiceListener<Object>... listeners) {
+    public static void setDefaultDataSourceName(String dataSourceName) {
+        ROOT_LOGGER.tracef("JPAService.setDefaultDataSourceName(%s), previous value = %s", dataSourceName, JPAService.defaultDataSourceName);
+        defaultDataSourceName = dataSourceName;
+    }
+
+    public static ExtendedPersistenceInheritance getDefaultExtendedPersistenceInheritance() {
+        ROOT_LOGGER.tracef("JPAService.getDefaultExtendedPersistenceInheritance() == %s", defaultExtendedPersistenceInheritance.toString());
+        return defaultExtendedPersistenceInheritance;
+    }
+
+    public static void setDefaultExtendedPersistenceInheritance(ExtendedPersistenceInheritance defaultExtendedPersistenceInheritance) {
+        ROOT_LOGGER.tracef("JPAService.setDefaultExtendedPersistenceInheritance(%s)", defaultExtendedPersistenceInheritance.toString());
+        JPAService.defaultExtendedPersistenceInheritance = defaultExtendedPersistenceInheritance;
+    }
+
+    public static boolean isDefaultVFS() {
+        ROOT_LOGGER.tracef("JPAService.isDefaultVFS() == %b", defaultVFS);
+        return defaultVFS;
+    }
+
+    public static void setDefaultVFS(boolean defaultVFS) {
+        ROOT_LOGGER.tracef("JPAService.setDefaultVFS(%b), previous value == %b", defaultVFS, JPAService.defaultVFS);
+        JPAService.defaultVFS = defaultVFS;
+    }
+
+    public static ServiceController<?> addService(
+            final ServiceTarget target,
+            final String defaultDataSourceName,
+            final ExtendedPersistenceInheritance defaultExtendedPersistenceInheritance,
+            final boolean defaultVFS,
+            final ServiceListener<Object>... listeners) {
         JPAService jpaService = new JPAService();
-        JPAService.defaultDataSourceName = defaultDataSourceName;
+        setDefaultDataSourceName(defaultDataSourceName);
+        setDefaultExtendedPersistenceInheritance(defaultExtendedPersistenceInheritance);
+        setDefaultVFS(defaultVFS);
 
         // set the transaction manager to be accessible via TransactionUtil
         final Injector<TransactionManager> transactionManagerInjector =
@@ -106,10 +144,6 @@ public class JPAService implements Service<Void> {
     @Override
     public Void getValue() throws IllegalStateException, IllegalArgumentException {
         return null;
-    }
-
-    public void setDefaultDataSourceName(String dataSourceName) {
-        defaultDataSourceName = dataSourceName;
     }
 
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/Attribute.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/Attribute.java
@@ -31,7 +31,9 @@ import java.util.Map;
 enum Attribute {
 
     UNKNOWN(null),
-    DEFAULT_DATASOURCE_NAME(CommonAttributes.DEFAULT_DATASOURCE),;
+    DEFAULT_DATASOURCE_NAME(CommonAttributes.DEFAULT_DATASOURCE),
+    DEFAULT_EXTENDEDPERSISTENCEINHERITANCE_NAME(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE),
+    DEFAULT_VFS_NAME(CommonAttributes.DEFAULT_VFS), ;
     private final String name;
 
     Attribute(final String name) {

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/Element.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/Element.java
@@ -31,7 +31,9 @@ public enum Element {
     // must be first
     UNKNOWN(null),
     JPA(CommonAttributes.JPA),
-    DEFAULT_DATASOURCE(CommonAttributes.DEFAULT_DATASOURCE),;
+    DEFAULT_DATASOURCE(CommonAttributes.DEFAULT_DATASOURCE),
+    DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE),
+    DEFAULT_VFS(CommonAttributes.DEFAULT_VFS),;
 
     private final String name;
 

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -29,9 +29,13 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.jpa.config.Configuration;
+import org.jboss.as.jpa.config.ExtendedPersistenceInheritance;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -44,7 +48,7 @@ public class JPADefinition extends SimpleResourceDefinition {
 
     private JPADefinition() {
         super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JPAExtension.SUBSYSTEM_NAME),
-                JPAExtension.getResourceDescriptionResolver(null),
+                JPAExtension.getResourceDescriptionResolver(),
                 JPASubSystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
     }
@@ -58,8 +62,27 @@ public class JPADefinition extends SimpleResourceDefinition {
                     .setDefaultValue(null)
                     .build();
 
+    protected static final SimpleAttributeDefinition DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE =
+            new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setXmlName(CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setValidator(new EnumValidator<ExtendedPersistenceInheritance>(ExtendedPersistenceInheritance.class,true,true))
+                    .setDefaultValue(new ModelNode(ExtendedPersistenceInheritance.DEEP.toString()))
+                    .build();
+
+    protected static final SimpleAttributeDefinition DEFAULT_VFS =
+            new SimpleAttributeDefinitionBuilder(CommonAttributes.DEFAULT_VFS, ModelType.BOOLEAN, true)
+                    .setAllowExpression(true)
+                    .setXmlName(CommonAttributes.DEFAULT_VFS)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode(true))
+                    .build();
+
     @Override
     public void registerAttributes(ManagementResourceRegistration registration) {
         registration.registerReadWriteAttribute(DEFAULT_DATASOURCE, null, new ReloadRequiredWriteAttributeHandler(DEFAULT_DATASOURCE));
+        registration.registerReadWriteAttribute(DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE, null, new ReloadRequiredWriteAttributeHandler(DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE));
+        registration.registerReadWriteAttribute(DEFAULT_VFS, null, new ReloadRequiredWriteAttributeHandler(DEFAULT_VFS));
     }
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPASubsystemTransformer_1_1.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/JPASubsystemTransformer_1_1.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,12 +22,31 @@
 
 package org.jboss.as.jpa.subsystem;
 
+import org.jboss.as.controller.transform.AbstractSubsystemTransformer;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.dmr.ModelNode;
+
 /**
- * @author Scott Marlow
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
-interface CommonAttributes {
-    String DEFAULT_DATASOURCE = "default-datasource";
-    String JPA = "jpa";
-    String DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE = "default-extended-persistence-inheritance";
-    String DEFAULT_VFS = "default-vfs";
+public class JPASubsystemTransformer_1_1 extends AbstractSubsystemTransformer {
+
+    public JPASubsystemTransformer_1_1() {
+        super(CommonAttributes.JPA);
+    }
+
+    @Override
+    public ModelNode transformModel(TransformationContext context, ModelNode model) {
+        remove(model, CommonAttributes.DEFAULT_EXTENDEDPERSISTENCE_INHERITANCE);
+        remove(model, CommonAttributes.DEFAULT_VFS);
+        return model;
+    }
+
+    private void remove(ModelNode model, String name) {
+        if (model.has(name)) {
+            model.remove(name);
+        }
+
+    }
+
 }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/Namespace.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/subsystem/Namespace.java
@@ -31,12 +31,9 @@ import java.util.Map;
 enum Namespace {
     // must be first
     UNKNOWN(null),
-    JPA_1_0("urn:jboss:domain:jpa:1.0"),;
-
-    /**
-     * The current namespace version.
-     */
-    public static final Namespace CURRENT = JPA_1_0;
+    JPA_1_0("urn:jboss:domain:jpa:1.0"),
+    JPA_1_1("urn:jboss:domain:jpa:1.1"),
+    ;
 
     private final String name;
 

--- a/jpa/core/src/main/resources/org/jboss/as/jpa/subsystem/LocalDescriptions.properties
+++ b/jpa/core/src/main/resources/org/jboss/as/jpa/subsystem/LocalDescriptions.properties
@@ -1,6 +1,10 @@
 jpa=The configuration of the JPA subsystem.
 jpa.add=Add the JPA subsystem.
 jpa.remove=Remove the JPA subsystem.
+default-datasource=The name of the default global datasource.
 jpa.default-datasource=The name of the default global datasource.
+jpa.default-extended-persistence-inheritance=Controls how JPA extended persistence context (XPC) inheritance is performed. 'DEEP' shares the extended persistence context at top bean level.  'SHALLOW' the extended persistece context is only shared with the parent bean (never with sibling beans).
+jpa.default-vfs=Set to false to enable FILE based URLS to be passed to the persistence provider at deployment time.  Set to true to enable VFS based URLS to be used.
 jpa.hibernate-persistence-unit=Persistence unit
+hibernate-persistence-unit=Persistence unit
 

--- a/jpa/core/src/test/java/org/jboss/as/jpa/subsystem/JPA10SubsystemTestCase.java
+++ b/jpa/core/src/test/java/org/jboss/as/jpa/subsystem/JPA10SubsystemTestCase.java
@@ -34,7 +34,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRI
 import java.io.IOException;
 
 import junit.framework.Assert;
-
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.transform.OperationTransformer;
@@ -42,58 +41,26 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-public class JPASubsystemTestCase extends AbstractSubsystemBaseTest {
 
-    public JPASubsystemTestCase() {
+public class JPA10SubsystemTestCase extends AbstractSubsystemBaseTest {
+
+    public JPA10SubsystemTestCase() {
         super(JPAExtension.SUBSYSTEM_NAME, new JPAExtension());
     }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return
-            "<subsystem xmlns=\"urn:jboss:domain:jpa:1.0\">" +
-                "    <jpa default-datasource=\"\"/>" +
-                "</subsystem>";
+        return readResource("subsystem-1.0.xml");
     }
 
-    @Test
-    public void testTransformers_1_1_0() throws Exception {
-        System.setProperty("org.jboss.as.jpa.testBadExpr", "hello");
-
-        try {
-            ModelVersion oldVersion = ModelVersion.create(1, 1, 0);
-            KernelServicesBuilder builder = createKernelServicesBuilder(null)
-                    .setSubsystemXml(getSubsystemXml());
-            builder.createLegacyKernelServicesBuilder(null, oldVersion)
-                    .setExtensionClassName(JPAExtension.class.getName())
-                    .addMavenResourceURL("org.jboss.as:jboss-as-jpa:7.1.2.Final");
-            KernelServices mainServices = builder.build();
-            KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);
-            Assert.assertNotNull(legacyServices);
-
-            checkSubsystemModelTransformation(mainServices, oldVersion);
-
-            final ModelNode operation = new ModelNode();
-            operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-            operation.get(OP_ADDR).add(SUBSYSTEM, JPAExtension.SUBSYSTEM_NAME);
-            operation.get(NAME).set(JPADefinition.DEFAULT_DATASOURCE.getName());
-            operation.get(VALUE).set("${org.jboss.as.jpa.testBadExpr}");
-
-            final ModelNode mainResult = mainServices.executeOperation(operation);
-            System.out.println(mainResult);
-            Assert.assertTrue(SUCCESS.equals(mainResult.get(OUTCOME).asString()));
-
-            final OperationTransformer.TransformedOperation op = mainServices.transformOperation(oldVersion, operation);
-            final ModelNode result = mainServices.executeOperation(oldVersion, op);
-            Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
-
-        } finally {
-            System.clearProperty("org.jboss.as.jpa.testBadExpr");
-        }
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        //no need to compare
     }
 }

--- a/jpa/core/src/test/java/org/jboss/as/jpa/subsystem/JPA11SubsystemTestCase.java
+++ b/jpa/core/src/test/java/org/jboss/as/jpa/subsystem/JPA11SubsystemTestCase.java
@@ -1,0 +1,98 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.jpa.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import java.io.IOException;
+
+import junit.framework.Assert;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+
+public class JPA11SubsystemTestCase extends AbstractSubsystemBaseTest {
+
+    public JPA11SubsystemTestCase() {
+        super(JPAExtension.SUBSYSTEM_NAME, new JPAExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("subsystem-1.1.xml");
+    }
+
+    @Test
+    public void testTransformers_1_1_0() throws Exception {
+        System.setProperty("org.jboss.as.jpa.testBadExpr", "hello");
+
+        try {
+            ModelVersion oldVersion = ModelVersion.create(1, 1, 0);
+            KernelServicesBuilder builder = createKernelServicesBuilder(null)
+                    .setSubsystemXml(getSubsystemXml());
+            builder.createLegacyKernelServicesBuilder(null, oldVersion)
+                    .setExtensionClassName(JPAExtension.class.getName())
+                    .addMavenResourceURL("org.jboss.as:jboss-as-jpa:7.1.2.Final")
+                    .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.2.Final")
+                    .addParentFirstClassPattern("org.jboss.as.controller.*");
+            KernelServices mainServices = builder.build();
+            KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);
+            Assert.assertNotNull(legacyServices);
+
+            checkSubsystemModelTransformation(mainServices, oldVersion);
+
+            final ModelNode operation = new ModelNode();
+            operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            operation.get(OP_ADDR).add(SUBSYSTEM, JPAExtension.SUBSYSTEM_NAME);
+            operation.get(NAME).set(JPADefinition.DEFAULT_DATASOURCE.getName());
+            operation.get(VALUE).set("${org.jboss.as.jpa.testBadExpr}");
+
+            final ModelNode mainResult = mainServices.executeOperation(operation);
+            System.out.println(mainResult);
+            Assert.assertTrue(SUCCESS.equals(mainResult.get(OUTCOME).asString()));
+
+            final OperationTransformer.TransformedOperation op = mainServices.transformOperation(oldVersion, operation);
+            final ModelNode result = mainServices.executeOperation(oldVersion, op);
+            Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        } catch (Throwable t) {
+            Assert.fail(t.getMessage());
+        } finally {
+            System.clearProperty("org.jboss.as.jpa.testBadExpr");
+        }
+    }
+}

--- a/jpa/core/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.0.xml
+++ b/jpa/core/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.0.xml
@@ -1,0 +1,3 @@
+<subsystem xmlns="urn:jboss:domain:jpa:1.0">
+    <jpa default-datasource=""/>
+</subsystem>

--- a/jpa/core/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.1.xml
+++ b/jpa/core/src/test/resources/org/jboss/as/jpa/subsystem/subsystem-1.1.xml
@@ -1,0 +1,3 @@
+<subsystem xmlns="urn:jboss:domain:jpa:1.1">
+    <jpa default-datasource="" default-extended-persistence-inheritance="DEEP" default-vfs="false"/>
+</subsystem>

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestUtils.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestUtils.java
@@ -95,7 +95,9 @@ public class ModelTestUtils {
      */
     public static ModelNode checkResultAndGetContents(ModelNode result) {
         checkOutcome(result);
-        Assert.assertTrue(result.hasDefined(RESULT));
+        Assert.assertTrue("could not check for result as its missing!  look for yourself here [" + result.toString() +
+                "] and result.hasDefined(RESULT) returns " + result.hasDefined(RESULT)
+                , result.hasDefined(RESULT));
         return result.get(RESULT);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/persistence.xml
@@ -27,10 +27,8 @@
 		<description>Persistence Unit.</description>
 		<jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
 		<properties>
-			<property name="hibernate.hbm2ddl.auto" value="create-drop" />
-			<property name="hibernate.show_sql" value="true" />
-                        <property name="hibernate.ejb.use_class_enhancer" value="true" />
-                        <property name="jboss.as.jpa.vfs" value="false" />                        
+            <property name="hibernate.ejb.use_class_enhancer" value="true" />
+            <property name="jboss.as.jpa.vfs" value="false" />
 		</properties>
 	</persistence-unit>
 </persistence>


### PR DESCRIPTION
VFS setting defaults to true, so that PersistenceUnitInfo URLs will be VFS based.  If VFS is false, FILE based URLs will be used.  See  AS7-5062 for more background on this change.

The extended persistence context inheritance defaults to DEEP which is how JBoss AS 5.x-7.x works.  Changing it to SHALLOW, is for alternative way that was discussed recently on the JPA EG and is also how some other vendors work.  See  AS7-4940 for more background on this change.

Thanks to Tomaz for help with this change!
