### PR TITLE
[master only] Fix for AS7-5845

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/PluggableMBeanServerImpl.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/PluggableMBeanServerImpl.java
@@ -281,7 +281,8 @@ class PluggableMBeanServerImpl implements PluggableMBeanServer {
                 }
             }
         }
-        return false;
+        // check if it's registered with the root (a.k.a platform) MBean server
+        return rootMBeanServer.isRegistered(name);
     }
 
     @Override


### PR DESCRIPTION
This fixes the issue reported in https://issues.jboss.org/browse/AS7-5845 where the isRegistered() implementation was buggy and would result in the Arquillian MBean service to stay around even after undeploy.
