### PR TITLE
AS7-5815 Upgrading JBossTS to 4.17.2.Final

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1063,11 +1063,11 @@
         </module-def>
 
         <module-def name="org.jboss.jts">
-            <maven-resource group="org.jboss.jbossts" artifact="jbossjts"/>
+            <maven-resource group="org.jboss.jbossts.jts" artifact="jbossjts-jacorb"/>
         </module-def>
 
         <module-def name="org.jboss.jts.integration">
-            <maven-resource group="org.jboss.jbossts" artifact="jbossjts-integration"/>
+            <maven-resource group="org.jboss.jbossts.jts" artifact="jbossjts-integration"/>
         </module-def>
 
         <module-def name="org.jboss.metadata">
@@ -1257,8 +1257,7 @@
         </module-def>
 
         <module-def name="org.jboss.xts">
-            <maven-resource group="org.jboss.jbossts" artifact="jbossxts"/>
-            <maven-resource group="org.jboss.jbossts" artifact="jbossxts-api"/>
+            <maven-resource group="org.jboss.jbossts.xts" artifact="jbossxts"/>
             <maven-resource group="org.jboss.jbossts" artifact="jbosstxbridge"/>
         </module-def>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1218,12 +1218,12 @@
                 </dependency>
 
                 <dependency>
-                    <groupId>org.jboss.jbossts</groupId>
-                    <artifactId>jbossjts</artifactId>
+                    <groupId>org.jboss.jbossts.jts</groupId>
+                    <artifactId>jbossjts-jacorb</artifactId>
                 </dependency>
 
                 <dependency>
-                    <groupId>org.jboss.jbossts</groupId>
+                    <groupId>org.jboss.jbossts.jts</groupId>
                     <artifactId>jbossjts-integration</artifactId>
                 </dependency>
 
@@ -1233,13 +1233,14 @@
                 </dependency>
 
                 <dependency>
-                    <groupId>org.jboss.jbossts</groupId>
+                    <groupId>org.jboss.jbossts.xts</groupId>
                     <artifactId>jbossxts</artifactId>
                 </dependency>
 
                 <dependency>
-                    <groupId>org.jboss.jbossts</groupId>
-                    <artifactId>jbossxts-api</artifactId>
+                    <groupId>org.jboss.jbossts.xts</groupId>
+                    <artifactId>jbossxts</artifactId>
+                    <classifier>api</classifier>
                 </dependency>
 
                 <dependency>
@@ -1932,9 +1933,9 @@
                                         <include>org.jboss:jboss-remote-naming</include>
                                         <include>org.jboss.jbossts:jbosstxbridge</include>
 
-                                        <!--
-                                        <include>org.jboss.jbossts:jbossxts</include>
-                                        <include>org.jboss.jbossts:jbossxts-api</include>
+                                        <!--                                        
+                                        <include>org.jboss.jbossts.xts:jbossxts</include>
+                                        <include>org.jboss.jbossts.xts:jbossxts-api</include>
                                         -->
                                         <include>org.jboss:jboss-vfs</include>
 

--- a/build/src/license/licenses.xml
+++ b/build/src/license/licenses.xml
@@ -2281,8 +2281,8 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.jbossts</groupId>
-      <artifactId>jbossjts</artifactId>
+      <groupId>org.jboss.jbossts.jts</groupId>
+      <artifactId>jbossjts-jacorb</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License, Version 2.1</name>
@@ -2291,7 +2291,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.jbossts</groupId>
+      <groupId>org.jboss.jbossts.jts</groupId>
       <artifactId>jbossjts-integration</artifactId>
       <licenses>
         <license>
@@ -2311,7 +2311,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.jbossts</groupId>
+      <groupId>org.jboss.jbossts.xts</groupId>
       <artifactId>jbossxts</artifactId>
       <licenses>
         <license>
@@ -2321,8 +2321,9 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.jbossts</groupId>
-      <artifactId>jbossxts-api</artifactId>
+      <groupId>org.jboss.jbossts.xts</groupId>
+      <artifactId>jbossxts</artifactId>
+      <classifier>api</classifier>
       <licenses>
         <license>
           <name>GNU Lesser General Public License, Version 2.1</name>

--- a/jacorb/pom.xml
+++ b/jacorb/pom.xml
@@ -102,8 +102,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.jbossts</groupId>
-            <artifactId>jbossjts</artifactId>
+            <groupId>org.jboss.jbossts.jts</groupId>
+            <artifactId>jbossjts-jacorb</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,9 @@
         <version.org.jboss.jandex>1.0.3.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.1.3.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.0.0.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.jbossts.jbossjts>4.16.6.Final</version.org.jboss.jbossts.jbossjts>
-        <version.org.jboss.jbossts.jbossjts-integration>4.16.6.Final</version.org.jboss.jbossts.jbossjts-integration>
-        <version.org.jboss.jbossts.jbossxts>4.16.6.Final</version.org.jboss.jbossts.jbossxts>
+        <version.org.jboss.jbossts.jbossjts>4.17.2.Final</version.org.jboss.jbossts.jbossjts>
+        <version.org.jboss.jbossts.jbossjts-integration>4.17.2.Final</version.org.jboss.jbossts.jbossjts-integration>
+        <version.org.jboss.jbossts.jbossxts>4.17.2.Final</version.org.jboss.jbossts.jbossxts>
         <version.org.jboss.jboss-vfs>3.1.0.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.jsfunit>2.0.0.Beta1</version.org.jboss.jsfunit>
         <version.org.jboss.logging.jboss-logging>3.1.2.GA</version.org.jboss.logging.jboss-logging>
@@ -4104,8 +4104,8 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.jbossts</groupId>
-                <artifactId>jbossjts</artifactId>
+                <groupId>org.jboss.jbossts.jts</groupId>
+                <artifactId>jbossjts-jacorb</artifactId>
                 <version>${version.org.jboss.jbossts.jbossjts}</version>
                 <exclusions>
                     <exclusion>
@@ -4240,7 +4240,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.jbossts</groupId>
+                <groupId>org.jboss.jbossts.jts</groupId>
                 <artifactId>jbossjts-integration</artifactId>
                 <version>${version.org.jboss.jbossts.jbossjts-integration}</version>
                 <exclusions>
@@ -4384,7 +4384,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.jbossts</groupId>
+                <groupId>org.jboss.jbossts.xts</groupId>
                 <artifactId>jbossxts</artifactId>
                 <version>${version.org.jboss.jbossts.jbossxts}</version>
                 <exclusions>
@@ -4444,8 +4444,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.jbossts</groupId>
-                <artifactId>jbossxts-api</artifactId>
+                <groupId>org.jboss.jbossts.xts</groupId>
+                <artifactId>jbossxts</artifactId>
+                <classifier>api</classifier>
                 <version>${version.org.jboss.jbossts.jbossxts}</version>
                 <exclusions>
                     <exclusion>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -59,11 +59,11 @@
             <artifactId>jboss-transaction-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.jbossts</groupId>
-            <artifactId>jbossjts</artifactId>
+            <groupId>org.jboss.jbossts.jts</groupId>
+            <artifactId>jbossjts-jacorb</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.jbossts</groupId>
+            <groupId>org.jboss.jbossts.jts</groupId>
             <artifactId>jbossjts-integration</artifactId>
         </dependency>
 

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -73,16 +73,17 @@
             <artifactId>jboss-as-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.jbossts</groupId>
-            <artifactId>jbossjts</artifactId>
+            <groupId>org.jboss.jbossts.jts</groupId>
+            <artifactId>jbossjts-jacorb</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.jbossts</groupId>
+            <groupId>org.jboss.jbossts.xts</groupId>
             <artifactId>jbossxts</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.jbossts</groupId>
-            <artifactId>jbossxts-api</artifactId>
+            <groupId>org.jboss.jbossts.xts</groupId>
+            <artifactId>jbossxts</artifactId>
+            <classifier>api</classifier>
         </dependency>
         <dependency>
             <groupId>org.jboss.jbossts</groupId>


### PR DESCRIPTION
Note: this upgrade is for 7.2 branch, not the 7.1 branch. 7.1 branch must stay on JBossTS 4.16.x.

We've fixed the cause of the failure that broke 4.17.1.Final and also updated our CI to ensure that similar failures are caught in the future.

<disclaimer>
However, this is our first release of JBossTS, to go into AS7, since we moved to Maven, so there could be more environment issues.
</discalimer>
