### PR TITLE
Cli connection timeout on first attempt

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
@@ -52,11 +52,13 @@
                     </xs:annotation>
                 </xs:element>
 
+                <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1"/>
+
                 <xs:element ref="ssl" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    
+
     <xs:element name="default-controller">
         <xs:annotation>
             <xs:documentation>
@@ -71,7 +73,7 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    
+
     <xs:element name="validate-operation-requests" type="xs:boolean" default="true">
         <xs:annotation>
             <xs:documentation>
@@ -81,7 +83,7 @@
             </xs:documentation>
         </xs:annotation>
     </xs:element>
-    
+
     <xs:element name="history">
         <xs:annotation>
             <xs:documentation>
@@ -97,7 +99,15 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
-    
+
+    <xs:element name="connection-timeout" type="xs:int" default="5000">
+        <xs:annotation>
+            <xs:documentation>
+                The time allowed to establish a connection with the controller.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
     <xs:element name="ssl">
         <xs:annotation>
             <xs:documentation>
@@ -110,7 +120,7 @@
                 <xs:element name="key-store" type="xs:string" minOccurs="0" />
                 <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
                 <xs:element name="alias" type="xs:string" minOccurs="0" />
-                <xs:element name="key-password" type="xs:string" minOccurs="0" />                
+                <xs:element name="key-password" type="xs:string" minOccurs="0" />
                 <xs:element name="trust-store" type="xs:string" minOccurs="0" />
                 <xs:element name="trust-store-password" type="xs:string" minOccurs="0" />
                 <xs:element name="modify-trust-store" type="xs:boolean" default="true" minOccurs="0">

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -72,6 +72,13 @@ public interface CliConfig {
     int getHistoryMaxSize();
 
     /**
+     * Connection timeout period in milliseconds.
+     *
+     * @return connection timeout in milliseconds
+     */
+    int getConnectionTimeout();
+
+    /**
      * The global SSL configuration if it has been defined.
      *
      * @return The SSLConfig

--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -57,7 +57,7 @@ public abstract class CommandContextFactory {
             String username, char[] password) throws CliInitializationException;
 
     public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
-            String username, char[] password, boolean initConsole) throws CliInitializationException;
+            String username, char[] password, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
 
     public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
             String username, char[] password,

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -62,6 +62,7 @@ class CliConfigImpl implements CliConfig {
     private static final String HOST = "host";
     private static final String MAX_SIZE = "max-size";
     private static final String PORT = "port";
+    private static final String CONNECTION_TIMEOUT = "connection-timeout";
     private static final String RESOLVE_PARAMETER_VALUES = "resolve-parameter-values";
     private static final String VALIDATE_OPERATION_REQUESTS = "validate-operation-requests";
 
@@ -171,6 +172,8 @@ class CliConfigImpl implements CliConfig {
         historyFileName = ".jboss-cli-history";
         historyFileDir = SecurityActions.getSystemProperty("user.home");
         historyMaxSize = 500;
+
+        connectionTimeout = 5000;
     }
 
     private String defaultControllerHost;
@@ -180,6 +183,8 @@ class CliConfigImpl implements CliConfig {
     private String historyFileName;
     private String historyFileDir;
     private int historyMaxSize;
+
+    private int connectionTimeout;
 
     private boolean validateOperationRequests = true;
     private boolean resolveParameterValues = false;
@@ -214,6 +219,11 @@ class CliConfigImpl implements CliConfig {
     @Override
     public int getHistoryMaxSize() {
         return historyMaxSize;
+    }
+
+    @Override
+    public int getConnectionTimeout() {
+        return connectionTimeout;
     }
 
     @Override
@@ -342,6 +352,13 @@ class CliConfigImpl implements CliConfig {
                         config.validateOperationRequests = resolveBoolean(reader.getElementText());
                     } else if(localName.equals(RESOLVE_PARAMETER_VALUES)) {
                         config.resolveParameterValues = resolveBoolean(reader.getElementText());
+                    } else if (CONNECTION_TIMEOUT.equals(localName)) {
+                        final String text = reader.getElementText();
+                        try {
+                            config.connectionTimeout = Integer.parseInt(text);
+                        } catch(NumberFormatException e) {
+                            throw new XMLStreamException("Failed to parse " + JBOSS_CLI + " " + CONNECTION_TIMEOUT + " value '" + text + "'", e);
+                        }
                     } else {
                         throw new XMLStreamException("Unexpected element: " + localName);
                     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -59,7 +59,7 @@ public class CliLauncher {
             boolean version = false;
             String username = null;
             char[] password = null;
-            int timeout = -1;
+            int connectionTimeout = -1;
 
             for(String arg : args) {
                 if(arg.startsWith("--controller=") || arg.startsWith("controller=")) {
@@ -166,17 +166,17 @@ public class CliLauncher {
                 } else if (arg.startsWith("--password=")) {
                     password = (arg.startsWith("--") ? arg.substring(11) : arg.substring(9)).toCharArray();
                 } else if (arg.startsWith("--timeout=")) {
-                    if (timeout > 0) {
+                    if (connectionTimeout > 0) {
                         argError = "Duplicate argument '--timeout'";
                         break;
                     }
                     final String value = arg.substring(10);
                     try {
-                        timeout = Integer.parseInt(value);
+                        connectionTimeout = Integer.parseInt(value);
                     } catch (final NumberFormatException e) {
                         //
                     }
-                    if (timeout <= 0) {
+                    if (connectionTimeout <= 0) {
                         argError = "The timeout must be a valid positive integer: '" + value + "'";
                     }
                 } else if (arg.equals("--help") || arg.equals("-h")) {
@@ -231,31 +231,31 @@ public class CliLauncher {
             }
 
             if(version) {
-                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, connect, timeout);
+                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, connect, connectionTimeout);
                 VersionHandler.INSTANCE.handle(cmdCtx);
                 return;
             }
 
             if(file != null) {
-                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, connect, timeout);
+                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, connect, connectionTimeout);
                 processFile(file, cmdCtx);
                 return;
             }
 
             if(commands != null) {
-                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, connect, timeout);
+                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, connect, connectionTimeout);
                 processCommands(commands, cmdCtx);
                 return;
             }
 
             if (gui) {
-                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, true, timeout);
+                cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, false, true, connectionTimeout);
                 processGui(cmdCtx);
                 return;
             }
 
             // Interactive mode
-            cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, true, connect, timeout);
+            cmdCtx = initCommandContext(defaultControllerHost, defaultControllerPort, username, password, true, connect, connectionTimeout);
             cmdCtx.interact();
         } catch(Throwable t) {
             t.printStackTrace();
@@ -271,8 +271,8 @@ public class CliLauncher {
         System.exit(exitCode);
     }
 
-    private static CommandContext initCommandContext(String defaultHost, int defaultPort, String username, char[] password, boolean initConsole, boolean connect, final int timeout) throws CliInitializationException {
-        final CommandContext cmdCtx = CommandContextFactory.getInstance().newCommandContext(defaultHost, defaultPort, username, password, initConsole, timeout);
+    private static CommandContext initCommandContext(String defaultHost, int defaultPort, String username, char[] password, boolean initConsole, boolean connect, final int connectionTimeout) throws CliInitializationException {
+        final CommandContext cmdCtx = CommandContextFactory.getInstance().newCommandContext(defaultHost, defaultPort, username, password, initConsole, connectionTimeout);
         if(connect) {
             try {
                 cmdCtx.connectController();

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -56,14 +56,14 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerHost,
             int controllerPort, String username, char[] password)
             throws CliInitializationException {
-        return newCommandContext(controllerHost, controllerPort, username, password, false);
+        return newCommandContext(controllerHost, controllerPort, username, password, false, -1);
     }
 
     @Override
     public CommandContext newCommandContext(String controllerHost,
             int controllerPort, String username, char[] password,
-            boolean initConsole) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, initConsole);
+            boolean initConsole, final int connectionTimeout) throws CliInitializationException {
+        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -185,10 +185,10 @@ class CommandContextImpl implements CommandContext {
     private String username;
     /** the command line specified password */
     private char[] password;
+    /** the time to connect to a controller */
+    private final int connectionTimeout;
     /** The SSLContext when managed by the CLI */
     private SSLContext sslContext;
-    /** Operation timeout */
-    private final int connectionTimeout;
     /** The TrustManager in use by the SSLContext, a reference is kept to rejected certificates can be captured. */
     private LazyDelagatingTrustManager trustManager;
     /** various key/value pairs */
@@ -228,13 +228,13 @@ class CommandContextImpl implements CommandContext {
         this.console = null;
         this.operationCandidatesProvider = null;
         this.cmdCompleter = null;
-        this.connectionTimeout = -1;
         operationHandler = new OperationRequestHandler();
         initCommands();
         config = CliConfigImpl.load(this);
         defaultControllerHost = config.getDefaultControllerHost();
         defaultControllerPort = config.getDefaultControllerPort();
         resolveParameterValues = config.isResolveParameterValues();
+        this.connectionTimeout = config.getConnectionTimeout();
         initSSLContext();
     }
 
@@ -255,7 +255,7 @@ class CommandContextImpl implements CommandContext {
 
         this.username = username;
         this.password = password;
-        this.connectionTimeout = connectionTimeout;
+        this.connectionTimeout = connectionTimeout != -1 ? connectionTimeout : config.getConnectionTimeout();
 
         if (defaultControllerHost != null) {
             this.defaultControllerHost = defaultControllerHost;
@@ -294,7 +294,7 @@ class CommandContextImpl implements CommandContext {
 
         this.username = username;
         this.password = password;
-        this.connectionTimeout = -1;
+        this.connectionTimeout = config.getConnectionTimeout();
 
         if (defaultControllerHost != null) {
             this.defaultControllerHost = defaultControllerHost;

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -3,6 +3,7 @@ Usage: jboss-cli.sh/jboss-cli.bat [--help] [--version] [--controller=host:port]
                                   [--commands=command_or_operation1,command_or_operation2...]
                                   [--command=command_or_operation]
                                   [--user=username --password=password]
+                                  [--timeout=timeout]
 
  --help (-h)          - prints (this) basic description of the command line utility.
  --version            - prints the version info of the JBoss AS release, JVM and system environment.
@@ -11,7 +12,7 @@ Usage: jboss-cli.sh/jboss-cli.bat [--help] [--version] [--controller=host:port]
                         the arguments. The default controller host is localhost and the port is 9999.
  --connect (-c)       - instructs the CLI to connect to the controller on start-up (to avoid issuing
                         a separate connect command later).
- --gui                - GUI built on top of the CLI, the only difference is that it brings up a GUI 
+ --gui                - GUI built on top of the CLI, the only difference is that it brings up a GUI
                         instead of a command line. In this mode, the CLI will automatically connect
                         during start-up. You can optionally specify --controller, if necessary.
  --file               - specifies a path to a file which contains commands and operations (one per line)
@@ -30,11 +31,13 @@ Usage: jboss-cli.sh/jboss-cli.bat [--help] [--version] [--controller=host:port]
                         at the end of the argument list will be assumed to be the list of commands and operations.
  --user               - if the controller requires user authentication, this argument can be used to specify the user name
                         as a command line argument. If the argument isn't specified and the authentication is required
-                        the user will be prompted to enter the user name when the connect command is issued. 
+                        the user will be prompted to enter the user name when the connect command is issued.
  --password           - specifies the password for authentication while connecting to the controller as
                         a command line argument. If the argument isn't specified and the authentication is required
                         the user will be prompted to enter the password when the connect command is issued.
- 
+ --timeout            - specifies home many milliseconds to wait for a given command to return. The value provided
+                        must be a positive integer. Defaults to 5000 milliseconds when not provided.
+
 
 During the command line session for a list of commands available in the current context execute
 

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -67,6 +67,11 @@ public class MockCliConfig implements CliConfig {
     }
 
     @Override
+    public int getConnectionTimeout() {
+        return 5000;
+    }
+
+    @Override
     public boolean isValidateOperationRequests() {
         return true;
     }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -190,6 +190,20 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(hostName,  port, handler, sslContext, connectionTimeout));
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
          * @param hostName the remote host
          * @param port     the port
          * @param handler  CallbackHandler to obtain authentication information for the call.


### PR DESCRIPTION
I have experienced an issue connecting to AS7 from the CLI where the first attempt at running the 'connect' command fails every time however always succeeds on a second attempt. I have experienced this issue running a standalone server (7.1.2.Final and a build from source) on a laptop running Fedora 17 w/ Oracle jdk7u9 and the same laptop running Fedora 16 w/ Oracle jdk7r4.  Please let me know if more information about reproducing the issue is required.

When the first 'connect' command is issued there is a delay of ~6 seconds between sending the command and the first bytes getting written to the channel while the second call starts writing almost immediately. I added an optional CLI parameter has been added to set the timeout period. The default value remains as before.
