### PR TITLE
Jmx 2693

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -484,6 +484,17 @@ public abstract class AttributeDefinition {
                 }
             }
         }
+        addAllowedValuesToDescription(result, validator);
+        return result;
+    }
+
+    /**
+     * Adds the allowed values. Override for attributes who should not use the allowed values.
+     *
+     * @param result the node to add the allowed values to
+     * @param validator the validator to get the allowed values from
+     */
+    protected void addAllowedValuesToDescription(ModelNode result, ParameterValidator validator) {
         if (validator instanceof AllowedValuesValidator) {
             AllowedValuesValidator avv = (AllowedValuesValidator) validator;
             List<ModelNode> allowed = avv.getAllowedValues();
@@ -493,7 +504,6 @@ public abstract class AttributeDefinition {
                 }
             }
         }
-        return result;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
@@ -22,16 +22,15 @@
 
 package org.jboss.as.controller;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
 import org.jboss.as.controller.operations.validation.MinMaxValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -160,17 +159,7 @@ public class ObjectListAttributeDefinition extends ListAttributeDefinition {
                 }
             }
         }
-        if (validator instanceof AllowedValuesValidator) {
-            AllowedValuesValidator avv = (AllowedValuesValidator) validator;
-            List<ModelNode> allowed = avv.getAllowedValues();
-            if (allowed != null) {
-                for (ModelNode ok : allowed) {
-                    node.get(ModelDescriptionConstants.ALLOWED).add(ok);
-                }
-            }
-        }
-
-
+        addAllowedValuesToDescription(node, validator);
         valueType.addValueTypeDescription(node, prefix, bundle,resolver,locale);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.controller;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -35,7 +34,6 @@ import javax.xml.stream.XMLStreamWriter;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
 import org.jboss.as.controller.operations.validation.MinMaxValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -216,17 +214,12 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
                 }
             }
         }
-
-        if (validator instanceof AllowedValuesValidator) {
-            AllowedValuesValidator avv = (AllowedValuesValidator) validator;
-            List<ModelNode> allowed = avv.getAllowedValues();
-            if (allowed != null) {
-                for (ModelNode ok : allowed) {
-                    result.get(ModelDescriptionConstants.ALLOWED).add(ok);
-                }
-            }
-        }
         return result;
+    }
+
+    @Override
+    protected void addAllowedValuesToDescription(ModelNode result, ParameterValidator validator) {
+        //Don't add allowed values for object types, since they simply enumerate the fields given in the value type
     }
 
     public static final class Builder extends AbstractAttributeDefinitionBuilder<Builder, ObjectTypeAttributeDefinition> {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
@@ -22,16 +22,15 @@
 
 package org.jboss.as.controller;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
 import org.jboss.as.controller.operations.validation.MinMaxValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -157,15 +156,7 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
                 }
             }
         }
-        if (validator instanceof AllowedValuesValidator) {
-            AllowedValuesValidator avv = (AllowedValuesValidator) validator;
-            List<ModelNode> allowed = avv.getAllowedValues();
-            if (allowed != null) {
-                for (ModelNode ok : allowed) {
-                    result.get(ModelDescriptionConstants.ALLOWED).add(ok);
-                }
-            }
-        }
+        addAllowedValuesToDescription(result, validator);
         return result;
     }
 

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXExtension.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXExtension.java
@@ -23,7 +23,6 @@
 package org.jboss.as.jmx;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -51,12 +50,9 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
-import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.transform.AbstractOperationTransformer;
 import org.jboss.as.controller.transform.AbstractSubsystemTransformer;
 import org.jboss.as.controller.transform.OperationResultTransformer;
@@ -101,12 +97,7 @@ public class JMXExtension implements Extension {
     public void initialize(ExtensionContext context) {
         final SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
-        final boolean registerRuntimeOnly = context.isRuntimeOnlyRegistrationValid();
-        final ManagementResourceRegistration subsystem = registration.registerSubsystemModel(new JMXSubsystemRootResource());
-        subsystem.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
-        subsystem.registerSubModel(ExposeModelResourceResolved.INSTANCE);
-        subsystem.registerSubModel(ExposeModelResourceExpression.INSTANCE);
-        subsystem.registerSubModel(RemotingConnectorResource.INSTANCE);
+        registration.registerSubsystemModel(new JMXSubsystemRootResource());
         registration.registerXMLElementWriter(writer);
 
         registerTransformers1_0_0(registration);

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -64,12 +65,21 @@ public class JMXSubsystemRootResource extends SimpleResourceDefinition {
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadWriteAttribute(SHOW_MODEL_ALIAS, ShowModelAliasReadHandler.INSTANCE, ShowModelAliasWriteHandler.INSTANCE);
     }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerSubModel(ExposeModelResourceResolved.INSTANCE);
+        resourceRegistration.registerSubModel(ExposeModelResourceExpression.INSTANCE);
+        resourceRegistration.registerSubModel(RemotingConnectorResource.INSTANCE);
+    }
+
 
     private static class ShowModelAliasWriteHandler implements OperationStepHandler {
         static final ShowModelAliasWriteHandler INSTANCE = new ShowModelAliasWriteHandler();

--- a/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorRemove.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorRemove.java
@@ -25,8 +25,6 @@ package org.jboss.as.jmx;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -40,8 +38,6 @@ class RemotingConnectorRemove extends AbstractRemoveStepHandler {
         //
     }
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        final PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
-        final String name = address.getLastElement().getValue();
         context.removeService(RemotingConnectorService.SERVICE_NAME);
     }
 

--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -357,17 +357,6 @@ public class MBeanInfoFactory {
         return new ImmutableDescriptor(descriptions);
     }
 
-    private Descriptor createParameterDescriptor(ModelNode parameter) {
-        Map<String, String> descriptions = new HashMap<String, String>();
-        addMBeanExpressionSupport(descriptions);
-        Boolean allowExpressions = parameter.hasDefined(EXPRESSIONS_ALLOWED) && parameter.get(EXPRESSIONS_ALLOWED).asBoolean();
-        descriptions.put(DESC_EXPRESSIONS_ALLOWED, allowExpressions.toString());
-        descriptions.put(DESC_EXPRESSIONS_ALLOWED_DESC, allowExpressions ?
-                MESSAGES.descriptorParameterExpressionsAllowedTrue() : MESSAGES.descriptorParameterExpressionsAllowedFalse());
-        return new ImmutableDescriptor(descriptions);
-    }
-
-
     private void addMBeanExpressionSupport(Map<String, String> descriptions) {
         if (legacy) {
             descriptions.put(DESC_MBEAN_EXPR, "true");

--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -22,11 +22,9 @@
 package org.jboss.as.jmx.model;
 
 import static javax.management.JMX.DEFAULT_VALUE_FIELD;
-import static javax.management.JMX.LEGAL_VALUES_FIELD;
 import static javax.management.JMX.MAX_VALUE_FIELD;
 import static javax.management.JMX.MIN_VALUE_FIELD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
@@ -49,7 +47,6 @@ import static org.jboss.as.jmx.JmxMessages.MESSAGES;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -250,6 +247,7 @@ public class MBeanInfoFactory {
         }
         List<Property> propertyList = opNode.get(REQUEST_PROPERTIES).asPropertyList();
         List<OpenMBeanParameterInfo> params = new ArrayList<OpenMBeanParameterInfo>(propertyList.size());
+
         for (Property prop : propertyList) {
             ModelNode value = prop.getValue();
             String paramName = NameConverter.convertToCamelCase(prop.getName());
@@ -262,13 +260,8 @@ public class MBeanInfoFactory {
             if (!expressionsAllowed) {
                 Object defaultValue = getIfExists(value, DEFAULT);
                 descriptions.put(DEFAULT_VALUE_FIELD, defaultValue);
-                if (value.has(ALLOWED)) {
-                    List<ModelNode> allowed = value.get(ALLOWED).asList();
-                    descriptions.put(LEGAL_VALUES_FIELD, new HashSet<ModelNode>(allowed));
-                } else {
-                    descriptions.put(MIN_VALUE_FIELD, getIfExistsAsComparable(value, MIN));
-                    descriptions.put(MAX_VALUE_FIELD, getIfExistsAsComparable(value, MAX));
-                }
+                descriptions.put(MIN_VALUE_FIELD, getIfExistsAsComparable(value, MIN));
+                descriptions.put(MAX_VALUE_FIELD, getIfExistsAsComparable(value, MAX));
             }
 
             params.add(
@@ -291,12 +284,12 @@ public class MBeanInfoFactory {
         }
     }
 
-    private Comparable getIfExistsAsComparable(final ModelNode parentNode, final String name) {
+    private Comparable<?> getIfExistsAsComparable(final ModelNode parentNode, final String name) {
         if (parentNode.has(name)) {
             ModelNode defaultNode = parentNode.get(name);
             Object value = converters.fromModelNode(parentNode, defaultNode);
             if (value instanceof Comparable) {
-                return (Comparable) value;
+                return (Comparable<?>) value;
             }
         }
         return null;

--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -22,10 +22,14 @@
 package org.jboss.as.jmx.model;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
@@ -51,6 +55,7 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanNotificationInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.ObjectName;
+import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenMBeanAttributeInfo;
 import javax.management.openmbean.OpenMBeanAttributeInfoSupport;
 import javax.management.openmbean.OpenMBeanConstructorInfo;
@@ -253,8 +258,29 @@ public class MBeanInfoFactory {
                             getDescription(prop.getValue()),
                             converters.convertToMBeanType(value),
                             new ImmutableDescriptor(descriptions)));
+
         }
         return params.toArray(new OpenMBeanParameterInfo[params.size()]);
+    }
+
+    private Object getIfExists(final ModelNode parentNode, final String name) {
+        if (parentNode.has(DEFAULT)) {
+            ModelNode defaultNode = parentNode.get(DEFAULT);
+            return TypeConverter.fromModelNode(parentNode, defaultNode);
+        } else {
+            return null;
+        }
+    }
+
+    private Comparable getIfExistsAsComparable(final ModelNode parentNode, final String name) {
+        if (parentNode.has(name)) {
+            ModelNode defaultNode = parentNode.get(name);
+            Object value = TypeConverter.fromModelNode(parentNode, defaultNode);
+            if (value instanceof Comparable) {
+                return (Comparable) value;
+            }
+        }
+        return null;
     }
 
     private OpenType<?> getReturnType(ModelNode opNode) {

--- a/jmx/src/main/java/org/jboss/as/jmx/model/TypeConverters.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/TypeConverters.java
@@ -532,11 +532,7 @@ class TypeConverters {
                 final Map<String, Object> items = new HashMap<String, Object>();
                 for (String attrName : compositeType.keySet()) {
                     TypeConverter converter = getConverter(typeNode.get(attrName, TYPE), typeNode.get(attrName, VALUE_TYPE));
-                    try {
-                        items.put(attrName, converter.fromModelNode(node.get(attrName)));
-                    } catch (Exception e) {
-                        System.out.println("xxx");
-                    }
+                    items.put(attrName, converter.fromModelNode(node.get(attrName)));
                 }
 
                 try {

--- a/jmx/src/main/java/org/jboss/as/jmx/model/TypeConverters.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/TypeConverters.java
@@ -532,7 +532,11 @@ class TypeConverters {
                 final Map<String, Object> items = new HashMap<String, Object>();
                 for (String attrName : compositeType.keySet()) {
                     TypeConverter converter = getConverter(typeNode.get(attrName, TYPE), typeNode.get(attrName, VALUE_TYPE));
-                    items.put(attrName, converter.fromModelNode(node.get(attrName)));
+                    try {
+                        items.put(attrName, converter.fromModelNode(node.get(attrName)));
+                    } catch (Exception e) {
+                        System.out.println("xxx");
+                    }
                 }
 
                 try {

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -26,6 +26,14 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -38,9 +46,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -249,17 +259,35 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(IntOperationWithParams.OPERATION_JMX_NAME, op.getName());
         Assert.assertEquals("Test2", op.getDescription());
         Assert.assertEquals(String.class.getName(), op.getReturnType());
-        Assert.assertEquals(3, op.getSignature().length);
+        Assert.assertEquals(5, op.getSignature().length);
+
         Assert.assertEquals("param1", op.getSignature()[0].getName());
         Assert.assertEquals("Param1", op.getSignature()[0].getDescription());
         Assert.assertEquals(Long.class.getName(), op.getSignature()[0].getType());
+
         Assert.assertEquals("param2", op.getSignature()[1].getName());
         Assert.assertEquals("Param2", op.getSignature()[1].getDescription());
         Assert.assertEquals(String[].class.getName(), op.getSignature()[1].getType());
+
         Assert.assertEquals("param3", op.getSignature()[2].getName());
         Assert.assertEquals("Param3", op.getSignature()[2].getDescription());
         Assert.assertEquals(TabularData.class.getName(), op.getSignature()[2].getType());
         assertMapType(assertCast(OpenMBeanParameterInfo.class, op.getSignature()[2]).getOpenType(), SimpleType.STRING, SimpleType.INTEGER);
+
+        Assert.assertEquals("param4", op.getSignature()[3].getName());
+        Assert.assertEquals("Param4", op.getSignature()[3].getDescription());
+        Assert.assertEquals(Integer.class.getName(), op.getSignature()[3].getType());
+        OpenMBeanParameterInfo parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[3]);
+        Assert.assertEquals(6, parameterInfo.getDefaultValue());
+        Assert.assertEquals(5, parameterInfo.getMinValue());
+        Assert.assertEquals(10, parameterInfo.getMaxValue());
+
+        Assert.assertEquals("param5", op.getSignature()[4].getName());
+        Assert.assertEquals("Param5", op.getSignature()[4].getDescription());
+        Assert.assertEquals(Integer.class.getName(), op.getSignature()[4].getType());
+        parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertEquals(new HashSet<Object>(Arrays.asList(3, 5, 7)), parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());
@@ -792,8 +820,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         String result = assertCast(String.class, connection.invoke(
                 name,
                 IntOperationWithParams.OPERATION_JMX_NAME,
-                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3)},
-                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName()}));
+                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3), 5, 5},
+                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()}));
         Assert.assertEquals("A105", result);
         Assert.assertTrue(IntOperationWithParams.INSTANCE_NO_EXPRESSIONS.invoked);
 
@@ -1473,6 +1501,18 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
                 node.get(REQUEST_PROPERTIES, "param3", VALUE_TYPE).set(ModelType.INT);
                 node.get(REQUEST_PROPERTIES, "param3", DESCRIPTION).set("Param3");
                 node.get(REQUEST_PROPERTIES, "param3", EXPRESSIONS_ALLOWED).set(allowExpressions);
+                node.get(REQUEST_PROPERTIES, "param4", TYPE).set(ModelType.INT);
+                node.get(REQUEST_PROPERTIES, "param4", DESCRIPTION).set("Param4");
+                node.get(REQUEST_PROPERTIES, "param4", EXPRESSIONS_ALLOWED).set(allowExpressions);
+                node.get(REQUEST_PROPERTIES, "param4", DEFAULT).set(6);
+                node.get(REQUEST_PROPERTIES, "param4", MIN).set(5);
+                node.get(REQUEST_PROPERTIES, "param4", MAX).set(10);
+                node.get(REQUEST_PROPERTIES, "param5", TYPE).set(ModelType.INT);
+                node.get(REQUEST_PROPERTIES, "param5", DESCRIPTION).set("Param5");
+                node.get(REQUEST_PROPERTIES, "param5", EXPRESSIONS_ALLOWED).set(allowExpressions);
+                node.get(REQUEST_PROPERTIES, "param5", ALLOWED).add(3);
+                node.get(REQUEST_PROPERTIES, "param5", ALLOWED).add(5);
+                node.get(REQUEST_PROPERTIES, "param5", ALLOWED).add(7);
                 node.get(REPLY_PROPERTIES, TYPE).set(ModelType.STRING);
                 node.get(REPLY_PROPERTIES, DESCRIPTION).set("Return");
                 return node;

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -110,7 +110,6 @@ import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
-import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceName;
@@ -1089,24 +1088,10 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         return null;
     }
 
-    private void assertEqualByteArray(byte[] bytes, int...expected) {
-        Assert.assertEquals(expected.length, bytes.length);
-        for (int i = 0 ; i < bytes.length ; i++) {
-            Assert.assertEquals(expected[i], bytes[i]);
-        }
-    }
-
     private void assertEqualByteArray(byte[] bytes, byte...expected) {
         Assert.assertEquals(expected.length, bytes.length);
         for (int i = 0 ; i < bytes.length ; i++) {
             Assert.assertEquals(expected[i], bytes[i]);
-        }
-    }
-
-    private void assertEqualList(List<?> list, Object...expected) {
-        Assert.assertEquals(expected.length, list.size());
-        for (int i = 0 ; i < list.size() ; i++) {
-            Assert.assertEquals(expected[i], list.get(i));
         }
     }
 
@@ -1209,7 +1194,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
                 + "<expose-expression-model/>"
                 + "<remoting-connector/>" + "</subsystem>"
                 + additionalInitialization.getExtraXml();
-        KernelServices services = super.installInController(additionalInitialization, subsystemXml);
+        createKernelServicesBuilder(additionalInitialization).setSubsystemXml(subsystemXml).build();
 
         // Make sure that we can connect to the MBean server
         String host = "localhost";

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -22,10 +22,6 @@
 package org.jboss.as.jmx;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPRESSIONS_ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
@@ -238,7 +234,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -319,7 +315,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -361,7 +357,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -382,17 +378,35 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(IntOperationWithParams.OPERATION_JMX_NAME, op.getName());
         Assert.assertEquals("Test2", op.getDescription());
         Assert.assertEquals(String.class.getName(), op.getReturnType());
-        Assert.assertEquals(3, op.getSignature().length);
+        Assert.assertEquals(5, op.getSignature().length);
+
         Assert.assertEquals("param1", op.getSignature()[0].getName());
         Assert.assertEquals("Param1", op.getSignature()[0].getDescription());
         Assert.assertEquals(String.class.getName(), op.getSignature()[0].getType());
+
         Assert.assertEquals("param2", op.getSignature()[1].getName());
         Assert.assertEquals("Param2", op.getSignature()[1].getDescription());
         Assert.assertEquals(String[].class.getName(), op.getSignature()[1].getType());
+
         Assert.assertEquals("param3", op.getSignature()[2].getName());
         Assert.assertEquals("Param3", op.getSignature()[2].getDescription());
         Assert.assertEquals(TabularData.class.getName(), op.getSignature()[2].getType());
         assertMapType(assertCast(OpenMBeanParameterInfo.class, op.getSignature()[2]).getOpenType(), SimpleType.STRING, SimpleType.STRING);
+
+        Assert.assertEquals("param4", op.getSignature()[3].getName());
+        Assert.assertEquals("Param4", op.getSignature()[3].getDescription());
+        Assert.assertEquals(String.class.getName(), op.getSignature()[3].getType());
+        OpenMBeanParameterInfo parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[3]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getMinValue());
+        Assert.assertNull(parameterInfo.getMaxValue());
+
+        Assert.assertEquals("param5", op.getSignature()[4].getName());
+        Assert.assertEquals("Param5", op.getSignature()[4].getDescription());
+        Assert.assertEquals(String.class.getName(), op.getSignature()[4].getType());
+        parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());
@@ -849,8 +863,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
             connection.invoke(
                 name,
                 IntOperationWithParams.OPERATION_JMX_NAME,
-                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3)},
-                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName()});
+                new Object[] {100L, new String[] {"A"}, Collections.singletonMap("test", 3), 5, 5},
+                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()});
             Assert.fail("Should not have been able to invoke method");
         } catch (Exception expected) {
         }
@@ -870,8 +884,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         String result = assertCast(String.class, connection.invoke(
                 name,
                 IntOperationWithParams.OPERATION_JMX_NAME,
-                new Object[] {"${should.not.exist!!!!!:100}", new String[] {"${should.not.exist!!!!!:A}"}, Collections.singletonMap("test", "${should.not.exist!!!!!:3}")},
-                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName()}));
+                new Object[] {"${should.not.exist!!!!!:100}", new String[] {"${should.not.exist!!!!!:A}"}, Collections.singletonMap("test", "${should.not.exist!!!!!:3}"), "${should.not.exist!!!!!:5}", "${should.not.exist!!!!!:5}"},
+                new String[] {Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()}));
         Assert.assertEquals("A105", result);
         Assert.assertTrue(IntOperationWithParams.INSTANCE_EXPRESSIONS.invoked);
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -42,11 +42,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -283,7 +281,6 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(Integer.class.getName(), op.getSignature()[4].getType());
         parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
         Assert.assertNull(parameterInfo.getDefaultValue());
-        Assert.assertEquals(new HashSet<Object>(Arrays.asList(3, 5, 7)), parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -42,9 +42,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -232,7 +234,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -281,6 +283,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals(Integer.class.getName(), op.getSignature()[4].getType());
         parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
         Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertEquals(new HashSet<Object>(Arrays.asList(3, 5, 7)), parameterInfo.getLegalValues());
 
         op = findOperation(operations, ComplexOperation.OPERATION_NAME);
         Assert.assertEquals(ComplexOperation.OPERATION_NAME, op.getName());
@@ -312,7 +316,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -354,7 +358,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-//        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -402,6 +406,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertEquals("Param5", op.getSignature()[4].getDescription());
         Assert.assertEquals(String.class.getName(), op.getSignature()[4].getType());
         parameterInfo = assertCast(OpenMBeanParameterInfo.class, op.getSignature()[4]);
+        Assert.assertNull(parameterInfo.getDefaultValue());
+        Assert.assertNull(parameterInfo.getLegalValues());
         Assert.assertNull(parameterInfo.getDefaultValue());
         Assert.assertNull(parameterInfo.getLegalValues());
 

--- a/jmx/src/test/java/org/jboss/as/jmx/model/ExpressionTypeConverterUnitTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/ExpressionTypeConverterUnitTestCase.java
@@ -680,7 +680,7 @@ public class ExpressionTypeConverterUnitTestCase {
         ModelNode description = createDescription(ModelType.LIST, ModelType.INT);
         description.get(EXPRESSIONS_ALLOWED).set(true);
         TypeConverter converter = getConverter(description);
-        ArrayType<?> arrayType = assertCast(ArrayType.class, converter.getOpenType());
+        assertCast(ArrayType.class, converter.getOpenType());
 
         ModelNode node = new ModelNode();
         node.addExpression("${this.should.not.exist.!!!!!:1}");

--- a/logging/src/main/java/org/jboss/as/logging/PropertyObjectTypeAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PropertyObjectTypeAttributeDefinition.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.operations.validation.ObjectTypeValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.logging.resolvers.ModelNodeResolver;
 import org.jboss.dmr.ModelNode;
@@ -48,10 +49,10 @@ public class PropertyObjectTypeAttributeDefinition extends ObjectTypeAttributeDe
 
     private PropertyObjectTypeAttributeDefinition(final String name, final String xmlName, final String propertyName, final String suffix,
                                                   final AttributeDefinition[] valueTypes, final boolean allowNull, final ModelNodeResolver<String> resolver,
-                                                  final ParameterCorrector corrector, final String[] alternatives, final String[] requires,
+                                                  final ParameterValidator validator, final ParameterCorrector corrector, final String[] alternatives, final String[] requires,
                                                   final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecationData,
                                                   final AttributeAccess.Flag... flags) {
-        super(name, xmlName, suffix, valueTypes, allowNull, new ObjectTypeValidator(allowNull, valueTypes), corrector, alternatives, requires, attributeMarshaller, resourceOnly, deprecationData, flags);
+        super(name, xmlName, suffix, valueTypes, allowNull, validator, corrector, alternatives, requires, attributeMarshaller, resourceOnly, deprecationData, flags);
         this.propertyName = propertyName;
         this.resolver = resolver;
     }
@@ -107,7 +108,11 @@ public class PropertyObjectTypeAttributeDefinition extends ObjectTypeAttributeDe
 
         public PropertyObjectTypeAttributeDefinition build() {
             if (xmlName == null) xmlName = name;
-            return new PropertyObjectTypeAttributeDefinition(name, xmlName, propertyName, suffix, valueTypes, allowNull, resolver, corrector, alternatives, requires, attributeMarshaller, resourceOnly, deprecated, flags);
+            ParameterValidator validator = this.validator;
+            if (validator == null) {
+                validator = new ObjectTypeValidator(allowNull, valueTypes);
+            }
+            return new PropertyObjectTypeAttributeDefinition(name, xmlName, propertyName, suffix, valueTypes, allowNull, resolver, validator, corrector, alternatives, requires, attributeMarshaller, resourceOnly, deprecated, flags);
         }
 
         public Builder setSuffix(final String suffix) {


### PR DESCRIPTION
Supersedes #2693. The problem in #2693 was due to complex value types incorrectly returning useless 'allowed' values in the description, simply enumerating the value type keys, e.g.:
http://pastebin.com/dbfxjJKK
