### PR TITLE
AS7-5389 Remove repetitive File.deleteOnExit() calls

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/ControllerClientLogger.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ControllerClientLogger.java
@@ -55,4 +55,13 @@ public interface ControllerClientLogger extends BasicLogger {
     @Message(id = 10600, value = "Closing leaked controller client")
     void leakedControllerClient(@Cause Throwable allocationStackTrace);
 
+    /**
+     * Logs a warnning message indicating a temp file could not be deleted.
+     *
+     * @param name temp filename
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 10601, value = "Cannot delete temp file %s, will be deleted on exit")
+    void cannotDeleteTempFile(String name);
+
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/InputStreamEntry.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/InputStreamEntry.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller.client.impl;
 
+import org.jboss.as.controller.client.ControllerClientLogger;
 import org.jboss.as.protocol.StreamUtils;
 
 import java.io.ByteArrayInputStream;
@@ -116,7 +117,6 @@ public interface InputStreamEntry extends Closeable {
         public synchronized int initialize() throws IOException {
             if(temp == null) {
                 temp = File.createTempFile("client", "stream");
-                temp.deleteOnExit();
                 final FileOutputStream os = new FileOutputStream(temp);
                 try {
                     StreamUtils.copyStream(original, os);
@@ -144,7 +144,10 @@ public interface InputStreamEntry extends Closeable {
 
         @Override
         public synchronized void close() throws IOException {
-            temp.delete();
+            if (!temp.delete()) {
+                ControllerClientLogger.ROOT_LOGGER.cannotDeleteTempFile(temp.getName());
+                temp.deleteOnExit();
+            }
             temp = null;
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerLogger.java
@@ -395,4 +395,13 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.INFO)
     @Message(id = 14627, value = "Attribute %s is deprecated, and it might be removed in future version!")
     void attributeDeprecated(String name);
+
+    /**
+     * Logs a warnning message indicating a temp file could not be deleted.
+     *
+     * @param name temp filename
+     */
+    @LogMessage(level = Level.WARN)
+    @Message(id = 14628, value = "Cannot delete temp file %s, will be deleted on exit")
+    void cannotDeleteTempFile(String name);
 }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
@@ -292,7 +292,6 @@ public class ConfigurationFile {
             } else {
                 copySource = new File(mainFile.getParentFile(), mainFile.getName() + ".boot");
                 FilePersistenceUtils.deleteFile(copySource);
-                copySource.deleteOnExit();
             }
 
             try {

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -41,9 +41,7 @@ import org.xnio.IoUtils;
 class FilePersistenceUtils {
 
     static File createTempFile(File fileName) {
-        File tempFileName = new File(fileName.getParentFile(), fileName.getName() + ".tmp");
-        tempFileName.deleteOnExit();
-        return tempFileName;
+        return new File(fileName.getParentFile(), fileName.getName() + ".tmp");
     }
 
     static ExposedByteArrayOutputStream marshalXml(final AbstractConfigurationPersister persister, final ModelNode model) throws ConfigurationPersistenceException {
@@ -100,6 +98,7 @@ class FilePersistenceUtils {
     static void deleteFile(File file) {
         if (file.exists()) {
             if (!file.delete() && file.exists()) {
+                file.deleteOnExit();
                 throw new IllegalStateException(MESSAGES.couldNotDeleteFile(file));
             }
         }

--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
@@ -172,6 +172,7 @@ public interface ContentRepository {
                 if(hasContent(sha1Bytes)) {
                     // we've already got this content
                     if (!tmp.delete()) {
+                        DeploymentRepositoryLogger.ROOT_LOGGER.cannotDeleteTempFile(tmp.getName());
                         tmp.deleteOnExit();
                     }
                     DeploymentRepositoryLogger.ROOT_LOGGER.debugf("Content was already present in repository at location %s", realFile.getAbsolutePath());
@@ -266,9 +267,11 @@ public interface ContentRepository {
 
                     } finally {
                         if (!tmpFile.delete()) {
+                            DeploymentRepositoryLogger.ROOT_LOGGER.cannotDeleteTempFile(tmpFile.getName());
                             tmpFile.deleteOnExit();
                         }
                         if (localTmp.exists() && !localTmp.delete()) {
+                            DeploymentRepositoryLogger.ROOT_LOGGER.cannotDeleteTempFile(localTmp.getName());
                             localTmp.deleteOnExit();
                         }
                     }
@@ -300,15 +303,18 @@ public interface ContentRepository {
             public void removeContent(byte[] hash) {
                 File file = getDeploymentContentFile(hash, true);
                 if(!file.delete()) {
+                    DeploymentRepositoryLogger.ROOT_LOGGER.cannotDeleteTempFile(file.getName());
                     file.deleteOnExit();
                 }
                 File parent = file.getParentFile();
                 if (!parent.delete()) {
+                    DeploymentRepositoryLogger.ROOT_LOGGER.cannotDeleteTempFile(parent.getName());
                     parent.deleteOnExit();
                 }
                 parent = parent.getParentFile();
                 if (parent.list().length == 0) {
                     if (!parent.delete()) {
+                        DeploymentRepositoryLogger.ROOT_LOGGER.cannotDeleteTempFile(parent.getName());
                         parent.deleteOnExit();
                     }
                 }

--- a/deployment-repository/src/main/java/org/jboss/as/repository/DeploymentRepositoryLogger.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/DeploymentRepositoryLogger.java
@@ -23,6 +23,7 @@
 package org.jboss.as.repository;
 
 import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.LogMessage;
@@ -56,4 +57,8 @@ interface DeploymentRepositoryLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 14901, value = "Content removed from location %s")
     void contentRemoved(String path);
+
+    @LogMessage(level = WARN)
+    @Message(id = 14902, value = "Cannot delete temp file %s, will be deleted on exit")
+    void cannotDeleteTempFile(String path);
 }


### PR DESCRIPTION
- only use File.deleteOnExit() as last resort after delete failed and was logged
