### PR TITLE
Add JCA xml schema from IronJacamar.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -156,6 +156,15 @@
             <mapper type="flatten"/>
         </unzip>
 
+        <!-- Copy the IronJacamar specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <unzip src="${org.jboss.ironjacamar:ironjacamar-common-api:jar}" dest="${output.dir}/docs/schema/">
+            <patternset>
+                <include name="*.dtd"/>
+                <include name="*.xsd"/>
+            </patternset>
+            <mapper type="flatten"/>
+        </unzip>
+
     </target>
 
     <target name="copy-client">


### PR DESCRIPTION
Adds the various JCA schema to the docs/schema directory of the distribution build
