### PR TITLE
[master only] Reverts JCA schema additions

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -156,15 +156,6 @@
             <mapper type="flatten"/>
         </unzip>
 
-        <!-- Copy the IronJacamar specific schemas to the JBOSS_HOME/docs/schema folder -->
-        <unzip src="${org.jboss.ironjacamar:ironjacamar-common-api:jar}" dest="${output.dir}/docs/schema/">
-            <patternset>
-                <include name="*.dtd"/>
-                <include name="*.xsd"/>
-            </patternset>
-            <mapper type="flatten"/>
-        </unzip>
-
     </target>
 
     <target name="copy-client">


### PR DESCRIPTION
Reverts the commit to introduce JCA xsds in the AS distribution as part of PR https://github.com/jbossas/jboss-as/pull/3352

This reverts commit 445dfa5f2813aea0d451c1e595d07c00ab515fbe.
