### PR TITLE
cli things

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
@@ -139,6 +139,7 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
     }
 
     class DefaultValueState implements ValueState {
+
         private ModelNode wrapper;
         private boolean list;
 
@@ -196,7 +197,11 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
             if(wrapper != null) {
                 if(name == null) {
                     if(buf != null && buf.length() > 0) {
-                        wrapper.add(getStringValue());
+                        if(list || wrapper.getType().equals(ModelType.LIST)) {
+                            wrapper.add(getStringValue());
+                        } else {
+                            wrapper.set(getStringValue());
+                        }
                     }
                 } else {
                     addChild(wrapper, name, getStringValue());
@@ -309,18 +314,5 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
         public boolean isList() {
             return true;
         }
-    }
-
-    public static void main(String[] args) throws Exception {
-
-        ModelNode one = new ModelNode();
-        one.get("prop1").set("value1");
-        one.get("prop2").set("value2");
-        System.out.println(one);
-
-        ModelNode two = new ModelNode();
-        two.add("prop1", "value1");
-        two.add("prop2", "value2");
-        System.out.println(two);
     }
 }


### PR DESCRIPTION
A few commits I had around for some time in different branches and would like to get in:
- recognition of the cli process timeout in the testsuite;
- how the default parameter value completer is chosen for types described with value-type and/or allowed;
- recognition of list and non-list parameter values in the simplified dmr format.

I think these should be cherry-picked for 7.1 too.

Thanks,
Alexey
