### PR TITLE
[AS7-5832] Unable to read undefined queue attributes

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
@@ -90,9 +90,19 @@ public class JMSQueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         } else if (JMSQueueDefinition.QUEUE_ADDRESS.getName().equals(attributeName)) {
             context.getResult().set(control.getAddress());
         } else if (JMSQueueDefinition.EXPIRY_ADDRESS.getName().equals(attributeName)) {
-            context.getResult().set(control.getExpiryAddress());
+            // create the result node in all cases
+            ModelNode result = context.getResult();
+            String expiryAddress = control.getExpiryAddress();
+            if (expiryAddress != null) {
+                result.set(expiryAddress);
+            }
         } else if (JMSQueueDefinition.DEAD_LETTER_ADDRESS.getName().equals(attributeName)) {
-            context.getResult().set(control.getDeadLetterAddress());
+            // create the result node in all cases
+            ModelNode result = context.getResult();
+            String dla = control.getDeadLetterAddress();
+            if (dla != null) {
+                result.set(dla);
+            }
         } else if (CommonAttributes.PAUSED.getName().equals(attributeName)) {
             try {
                 context.getResult().set(control.isPaused());


### PR DESCRIPTION
- if jms-queue's dead-letter-address or expiry-address are null,
  return an undefined outcome result to avoid a IllegalArgumentException
  when setting a null value on a ModelNode
