### PR TITLE
Add missing finalize() call to super.finalize()

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/RemotingModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/RemotingModelControllerClient.java
@@ -27,8 +27,6 @@ import org.jboss.as.controller.client.ControllerClientMessages;
 import static org.jboss.as.controller.client.ControllerClientMessages.MESSAGES;
 
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -148,13 +146,17 @@ public class RemotingModelControllerClient extends AbstractModelControllerClient
 
     @Override
     protected void finalize() throws Throwable {
-        if(! closed) {
-            // Create the leak description
-            final Throwable t = ControllerClientMessages.MESSAGES.controllerClientNotClosed();
-            t.setStackTrace(allocationStackTrace);
-            ControllerClientLogger.ROOT_LOGGER.leakedControllerClient(t);
-            // Close
-            StreamUtils.safeClose(this);
+        try {
+            if(! closed) {
+                // Create the leak description
+                final Throwable t = ControllerClientMessages.MESSAGES.controllerClientNotClosed();
+                t.setStackTrace(allocationStackTrace);
+                ControllerClientLogger.ROOT_LOGGER.leakedControllerClient(t);
+                // Close
+                StreamUtils.safeClose(this);
+            }
+        } finally {
+            super.finalize();
         }
     }
 


### PR DESCRIPTION
Minor thing to remove an IDE warn; I noticed this while looking into something else.
