### PR TITLE
local-only web cache to enable session persistence in non-HA environments

### DIFF
--- a/build/src/main/resources/configuration/subsystems/infinispan.xml
+++ b/build/src/main/resources/configuration/subsystems/infinispan.xml
@@ -7,6 +7,11 @@
     </subsystem>
     <supplement name="default">
         <replacement placeholder="CACHE-CONTAINERS">
+            <cache-container name="web" aliases="standard-session-cache" default-cache="local-web" module="org.jboss.as.clustering.web.infinispan">
+                <local-cache name="local-web" batching="true">
+                    <file-store passivation="false" purge="false"/>
+                </local-cache>
+            </cache-container>
             <cache-container name="hibernate" default-cache="local-query" module="org.jboss.as.jpa.hibernate:4">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -64,6 +64,18 @@
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
+
+        <container qualifier="container-single" mode="manual" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>
+                <property name="serverConfig">standalone.xml</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
         
     </group>
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
@@ -39,6 +39,7 @@ public class ClusteringTestConstants {
     /**
      * Manual container with unmanaged deployments names.
      */
+    public static final String CONTAINER_SINGLE = "container-single";
     public static final String CONTAINER_1 = "container-0";
     public static final String CONTAINER_2 = "container-1";
     public static final String[] CONTAINERS = new String[] { CONTAINER_1, CONTAINER_2 };

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,22 +19,33 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.clustering.single.web;
+package org.jboss.as.test.clustering.cluster.web;
 
-import java.io.IOException;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_SINGLE;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
 
-import java.net.URL;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URL;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -43,26 +54,39 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Validate the <distributable/> works for single node.
- * 
- * @author Paul Ferraro
+ * Validates that session passivation in non-HA environment works (on single node).
+ *
+ * @author Radoslav Husar
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class SimpleWebTestCase {
+public class NonHaWebSessionPersistenceTestCase {
 
-    @Deployment(name = "deployment-single")
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_SINGLE)
     public static Archive<?> deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
-        war.setWebXML(SimpleWebTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
+        war.setWebXML(NonHaWebSessionPersistenceTestCase.class.getPackage(), "web.xml");
         return war;
     }
 
+    @ArquillianResource
+    private ContainerController controller;
+    @ArquillianResource
+    private Deployer deployer;
+
     @Test
-    @OperateOnDeployment("deployment-single")
-    public void test(@ArquillianResource(SimpleServlet.class) URL baseURL) throws ClientProtocolException, IOException {
+    @InSequence(-1)
+    public void testStartContainerAndDeployment() {
+        controller.start(CONTAINER_SINGLE);
+        deployer.deploy(DEPLOYMENT_1);
+    }
+
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_1)
+    public void testSessionPersistence(@ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL) throws ClientProtocolException, IOException {
         DefaultHttpClient client = new DefaultHttpClient();
 
         String url = baseURL.toString() + "simple";
@@ -74,14 +98,19 @@ public class SimpleWebTestCase {
             Assert.assertFalse(Boolean.valueOf(response.getFirstHeader("serialized").getValue()));
             response.getEntity().getContent().close();
 
+            controller.stop(CONTAINER_SINGLE);
+            controller.start(CONTAINER_SINGLE);
+
             response = client.execute(new HttpGet(url));
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            // This won't be true unless we have somewhere to which to replicate or session persistence is configured (current default)
             Assert.assertTrue(Boolean.valueOf(response.getFirstHeader("serialized").getValue()));
             response.getEntity().getContent().close();
         } finally {
             client.getConnectionManager().shutdown();
         }
+
+        deployer.undeploy(DEPLOYMENT_1);
+        controller.stop(CONTAINER_SINGLE);
     }
 }


### PR DESCRIPTION
- preloading kept to default (false) to limit io operations of the inefficient file store on startup. think otherwise? should i add the explicit default for easier usability?
- test - there is no real good place to put it. eventually, the /single tests we want to move out of clustering ts and these tests are using managed containers and i dont want to introduce a lot of silly code just to have one test manual container (needed for restart). another option is to add another surefire execution which also stinks... let me know if you have a better idea.
- PR for 7.1 branch -- imho not desirable.
