### PR TITLE
[7.1][AS7-5832] Unable to read undefined queue attributes

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
@@ -108,9 +108,19 @@ public class JMSQueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         } else if (QUEUE_ADDRESS.getName().equals(attributeName)) {
             context.getResult().set(control.getAddress());
         } else if (EXPIRY_ADDRESS.getName().equals(attributeName)) {
-            context.getResult().set(control.getExpiryAddress());
+            // create the result node in all cases
+            ModelNode result = context.getResult();
+            String expiryAddress = control.getExpiryAddress();
+            if (expiryAddress != null) {
+                result.set(expiryAddress);
+            }
         } else if (DEAD_LETTER_ADDRESS.getName().equals(attributeName)) {
-            context.getResult().set(control.getDeadLetterAddress());
+            // create the result node in all cases
+            ModelNode result = context.getResult();
+            String dla = control.getDeadLetterAddress();
+            if (dla != null) {
+                result.set(dla);
+            }
         } else if (PAUSED.equals(attributeName)) {
             try {
                 context.getResult().set(control.isPaused());


### PR DESCRIPTION
- if jms-queue's dead-letter-address or expiry-address are null,
  return an undefined outcome result to avoid a IllegalArgumentException
  when setting a null value on a ModelNode
