### PR TITLE
AS7-5627 Scripts need to preserve arguments boundary

### DIFF
--- a/build/src/main/resources/bin/add-user.sh
+++ b/build/src/main/resources/bin/add-user.sh
@@ -69,4 +69,4 @@ eval \"$JAVA\" $JAVA_OPTS \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.domain-add-user \
-         "$@"
+         '"$@"'

--- a/build/src/main/resources/bin/appclient.sh
+++ b/build/src/main/resources/bin/appclient.sh
@@ -125,6 +125,6 @@ eval \"$JAVA\" $JAVA_OPTS \
  org.jboss.as.appclient \
  -Djboss.home.dir=\"$JBOSS_HOME\" \
  -Djboss.server.base.dir=\"$JBOSS_HOME/appclient\" \
- "$@"
+ '"$@"'
 JBOSS_STATUS=$?
 exit $JBOSS_STATUS

--- a/build/src/main/resources/bin/domain.sh
+++ b/build/src/main/resources/bin/domain.sh
@@ -188,7 +188,7 @@ while true; do
          $HOST_CONTROLLER_JAVA_OPTS \
          -- \
          -default-jvm \"$JAVA_FROM_JVM\" \
-         "$@"
+         '"$@"'
       JBOSS_STATUS=$?
    else
       # Execute the JVM in the background
@@ -207,7 +207,7 @@ while true; do
          $HOST_CONTROLLER_JAVA_OPTS \
          -- \
          -default-jvm \"$JAVA_FROM_JVM\" \
-         "$@" "&"
+         '"$@"' "&"
       JBOSS_PID=$!
       # Trap common signals and relay them to the jboss process
       trap "kill -HUP  $JBOSS_PID" HUP

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -24,7 +24,7 @@ do
           shift 
           break;;
       *)
-          SERVER_OPTS="$SERVER_OPTS $1"
+          SERVER_OPTS="$SERVER_OPTS \"$1\""
           ;;
     esac
     shift

--- a/build/src/main/resources/bin/wsconsume.sh
+++ b/build/src/main/resources/bin/wsconsume.sh
@@ -77,4 +77,4 @@ eval \"$JAVA\" $JAVA_OPTS \
     org.jboss.modules.Main \
     -mp \"$JBOSS_HOME/modules\" \
     org.jboss.ws.tools.wsconsume \
-    "$@"
+    '"$@"'

--- a/build/src/main/resources/bin/wsprovide.sh
+++ b/build/src/main/resources/bin/wsprovide.sh
@@ -72,4 +72,4 @@ eval \"$JAVA\" $JAVA_OPTS \
     -jar \"$JBOSS_HOME/jboss-modules.jar\" \
     -mp \"$JBOSS_HOME/modules\" \
     org.jboss.ws.tools.wsprovide \
-    "$@"
+    '"$@"'


### PR DESCRIPTION
Added additional quoting to command line args to scripts so that jboss modules can get valid args:

standalone.sh
domain.sh
appclient.sh
add-user.sh
wsconsume.sh
wsprovice.sh
