### PR TITLE
[AS7-5808][AS7-5814] messaging security-settings permission

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -599,7 +599,15 @@
           <xs:element maxOccurs="unbounded" minOccurs="0" name="permission">
              <xs:complexType>
                 <xs:attribute name="type" type="xs:string" use="required"/>
-                <xs:attribute name="roles" type="xs:string" use="required"/>
+                <xs:attribute name="roles" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                List of roles that are granted the permission for the given type. The roles must be separated by spaces or commas.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
        </xs:sequence>

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -598,7 +598,7 @@
        <xs:sequence>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="permission">
              <xs:complexType>
-                <xs:attribute name="type" type="xs:string" use="required"/>
+                <xs:attribute name="type" type="security-permissionType" use="required"/>
                 <xs:attribute name="roles" type="xs:string" use="required">
                     <xs:annotation>
                         <xs:documentation>
@@ -1034,6 +1034,32 @@
          <xs:enumeration value="AT_MOST_ONCE"/>
          <xs:enumeration value="DUPLICATES_OK"/>
          <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="security-permissionType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="send"/>
+         <xs:enumeration value="consume"/>
+         <xs:enumeration value="createDurableQueue"/>
+         <xs:enumeration value="deleteDurableQueue"/>
+         <xs:enumeration value="createNonDurableQueue"/>
+         <xs:enumeration value="deleteNonDurableQueue"/>
+         <xs:enumeration value="manage"/>
+         <xs:enumeration value="createTempQueue">
+             <xs:annotation>
+                 <xs:documentation>
+                     Deprecated. use createNonDurableQueue instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="deleteTempQueue">
+             <xs:annotation>
+                 <xs:documentation>
+                     Deprecated. use deleteNonDurableQueue instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:enumeration>
       </xs:restriction>
    </xs:simpleType>
 

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.messaging;
 
+import static java.util.Arrays.asList;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -36,6 +37,7 @@ import static org.jboss.as.messaging.Element.DISCOVERY_GROUP_REF;
 import static org.jboss.as.messaging.Element.STATIC_CONNECTORS;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -304,6 +306,18 @@ public class Messaging13SubsystemParser extends Messaging12SubsystemParser {
                     throw ParseUtils.unexpectedElement(reader);
             }
         }
+    }
+
+    /**
+     * [AS7-5808] Support space-separated roles names for backwards compatibility and comma-separated ones for compatibility with
+     * HornetQ configuration.
+     *
+     * Roles are persisted using space character delimiter in {@link MessagingXMLWriter}.
+     */
+    @Override
+    protected List<String> parseRolesAttribute(XMLExtendedStreamReader reader, int index) throws XMLStreamException {
+        String roles = reader.getAttributeValue(index);
+        return asList(roles.split("[,\\s]+"));
     }
 
     static void handleSingleAttribute(final XMLExtendedStreamReader reader, final Element element, final String modelName, String attributeName, final ModelNode node) throws XMLStreamException {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -954,7 +954,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         }
     }
 
-    static ModelNode processSecuritySettings(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
+    private ModelNode processSecuritySettings(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
         final ModelNode security = new ModelNode();
         String localName = null;
         do {
@@ -980,7 +980,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         return security;
     }
 
-    static void parseSecurityRoles(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
+    private void parseSecurityRoles(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
 
         final Map<String, Set<AttributeDefinition>> permsByRole = new HashMap<String, Set<AttributeDefinition>>();
         String localName = null;
@@ -1002,7 +1002,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 required.remove(attribute);
                 switch (attribute) {
                     case ROLES_ATTR_NAME:
-                        roles = reader.getListAttributeValue(i);
+                        roles = parseRolesAttribute(reader, i);
                         break;
                     case TYPE_ATTR_NAME:
                         perm = SecurityRoleDefinition.ROLE_ATTRIBUTES_BY_XML_NAME.get(reader.getAttributeValue(i));
@@ -1051,6 +1051,10 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
 
             operations.add(operation);
         }
+    }
+
+    protected List<String> parseRolesAttribute(final XMLExtendedStreamReader reader, int index) throws XMLStreamException {
+        return reader.getListAttributeValue(index);
     }
 
     static void processConnectors(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {


### PR DESCRIPTION
- accept a comma-separated list of security roles (to be compatible with HornetQ configuration) in addition to space delimiter
- change security-settings permission type for a free form xs:string to an enumaration of the accepted values
