### PR TITLE
deployment overlay wildcards changes

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -230,11 +230,6 @@ public class Util {
         return regex;
     }
 
-    public static void main(String[] args) throws Exception {
-
-        System.out.println(wildcardToJavaRegex("a*.war"));
-    }
-
     public static boolean listContains(ModelNode operationResult, String item) {
         if(!operationResult.hasDefined(RESULT))
             return false;

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -224,17 +224,15 @@ public class Util {
         if(expr == null) {
             throw new IllegalArgumentException("expr is null");
         }
-        final StringBuilder buf = new StringBuilder();
-        for(int i = 0; i < expr.length(); ++i) {
-            final char ch = expr.charAt(i);
-            if(ch == '*') {
-                buf.append('.');
-            } else if(ch == '.') {
-                buf.append('\\');
-            }
-            buf.append(ch);
-        }
-        return buf.toString();
+        String regex = expr.replaceAll("([(){}\\[\\].+^$])", "\\\\$1"); // escape regex characters
+        regex = regex.replaceAll("\\*", ".*"); // replace * with .*
+        regex = regex.replaceAll("\\?", "."); // replace ? with .
+        return regex;
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        System.out.println(wildcardToJavaRegex("a*.war"));
     }
 
     public static boolean listContains(ModelNode operationResult, String item) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
@@ -1037,24 +1037,26 @@ public class DeploymentOverlayHandler extends CommandHandlerWithHelp {
                 op.get(Util.REGULAR_EXPRESSION).set(true);
                 steps.add(op);
 
-                final List<String> matchingDeployments = Util.getMatchingDeployments(ctx.getModelControllerClient(), link, serverGroup);
-                if(!matchingDeployments.isEmpty()) {
-                    if(serverGroup == null) {
-                        for(String deployment : matchingDeployments) {
-                            final ModelNode step = new ModelNode();
-                            final ModelNode addr = step.get(Util.ADDRESS);
-                            addr.add(Util.DEPLOYMENT, deployment);
-                            step.get(Util.OPERATION).set(Util.REDEPLOY);
-                            steps.add(step);
-                        }
-                    } else {
-                        for(String deployment : matchingDeployments) {
-                            final ModelNode step = new ModelNode();
-                            final ModelNode addr = step.get(Util.ADDRESS);
-                            addr.add(Util.SERVER_GROUP, serverGroup);
-                            addr.add(Util.DEPLOYMENT, deployment);
-                            step.get(Util.OPERATION).set(Util.REDEPLOY);
-                            steps.add(step);
+                if(redeployAffected.isPresent(ctx.getParsedCommandLine())) {
+                    final List<String> matchingDeployments = Util.getMatchingDeployments(ctx.getModelControllerClient(), link, serverGroup);
+                    if(!matchingDeployments.isEmpty()) {
+                        if(serverGroup == null) {
+                            for(String deployment : matchingDeployments) {
+                                final ModelNode step = new ModelNode();
+                                final ModelNode addr = step.get(Util.ADDRESS);
+                                addr.add(Util.DEPLOYMENT, deployment);
+                                step.get(Util.OPERATION).set(Util.REDEPLOY);
+                                steps.add(step);
+                            }
+                        } else {
+                            for(String deployment : matchingDeployments) {
+                                final ModelNode step = new ModelNode();
+                                final ModelNode addr = step.get(Util.ADDRESS);
+                                addr.add(Util.SERVER_GROUP, serverGroup);
+                                addr.add(Util.DEPLOYMENT, deployment);
+                                step.get(Util.OPERATION).set(Util.REDEPLOY);
+                                steps.add(step);
+                            }
                         }
                     }
                 }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
@@ -38,6 +38,23 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
 
     public static final ServiceName SERVICE_NAME = DeploymentOverlayIndexService.SERVICE_NAME.append("deploymentOverlayLinkService");
 
+    private static String wildcardToJavaRegexp(String expr) {
+        if(expr == null) {
+            throw new IllegalArgumentException("expr is null");
+        }
+        final StringBuilder buf = new StringBuilder();
+        for(int i = 0; i < expr.length(); ++i) {
+            final char ch = expr.charAt(i);
+            if(ch == '*') {
+                buf.append('.');
+            } else if(ch == '.') {
+                buf.append('\\');
+            }
+            buf.append(ch);
+        }
+        return buf.toString();
+    }
+
     private final InjectedValue<DeploymentOverlayIndexService> deploymentOverlayIndexServiceInjectedValue = new InjectedValue<DeploymentOverlayIndexService>();
     private final InjectedValue<DeploymentOverlayService> deploymentOverlayServiceInjectedValue = new InjectedValue<DeploymentOverlayService>();
     private final String deployment;
@@ -50,7 +67,7 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
         this.priority = priority;
         this.regex = regex;
         if (regex) {
-            this.pattern = Pattern.compile(deployment);
+            this.pattern = Pattern.compile(wildcardToJavaRegexp(deployment));
         } else {
             this.pattern = null;
         }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
@@ -42,17 +42,10 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
         if(expr == null) {
             throw new IllegalArgumentException("expr is null");
         }
-        final StringBuilder buf = new StringBuilder();
-        for(int i = 0; i < expr.length(); ++i) {
-            final char ch = expr.charAt(i);
-            if(ch == '*') {
-                buf.append('.');
-            } else if(ch == '.') {
-                buf.append('\\');
-            }
-            buf.append(ch);
-        }
-        return buf.toString();
+        String regex = expr.replaceAll("([(){}\\[\\].+^$])", "\\\\$1"); // escape regex characters
+        regex = regex.replaceAll("\\*", ".*"); // replace * with .*
+        regex = regex.replaceAll("\\?", "."); // replace ? with .
+        return regex;
     }
 
     private final InjectedValue<DeploymentOverlayIndexService> deploymentOverlayIndexServiceInjectedValue = new InjectedValue<DeploymentOverlayIndexService>();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
@@ -306,7 +306,6 @@ public class DomainDeploymentOverlayTestCase {
         ctx.handle("/server-group=main-server-group/deployment=" + war1.getName() + ":redeploy");
         ctx.handle("/server-group=main-server-group/deployment=" + war2.getName() + ":redeploy");
         ctx.handle("/server-group=main-server-group/deployment=" + war3.getName() + ":redeploy");
-/* TODO this below fails
         ctx.handle("deployment-overlay remove --name=overlay-test --content=WEB-INF/web.xml --redeploy-affected");
 
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
@@ -324,7 +323,7 @@ public class DomainDeploymentOverlayTestCase {
         assertEquals("OVERRIDDEN", performHttpCall("slave", "main-three", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "deployment1"));
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
-*/    }
+    }
 
     @Test
     public void testRedeployAffected() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
@@ -56,7 +56,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -208,7 +207,7 @@ public class DomainDeploymentOverlayTestCase {
     public void testWildcardOverride() throws Exception {
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment.*\\.war --server-groups=main-server-group --redeploy-affected");
+                + " --wildcards=deployment*.war --server-groups=main-server-group --redeploy-affected");
 
         ctx.handle("deploy --server-groups=main-server-group " + war1.getAbsolutePath());
         ctx.handle("deploy --server-groups=main-server-group " + war2.getAbsolutePath());
@@ -223,9 +222,6 @@ public class DomainDeploymentOverlayTestCase {
     }
 
     @Test
-    @Ignore
-    // TODO this because the cli is using wildcards instead of regexp
-    // to determine the matching deployments
     public void testWildcardOverrideWithRedeployAffected() throws Exception {
 
         ctx.handle("deploy --server-groups=main-server-group " + war1.getAbsolutePath());
@@ -233,7 +229,7 @@ public class DomainDeploymentOverlayTestCase {
         ctx.handle("deploy --server-groups=main-server-group " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment.*\\.war --server-groups=main-server-group --redeploy-affected");
+                + " --wildcards=deployment*.war --server-groups=main-server-group --redeploy-affected");
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -260,7 +256,7 @@ public class DomainDeploymentOverlayTestCase {
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "deployment1"));
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
 
-        ctx.handle("deployment-overlay link --name=overlay-test --wildcards=a.*\\.war --server-groups=main-server-group");
+        ctx.handle("deployment-overlay link --name=overlay-test --wildcards=a*.war --server-groups=main-server-group");
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -298,7 +294,7 @@ public class DomainDeploymentOverlayTestCase {
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "deployment1"));
         assertEquals("OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
 
-        ctx.handle("deployment-overlay remove --name=overlay-test --wildcards=a.*\\.war --server-groups=main-server-group");
+        ctx.handle("deployment-overlay remove --name=overlay-test --wildcards=a*.war --server-groups=main-server-group");
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -338,7 +334,7 @@ public class DomainDeploymentOverlayTestCase {
         ctx.handle("deploy --server-groups=main-server-group " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath());
-        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war --wildcards=a.*\\.war --server-groups=main-server-group");
+        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war --wildcards=a*.war --server-groups=main-server-group");
 
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -351,10 +347,10 @@ public class DomainDeploymentOverlayTestCase {
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
-        // TODO wildcard in cli vs regexp in the model assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "another"));
+        assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "another"));
         assertEquals("OVERRIDDEN", performHttpCall("slave", "main-three", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "deployment1"));
-        // TODO wildcard in cli vs regexp in the model assertEquals("OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
+        assertEquals("OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
     }
 
     private String performHttpCall(String host, String server, String deployment) throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -58,7 +58,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HASH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INPUT_STREAM_INDEX;
@@ -268,7 +267,7 @@ public class DeploymentOverlayTestCase {
         addr = new ModelNode();
         addr.add(ModelDescriptionConstants.SERVER_GROUP, "main-server-group");
         addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, TEST_WILDCARD);
-        addr.add(ModelDescriptionConstants.DEPLOYMENT, ".*\\.war");
+        addr.add(ModelDescriptionConstants.DEPLOYMENT, "*.war");
         op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
         op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
         op.get(ModelDescriptionConstants.REGULAR_EXPRESSION).set(true);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
@@ -19,7 +19,6 @@ import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -104,7 +103,7 @@ public class DeploymentOverlayTestCase {
             op = new ModelNode();
             addr = new ModelNode();
             addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, TEST_WILDCARD);
-            addr.add(ModelDescriptionConstants.DEPLOYMENT, ".*.war");
+            addr.add(ModelDescriptionConstants.DEPLOYMENT, "*.war");
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
             op.get(ModelDescriptionConstants.REGULAR_EXPRESSION).set(true);
@@ -122,7 +121,7 @@ public class DeploymentOverlayTestCase {
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
-            removeDeploymentItem(managementClient, TEST_WILDCARD, ".*.war");
+            removeDeploymentItem(managementClient, TEST_WILDCARD, "*.war");
             removeContentItem(managementClient, TEST_WILDCARD, "WEB-INF/web.xml");
 
             removeContentItem(managementClient, TEST_WILDCARD, "WEB-INF/classes/wildcard-new-file");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
@@ -50,7 +50,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -196,7 +195,7 @@ public class DeploymentOverlayTestCase {
     public void testWildcardOverride() throws Exception {
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment.*\\.war");
+                + " --wildcards=deployment*.war");
 
         ctx.handle("deploy " + war1.getAbsolutePath());
         ctx.handle("deploy " + war2.getAbsolutePath());
@@ -211,9 +210,6 @@ public class DeploymentOverlayTestCase {
     }
 
     @Test
-    @Ignore
-    // TODO this because the cli is using wildcards instead of regexp
-    // to determine the matching deployments
     public void testWildcardOverrideWithRedeployAffected() throws Exception {
 
         ctx.handle("deploy " + war1.getAbsolutePath());
@@ -221,9 +217,9 @@ public class DeploymentOverlayTestCase {
         ctx.handle("deploy " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment.*\\.war --redeploy-affected");
+                + " --wildcards=deployment*.war --redeploy-affected");
 
-        Thread.sleep(2000);
+        //Thread.sleep(2000);
         String response = readResponse("deployment0");
         assertEquals("OVERRIDDEN", response);
         response = readResponse("deployment1");
@@ -249,7 +245,7 @@ public class DeploymentOverlayTestCase {
         response = readResponse("another");
         assertEquals("NON OVERRIDDEN", response);
 
-        ctx.handle("deployment-overlay link --name=overlay-test --wildcards=a.*\\.war");
+        ctx.handle("deployment-overlay link --name=overlay-test --wildcards=a*.war");
 
         response = readResponse("deployment0");
         assertEquals("OVERRIDDEN", response);
@@ -287,7 +283,7 @@ public class DeploymentOverlayTestCase {
         response = readResponse("another");
         assertEquals("OVERRIDDEN", response);
 
-        ctx.handle("deployment-overlay remove --name=overlay-test --wildcards=a.*\\.war");
+        ctx.handle("deployment-overlay remove --name=overlay-test --wildcards=a*.war");
 
         response = readResponse("deployment0");
         assertEquals("OVERRIDDEN", response);
@@ -334,7 +330,7 @@ public class DeploymentOverlayTestCase {
         ctx.handle("deploy " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath());
-        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war --wildcards=a.*\\.war");
+        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war --wildcards=a*.war");
 
         String response = readResponse("deployment0");
         assertEquals("NON OVERRIDDEN", response);
@@ -349,10 +345,8 @@ public class DeploymentOverlayTestCase {
         assertEquals("OVERRIDDEN", response);
         response = readResponse("deployment1");
         assertEquals("NON OVERRIDDEN", response);
-        // TODO the below will fail because CLI uses simple wildcards to determine the target deployments
-        // instead of true regexp
-//        response = readResponse("another");
-//        assertEquals("OVERRIDDEN", response);
+        response = readResponse("another");
+        assertEquals("OVERRIDDEN", response);
     }
 
     protected String readResponse(String warName) throws IOException, ExecutionException, TimeoutException,


### PR DESCRIPTION
This switches from the Java regex syntax for deployment overlay links to simpler glob style/wildcard expressions, which is easier for users.
And fixes overlay content removal issue in the domain mode in the CLI deployment-overlay command handler.

Stuart has reviewed the changes.

Thanks,
Alexey
