### PR TITLE
JBPAPP-10054: LookUpTestCase activation

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -190,6 +190,7 @@
                                 <configuration>
                                     <!-- Tests to execute. Overriden in webProfileExclusion.profile . -->
                                     <includes>
+                                        <include>org/jboss/as/test/integration/ee/remotelookup/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/ejb/iiop/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/*/security/**/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/mdb/**/*TestCase*.java</include>


### PR DESCRIPTION
LookUpTestCase  will be run on basic integration full profile. Already in master but I forgot for 7.1. 
In case of being next testing cycle it would be fine to have it there.
