### PR TITLE
[8.0] Speeding up clustering testsuite

### DIFF
--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -86,12 +86,15 @@
                                 <phase>none</phase>
                             </execution>
 
-                            <!-- TCP clustering tests with manual containers with unmanaged deployment. -->
+                            <!-- TCP clustering tests with custom containers with manual deployments. -->
                             <execution>
-                                <id>ts.surefire.clust.multinode-manual-tcp-sync</id>
+                                <id>ts.surefire.clust.custom-manual-tcp-sync</id>
                                 <phase>test</phase> 
                                 <goals><goal>test</goal></goals>
                                 <configuration>
+                                    <!-- Force the order of tests -->
+                                    <runOrder>reversealphabetical</runOrder>
+
                                     <!-- Tests to execute. -->
                                     <includes>
                                         <include>org/jboss/as/test/clustering/cluster/**/*TestCase.java</include>

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -36,7 +36,7 @@
 
     <group qualifier="clustering-all">
 
-        <container qualifier="container-0" default="true" mode="manual" managed="false">
+        <container qualifier="container-0" mode="custom" managed="false" default="true">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-0</property>
                 <!-- AS7-2493 different jboss.node.name must be specified -->
@@ -51,7 +51,7 @@
             </configuration>
         </container>
 
-        <container qualifier="container-1" mode="manual" managed="false">
+        <container qualifier="container-1" mode="custom" managed="false">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-1 -Djboss.node.name=node-1 -Djboss.port.offset=100</property>

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -65,7 +65,7 @@
             </configuration>
         </container>
 
-        <container qualifier="container-single" mode="manual" managed="false">
+        <container qualifier="container-single" mode="custom" managed="false">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/AbstractEJBDirectory.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/AbstractEJBDirectory.java
@@ -41,7 +41,7 @@ public abstract class AbstractEJBDirectory implements EJBDirectory {
     protected enum Type {
         STATEFUL, STATELESS, SINGLETON, HOME
     };
-    
+
     protected AbstractEJBDirectory(Properties env) throws NamingException {
         this.context = new InitialContext(env);
     }
@@ -59,7 +59,7 @@ public abstract class AbstractEJBDirectory implements EJBDirectory {
     public <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException {
         return this.lookup(beanName, beanInterface, Type.STATEFUL);
     }
-    
+
     public <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
         return this.lookupStateless(beanClass.getSimpleName(), beanInterface);
     }
@@ -68,7 +68,7 @@ public abstract class AbstractEJBDirectory implements EJBDirectory {
     public <T> T lookupStateless(String beanName, Class<T> beanInterface) throws NamingException {
         return this.lookup(beanName, beanInterface, Type.STATELESS);
     }
-    
+
     public <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
         return this.lookupSingleton(beanClass.getSimpleName(), beanInterface);
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterHttpClientUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterHttpClientUtil.java
@@ -21,18 +21,20 @@
  */
 package org.jboss.as.test.clustering;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO_REPLICATE;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.junit.Assert;
 
@@ -66,6 +68,16 @@ public final class ClusterHttpClientUtil {
         return tryGet(client, url, ClusteringTestConstants.GRACE_TIME_TO_REPLICATE);
     }
 
+    public static HttpResponse tryGet(final HttpClient client, final HttpUriRequest r) throws IOException {
+        final long startTime;
+        HttpResponse response = client.execute(r);
+        startTime = System.currentTimeMillis();
+        while(response.getStatusLine().getStatusCode() != HttpServletResponse.SC_OK && startTime + GRACE_TIME_TO_REPLICATE > System.currentTimeMillis()) {
+            response = client.execute(r);
+        }
+        return response;
+    }
+
     /**
      * Tries a get on the provided client with specified graceTime in milliseconds.
      *
@@ -76,13 +88,7 @@ public final class ClusterHttpClientUtil {
      * @throws IOException
      */
     public static HttpResponse tryGet(final HttpClient client, final String url, final long graceTime) throws IOException {
-        final long startTime;
-        HttpResponse response = client.execute(new HttpGet(url));
-        startTime = System.currentTimeMillis();
-        while (response.getStatusLine().getStatusCode() != HttpServletResponse.SC_OK && startTime + graceTime > System.currentTimeMillis()) {
-            response = client.execute(new HttpGet(url));
-        }
-        return response;
+        return tryGet(client, new HttpGet(url));
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
@@ -69,7 +69,7 @@ public interface ClusteringTestConstants {
      * Name of cluster for remote client.
      */
     String CLUSTER_NAME = "ejb";
-    
+
     /**
      * Timeouts.
      */

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
@@ -29,47 +29,59 @@ import org.jboss.as.test.shared.TimeoutUtil;
  * @author Radoslav Husar
  * @version Feb 2012
  */
-public class ClusteringTestConstants {
+public interface ClusteringTestConstants {
 
     /**
      * Test configuration.
      */
-    public static final String TEST_CACHE_MODE = System.getProperty("stack");
+    String TEST_CACHE_MODE = System.getProperty("stack");
 
     /**
      * Manual container with unmanaged deployments names.
      */
-    public static final String CONTAINER_SINGLE = "container-single";
-    public static final String CONTAINER_1 = "container-0";
-    public static final String CONTAINER_2 = "container-1";
-    public static final String[] CONTAINERS = new String[] { CONTAINER_1, CONTAINER_2 };
+    String CONTAINER_SINGLE = "container-single";
+    String CONTAINER_1 = "container-0";
+    String CONTAINER_2 = "container-1";
+    String[] CONTAINERS = new String[] { CONTAINER_1, CONTAINER_2 };
 
     /**
      * Deployment names.
      */
-    public static final String DEPLOYMENT_1 = "deployment-0";
-    public static final String DEPLOYMENT_2 = "deployment-1";
-    public static final String[] DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2 };
+    String DEPLOYMENT_1 = "deployment-0";
+    String DEPLOYMENT_2 = "deployment-1";
+    String[] DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2 };
+
+    /**
+     * Some helper deployment names.
+     */
+    String DEPLOYMENT_HELPER_1 = "deployment-helper-0";
+    String DEPLOYMENT_HELPER_2 = "deployment-helper-1";
+    String[] DEPLOYMENT_HELPERS = new String[] { DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2 };
 
     /**
      * Node names passed in arquillian.xml via -Djboss.node.name property.
      */
-    public static final String NODE_1 = "node-0";
-    public static final String NODE_2 = "node-1";
-    public static final String[] NODES = new String[] { NODE_1, NODE_2 };
+    String NODE_1 = "node-0";
+    String NODE_2 = "node-1";
+    String[] NODES = new String[] { NODE_1, NODE_2 };
 
     /**
      * Name of cluster for remote client.
      */
-    public static final String CLUSTER_NAME = "ejb";
+    String CLUSTER_NAME = "ejb";
     
     /**
      * Timeouts.
      */
-    public static final int GRACE_TIME_TO_REPLICATE = 3000;
+    int GRACE_TIME_TO_REPLICATE = 3000;
 
-    public static final int CLUSTER_ESTABLISHMENT_WAIT_MS = TimeoutUtil.adjust(100);
-    public static final int CLUSTER_ESTABLISHMENT_LOOP_COUNT = 20;
-    public static final int WAIT_FOR_PASSIVATION_MS = TimeoutUtil.adjust(5);
-    public static final int HTTP_REQUEST_WAIT_TIME_S = TimeoutUtil.adjust(5);
+    /**
+     * TODO: This will be removed.
+     */
+    int GRACE_TIME_TO_MEMBERSHIP_CHANGE = 10000;
+
+    int CLUSTER_ESTABLISHMENT_WAIT_MS = TimeoutUtil.adjust(100);
+    int CLUSTER_ESTABLISHMENT_LOOP_COUNT = 20;
+    int WAIT_FOR_PASSIVATION_MS = TimeoutUtil.adjust(5);
+    int HTTP_REQUEST_WAIT_TIME_S = TimeoutUtil.adjust(5);
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/DMRUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/DMRUtil.java
@@ -16,17 +16,17 @@ import org.jboss.dmr.ModelNode;
  */
 public class DMRUtil {
     private static final Logger log = Logger.getLogger(DMRUtil.class);
-    
+
     private static final String IDLE_TIMEOUT_ATTR = "idle-timeout";
     private static final String PASSIVATE_EVENTS_ON_REPLICATE_ATTR = "passivate-events-on-replicate";
-    
+
     /**
      * Hidden constructor.
      */
     private DMRUtil() {
-        
+
     }
-    
+
     /**
      * Returning modelnode address for DRM to be able to set cache attributes (client drm call).
      */
@@ -50,7 +50,7 @@ public class DMRUtil {
         operation.get("value").set(1L);
         // ModelNode result = client.execute(operation);
         ModelNode result = ManagementOperations.executeOperationRaw(client, operation);
-        Assert.assertEquals("Setting of passivation idle timeout attribute was not sucessful" ,SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals("Setting of passivation idle timeout attribute was not sucessful", SUCCESS, result.get(OUTCOME).asString());
         log.info("modelnode operation " + WRITE_ATTRIBUTE_OPERATION + " " + IDLE_TIMEOUT_ATTR + " =1: " + result);
     }
 
@@ -84,11 +84,11 @@ public class DMRUtil {
         Assert.assertEquals("Unset of attribute " + attrName + " on server was not sucessful", SUCCESS, result.get(OUTCOME).asString());
         log.info("unset modelnode operation " + UNDEFINE_ATTRIBUTE_OPERATION + " on " + attrName + ": " + result);
     }
-    
+
     public static void unsetIdleTimeoutPassivationAttribute(ModelControllerClient client) throws Exception {
         unsetPassivationAttributes(client, IDLE_TIMEOUT_ATTR);
     }
-    
+
     public static void unsetPassivationOnReplicate(ModelControllerClient client) throws Exception {
         unsetPassivationAttributes(client, PASSIVATE_EVENTS_ON_REPLICATE_ATTR);
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
@@ -42,7 +42,7 @@ public class EJBClientContextSelector {
     }
     
     public static ContextSelector<EJBClientContext> setup(String file, Properties propertiesToReplace) throws IOException {
-        // setup the selector
+        // setUp the selector
         final InputStream inputStream = EJBClientContextSelector.class.getClassLoader().getResourceAsStream(file);
         if (inputStream == null) {
             throw new IllegalStateException("Could not find " + file + " in classpath");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBClientContextSelector.java
@@ -34,13 +34,12 @@ import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 
 /**
  * @author Paul Ferraro
- *
  */
 public class EJBClientContextSelector {
     public static ContextSelector<EJBClientContext> setup(String file) throws IOException {
         return setup(file, null);
     }
-    
+
     public static ContextSelector<EJBClientContext> setup(String file, Properties propertiesToReplace) throws IOException {
         // setUp the selector
         final InputStream inputStream = EJBClientContextSelector.class.getClassLoader().getResourceAsStream(file);
@@ -49,14 +48,14 @@ public class EJBClientContextSelector {
         }
         final Properties properties = new Properties();
         properties.load(inputStream);
-        
+
         // add or replace properties passed from file
-        if(propertiesToReplace != null) {
-            for(Object key: propertiesToReplace.keySet()) {
+        if (propertiesToReplace != null) {
+            for (Object key: propertiesToReplace.keySet()) {
                 properties.put(key, propertiesToReplace.get(key));
             }
         }
-        
+
         final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
         final ConfigBasedEJBClientContextSelector selector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration);
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBDirectory.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBDirectory.java
@@ -28,19 +28,24 @@ import javax.naming.NamingException;
 
 /**
  * EJB lookup helper
+ *
  * @author Paul Ferraro
  */
 public interface EJBDirectory {
     <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException;
+
     <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
 
     <T> T lookupStateless(String beanName, Class<T> beanInterface) throws NamingException;
+
     <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
 
     <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws NamingException;
+
     <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
 
     <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) throws NamingException;
+
     <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws NamingException;
 
     void close() throws NamingException;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/LocalEJBDirectory.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/LocalEJBDirectory.java
@@ -28,11 +28,10 @@ import javax.naming.NamingException;
 
 /**
  * @author Paul Ferraro
- *
  */
 public class LocalEJBDirectory extends AbstractEJBDirectory {
     private final String module;
-    
+
     public LocalEJBDirectory(String module) throws NamingException {
         super(new Properties());
         this.module = module;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeInfoServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeInfoServlet.java
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * @author Ondrej Chaloupka
  */
-@WebServlet(urlPatterns = { "/nodename" })
+@WebServlet(urlPatterns = {"/nodename"})
 public class NodeInfoServlet extends HttpServlet {
     private static final long serialVersionUID = 1L;
     public static final String URL = "nodename";

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -22,17 +22,33 @@
 package org.jboss.as.test.clustering;
 
 import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.test.api.ArquillianResource;
 
 /**
- * Helper class to start and stop container including a deployment.
+ * Utility class to start and stop containers and/or deployments.
  *
  * @author Radoslav Husar
+ * @version Oct 2012
  */
 public final class NodeUtil {
 
-    private NodeUtil() {
+    public static void deploy(Deployer deployer, String... deployments) {
+        for (int i = 0; i < deployments.length; i++) {
+            System.out.println(new Date() + " deploying deployment=" + deployments[i]);
+            deployer.deploy(deployments[i]);
+        }
+    }
+
+    public static void undeploy(Deployer deployer, String... deployments) {
+        for (int i = 0; i < deployments.length; i++) {
+            System.out.println(new Date() + " undeploying deployment=" + deployments[i]);
+            deployer.undeploy(deployments[i]);
+        }
     }
 
     public static void start(ContainerController controller, Deployer deployer, String container, String deployment) {
@@ -46,12 +62,36 @@ public final class NodeUtil {
         }
     }
 
+    public static void start(ContainerController controller, String[] containers) {
+        // TODO do this in parallel.
+        for (int i = 0; i < containers.length; i++) {
+            try {
+                System.out.println(new Date() + "starting deployment=NONE, container=" + containers[i]);
+                controller.start(containers[i]);
+            } catch (Throwable e) {
+                e.printStackTrace(System.err);
+            }
+        }
+    }
+
     public static void start(ContainerController controller, String container) {
         try {
             System.out.println(new Date() + "starting deployment=NONE, container=" + container);
             controller.start(container);
         } catch (Throwable e) {
             e.printStackTrace(System.err);
+        }
+    }
+
+    public static void stop(ContainerController controller, String[] containers) {
+        for (int i = 0; i < containers.length; i++) {
+            try {
+                System.out.println(new Date() + "stopping container=" + containers[i]);
+                controller.stop(containers[i]);
+                System.out.println(new Date() + "stopped container=" + containers[i]);
+            } catch (Throwable e) {
+                e.printStackTrace(System.err);
+            }
         }
     }
 
@@ -73,5 +113,8 @@ public final class NodeUtil {
         } catch (Throwable e) {
             e.printStackTrace(System.err);
         }
+    }
+
+    private NodeUtil() {
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
 
 /**
  * Utility class to start and stop containers and/or deployments.
@@ -37,28 +38,30 @@ import org.jboss.arquillian.test.api.ArquillianResource;
  */
 public final class NodeUtil {
 
+    private static final Logger log = Logger.getLogger(NodeUtil.class);
+
     public static void deploy(Deployer deployer, String... deployments) {
         for (int i = 0; i < deployments.length; i++) {
-            System.out.println(new Date() + " deploying deployment=" + deployments[i]);
+            log.info("Deploying deployment=" + deployments[i]);
             deployer.deploy(deployments[i]);
         }
     }
 
     public static void undeploy(Deployer deployer, String... deployments) {
         for (int i = 0; i < deployments.length; i++) {
-            System.out.println(new Date() + " undeploying deployment=" + deployments[i]);
+            log.info("Undeploying deployment=" + deployments[i]);
             deployer.undeploy(deployments[i]);
         }
     }
 
     public static void start(ContainerController controller, Deployer deployer, String container, String deployment) {
         try {
-            System.out.println(new Date() + "starting deployment=" + deployment + ", container=" + container);
+            log.info("Starting deployment=" + deployment + ", container=" + container);
             controller.start(container);
             deployer.deploy(deployment);
-            System.out.println(new Date() + "started deployment=" + deployment + ", container=" + container);
+            log.info("Started deployment=" + deployment + ", container=" + container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 
@@ -66,52 +69,52 @@ public final class NodeUtil {
         // TODO do this in parallel.
         for (int i = 0; i < containers.length; i++) {
             try {
-                System.out.println(new Date() + "starting deployment=NONE, container=" + containers[i]);
+                log.info("Starting deployment=NONE, container=" + containers[i]);
                 controller.start(containers[i]);
             } catch (Throwable e) {
-                e.printStackTrace(System.err);
+                log.error(e);
             }
         }
     }
 
     public static void start(ContainerController controller, String container) {
         try {
-            System.out.println(new Date() + "starting deployment=NONE, container=" + container);
+            log.info("Starting deployment=NONE, container=" + container);
             controller.start(container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 
     public static void stop(ContainerController controller, String[] containers) {
         for (int i = 0; i < containers.length; i++) {
             try {
-                System.out.println(new Date() + "stopping container=" + containers[i]);
+                log.info("Stopping container=" + containers[i]);
                 controller.stop(containers[i]);
-                System.out.println(new Date() + "stopped container=" + containers[i]);
+                log.info("Stopped container=" + containers[i]);
             } catch (Throwable e) {
-                e.printStackTrace(System.err);
+                log.error(e);
             }
         }
     }
 
     public static void stop(ContainerController controller, Deployer deployer, String container, String deployment) {
         try {
-            System.out.println(new Date() + "stopping deployment=" + deployment + ", container=" + container);
+            log.info("Stopping deployment=" + deployment + ", container=" + container);
             deployer.undeploy(deployment);
             controller.stop(container);
-            System.out.println(new Date() + "stopped deployment=" + deployment + ", container=" + container);
+            log.info("Stopped deployment=" + deployment + ", container=" + container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 
     public static void stop(ContainerController controller, String container) {
         try {
             controller.stop(container);
-            System.out.println(new Date() + "stopped deployment=NONE, container=" + container);
+            log.info("Stopped deployment=NONE, container=" + container);
         } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            log.error(e);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -21,13 +21,8 @@
  */
 package org.jboss.as.test.clustering;
 
-import java.util.Date;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.logging.Logger;
 
 /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/RemoteEJBDirectory.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/RemoteEJBDirectory.java
@@ -29,16 +29,16 @@ import javax.naming.NamingException;
 
 /**
  * @author Paul Ferraro
- *
  */
 public class RemoteEJBDirectory extends AbstractEJBDirectory {
     private static final Properties env = new Properties();
+
     static {
         env.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
     }
 
     private final String module;
-    
+
     public RemoteEJBDirectory(String module) throws NamingException {
         super(env);
         this.module = module;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListener.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListener.java
@@ -21,7 +21,9 @@
  */
 package org.jboss.as.test.clustering;
 
-
+/**
+ * @author Paul Ferraro
+ */
 public interface ViewChangeListener {
     void establishView(String cluster, String... members) throws InterruptedException;
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerBean.java
@@ -38,6 +38,9 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.StartException;
 
+/**
+ * @author Paul Ferraro
+ */
 @Stateless
 @Remote(ViewChangeListener.class)
 @Listener(sync = false)
@@ -61,8 +64,7 @@ public class ViewChangeListenerBean implements ViewChangeListener {
         try {
             EmbeddedCacheManager manager = ServiceContainerHelper.getValue(controller, EmbeddedCacheManager.class);
             manager.addListener(this);
-            try
-            {
+            try {
                 long start = System.currentTimeMillis();
                 long now = start;
                 long timeout = start + TIMEOUT;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerServlet.java
@@ -35,9 +35,10 @@ import javax.servlet.http.HttpServletResponse;
 
 /**
  * Utility servlet that waits until the specified cluster establishes a specific cluster membership.
+ *
  * @author Paul Ferraro
  */
-@WebServlet(urlPatterns = { ViewChangeListenerServlet.SERVLET_PATH })
+@WebServlet(urlPatterns = {ViewChangeListenerServlet.SERVLET_PATH})
 public class ViewChangeListenerServlet extends HttpServlet {
     private static final long serialVersionUID = -4382952409558738642L;
     private static final String SERVLET_NAME = "membership";

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.arquillian;
+
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.Container.State;
+import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+import org.jboss.logging.Logger;
+
+/**
+ * Arquillian extension which stops custom containers after testsuite run.
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @author Radoslav Husar
+ * @version $Revision: $
+ */
+public class StopCustomContainersOnAfterSuiteExtension implements LoadableExtension {
+
+    private static final Logger log = Logger.getLogger(StopCustomContainersOnAfterSuiteExtension.class);
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(StopCustomContainers.class);
+    }
+
+    public static class StopCustomContainers {
+        public void close(@Observes AfterSuite event, ContainerRegistry registry) {
+            for (Container c : registry.getContainers()) {
+                if (c.getState() == State.STARTED && "custom".equalsIgnoreCase(c.getContainerConfiguration().getMode())) {
+                    try {
+                        c.stop();
+                        log.info("Stopped custom container: " + c.getName());
+                    } catch (Exception e) {
+                        log.error("Failed to stop custom container: " + c.getName(), e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.test.clustering.arquillian;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.Container.State;
 import org.jboss.arquillian.container.spi.ContainerRegistry;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/arquillian/StopCustomContainersOnAfterSuiteExtension.java
@@ -21,9 +21,6 @@
  */
 package org.jboss.as.test.clustering.arquillian;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.Container.State;
 import org.jboss.arquillian.container.spi.ContainerRegistry;
@@ -50,7 +47,7 @@ public class StopCustomContainersOnAfterSuiteExtension implements LoadableExtens
 
     public static class StopCustomContainers {
         public void close(@Observes AfterSuite event, ContainerRegistry registry) {
-            for (Container c : registry.getContainers()) {
+            for (Container c: registry.getContainers()) {
                 if (c.getState() == State.STARTED && "custom".equalsIgnoreCase(c.getContainerConfiguration().getMode())) {
                     try {
                         c.stop();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.cluster;
+
+import java.util.Properties;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusteringTestConstants;
+import org.jboss.as.test.clustering.NodeUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Base cluster test that ensures the custom containers are already running.
+ *
+ * @author Radoslav Husar
+ * @version Oct 2012
+ */
+public abstract class ClusterAbstractTestCase implements ClusteringTestConstants {
+
+    @ArquillianResource
+    protected ContainerController controller;
+    @ArquillianResource
+    protected Deployer deployer;
+
+    /**
+     * Ensure the containers are running, otherwise start them.
+     */
+    @Test
+    @InSequence(-1)
+    @RunAsClient
+    public void testSetup() {
+        this.setUp();
+    }
+
+    /**
+     * Override this method for different behavior of the test.
+     */
+    protected void setUp() {
+        NodeUtil.start(controller, CONTAINERS);
+    }
+
+    protected void start(String container) {
+        NodeUtil.start(controller, container);
+    }
+
+    protected void start(String[] containers) {
+        NodeUtil.start(controller, containers);
+    }
+
+    protected void stop(String container) {
+        NodeUtil.stop(controller, container);
+    }
+
+    protected void stop(String[] containers) {
+        NodeUtil.stop(controller, containers);
+    }
+
+    protected void deploy(String deployment) {
+        NodeUtil.deploy(deployer, deployment);
+    }
+
+    protected void deploy(String[] deployments) {
+        NodeUtil.deploy(deployer, deployments);
+    }
+
+    protected void undeploy(String deployments) {
+        NodeUtil.undeploy(deployer, deployments);
+    }
+
+    protected void undeploy(String[] deployments) {
+        NodeUtil.undeploy(deployer, deployments);
+    }
+
+    /**
+     * Printout some debug info.
+     */
+    @BeforeClass
+    public static void printSystemProperties() {
+        // Enable for debugging if you like:
+        //Properties systemProperties = System.getProperties();
+        //System.out.println("System properties:\n" + systemProperties);
+    }
+
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.test.clustering.cluster;
 
-import java.util.Properties;
-
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.RunAsClient;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.logging.Logger;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -40,6 +41,8 @@ import org.junit.Test;
  * @version Oct 2012
  */
 public abstract class ClusterAbstractTestCase implements ClusteringTestConstants {
+
+    protected static final Logger log = Logger.getLogger(ClusterAbstractTestCase.class);
 
     @ArquillianResource
     protected ContainerController controller;
@@ -102,7 +105,7 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
     public static void printSystemProperties() {
         // Enable for debugging if you like:
         //Properties systemProperties = System.getProperties();
-        //System.out.println("System properties:\n" + systemProperties);
+        //log.info("System properties:\n" + systemProperties);
     }
 
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/StatefulBeanBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/StatefulBeanBase.java
@@ -34,7 +34,7 @@ import java.rmi.RemoteException;
  */
 public abstract class StatefulBeanBase {
     private static Logger log = Logger.getLogger(StatefulBeanBase.class);
-    
+
     protected int number;
 
     /**
@@ -51,31 +51,31 @@ public abstract class StatefulBeanBase {
         return NodeNameGetter.getNodeName();
     }
 
-    /** 
+    /**
      * Creating method for home interface...
      */
     public void ejbCreate() throws RemoteException, javax.ejb.CreateException {
     }
-    
-    /** 
+
+    /**
      * @Override on SessionBean
      */
     public void ejbActivate() throws EJBException, RemoteException {
     }
 
-    /** 
+    /**
      * @Override on SessionBean
      */
     public void ejbPassivate() throws EJBException, RemoteException {
     }
 
-    /** 
+    /**
      * @Override on SessionBean
      */
     public void ejbRemove() throws EJBException, RemoteException {
     }
 
-    /** 
+    /**
      * @Override on SessionBean
      */
     public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/StatefulRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/StatefulRemote.java
@@ -27,5 +27,6 @@ package org.jboss.as.test.clustering.cluster.ejb2;
  */
 public interface StatefulRemote extends javax.ejb.EJBObject {
     int getNumber();
+
     String incrementNumber();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/StatefulRemoteHome.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/StatefulRemoteHome.java
@@ -24,7 +24,10 @@ package org.jboss.as.test.clustering.cluster.ejb2;
 
 import javax.ejb.EJBHome;
 
+/**
+ * @author Ondrej Chaloupka
+ */
 public interface StatefulRemoteHome extends EJBHome {
     public StatefulRemote create() throws java.rmi.RemoteException, javax.ejb.CreateException;
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/invalidation/CacheInvalidationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/invalidation/CacheInvalidationTestCase.java
@@ -109,9 +109,9 @@ public class CacheInvalidationTestCase {
         if (previousSelector != null) {
             EJBClientContext.setSelector(previousSelector);
         }
-        if(controller.isStarted(CONTAINER_1))
+        if (controller.isStarted(CONTAINER_1))
             controller.stop(CONTAINER_1);
-        if(controller.isStarted(CONTAINER_2))
+        if (controller.isStarted(CONTAINER_2))
             controller.stop(CONTAINER_2);
         directory.close();
     }
@@ -130,7 +130,7 @@ public class CacheInvalidationTestCase {
 
         StatefulRemoteHome home = directory.lookupHome(StatefulBean.class, StatefulRemoteHome.class);
         StatefulRemote remote = home.create();
-        for(int i=0; i<25; i++) {
+        for (int i = 0; i < 25; i++) {
             remote.incrementNumber();
         }
         controller.stop(CONTAINER_1);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/ClusteredBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/ClusteredBean.java
@@ -33,7 +33,6 @@ import org.jboss.ejb3.annotation.Clustered;
 
 /**
  * @author Paul Ferraro
- *
  */
 @Stateful
 @StatefulTimeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
@@ -42,7 +41,7 @@ public class ClusteredBean {
     public static volatile boolean preDestroy = false;
     public static volatile boolean prePassivate = false;
     private int count = 0;
-    
+
     @PreDestroy
     public void preDestroy() {
         preDestroy = true;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/ClusteredCacheBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/ClusteredCacheBean.java
@@ -33,7 +33,6 @@ import org.jboss.ejb3.annotation.Cache;
 
 /**
  * @author Paul Ferraro
- *
  */
 @Stateful
 @StatefulTimeout(value = 1000L, unit = TimeUnit.MILLISECONDS)

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/NestedBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/NestedBean.java
@@ -33,22 +33,21 @@ import org.jboss.ejb3.annotation.Clustered;
 
 /**
  * @author Paul Ferraro
- *
  */
 @Stateful
 @StatefulTimeout(value = 1000L, unit = TimeUnit.MILLISECONDS)
 @Clustered
 public class NestedBean {
     public static volatile boolean preDestroy = false;
-    
+
     @EJB
     private ClusteredBean inner;
-    
+
     @PreDestroy
     public void preDestroy() {
         preDestroy = true;
     }
-    
+
     public int increment() {
         return this.inner.increment();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/StatefulTimeoutTestCase.java
@@ -27,21 +27,24 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.transaction.UserTransaction;
 
-import org.jboss.arquillian.container.test.api.*;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusteringTestConstants;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-import org.jboss.as.test.clustering.NodeUtil;
 
 /**
  * Tests that the stateful timeout annotation works
@@ -49,20 +52,12 @@ import org.jboss.as.test.clustering.NodeUtil;
  * @author Stuart Douglas
  */
 @RunWith(Arquillian.class)
-public class StatefulTimeoutTestCase {
+public class StatefulTimeoutTestCase extends ClusterAbstractTestCase {
 
     private static final String ARCHIVE_NAME = "StatefulTimeoutTestCase";
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
+
     @Inject
     private UserTransaction userTransaction;
-
-    @BeforeClass
-    public static void printSysProps() {
-        System.out.println("System properties:\n" + System.getProperties());
-    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false)
     @TargetsContainer(CONTAINER_1)
@@ -73,15 +68,13 @@ public class StatefulTimeoutTestCase {
     @Deployment(name = DEPLOYMENT_2, managed = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
-        jar.addPackage(StatefulTimeoutTestCase.class.getPackage());
-        jar.add(EmptyAsset.INSTANCE, "META-INF/beans.xml");
-        return jar;
+        return createJar();
     }
 
     private static Archive<?> createJar() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addPackage(StatefulTimeoutTestCase.class.getPackage());
+        jar.addClasses(ClusterAbstractTestCase.class, ClusteringTestConstants.class);
         jar.add(EmptyAsset.INSTANCE, "META-INF/beans.xml");
         return jar;
     }
@@ -90,18 +83,16 @@ public class StatefulTimeoutTestCase {
         return beanType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + beanType.getSimpleName() + "!" + beanType.getName()));
     }
 
+    /**
+     * Ensure the containers are running.
+     */
+    @Override
     @Test
     @InSequence(-1)
-    public void testStartContainers() {
-        NodeUtil.start(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.start(controller, deployer, CONTAINER_2, DEPLOYMENT_2);
-    }
-
-    @Test
-    @InSequence(1)
-    public void testStopContainers() {
-        NodeUtil.stop(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.stop(controller, deployer, CONTAINER_2, DEPLOYMENT_2);
+    @RunAsClient
+    public void testSetup() {
+        start(CONTAINERS);
+        deploy(DEPLOYMENTS);
     }
 
     @Test

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/ClusteredBeanDeploymentTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/ClusteredBeanDeploymentTestCase.java
@@ -22,7 +22,12 @@
 package org.jboss.as.test.clustering.cluster.ejb3.deployment;
 
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.ClusteringTestConstants;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -32,7 +37,7 @@ import org.junit.runner.RunWith;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
-import org.jboss.arquillian.container.test.api.*;
+
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
@@ -40,42 +45,29 @@ import org.jboss.as.test.clustering.NodeUtil;
 
 /**
  * The purpose of this testcase is to ensure that a EJB marked as clustered, either via annotation or deployment descriptor,
- * deploys successfully. This test does <b>not</b> check any clustering semantics (like failover, replication etc...)
+ * deploys successfully. This test does <b>not</b> check any clustering semantics (like failover, replication, etc...)
  *
  * @author Jaikiran Pai
  */
 @RunWith(Arquillian.class)
-public class ClusteredBeanDeploymentTestCase {
+public class ClusteredBeanDeploymentTestCase extends ClusterAbstractTestCase {
 
     private static final String DD_BASED_MODULE_NAME = "clustered-ejb-deployment";
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
 
     @Deployment(name = DEPLOYMENT_1, managed = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive createDDBasedDeployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, DD_BASED_MODULE_NAME + ".jar");
         ejbJar.addClasses(DDBasedClusteredBean.class, ClusteredBean.class);
+        ejbJar.addClasses(ClusterAbstractTestCase.class, ClusteringTestConstants.class);
         ejbJar.addAsManifestResource("cluster/ejb3/deployment/jboss-ejb3.xml", "jboss-ejb3.xml");
         return ejbJar;
     }
 
-    @Test
-    @InSequence(-1)
-    @RunAsClient
-    public void testStartContainers() {
-        NodeUtil.start(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.start(controller, CONTAINER_2);
-    }
-
-    @Test
-    @InSequence(1)
-    @RunAsClient
-    public void testStopContainers() {
-        NodeUtil.stop(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.stop(controller, CONTAINER_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENT_1);
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/ClusteredBeanDeploymentTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/ClusteredBeanDeploymentTestCase.java
@@ -40,7 +40,9 @@ import javax.naming.InitialContext;
 
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
+
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+
 import org.jboss.as.test.clustering.NodeUtil;
 
 /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/DDBasedClusteredBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/DDBasedClusteredBean.java
@@ -34,7 +34,7 @@ public class DDBasedClusteredBean {
     public int increment() {
         return count++;
     }
-    
+
     public int getCount() {
         return count;
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredBase.java
@@ -42,7 +42,7 @@ public class DisableClusteredBase implements java.io.Serializable, DisableCluste
     }
 
     public void setUpFailover(String failover) {
-        // To setup the failover property
+        // To setUp the failover property
         log.info("Setting up failover property: " + failover);
         System.setProperty("JBossCluster-DoFail", failover);
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredBase.java
@@ -30,7 +30,6 @@ import org.jboss.logging.Logger;
  * @author Brian Stansberry
  */
 public class DisableClusteredBase implements java.io.Serializable, DisableClusteredRemote {
-    /** The serialVersionUID */
     private static final long serialVersionUID = 1L;
 
     private Logger log = Logger.getLogger(getClass());

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredStatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredStatefulBean.java
@@ -29,7 +29,7 @@ import org.jboss.ejb3.annotation.Clustered;
 
 /**
  * Test for EJBTHREE-1346. The @Clustered is overridden via jboss-ejb3.xml
- * 
+ *
  * @author Ondrej Chaloupka
  * @author Brian Stansberry
  */
@@ -37,7 +37,6 @@ import org.jboss.ejb3.annotation.Clustered;
 @Clustered
 @Remote(DisableClusteredRemote.class)
 public class DisableClusteredStatefulBean extends DisableClusteredBase {
-    /** The serialVersionUID */
     private static final long serialVersionUID = 1L;
 
     // Only difference from superclass is the added class-level annotations

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredStatelessBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredStatelessBean.java
@@ -29,7 +29,7 @@ import org.jboss.ejb3.annotation.Clustered;
 
 /**
  * Test for EJBTHREE-1346. The @Clustered is overridden via jboss-ejb3.xml
- * 
+ *
  * @author Ondrej Chaloupka
  * @author Brian Stansberry
  */
@@ -37,7 +37,6 @@ import org.jboss.ejb3.annotation.Clustered;
 @Clustered
 @Remote(DisableClusteredRemote.class)
 public class DisableClusteredStatelessBean extends DisableClusteredBase {
-    /** The serialVersionUID */
     private static final long serialVersionUID = 1L;
 
     // Only difference from superclass is the added class-level annotations

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/jboss-ejb3.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/jboss-ejb3.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <jboss xmlns="http://www.jboss.com/xml/ns/javaee"
        xmlns:jee="http://java.sun.com/xml/ns/javaee"
        xmlns:c="urn:clustering:1.0">
@@ -9,7 +30,7 @@
             <jee:ejb-name>DisableClusteredAnnotationStateful</jee:ejb-name>
             <c:clustered>false</c:clustered>
         </c:clustering>
-                <c:clustering>
+        <c:clustering>
             <jee:ejb-name>DisableClusteredAnnotationStateless</jee:ejb-name>
             <c:clustered>false</c:clustered>
         </c:clustering>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/BeanParent.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/BeanParent.java
@@ -33,7 +33,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @SecurityDomain("other")
 public class BeanParent implements BeanRemote {
 
-    @RolesAllowed({ "Role1", "Role2", "Users" })
+    @RolesAllowed({"Role1", "Role2", "Users"})
     public String getNodeName() {
         return NodeNameGetter.getNodeName();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/FailoverWithSecurityTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/FailoverWithSecurityTestCase.java
@@ -22,15 +22,6 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.security;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
-
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -45,6 +36,7 @@ import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
 import org.jboss.as.test.clustering.ViewChangeListener;
 import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
@@ -59,35 +51,28 @@ import org.junit.runner.RunWith;
 
 /**
  * Test security login on failover.
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class FailoverWithSecurityTestCase {
+public class FailoverWithSecurityTestCase extends ClusterAbstractTestCase {
     private static Logger log = Logger.getLogger(FailoverWithSecurityTestCase.class);
 
     private static final String PROPERTIES_FILE = "cluster/ejb3/security/jboss-ejb-client.properties";
     private static final String ARCHIVE_NAME = "cluster-security-domain-test";
     private static RemoteEJBDirectory context;
 
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
-
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        Archive<?> archive = createDeployment();
-        return archive;
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        Archive<?> archive = createDeployment();
-        return archive;
+        return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
@@ -104,29 +89,24 @@ public class FailoverWithSecurityTestCase {
         context = new RemoteEJBDirectory(ARCHIVE_NAME);
     }
 
-    @Test
-    @InSequence(-1)
-    public void startServers() {
-        // Container is unmanaged, need to start manually.
-        // This is a little hacky @see https://community.jboss.org/thread/176096
-        controller.start(CONTAINER_1);
-        deployer.deploy(DEPLOYMENT_1);
-        controller.start(CONTAINER_2);
-        deployer.deploy(DEPLOYMENT_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     @Test
     @InSequence(1)
     public void testDomainSecurityAnnotation(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
                                              @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2)
-                    throws Exception {
-        
+            throws Exception {
+
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(PROPERTIES_FILE);
-        
+
         try {
             ViewChangeListener listener = context.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
             this.establishView(listener, NODE_1, NODE_2);
-            
+
             BeanRemote statelessBean = context.lookupStateless(StatelessBean.class, BeanRemote.class);
             BeanRemote statefulBean = context.lookupStateful(StatefulBean.class, BeanRemote.class);
 
@@ -134,10 +114,10 @@ public class FailoverWithSecurityTestCase {
             String statefulNodeName = statefulBean.getNodeName();
             Assert.assertNotNull("No name was returned from SLSB ", statelessNodeName);
             Assert.assertNotNull("No name was returned from SFSB ", statefulNodeName);
-            
+
             String stoppedContainer = null;
             String runningNode = null;
-            if(NODE_1.equals(statefulNodeName)) {
+            if (NODE_1.equals(statefulNodeName)) {
                 stoppedContainer = CONTAINER_1;
                 runningNode = NODE_2;
             } else {
@@ -152,10 +132,10 @@ public class FailoverWithSecurityTestCase {
             statefulNodeName = statefulBean.getNodeName();
             Assert.assertEquals("SLSB has to return the only running node " + runningNode, runningNode, statelessNodeName);
             Assert.assertEquals("SFSB has to return the only running node " + runningNode, runningNode, statefulNodeName);
-            
-            if(CONTAINER_1.equals(stoppedContainer)) {
+
+            if (CONTAINER_1.equals(stoppedContainer)) {
                 controller.start(CONTAINER_1);
-                
+
                 this.establishView(listener, NODE_1, NODE_2);
 
                 deployer.undeploy(DEPLOYMENT_2);
@@ -163,21 +143,22 @@ public class FailoverWithSecurityTestCase {
                 runningNode = NODE_1;
             } else {
                 controller.start(CONTAINER_2);
-                
+
                 this.establishView(listener, NODE_1, NODE_2);
 
                 deployer.undeploy(DEPLOYMENT_1);
                 controller.stop(CONTAINER_1);
                 runningNode = NODE_2;
             }
-            
+
             this.establishView(listener, runningNode);
-            
+
+
             statelessNodeName = statelessBean.getNodeName();
             statefulNodeName = statefulBean.getNodeName();
             Assert.assertEquals("SLSB has to return the only running node " + runningNode, runningNode, statelessNodeName);
             Assert.assertEquals("SFSB has to return the only running node " + runningNode, runningNode, statefulNodeName);
-            
+
         } finally {
             if (previousSelector != null) {
                 EJBClientContext.setSelector(previousSelector);
@@ -185,22 +166,9 @@ public class FailoverWithSecurityTestCase {
         }
     }
 
-    @Test
-    @InSequence(100)
-    public void stopServers(
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
-        if (client1.isServerInRunningState()) {
-            deployer.undeploy(DEPLOYMENT_1);
-            controller.stop(CONTAINER_1);
-        }
-        if (client2.isServerInRunningState()) {
-            deployer.undeploy(DEPLOYMENT_2);
-            controller.stop(CONTAINER_2);
-        }
-    }
 
     private void establishView(ViewChangeListener listener, String... members) throws InterruptedException {
         listener.establishView("ejb", members);
     }
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/StatefulBean.java
@@ -26,6 +26,9 @@ import javax.ejb.Stateful;
 
 import org.jboss.ejb3.annotation.Clustered;
 
+/**
+ * @author Ondrej Chaloupka
+ */
 @Stateful
 @Clustered
 public class StatefulBean extends BeanParent implements BeanRemote {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/StatelessBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/StatelessBean.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.clustering.cluster.ejb3.security;
 
 import javax.ejb.Stateless;
+
 import org.jboss.ejb3.annotation.Clustered;
 
 /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
@@ -93,7 +93,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
                 "</beans>"), "beans.xml");
         war.addClasses(ViewChangeListener.class, ViewChangeListenerBean.class, ViewChangeListenerServlet.class);
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 
@@ -118,7 +118,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         String url1 = baseURL1.toString() + "count";
         String url2 = baseURL2.toString() + "count";
 
-        System.out.println("URLs are: " + url1 + ", " + url2);
+        log.info("URLs are: " + url1 + ", " + url2);
 
         try {
             this.establishView(client, baseURL1, NODE_1);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
@@ -63,7 +63,6 @@ import org.junit.runner.RunWith;
 
 /**
  * @author Paul Ferraro
- *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -122,14 +121,14 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
 
         try {
             this.establishView(client, baseURL1, NODE_1);
-            
+
             assertEquals(20010101, this.queryCount(client, url1));
             assertEquals(20020202, this.queryCount(client, url1));
 
             start(CONTAINER_2);
 
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             assertEquals(20030303, this.queryCount(client, url1));
             assertEquals(20040404, this.queryCount(client, url1));
 
@@ -139,14 +138,14 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             stop(CONTAINER_2);
 
             this.establishView(client, baseURL1, NODE_1);
-            
+
             assertEquals(20070707, this.queryCount(client, url1));
             assertEquals(20080808, this.queryCount(client, url1));
 
             start(CONTAINER_2);
 
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             assertEquals(20090909, this.queryCount(client, url1));
             assertEquals(20101010, this.queryCount(client, url1));
 
@@ -154,9 +153,9 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             assertEquals(20121212, this.queryCount(client, url2));
 
             stop(CONTAINER_1);
-            
+
             this.establishView(client, baseURL2, NODE_2);
-            
+
             assertEquals(20131313, this.queryCount(client, url2));
             assertEquals(20141414, this.queryCount(client, url2));
 
@@ -164,7 +163,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             start(CONTAINER_1);
 
             this.establishView(client, baseURL2, NODE_1, NODE_2);
-            
+
             assertEquals(20151515, this.queryCount(client, url1));
             assertEquals(20161616, this.queryCount(client, url1));
 
@@ -191,7 +190,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
 
         try {
             this.establishView(client, baseURL1, NODE_1);
-            
+
             assertEquals(20010101, this.queryCount(client, url1));
             assertEquals(20020202, this.queryCount(client, url1));
 
@@ -199,7 +198,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             //deploy(DEPLOYMENT_2);
 
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             assertEquals(20030303, this.queryCount(client, url1));
             assertEquals(20040404, this.queryCount(client, url1));
 
@@ -209,14 +208,14 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             undeploy(DEPLOYMENT_2);
 
             this.establishView(client, baseURL1, NODE_1);
-            
+
             assertEquals(20070707, this.queryCount(client, url1));
             assertEquals(20080808, this.queryCount(client, url1));
 
             deploy(DEPLOYMENT_2);
 
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             assertEquals(20090909, this.queryCount(client, url1));
             assertEquals(20101010, this.queryCount(client, url1));
 
@@ -226,14 +225,14 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             undeploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_2);
-            
+
             assertEquals(20131313, this.queryCount(client, url2));
             assertEquals(20141414, this.queryCount(client, url2));
 
             deploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_1, NODE_2);
-            
+
             assertEquals(20151515, this.queryCount(client, url1));
             assertEquals(20161616, this.queryCount(client, url1));
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/Nested.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/Nested.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 
 /**
  * @author Paul Ferraro
- *
  */
 @Local
 public interface Nested {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/NestedBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/NestedBean.java
@@ -30,7 +30,6 @@ import org.jboss.ejb3.annotation.Clustered;
 
 /**
  * @author Paul Ferraro
- *
  */
 @Clustered
 @javax.ejb.Stateful(name = "NestedBean")

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/Stateful.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/Stateful.java
@@ -26,7 +26,6 @@ import javax.ejb.Local;
 
 /**
  * @author Paul Ferraro
- *
  */
 @Local
 public interface Stateful {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulBean.java
@@ -38,7 +38,7 @@ public class StatefulBean implements Stateful {
 
     @EJB
     private Nested nested;
-    
+
     public int increment() {
         return this.nested.increment();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulCDIInterceptor.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulCDIInterceptor.java
@@ -39,7 +39,7 @@ public class StatefulCDIInterceptor implements Serializable {
 
     @AroundInvoke
     public Object invoke(final InvocationContext context) throws Exception {
-        return ((Integer)context.proceed() ) + count.addAndGet(10000);
+        return ((Integer) context.proceed()) + count.addAndGet(10000);
     }
 
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulInterceptor.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulInterceptor.java
@@ -30,13 +30,12 @@ import javax.interceptor.InvocationContext;
 /**
  * @author Stuart Douglas
  */
-
 public class StatefulInterceptor implements Serializable {
 
     private final AtomicInteger count = new AtomicInteger(0);
 
     @AroundInvoke
     public Object invoke(final InvocationContext context) throws Exception {
-        return ((Integer)context.proceed() ) + count.addAndGet(100);
+        return ((Integer) context.proceed()) + count.addAndGet(100);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/StatefulServlet.java
@@ -36,9 +36,8 @@ import org.jboss.as.test.clustering.LocalEJBDirectory;
 
 /**
  * @author Paul Ferraro
- *
  */
-@WebServlet(urlPatterns = { "/count" })
+@WebServlet(urlPatterns = {"/count"})
 public class StatefulServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/web.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/bean/web.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
@@ -22,22 +22,11 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_LOOP_COUNT;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_WAIT_MS;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_NAME;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.HTTP_REQUEST_WAIT_TIME_S;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.WAIT_FOR_PASSIVATION_MS;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import javax.naming.NamingException;
 
 import org.junit.Assert;
@@ -75,7 +64,6 @@ import org.junit.runner.RunWith;
 
 /**
  * Clustering ejb passivation simple test.
- * Part of migration of tests from prior AS testsuites [JBQA-5855].
  *
  * @author Ondrej Chaloupka
  */
@@ -220,7 +208,7 @@ public class ClusterPassivationTestCase extends ClusterAbstractTestCase {
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
 
-        String nodeName1 = HttpRequest.get(baseURL1.toString() + NodeInfoServlet.URL , HTTP_REQUEST_WAIT_TIME_S, TimeUnit.SECONDS);
+        String nodeName1 = HttpRequest.get(baseURL1.toString() + NodeInfoServlet.URL, HTTP_REQUEST_WAIT_TIME_S, TimeUnit.SECONDS);
         node2deployment.put(nodeName1, DEPLOYMENT_1);
         node2container.put(nodeName1, CONTAINER_1);
         container2node.put(CONTAINER_1, nodeName1);
@@ -267,7 +255,7 @@ public class ClusterPassivationTestCase extends ClusterAbstractTestCase {
             Assert.assertTrue("Passivation of nested bean was not propagated", statefulBeanRemote.getNestedBeanPassivatedCalled() > 0);
             Assert.assertTrue("Activation of nested bean was not propagated", statefulBeanRemote.getNestedBeanActivatedCalled() > 0);
             Assert.assertTrue("Passivation of deep nested bean was not propagated", statefulBeanRemote.getDeepNestedBeanPassivatedCalled() > 0);
-            Assert.assertTrue("Activation of deep nested bean was not propagated",statefulBeanRemote.getDeepNestedBeanActivatedCalled() > 0);
+            Assert.assertTrue("Activation of deep nested bean was not propagated", statefulBeanRemote.getDeepNestedBeanActivatedCalled() > 0);
             Assert.assertTrue("Passivation of remote bean was not propagated", statefulBeanRemote.getRemoteNestedBeanPassivatedCalled() > 0);
             Assert.assertTrue("Activation of remote bean was not propagated", statefulBeanRemote.getRemoteNestedBeanActivatedCalled() > 0);
             statefulBeanRemote.resetNestedBean();
@@ -307,18 +295,18 @@ public class ClusterPassivationTestCase extends ClusterAbstractTestCase {
             Assert.assertTrue("Passivation of nested bean was not propagated", statefulBeanRemote.getNestedBeanPassivatedCalled() > 0);
             Assert.assertTrue("Activation of nested bean was not propagated", statefulBeanRemote.getNestedBeanActivatedCalled() > 0);
             Assert.assertTrue("Passivation of deep nested bean was not propagated", statefulBeanRemote.getDeepNestedBeanPassivatedCalled() > 0);
-            Assert.assertTrue("Activation of deep nested bean was not propagated",statefulBeanRemote.getDeepNestedBeanActivatedCalled() > 0);
+            Assert.assertTrue("Activation of deep nested bean was not propagated", statefulBeanRemote.getDeepNestedBeanActivatedCalled() > 0);
             Assert.assertTrue("Passivation of remote bean was not propagated", statefulBeanRemote.getRemoteNestedBeanPassivatedCalled() > 0);
             Assert.assertTrue("Activation of remote bean was not propagated", statefulBeanRemote.getRemoteNestedBeanActivatedCalled() > 0);
             statefulBeanRemote.resetNestedBean();
         } else {
             Assert.assertEquals("We suppose that the passivation is not provided.", "unknown", statefulBeanRemote.getPassivatedBy());
-            Assert.assertEquals("No passivation should be done",0, statefulBeanRemote.getNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done",0, statefulBeanRemote.getNestedBeanActivatedCalled());
-            Assert.assertEquals("No passivation should be done",0, statefulBeanRemote.getDeepNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done",0, statefulBeanRemote.getDeepNestedBeanActivatedCalled());
-            Assert.assertEquals("No passivation should be done",0, statefulBeanRemote.getRemoteNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done",0, statefulBeanRemote.getRemoteNestedBeanActivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getNestedBeanPassivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getNestedBeanActivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getDeepNestedBeanPassivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getDeepNestedBeanActivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanPassivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanActivatedCalled());
         }
         Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
         Assert.assertEquals(++clientNumber, statefulBeanRemote.getNumber()); // 43
@@ -417,7 +405,7 @@ public class ClusterPassivationTestCase extends ClusterAbstractTestCase {
         Assert.assertEquals("String data of dto defined in sfsb wasn't passivated correctly", stringData, sb.getDTOStringData());
         Assert.assertEquals("Int data of dto defined in sfsb wasn't passivated correctly", intData, sb.getDTONumberData());
         Assert.assertNull("String data of transient dto defined in sfsb has to be null after passivation", sb.getTransientDTOStringData());
-        Assert.assertEquals("Int data of transient dto has to be 0 after passivation", 0,sb.getTransientDTONumberData());
+        Assert.assertEquals("Int data of transient dto has to be 0 after passivation", 0, sb.getTransientDTONumberData());
         Assert.assertEquals("String data of dto defined in parent of sfsb wasn't passivated correctly", stringData, sb.getParentDTOStringData());
         Assert.assertNull("Transient string data of dto defined in parent of sfsb has to be null after passivation", sb.getParentDTOTransientStringData());
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
@@ -42,8 +42,6 @@ import javax.naming.NamingException;
 
 import org.junit.Assert;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -59,6 +57,7 @@ import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeInfoServlet;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.ejb.client.ClusterContext;
 import org.jboss.ejb.client.ContextSelector;
@@ -77,20 +76,18 @@ import org.junit.runner.RunWith;
 /**
  * Clustering ejb passivation simple test.
  * Part of migration of tests from prior AS testsuites [JBQA-5855].
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class ClusterPassivationTestCase {
+public class ClusterPassivationTestCase extends ClusterAbstractTestCase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestCase.class);
     public static final String ARCHIVE_NAME = "cluster-passivation-test";
     public static final String ARCHIVE_NAME_HELPER = "cluster-passivation-test-helper";
 
-    private static final String HELPER_DEPLOYMENT = "helper-";
-    
     private static EJBDirectory context;
-    
+
     @BeforeClass
     public static void beforeClass() throws Exception {
         context = new RemoteEJBDirectory(ARCHIVE_NAME);
@@ -100,11 +97,6 @@ public class ClusterPassivationTestCase {
     public static void destroy() throws NamingException {
         context.close();
     }
-
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
 
     // Properties pass amongst tests
     private static ContextSelector<EJBClientContext> previousSelector;
@@ -126,15 +118,15 @@ public class ClusterPassivationTestCase {
         Archive<?> archive = createDeployment();
         return archive;
     }
-    
-    @Deployment(name = HELPER_DEPLOYMENT +  DEPLOYMENT_1, managed = true, testable = false)
+
+    @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> helpDeployment0() {
         Archive<?> archive = createHelperDeployment();
         return archive;
     }
 
-    @Deployment(name = HELPER_DEPLOYMENT + DEPLOYMENT_2, managed = true, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> helpDeployment1() {
         Archive<?> archive = createHelperDeployment();
@@ -148,7 +140,7 @@ public class ClusterPassivationTestCase {
         log.info(war.toString(true));
         return war;
     }
-    
+
     private static Archive<?> createHelperDeployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME_HELPER + ".jar");
         jar.addClasses(StatefulBeanDeepNested.class, StatefulBeanDeepNestedRemote.class, StatefulBeanNestedParent.class, NodeNameGetter.class);
@@ -175,20 +167,22 @@ public class ClusterPassivationTestCase {
 
     /**
      * Start servers whether their are not started.
-     * 
+     *
      * @param client1 client for server1
      * @param client2 client for server2
      */
     private void startServers(ManagementClient client1, ManagementClient client2) {
         if (client1 == null || !client1.isServerInRunningState()) {
             log.info("Starting server: " + CONTAINER_1);
-            controller.start(CONTAINER_1);
-            deployer.deploy(DEPLOYMENT_1);
+            start(CONTAINER_1);
+            deploy(DEPLOYMENT_HELPER_1);
+            deploy(DEPLOYMENT_1);
         }
         if (client2 == null || !client2.isServerInRunningState()) {
             log.info("Starting server: " + CONTAINER_2);
-            controller.start(CONTAINER_2);
-            deployer.deploy(DEPLOYMENT_2);
+            start(CONTAINER_2);
+            deploy(DEPLOYMENT_HELPER_2);
+            deploy(DEPLOYMENT_2);
         }
     }
 
@@ -212,17 +206,16 @@ public class ClusterPassivationTestCase {
     @Test
     @InSequence(-2)
     public void arquillianStartServers() {
-        // Container is unmanaged, need to start manually.
-        // This is a little hacky - need for URL and client injection. @see https://community.jboss.org/thread/176096
         startServers(null, null);
     }
 
     /**
-     * Associtation of node names to deployment,container names and client context
+     * Association of node names to deployment,container names and client context
      */
     @Test
     @InSequence(-1)
-    public void defineMaps(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
+    public void defineMaps(
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
@@ -250,7 +243,7 @@ public class ClusterPassivationTestCase {
         // Loading context from file to get ejb:// remote context
         setupEJBClientContextSelector(); // setting context from .properties file
         final StatefulBeanRemote statefulBeanRemote = context.lookupStateful(StatefulBean.class, StatefulBeanRemote.class);
-        log.debug("Passivated (" + (isPassivation ? "TRUE" : "FALSE") + ") by on start: " + statefulBeanRemote.getPassivatedBy());
+        log.info("Passivated (" + (isPassivation ? "TRUE" : "FALSE") + ") by on start: " + statefulBeanRemote.getPassivatedBy());
 
         // Calling on server one
         int clientNumber = 40;
@@ -266,7 +259,7 @@ public class ClusterPassivationTestCase {
         // A small hack - deleting node (by name) from cluster which this client knows
         // It means that the next request (ejb call) will be passed to the server #2
         EJBClientContext.requireCurrent().getClusterContext(CLUSTER_NAME).removeClusterNode(calledNodeFirst);
-        
+
         if (isPassivation) {
             // this was redefined in @PrePassivate method on first server - checking whether second server knows about it
             Assert.assertEquals("Supposing to get passivation node which was set", calledNodeFirst, statefulBeanRemote.getPassivatedBy());
@@ -281,15 +274,15 @@ public class ClusterPassivationTestCase {
         } else {
             Assert.assertEquals("We suppose that the passivation is not provided", "unknown", statefulBeanRemote.getPassivatedBy());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done", 0,  statefulBeanRemote.getNestedBeanActivatedCalled());
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getNestedBeanActivatedCalled());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getDeepNestedBeanPassivatedCalled());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getDeepNestedBeanActivatedCalled());
             Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanPassivatedCalled());
-            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanActivatedCalled());            
+            Assert.assertEquals("No passivation should be done", 0, statefulBeanRemote.getRemoteNestedBeanActivatedCalled());
         }
-        
+
         String calledNodeSecond = statefulBeanRemote.incrementNumber(); // 42
-        Assert.assertEquals("Nested bean has to be calledn on the same node as parent one", calledNodeSecond, statefulBeanRemote.getNestedBeanNodeName());
+        Assert.assertEquals("Nested bean has to be called on the same node as parent one", calledNodeSecond, statefulBeanRemote.getNestedBeanNodeName());
         statefulBeanRemote.setPassivationNode(calledNodeSecond);
         log.info("Called node name second: " + calledNodeSecond);
         Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
@@ -333,7 +326,7 @@ public class ClusterPassivationTestCase {
 
     @Test
     @InSequence(1)
-    @Ignore("AS7-4266")
+    @Ignore("https://issues.jboss.org/browse/AS7-4266")
     public void testPassivationOverNodesPassivated(
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
@@ -365,8 +358,8 @@ public class ClusterPassivationTestCase {
         runPassivation(isPassivated);
         startServers(client1, client2);
     }
-    
-  
+
+
     @Test
     @InSequence(3)
     /**
@@ -384,12 +377,12 @@ public class ClusterPassivationTestCase {
         DMRUtil.setPassivationOnReplicate(client1.getControllerClient(), isPassivated);
         DMRUtil.setPassivationIdleTimeout(client2.getControllerClient());
         DMRUtil.setPassivationOnReplicate(client2.getControllerClient(), isPassivated);
-        
+
         log.info("Setting context selector...");
         setupEJBClientContextSelector();
-        
+
         final StatefulBeanChildRemote sb = context.lookupStateful(StatefulBeanChild.class, StatefulBeanChildRemote.class);
-        
+
         String stringData = "42";
         int intData = 42;
         String calledNodeName = sb.getNodeName();
@@ -397,7 +390,7 @@ public class ClusterPassivationTestCase {
         // redefine node2client maps
         node2client.put(container2node.get(CONTAINER_1), client1);
         node2client.put(container2node.get(CONTAINER_2), client2);
-        
+
         // 1. integer defined in sfsb bean
         sb.setInt(intData);
         // 2. DTO defined in sfsb
@@ -409,16 +402,16 @@ public class ClusterPassivationTestCase {
         // 4. DTO defined in parent of sfsb
         sb.setParentDTOStringData(stringData);
         sb.setParentDTOTransientStringData(stringData);
-                
+
         // waiting for passivation
         Thread.sleep(WAIT_FOR_PASSIVATION_MS);
-                
+
         // Stopping called node
         unsetPassivationAttributes(node2client.get(calledNodeName).getControllerClient());
-        deployer.undeploy(node2deployment.get(calledNodeName));
-        controller.stop(node2container.get(calledNodeName));
+        undeploy(node2deployment.get(calledNodeName));
+        stop(node2container.get(calledNodeName));
         log.info("Node " + calledNodeName + " was stopped.");
-        
+
         // checking data
         Assert.assertEquals("Int sfsb data wasn't passivated correctly", intData, sb.getInt());
         Assert.assertEquals("String data of dto defined in sfsb wasn't passivated correctly", stringData, sb.getDTOStringData());
@@ -441,41 +434,22 @@ public class ClusterPassivationTestCase {
             EJBClientContext.setSelector(previousSelector);
         }
 
+        // Start containers to clean them
+        start(CONTAINERS);
+
         // unset & undeploy & stop
-        // the try blocks were added to be sure that the attemp for undeploy will be provided although that
+        // the try blocks were added to be sure that the attempt for undeploy will be provided although that
         // client1/2 does not respond - e.g. after failed reload operation
         if(client1.isServerInRunningState()) {
             unsetPassivationAttributes(client1.getControllerClient());
-        }
-        try {
-            deployer.undeploy(DEPLOYMENT_1);
-        } catch (Exception e) {
-            log.warnf("Deployment %s can't be undeployed from container %s because of exception %s. " +
-            		"Ignore this warning when server was already stopped by other test before.", DEPLOYMENT_1, CONTAINER_1, e.getClass().getName() + ": " + e.getMessage());
-        } finally {
-            try {
-                controller.stop(CONTAINER_1);
-            } catch (Exception e) {
-                log.warnf("Container %s can't be stopped because of exception %s. " +
-                        "Ignore this warning when server was already stopped by other test before.", CONTAINER_1, e.getClass().getName() + ": " + e.getMessage());
-            }
         }
         
         if(client2.isServerInRunningState()) {
             unsetPassivationAttributes(client2.getControllerClient());
         }
-        try {
-            deployer.undeploy(DEPLOYMENT_2);
-        } catch (Exception e) {
-            log.warnf("Deployment %s can't be undeployed from container %s because of exception %s. " +
-                    "Ignore this warning when server was already stopped by other test before.", DEPLOYMENT_2, CONTAINER_2, e.getClass().getName() + ": " + e.getMessage());
-        } finally {
-            try {
-                controller.stop(CONTAINER_2);
-            } catch (Exception e) {
-                log.warnf("Container %s can't be stopped because of exception %s. " +
-                        "Ignore this warning when server was already stopped by other test before.", CONTAINER_2, e.getClass().getName() + ": " + e.getMessage());
-            }
-        }
+
+        // Undeploy
+        undeploy(DEPLOYMENTS);
+        undeploy(DEPLOYMENT_HELPERS);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBean.java
@@ -37,19 +37,19 @@ import org.jboss.logging.Logger;
 @Clustered
 @Stateful
 public class StatefulBean implements StatefulBeanRemote {
-    private static Logger log = Logger.getLogger(StatefulBean.class);    
+    private static Logger log = Logger.getLogger(StatefulBean.class);
     private int number;
     private String passivatedBy = "unknown";
     private String actIfIsNode;
     private int postActivateCalled = 0;
     private int prePassivateCalled = 0;
-    
+
     @EJB
     private StatefulBeanNested beanNested;
 
     @EJB(lookup = "java:global/cluster-passivation-test-helper/StatefulBeanDeepNested!org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation.StatefulBeanDeepNestedRemote")
     private StatefulBeanDeepNestedRemote beanNestedRemote;
-    
+
     /**
      * Getting number.
      */
@@ -97,33 +97,41 @@ public class StatefulBean implements StatefulBeanRemote {
         postActivateCalled++;
         log.info("Activating with number: " + number + " and was passivated by " + getPassivatedBy() + ", postActivate method called " + postActivateCalled + " times");
     }
-    
+
     public void resetNestedBean() {
         beanNested.reset();
         beanNested.resetDeepNested();
         beanNestedRemote.reset();
     }
+
     public int getNestedBeanActivatedCalled() {
         return beanNested.getActivatedCalled();
     }
+
     public int getNestedBeanPassivatedCalled() {
         return beanNested.getPassivatedCalled();
     }
+
     public int getDeepNestedBeanActivatedCalled() {
         return beanNested.getDeepNestedActivatedCalled();
     }
+
     public int getDeepNestedBeanPassivatedCalled() {
         return beanNested.getDeepNestedPassivatedCalled();
     }
+
     public String getNestedBeanNodeName() {
         return beanNested.getNodeName();
     }
+
     public int getRemoteNestedBeanPassivatedCalled() {
         return beanNestedRemote.getPassivatedCalled();
     }
+
     public int getRemoteNestedBeanActivatedCalled() {
         return beanNestedRemote.getActivatedCalled();
     }
+
     public String getRemoteNestedBeanNodeName() {
         return beanNestedRemote.getNodeName();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChild.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChild.java
@@ -35,52 +35,53 @@ import org.jboss.logging.Logger;
 @Stateful
 public class StatefulBeanChild extends StatefulBeanParent implements StatefulBeanChildRemote {
     private static final Logger log = Logger.getLogger(StatefulBeanChild.class);
-    
+
     private TestingDTO dto = new TestingDTO();
     private transient TestingDTO transientDto = new TestingDTO();
-       
+
     public int getInt() {
         return intNumber;
     }
+
     public void setInt(int parentInt) {
         this.intNumber = parentInt;
     }
-    
+
     public String getNodeName() {
         String nodeName = NodeNameGetter.getNodeName();
         log.info(this.getClass().getSimpleName() + " called on node " + nodeName);
         return nodeName;
     }
-    
+
     // ---- Methods for manipulation with dto data ----
     public void setDTOStringData(String str) {
         dto.setData(str);
     }
-    
+
     public String getDTOStringData() {
         return dto.getData();
     }
-    
+
     public void setDTONumberData(int number) {
         dto.setNumber(number);
     }
-    
+
     public int getDTONumberData() {
         return dto.getNumber();
     }
-    
+
     public void setTransientDTOStringData(String str) {
         transientDto.setData(str);
     }
-    
+
     public String getTransientDTOStringData() {
         return transientDto.getData();
     }
-    
+
     public void setTransientDTONumberData(int number) {
         transientDto.setNumber(number);
     }
-    
+
     public int getTransientDTONumberData() {
         return transientDto.getNumber();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChildRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanChildRemote.java
@@ -30,25 +30,35 @@ import javax.ejb.Remote;
 @Remote
 public interface StatefulBeanChildRemote {
     int getInt();
+
     void setInt(int parentInt);
-    
+
     String getNodeName();
-    
+
     // standard dto
     void setDTOStringData(String str);
+
     String getDTOStringData();
+
     void setDTONumberData(int number);
+
     int getDTONumberData();
-    
+
     // dto defined as transient
     void setTransientDTOStringData(String str);
-    String getTransientDTOStringData();   
+
+    String getTransientDTOStringData();
+
     void setTransientDTONumberData(int number);
-    int getTransientDTONumberData();    
+
+    int getTransientDTONumberData();
 
     // dto defined in parent class
     void setParentDTOStringData(String str);
+
     String getParentDTOStringData();
+
     void setParentDTOTransientStringData(String str);
+
     String getParentDTOTransientStringData();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanDeepNested.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanDeepNested.java
@@ -28,6 +28,7 @@ import org.jboss.ejb3.annotation.Cache;
 
 /**
  * Simple bean which will be injected in {@link StatefulBeanNested}.
+ *
  * @author Ondrej Chaloupka
  */
 @Stateful

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanDeepNestedRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanDeepNestedRemote.java
@@ -30,7 +30,10 @@ import javax.ejb.Remote;
 @Remote
 public interface StatefulBeanDeepNestedRemote {
     void reset();
+
     String getNodeName();
+
     int getPassivatedCalled();
+
     int getActivatedCalled();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanNested.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanNested.java
@@ -32,7 +32,7 @@ import org.jboss.logging.Logger;
 
 /**
  * Simple Stateful bean to be nested in other bean.
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @Stateful
@@ -40,24 +40,24 @@ import org.jboss.logging.Logger;
 @LocalBean
 public class StatefulBeanNested extends StatefulBeanNestedParent {
     private static final Logger log = Logger.getLogger(StatefulBeanNested.class);
-    
+
     @EJB
     StatefulBeanDeepNestedRemote deepNestedBean;
-    
+
     public String getNodeName() {
         String nodeName = NodeNameGetter.getNodeName();
         log.info("Bean " + this.getClass().getSimpleName() + " was called on " + nodeName);
         return nodeName;
     }
-    
+
     public int getDeepNestedPassivatedCalled() {
         return deepNestedBean.getPassivatedCalled();
     }
-    
+
     public int getDeepNestedActivatedCalled() {
         return deepNestedBean.getActivatedCalled();
     }
-    
+
     public void resetDeepNested() {
         deepNestedBean.reset();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanNestedParent.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanNestedParent.java
@@ -33,37 +33,37 @@ import org.jboss.logging.Logger;
  */
 public class StatefulBeanNestedParent {
     private static final Logger log = Logger.getLogger(StatefulBeanNestedParent.class);
-    
+
     private int passivatedCalled = 0;
     private int activatedCalled = 0;
-    
+
     public void reset() {
         passivatedCalled = 0;
         activatedCalled = 0;
     }
-    
+
     public String getNodeName() {
         return NodeNameGetter.getNodeName();
     }
-    
+
     public int getPassivatedCalled() {
         return passivatedCalled;
     }
-    
+
     public int getActivatedCalled() {
         return activatedCalled;
     }
-    
+
     @PrePassivate
     public void prePassivate() {
         passivatedCalled++;
         log.info(this.getClass().getSimpleName() + " prePassivated() called " + passivatedCalled + " times");
     }
-    
+
     @PostActivate
     public void postActivate() {
         activatedCalled++;
         log.info(this.getClass().getSimpleName() + " postActivate() called " + activatedCalled + " times");
     }
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanParent.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanParent.java
@@ -33,15 +33,15 @@ public class StatefulBeanParent {
     public void setParentDTOStringData(String str) {
         dtoParent.setData(str);
     }
-    
+
     public String getParentDTOStringData() {
         return dtoParent.getData();
     }
-    
+
     public void setParentDTOTransientStringData(String str) {
         dtoParent.setTransientData(str);
     }
-    
+
     public String getParentDTOTransientStringData() {
         return dtoParent.getTransientData();
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/StatefulBeanRemote.java
@@ -30,19 +30,31 @@ import javax.ejb.Remote;
 @Remote
 public interface StatefulBeanRemote {
     int getNumber();
+
     String setNumber(int number);
+
     String incrementNumber();
+
     void setPassivationNode(String node);
+
     String getPassivatedBy();
-    
+
     // nested bean working methods
     void resetNestedBean();
+
     int getNestedBeanActivatedCalled();
+
     int getNestedBeanPassivatedCalled();
+
     int getDeepNestedBeanActivatedCalled();
+
     int getDeepNestedBeanPassivatedCalled();
+
     String getNestedBeanNodeName();
+
     int getRemoteNestedBeanPassivatedCalled();
+
     int getRemoteNestedBeanActivatedCalled();
+
     String getRemoteNestedBeanNodeName();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTO.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTO.java
@@ -27,19 +27,22 @@ package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
  */
 public class TestingDTO extends TestingDTOParent {
     private static final long serialVersionUID = 1L;
-    
+
     private transient int transientNumber;
     private int number;
-        
+
     public int getTransientInt() {
         return transientNumber;
     }
+
     public void setTransientNumber(int num) {
         this.transientNumber = num;
     }
+
     public int getNumber() {
         return number;
     }
+
     public void setNumber(int num) {
         this.number = num;
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTOParent.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/TestingDTOParent.java
@@ -29,21 +29,24 @@ import java.io.Serializable;
  */
 public class TestingDTOParent implements Serializable {
     private static final long serialVersionUID = 1L;
-    
+
     private String data;
     private transient String transientData;
-       
+
     public String getData() {
         return data;
     }
+
     public void setData(String data) {
         this.data = data;
     }
+
     public String getTransientData() {
         return transientData;
     }
+
     public void setTransientData(String transientData) {
         this.transientData = transientData;
     }
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/CDIDecorator.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/CDIDecorator.java
@@ -39,6 +39,6 @@ public abstract class CDIDecorator implements DecoratorInterface, Serializable {
 
     @Override
     public String getMessage() {
-        return  "Hello " + delegate.getMessage();
+        return "Hello " + delegate.getMessage();
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/CounterBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/CounterBean.java
@@ -47,7 +47,7 @@ public class CounterBean implements RemoteCounter {
 
     @Inject
     public CounterBean(DecoratorInterface bean) {
-        if(!"Hello World".equals(bean.getMessage())) {
+        if (!"Hello World".equals(bean.getMessage())) {
             throw new RuntimeException("bean was not decorated");
         }
         this.bean = bean;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
@@ -22,11 +22,6 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
-
 import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
@@ -41,6 +36,7 @@ import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
 import org.jboss.as.test.clustering.ViewChangeListener;
 import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
@@ -52,6 +48,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -64,7 +61,8 @@ import org.junit.runner.RunWith;
  * @see https://issues.jboss.org/browse/AS7-3492
  */
 @RunWith(Arquillian.class)
-public class LocalEJBClientFailoverTestCase {
+@Ignore("https://issues.jboss.org/browse/AS7-5318")
+public class LocalEJBClientFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final Logger logger = Logger.getLogger(LocalEJBClientFailoverTestCase.class);
 
@@ -91,7 +89,7 @@ public class LocalEJBClientFailoverTestCase {
     private boolean nodeNameAppDeployedOnContainerTwo;
 
     @Deployment(name = CLIENT_ARQ_DEPLOYMENT, testable = false, managed = false)
-    @TargetsContainer(ClusteringTestConstants.CONTAINER_2)
+    @TargetsContainer(CONTAINER_2)
     public static Archive<?> createClientApplication() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, CLIENT_APP_MODULE_NAME + ".jar");
         jar.addClasses(ClientSFSB.class, ClientSFSBRemote.class, NodeNameRetriever.class);
@@ -99,15 +97,16 @@ public class LocalEJBClientFailoverTestCase {
         return jar;
     }
 
+
     @Deployment(name = NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1, testable = false, managed = false)
-    @TargetsContainer(ClusteringTestConstants.CONTAINER_1)
+    @TargetsContainer(CONTAINER_1)
     public static Archive<?> createNodeNameApplicationForContainer1() {
         return createNodeNameApplication();
     }
 
     @Deployment(name = NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2, testable = false, managed = false)
-    @TargetsContainer(ClusteringTestConstants.CONTAINER_2)
-    public static Archive<?> createNodeNameApplicationForContainer2() {
+    @TargetsContainer(CONTAINER_2)
+    public static Archive createNodeNameApplicationForContainer2() {
         return createNodeNameApplication();
     }
 
@@ -133,44 +132,24 @@ public class LocalEJBClientFailoverTestCase {
     @After
     public void afterTest() throws Exception {
         if (clientAppDeployed) {
-            try {
-                this.deployer.undeploy(CLIENT_ARQ_DEPLOYMENT);
-            } catch (Exception e) {
-                logger.error("Could not undeploy " + CLIENT_ARQ_DEPLOYMENT, e);
-            }
+            undeploy(CLIENT_ARQ_DEPLOYMENT);
         }
+
         if (nodeNameAppDeployedOnContainerOne) {
-            try {
-                this.deployer.undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1);
-            } catch (Exception e) {
-                logger.error("Could not undeploy " + NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1, e);
-            }
+            undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1);
         }
 
         if (nodeNameAppDeployedOnContainerTwo) {
-            try {
-                this.deployer.undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
-            } catch (Exception e) {
-                logger.error("Could not undeploy " + NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2, e);
-            }
+            undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
         }
 
         if (containerOneStarted) {
-            try {
-                this.container.stop(CONTAINER_1);
-            } catch (Exception e) {
-                logger.error("Failed to stop " + CONTAINER_1, e);
-            }
+            stop(CONTAINER_1);
         }
 
         if (containerTwoStarted) {
-            try {
-                this.container.stop(CONTAINER_2);
-            } catch (Exception e) {
-                logger.error("Failed to stop " + CONTAINER_2, e);
-            }
+            stop(CONTAINER_2);
         }
-
     }
 
     /**
@@ -188,18 +167,15 @@ public class LocalEJBClientFailoverTestCase {
      */
     @Test
     public void testFailoverWhenLocalTargetApplicationIsUndeployed() throws Exception {
-        // Container is unmanaged, so start it ourselves
-        this.container.start(CONTAINER_1);
+
         containerOneStarted = true;
-        // start the other container too
-        this.container.start(CONTAINER_2);
         containerTwoStarted = true;
 
-        this.deployer.deploy(CLIENT_ARQ_DEPLOYMENT);
+        deploy(CLIENT_ARQ_DEPLOYMENT);
         clientAppDeployed = true;
-        this.deployer.deploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1);
+        deploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1);
         nodeNameAppDeployedOnContainerOne = true;
-        this.deployer.deploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
+        deploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
         nodeNameAppDeployedOnContainerTwo = true;
 
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/local-ejb-sfsb-failover-jboss-ejb-client.properties");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
@@ -181,9 +181,9 @@ public class LocalEJBClientFailoverTestCase extends ClusterAbstractTestCase {
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/local-ejb-sfsb-failover-jboss-ejb-client.properties");
         try {
             final ViewChangeListener listener = directory.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODE_1, NODE_2);
-            
+
             final ClientSFSBRemote clientSFSB = clientDirectory.lookupStateful(ClientSFSB.class, ClientSFSBRemote.class);
             // invoke on non-clustered SFSB which invokes/delegates to clustered SFSB on same node
             final String sfsbNodeName = clientSFSB.invokeAndFetchNodeNameFromClusteredSFSBRemoteBean();
@@ -194,7 +194,7 @@ public class LocalEJBClientFailoverTestCase extends ClusterAbstractTestCase {
             // now undeploy the clustered sfsb app on the node which has the client application
             this.deployer.undeploy(NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2);
             nodeNameAppDeployedOnContainerTwo = false;
-            
+
             this.establishView(listener, NODE_1);
 
             // now invoke again on the same non-clustered sfsb

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -22,29 +22,20 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
-
 import javax.naming.NamingException;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
 import org.jboss.as.test.clustering.ViewChangeListener;
 import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
@@ -62,29 +53,23 @@ import org.junit.runner.RunWith;
 /**
  * Tests that invocations on a clustered stateful session bean from a remote EJB client, failover to
  * other node(s) in cases like a node going down
- *
+ * <p/>
  * This test also replicates some decorated CDI beans, to make sure they are replicated correctly.
  *
  * @author Jaikiran Pai
  * @author Radoslav Husar
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 @Ignore("AS7-6379")
-public class RemoteEJBClientStatefulBeanFailoverTestCase {
+public class RemoteEJBClientStatefulBeanFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final Logger logger = Logger.getLogger(RemoteEJBClientStatefulBeanFailoverTestCase.class);
 
     private static final String MODULE_NAME = "remote-ejb-client-stateful-bean-failover-test";
 
     private static EJBDirectory context;
-
-    @ArquillianResource
-    private ContainerController container;
-
-    @ArquillianResource
-    private Deployer deployer;
-
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -100,8 +85,13 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase {
 
     private static Archive<?> createDeployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
-        ejbJar.addPackage(CounterBean.class.getPackage());
-        ejbJar.addClasses(NodeNameGetter.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+
+        // CounterBean package but don't include the tests
+        ejbJar.addClasses(CDIDecorator.class, ClientSFSBRemote.class, DestructionCounterSingleton.class,
+                NodeNameRetriever.class, CDIManagedBean.class, CounterBean.class, DecoratorInterface.class,
+                NodeNameSFSB.class, ClientSFSB.class, CounterResult.class, DestructionCounterRemote.class,
+                RemoteCounter.class, ViewChangeListener.class, ViewChangeListenerBean.class, NodeNameGetter.class);
+        ejbJar.addClass(NodeNameGetter.class);
         ejbJar.addAsManifestResource(new StringAsset("<beans>" +
                 "<decorators><class>" + CDIDecorator.class.getName() + "</class></decorators>" +
                 "</beans>"), "beans.xml");
@@ -119,6 +109,14 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase {
         context.close();
     }
 
+    @Override
+    protected void setUp() {
+        super.setUp();
+
+        // Also deploy
+        deploy(DEPLOYMENTS);
+    }
+
     /**
      * Starts 2 nodes with the clustered beans deployed on each node. Invokes a clustered SFSB a few times.
      * Then stops a node from among the cluster (the one which received the last invocation) and continues invoking
@@ -129,8 +127,8 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase {
      */
     @Test
     @InSequence(1)
-    public void testFailoverFromRemoteClientWhenOneNodeGoesDown() throws Exception {
-        this.failoverFromRemoteClient(false);
+    public void testRemoteClientFailoverOnShutdown() throws Exception {
+        this.remoteClientFailover(false);
     }
 
     /**
@@ -140,21 +138,14 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase {
      */
     @Test
     @InSequence(2)
-    public void testFailoverFromRemoteClientWhenOneNodeUndeploys() throws Exception {
-        this.failoverFromRemoteClient(true);
-
-        //Assert.fail("Show me the logs.");
+    public void testRemoteClientFailoverOnUndeploy() throws Exception {
+        this.remoteClientFailover(true);
     }
 
-    private void failoverFromRemoteClient(boolean undeployOnly) throws Exception {
-        // Container is unmanaged, so start it ourselves
-        this.container.start(CONTAINER_1);
-        // deploy to container1
-        this.deployer.deploy(DEPLOYMENT_1);
-
-        // start the other container too
-        this.container.start(CONTAINER_2);
-        this.deployer.deploy(DEPLOYMENT_2);
+    private void remoteClientFailover(boolean undeployOnly) throws Exception {
+        //DEBUG
+        //stop(CONTAINERS);
+        //start(CONTAINERS);
 
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties");
         boolean container1Stopped = false;
@@ -183,19 +174,19 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase {
             final String previousInvocationNodeName = result.getNodeName();
             // the value is configured in arquillian.xml of the project
             if (previousInvocationNodeName.equals(NODE_1)) {
-                this.deployer.undeploy(DEPLOYMENT_1);
+                undeploy(DEPLOYMENT_1);
                 if (!undeployOnly) {
-                    this.container.stop(CONTAINER_1);
-                    container1Stopped = true;
+                    stop(CONTAINER_1);
                 }
+                container1Stopped = true;
 
                 this.establishView(listener, NODE_2);
             } else {
-                this.deployer.undeploy(DEPLOYMENT_2);
+                undeploy(DEPLOYMENT_2);
                 if (!undeployOnly) {
-                    this.container.stop(CONTAINER_2);
-                    container2Stopped = true;
+                    stop(CONTAINER_2);
                 }
+                container2Stopped = true;
                 
                 this.establishView(listener, NODE_1);
             }
@@ -233,15 +224,28 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase {
             if (previousSelector != null) {
                 EJBClientContext.setSelector(previousSelector);
             }
-            // shutdown the containers
-            if (!container1Stopped) {
-                this.deployer.undeploy(DEPLOYMENT_1);
-                this.container.stop(CONTAINER_1);
+
+            // Restore deployment for undeployment test
+            if (container1Stopped) {
+                if (undeployOnly) {
+                    undeploy(DEPLOYMENT_2);
+                    deploy(DEPLOYMENTS); // This test required redeployment :-(
+                } else {
+                    undeploy(DEPLOYMENT_2);
+                    start(CONTAINER_1);
+                    deploy(DEPLOYMENTS);
+                }
             }
 
-            if (!container2Stopped) {
-                this.deployer.undeploy(DEPLOYMENT_2);
-                this.container.stop(CONTAINER_2);
+            if (container2Stopped) {
+                if (undeployOnly) {
+                    undeploy(DEPLOYMENT_1);
+                    deploy(DEPLOYMENTS); // This test required redeployment :-(
+                } else {
+                    undeploy(DEPLOYMENT_1);
+                    start(CONTAINER_2);
+                    deploy(DEPLOYMENTS);
+                }
             }
         }
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -152,9 +152,9 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends ClusterAbstract
         boolean container2Stopped = false;
         try {
             final ViewChangeListener listener = context.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODE_1, NODE_2);
-            
+
             final RemoteCounter remoteCounter = context.lookupStateful(CounterBean.class, RemoteCounter.class);
             final DestructionCounterRemote destructionCounter = context.lookupSingleton(DestructionCounterSingleton.class, DestructionCounterRemote.class);
             // invoke on the bean a few times
@@ -187,7 +187,7 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends ClusterAbstract
                     stop(CONTAINER_2);
                 }
                 container2Stopped = true;
-                
+
                 this.establishView(listener, NODE_1);
             }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/dd/RemoteEJBClientDDBasedSFSBFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/dd/RemoteEJBClientDDBasedSFSBFailoverTestCase.java
@@ -22,25 +22,18 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover.dd;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
 
 import javax.naming.NamingException;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover.CounterResult;
 import org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover.RemoteCounter;
 import org.jboss.ejb.client.ContextSelector;
@@ -63,19 +56,12 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class RemoteEJBClientDDBasedSFSBFailoverTestCase {
+public class RemoteEJBClientDDBasedSFSBFailoverTestCase extends ClusterAbstractTestCase {
     private static final Logger logger = Logger.getLogger(RemoteEJBClientDDBasedSFSBFailoverTestCase.class);
 
     private static final String MODULE_NAME = "remote-ejb-client-dd-based-stateful-bean-failover-test";
 
     private static EJBDirectory context;
-
-    @ArquillianResource
-    private ContainerController container;
-
-    @ArquillianResource
-    private Deployer deployer;
-
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -108,6 +94,12 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase {
         context.close();
     }
 
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
+    }
+
     /**
      * Starts 2 nodes with the clustered beans deployed on each node. Invokes a (deployment descriptor based) clustered SFSB a few times.
      * Then stops a node from among the cluster (the one which received the last invocation) and continues invoking
@@ -117,15 +109,7 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase {
      * @throws Exception
      */
     @Test
-    public void testFailoverFromRemoteClientWhenOneNodeGoesDown() throws Exception {
-        // Container is unmanaged, so start it ourselves
-        this.container.start(CONTAINER_1);
-        // deploy to container1
-        this.deployer.deploy(DEPLOYMENT_1);
-
-        // start the other container too
-        this.container.start(CONTAINER_2);
-        this.deployer.deploy(DEPLOYMENT_2);
+    public void testRemoteClientFailoverOnShutdown() throws Exception {
 
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties");
         boolean container1Stopped = false;
@@ -147,12 +131,12 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase {
             final String previousInvocationNodeName = result.getNodeName();
             // the value is configured in arquillian.xml of the project
             if (previousInvocationNodeName.equals(NODE_1)) {
-                this.deployer.undeploy(DEPLOYMENT_1);
-                this.container.stop(CONTAINER_1);
+                undeploy(DEPLOYMENT_1);
+                stop(CONTAINER_1);
                 container1Stopped = true;
             } else {
-                this.deployer.undeploy(DEPLOYMENT_2);
-                this.container.stop(CONTAINER_2);
+                undeploy(DEPLOYMENT_2);
+                stop(CONTAINER_2);
                 container2Stopped = true;
             }
             // invoke again
@@ -180,16 +164,6 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase {
             // reset the selector
             if (previousSelector != null) {
                 EJBClientContext.setSelector(previousSelector);
-            }
-            // shutdown the containers
-            if (!container1Stopped) {
-                this.deployer.undeploy(DEPLOYMENT_1);
-                this.container.stop(CONTAINER_1);
-            }
-
-            if (!container2Stopped) {
-                this.deployer.undeploy(DEPLOYMENT_2);
-                this.container.stop(CONTAINER_2);
             }
         }
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
@@ -129,9 +129,9 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
 
         try {
             ViewChangeListener listener = context.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODES[0]);
-            
+
             Stateless bean = context.lookupStateless(StatelessBean.class, Stateless.class);
 
             assertEquals(NODES[0], bean.getNodeName());
@@ -140,7 +140,7 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
             deploy(DEPLOYMENT_2);
 
             this.establishView(listener, NODES);
-            
+
             List<String> results = new ArrayList<String>(10);
             for (int i = 0; i < 10; ++i) {
                 results.add(bean.getNodeName());
@@ -178,9 +178,9 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
 
         try {
             ViewChangeListener listener = context.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODES[0]);
-            
+
             Stateless bean = context.lookupStateless(StatelessBean.class, Stateless.class);
 
             assertEquals(NODES[0], bean.getNodeName());
@@ -203,7 +203,7 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
             undeploy(DEPLOYMENT_1);
 
             this.establishView(listener, NODES[1]);
-            
+
             assertEquals(NODES[1], bean.getNodeName());
         } finally {
             // reset the selector
@@ -237,13 +237,13 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
 
         try {
             ViewChangeListener listener = context.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODES);
-            
+
             Stateless bean = context.lookupStateless(StatelessBean.class, Stateless.class);
 
             String node = bean.getNodeName();
-            log.info("Node called : " + node);
+            log.info("Node called: " + node);
 
             validateBalancing(bean, numberOfCalls, numberOfServers, serversProcessedAtLeast);
 
@@ -254,23 +254,23 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
 
             bean = context.lookupStateless(StatelessBean.class, Stateless.class);
             node = bean.getNodeName();
-            log.info("Node called : " + node);
+            log.info("Node called: " + node);
 
             validateBalancing(bean, numberOfCalls, numberOfServers, serversProcessedAtLeast);
 
             stop(CONTAINER_1);
-            
+
             this.establishView(listener, NODES[1]);
-            
+
             node = bean.getNodeName();
-            log.info("Node called : " + node);
+            log.info("Node called: " + node);
 
             start(CONTAINER_1);
-            
+
             this.establishView(listener, NODES);
 
             node = bean.getNodeName();
-            log.info("Node called : " + node);
+            log.info("Node called: " + node);
 
             validateBalancing(bean, numberOfCalls, numberOfServers, serversProcessedAtLeast);
         } finally {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
@@ -22,13 +22,6 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateless;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINERS;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENTS;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODES;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -37,22 +30,20 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.naming.NamingException;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
 import org.jboss.as.test.clustering.ViewChangeListener;
 import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb3.stateless.bean.Stateless;
 import org.jboss.as.test.clustering.cluster.ejb3.stateless.bean.StatelessBean;
 import org.jboss.ejb.client.ContextSelector;
@@ -71,11 +62,11 @@ import org.junit.runner.RunWith;
 /**
  * @author Paul Ferraro
  * @author Ondrej Chaloupka
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//@Ignore // AS7-5211 unstable test
-public class RemoteStatelessFailoverTestCase {
+public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
     private static final Logger log = Logger.getLogger(RemoteStatelessFailoverTestCase.class);
     private static final String MODULE_NAME = "remote-ejb-client-stateless-bean-failover-test";
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
@@ -85,15 +76,6 @@ public class RemoteStatelessFailoverTestCase {
     private static final String HOST_2 = System.getProperty("node1");
     private static final String REMOTE_PORT_PROPERTY_NAME = "remote.connection.default.port";
     private static final String REMOTE_HOST_PROPERTY_NAME = "remote.connection.default.host";
-
-    @ArquillianResource
-    private ContainerController container;
-
-    @ArquillianResource
-    private Deployer deployer;
-
-    private boolean[] deployed = new boolean[] { false, false };
-    private boolean[] started = new boolean[] { false, false };
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -126,10 +108,22 @@ public class RemoteStatelessFailoverTestCase {
         context.close();
     }
 
+    @Override
+    protected void setUp() {
+        stop(CONTAINER_2);
+
+        // Make sure only one container is running now.
+        start(CONTAINER_1);
+        deploy(DEPLOYMENT_1);
+    }
+
     @Test
+    @InSequence(1)
     public void testFailoverOnStop() throws Exception {
-        this.start(0);
-        this.deploy(0);
+
+        // In case something went wrong.
+        start(CONTAINER_1);
+        deploy(DEPLOYMENT_1);
 
         final ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
@@ -142,8 +136,8 @@ public class RemoteStatelessFailoverTestCase {
 
             assertEquals(NODES[0], bean.getNodeName());
 
-            this.start(1);
-            this.deploy(1);
+            start(CONTAINER_2);
+            deploy(DEPLOYMENT_2);
 
             this.establishView(listener, NODES);
             
@@ -157,7 +151,7 @@ public class RemoteStatelessFailoverTestCase {
                 Assert.assertTrue(String.valueOf(frequency), frequency > 0);
             }
 
-            this.stop(0);
+            stop(CONTAINER_1);
 
             this.establishView(listener, NODES[1]);
 
@@ -167,19 +161,18 @@ public class RemoteStatelessFailoverTestCase {
             if (selector != null) {
                 EJBClientContext.setSelector(selector);
             }
-            // shutdown the containers
-            for (int i = 0; i < NODES.length; ++i) {
-                this.undeploy(i);
-                this.stop(i);
-            }
+            // shutdown the 2nd container
+            stop(CONTAINER_2);
         }
     }
 
     @Test
+    @InSequence(2)
     public void testFailoverOnUndeploy() throws Exception {
-        // Container is unmanaged, so start it ourselves
-        this.start(0);
-        this.deploy(0);
+
+        // In case the previous test failed.
+        start(CONTAINER_1);
+        deploy(DEPLOYMENT_1);
 
         final ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
@@ -192,8 +185,8 @@ public class RemoteStatelessFailoverTestCase {
 
             assertEquals(NODES[0], bean.getNodeName());
 
-            this.start(1);
-            this.deploy(1);
+            start(CONTAINER_2);
+            deploy(DEPLOYMENT_2); // TODO: Should be still deployed.
 
             this.establishView(listener, NODES);
 
@@ -207,7 +200,7 @@ public class RemoteStatelessFailoverTestCase {
                 Assert.assertTrue(String.valueOf(frequency), frequency > 0);
             }
 
-            this.undeploy(0);
+            undeploy(DEPLOYMENT_1);
 
             this.establishView(listener, NODES[1]);
             
@@ -217,11 +210,8 @@ public class RemoteStatelessFailoverTestCase {
             if (selector != null) {
                 EJBClientContext.setSelector(selector);
             }
-            // shutdown the containers
-            for (int i = 0; i < NODES.length; ++i) {
-                this.undeploy(i);
-                this.stop(i);
-            }
+
+            // Keep containers running
         }
     }
 
@@ -229,18 +219,21 @@ public class RemoteStatelessFailoverTestCase {
      * Basic load balance testing. A random distribution is used amongst nodes for client now.
      */
     @Test
-    public void testLoadbalance() throws Exception {
-        this.start(0);
-        this.deploy(0);
-        this.start(1);
-        this.deploy(1);
+    @InSequence(3)
+    public void testLoadBalance() throws Exception {
+
+        // In case the previous test failed.
+        start(CONTAINER_1);
+        deploy(DEPLOYMENT_1);
+        start(CONTAINER_2);
+        deploy(DEPLOYMENT_2);
 
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         int numberOfServers = 2;
         int numberOfCalls = 50;
         // there will be at least 20% of calls processed by all servers
-        double serversProccessedAtLeast = 0.2;
+        double serversProcessedAtLeast = 0.2;
 
         try {
             ViewChangeListener listener = context.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
@@ -252,7 +245,7 @@ public class RemoteStatelessFailoverTestCase {
             String node = bean.getNodeName();
             log.info("Node called : " + node);
 
-            validateBalancing(bean, numberOfCalls, numberOfServers, serversProccessedAtLeast);
+            validateBalancing(bean, numberOfCalls, numberOfServers, serversProcessedAtLeast);
 
             Properties contextChangeProperties = new Properties();
             contextChangeProperties.put(REMOTE_PORT_PROPERTY_NAME, PORT_2.toString());
@@ -263,32 +256,27 @@ public class RemoteStatelessFailoverTestCase {
             node = bean.getNodeName();
             log.info("Node called : " + node);
 
-            validateBalancing(bean, numberOfCalls, numberOfServers, serversProccessedAtLeast);
+            validateBalancing(bean, numberOfCalls, numberOfServers, serversProcessedAtLeast);
 
-            this.stop(0);
+            stop(CONTAINER_1);
             
             this.establishView(listener, NODES[1]);
             
             node = bean.getNodeName();
             log.info("Node called : " + node);
 
-            this.start(0);
+            start(CONTAINER_1);
             
             this.establishView(listener, NODES);
-            
+
             node = bean.getNodeName();
             log.info("Node called : " + node);
 
-            validateBalancing(bean, numberOfCalls, numberOfServers, serversProccessedAtLeast);
+            validateBalancing(bean, numberOfCalls, numberOfServers, serversProcessedAtLeast);
         } finally {
             // reset the selector
             if (previousSelector != null) {
                 EJBClientContext.setSelector(previousSelector);
-            }
-            // shutdown the containers
-            for (int i = 0; i < NODES.length; ++i) {
-                this.undeploy(i);
-                this.stop(i);
             }
         }
     }
@@ -305,43 +293,15 @@ public class RemoteStatelessFailoverTestCase {
 
         Set<String> entries = new HashSet<String>();
         entries.addAll(results);
-        
+
         Assert.assertEquals(expectedServers, entries.size());
-        
+
         double minCalls = minPercentage * numCalls;
         for (String entry: entries) {
             int frequency = Collections.frequency(results, entry);
             Assert.assertTrue(Integer.toString(frequency), frequency >= minCalls);
         }
         System.out.println(String.format("All %d servers processed at least %f of calls", expectedServers, minCalls));
-    }
-
-    private void deploy(int index) {
-        if (this.started[index] && !this.deployed[index]) {
-            this.deployer.deploy(DEPLOYMENTS[index]);
-            this.deployed[index] = true;
-        }
-    }
-
-    private void undeploy(int index) {
-        if (this.started[index] && this.deployed[index]) {
-            this.deployer.undeploy(DEPLOYMENTS[index]);
-            this.deployed[index] = false;
-        }
-    }
-
-    private void start(int index) {
-        if (!this.started[index]) {
-            this.container.start(CONTAINERS[index]);
-            this.started[index] = true;
-        }
-    }
-
-    private void stop(int index) {
-        if (this.started[index]) {
-            this.container.stop(CONTAINERS[index]);
-            this.started[index] = false;
-        }
     }
 
     private void establishView(ViewChangeListener listener, String... members) throws InterruptedException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/RemoteStatelessFailoverTestCase.java
@@ -301,7 +301,7 @@ public class RemoteStatelessFailoverTestCase extends ClusterAbstractTestCase {
             int frequency = Collections.frequency(results, entry);
             Assert.assertTrue(Integer.toString(frequency), frequency >= minCalls);
         }
-        System.out.println(String.format("All %d servers processed at least %f of calls", expectedServers, minCalls));
+        log.info(String.format("All %d servers processed at least %f of calls", expectedServers, minCalls));
     }
 
     private void establishView(ViewChangeListener listener, String... members) throws InterruptedException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/bean/Stateless.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/bean/Stateless.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.clustering.cluster.ejb3.stateless.bean;
 
 /**
  * @author Paul Ferraro
- *
  */
 public interface Stateless {
     String getNodeName();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/bean/StatelessBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateless/bean/StatelessBean.java
@@ -32,7 +32,6 @@ import org.jboss.logging.Logger;
 
 /**
  * @author Paul Ferraro
- *
  */
 @javax.ejb.Stateless
 @Clustered
@@ -42,6 +41,7 @@ public class StatelessBean implements Stateless {
 
     /**
      * {@inheritDoc}
+     *
      * @see org.jboss.as.test.clustering.cluster.ejb3.stateless.bean.Stateless#getNodeName()
      */
     @javax.ejb.TransactionAttribute(TransactionAttributeType.SUPPORTS)

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
@@ -71,20 +71,20 @@ import org.junit.runner.RunWith;
 public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final String persistence_xml =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
-            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
-            "  <persistence-unit name=\"mypc\">" +
-            "    <description>Persistence Unit." +
-            "    </description>" +
-            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
-            "<shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>" +
-            "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
-            "<property name=\"hibernate.cache.use_second_level_cache\" value=\"true\" />" +
-            "<property name=\"hibernate.generate_statistics\" value=\"true\" />" +
-            "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
-            "</properties>" +
-            "  </persistence-unit>" +
-            "</persistence>";
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+                    "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+                    "  <persistence-unit name=\"mypc\">" +
+                    "    <description>Persistence Unit." +
+                    "    </description>" +
+                    "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+                    "<shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>" +
+                    "<properties> <property name=\"hibernate.hbm2ddl.auto\" value=\"create-drop\"/>" +
+                    "<property name=\"hibernate.cache.use_second_level_cache\" value=\"true\" />" +
+                    "<property name=\"hibernate.generate_statistics\" value=\"true\" />" +
+                    "<property name=\"hibernate.show_sql\" value=\"true\"/>" +
+                    "</properties>" +
+                    "  </persistence-unit>" +
+                    "</persistence>";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -119,7 +119,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
     /**
      * Use the second level cache statistics to ensure that deleting an entity on a cluster node, will
      * remove the entity from the second level cache on other nodes.
-     *
+     * <p/>
      * Note that this test writes to the separate databases on both cluster nodes (so that both nodes can
      * read the entity from the database).  The important thing is that the second level cache entries are
      * invalidated when the entity is deleted from either database.
@@ -128,7 +128,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
      * @param baseURL2
      * @throws IOException
      * @throws InterruptedException
-     * @throws URISyntaxException 
+     * @throws URISyntaxException
      */
     @Test
     @InSequence(1)
@@ -157,9 +157,9 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
         try {
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             assertExecuteUrl(client, xpc1_echo_url + "StartingTestSecondLevelCache");  // echo message to server.log
-            assertExecuteUrl(client,xpc2_echo_url + "StartingTestSecondLevelCache"); // echo message to server.log
+            assertExecuteUrl(client, xpc2_echo_url + "StartingTestSecondLevelCache"); // echo message to server.log
 
             String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity in node1 in memory db");                           //
             assertEquals(employeeName, "Tom Brady");
@@ -168,7 +168,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
             employeeName = executeUrlWithAnswer(client, xpc1_get_url, "on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
 
-            String employeesInCache = executeUrlWithAnswer(client,xpc1_secondLevelCacheEntries_url, "get number of elements in node1 second level cache (should be zero)");
+            String employeesInCache = executeUrlWithAnswer(client, xpc1_secondLevelCacheEntries_url, "get number of elements in node1 second level cache (should be zero)");
             assertEquals(employeesInCache, "0");    // we read the entity from the extended persistence context (hasn't been flushed yet)
 
             assertExecuteUrl(client, xpc1_flush_url); // flush changes to db
@@ -183,17 +183,17 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
             assertEquals(employeeName, "Tom Brady");
 
             // we should of read one Employee entity on node2, ensure the second level cache contains one entry
-            employeesInCache = executeUrlWithAnswer(client,xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
+            employeesInCache = executeUrlWithAnswer(client, xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
             assertEquals(employeesInCache, "1");
 
-            assertExecuteUrl(client,xpc1_echo_url + "testSecondLevelCacheclearedXPC");
-            assertExecuteUrl(client,xpc2_echo_url + "testSecondLevelCacheclearedXPC");
+            assertExecuteUrl(client, xpc1_echo_url + "testSecondLevelCacheclearedXPC");
+            assertExecuteUrl(client, xpc2_echo_url + "testSecondLevelCacheclearedXPC");
 
-            assertExecuteUrl(client,xpc2_delete_url);   // deleting the entity on one node should remove it from both nodes second level cache
-            assertExecuteUrl(client,xpc1_echo_url + "testSecondLevelCachedeletedEnityOnNode2");
-            assertExecuteUrl(client,xpc1_echo_url + "2lcOnNode1ShouldHaveZeroElemementsLoaded");
+            assertExecuteUrl(client, xpc2_delete_url);   // deleting the entity on one node should remove it from both nodes second level cache
+            assertExecuteUrl(client, xpc1_echo_url + "testSecondLevelCachedeletedEnityOnNode2");
+            assertExecuteUrl(client, xpc1_echo_url + "2lcOnNode1ShouldHaveZeroElemementsLoaded");
 
-            employeesInCache = executeUrlWithAnswer(client,xpc1_secondLevelCacheEntries_url, "get number of elements in node1 second level cache (should be zero)");
+            employeesInCache = executeUrlWithAnswer(client, xpc1_secondLevelCacheEntries_url, "get number of elements in node1 second level cache (should be zero)");
             assertEquals(employeesInCache, "0");
 
             employeesInCache = executeUrlWithAnswer(client, xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
@@ -287,7 +287,8 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
             return header.getValue();
         } finally {
             org.apache.http.client.utils.HttpClientUtils.closeQuietly(response);
-     }}
+        }
+    }
 
     private void assertExecuteUrl(HttpClient client, String url) throws IOException {
         HttpResponse response = client.execute(new HttpGet(url));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2013, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,30 +22,20 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.xpc;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Date;
-import java.util.Properties;
-
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.HttpClientUtils;
+//import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -60,24 +50,25 @@ import org.jboss.as.test.clustering.LocalEJBDirectory;
 import org.jboss.as.test.clustering.ViewChangeListener;
 import org.jboss.as.test.clustering.ViewChangeListenerBean;
 import org.jboss.as.test.clustering.ViewChangeListenerServlet;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb3.xpc.bean.StatefulBean;
+import org.jboss.as.test.http.util.HttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Paul Ferraro
  * @author Scott Marlow
- *
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class StatefulWithXPCFailoverTestCase {
+public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final String persistence_xml =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
@@ -94,19 +85,6 @@ public class StatefulWithXPCFailoverTestCase {
             "</properties>" +
             "  </persistence-unit>" +
             "</persistence>";
-
-    @ArquillianResource
-    ContainerController controller;
-    @ArquillianResource
-    Deployer deployer;
-
-
-
-    @BeforeClass
-    public static void printSysProps() {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -132,85 +110,10 @@ public class StatefulWithXPCFailoverTestCase {
         return war;
     }
 
-    @Test
-    @InSequence(1)
-    public void testArquillianWorkaroundSecond() {
-        // Container is unmanaged, need to start manually.
-        start(DEPLOYMENT_1, CONTAINER_1);
-
-        // TODO: This is nasty. I need to start it to be able to inject it later and then stop it again!
-        // https://community.jboss.org/thread/176096
-        start(DEPLOYMENT_2, CONTAINER_2);
-    }
-
-    @Test
-    @InSequence(2)
-    public void testBasicXPC(
-            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException, InterruptedException, URISyntaxException {
-
-        // TODO: This is nasty. I need to start it to be able to inject it later and then stop it again!
-        // https://community.jboss.org/thread/176096
-        stop(DEPLOYMENT_2, CONTAINER_2);
-
-        DefaultHttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
-
-        String xpc1_create_url = baseURL1 + "count?command=createEmployee";
-        String xpc1_get_url = baseURL1 + "count?command=getEmployee";
-        String xpc2_get_url = baseURL2 + "count?command=getEmployee";
-        String xpc1_getempsecond_url = baseURL1 + "count?command=getSecondBeanEmployee";
-        String xpc2_getempsecond_url = baseURL2 + "count?command=getSecondBeanEmployee";
-        String xpc2_getdestroy_url = baseURL2 + "count?command=destroy";
-
-        try {
-            this.establishView(client, baseURL1, NODE_1);
-            // extended persistence context is available on node1
-
-            System.out.println(new Date() + "create employee entity ");
-            String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity that lives in the extended persistence context that this test will verify is always available");
-            assertEquals(employeeName, "Tom Brady");
-
-            System.out.println(new Date() + "1. about to read entity on node1");
-            // ensure that we can get it from node 1
-            employeeName = executeUrlWithAnswer(client, xpc1_get_url, "1. xpc on node1, node1 should be able to read entity on node1");
-            assertEquals(employeeName, "Tom Brady");
-            employeeName = executeUrlWithAnswer(client, xpc1_getempsecond_url, "1. xpc on node1, node1 should be able to read entity from second bean on node1");
-            assertEquals(employeeName, "Tom Brady");
-
-            start(DEPLOYMENT_2, CONTAINER_2);
-
-            this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
-            System.out.println(new Date() + "2. started node2 + deployed, about to read entity on node1");
-
-            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "2. started node2, xpc on node1, node1 should be able to read entity on node1");
-            assertEquals(employeeName, "Tom Brady");
-            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "2. started node2, xpc on node1, node1 should be able to read entity from second bean on node1");
-            assertEquals(employeeName, "Tom Brady");
-
-            // failover to deployment2
-            stop(DEPLOYMENT_1, CONTAINER_1); // failover #1 to node 2
-
-            this.establishView(client, baseURL2, NODE_2);
-            
-            System.out.println(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
-
-            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc");
-            assertEquals(employeeName, "Tom Brady");
-            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc that is on node2 (second bean)");
-            assertEquals(employeeName, "Tom Brady");
-
-            String destroyed = executeUrlWithAnswer(client, xpc2_getdestroy_url, "4. destroy the bean on node2");
-            assertEquals(destroyed, "destroy");
-            System.out.println(new Date() + "4. test is done");
-
-        } finally {
-            HttpClientUtils.closeQuietly(client);
-
-            stop(DEPLOYMENT_1, CONTAINER_1);
-            stop(DEPLOYMENT_2, CONTAINER_2);
-        }
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     /**
@@ -228,13 +131,11 @@ public class StatefulWithXPCFailoverTestCase {
      * @throws URISyntaxException 
      */
     @Test
-    @InSequence(3)
+    @InSequence(1)
     public void testSecondLevelCache(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
             throws IOException, InterruptedException, URISyntaxException {
-        start(DEPLOYMENT_1, CONTAINER_1);
-        start(DEPLOYMENT_2, CONTAINER_2);
 
         DefaultHttpClient client = new DefaultHttpClient();
 
@@ -295,7 +196,7 @@ public class StatefulWithXPCFailoverTestCase {
             employeesInCache = executeUrlWithAnswer(client,xpc1_secondLevelCacheEntries_url, "get number of elements in node1 second level cache (should be zero)");
             assertEquals(employeesInCache, "0");
 
-            employeesInCache = executeUrlWithAnswer(client,xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
+            employeesInCache = executeUrlWithAnswer(client, xpc2_secondLevelCacheEntries_url, "get number of elements in node2 second level cache (should be zero)");
             assertEquals(employeesInCache, "0");
 
             assertExecuteUrl(client, xpc1_delete_url);
@@ -304,11 +205,77 @@ public class StatefulWithXPCFailoverTestCase {
             assertEquals(destroyed, "destroy");
 
         } finally {
-            HttpClientUtils.closeQuietly(client);
-
-            stop(DEPLOYMENT_1, CONTAINER_1);
-            stop(DEPLOYMENT_2, CONTAINER_2);
+            org.apache.http.client.utils.HttpClientUtils.closeQuietly(client);
+            client.getConnectionManager().shutdown();
         }
+    }
+
+    @Test
+    @InSequence(2)
+    public void testBasicXPC(
+            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
+            @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
+            throws IOException, InterruptedException {
+
+        stop(CONTAINER_2);
+
+        DefaultHttpClient client = HttpClientUtils.relaxedCookieHttpClient();
+
+        String xpc1_create_url = baseURL1 + "count?command=createEmployee";
+        String xpc1_get_url = baseURL1 + "count?command=getEmployee";
+        String xpc2_get_url = baseURL2 + "count?command=getEmployee";
+        String xpc1_getempsecond_url = baseURL1 + "count?command=getSecondBeanEmployee";
+        String xpc2_getempsecond_url = baseURL2 + "count?command=getSecondBeanEmployee";
+        String xpc2_getdestroy_url = baseURL2 + "count?command=destroy";
+
+        try {
+            // extended persistence context is available on node1
+
+            System.out.println(new Date() + "create employee entity ");
+            String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity that lives in the extended persistence context that this test will verify is always available");
+            assertEquals(employeeName, "Tom Brady");
+
+            System.out.println(new Date() + "1. about to read entity on node1");
+            // ensure that we can get it from node 1
+            employeeName = executeUrlWithAnswer(client, xpc1_get_url, "1. xpc on node1, node1 should be able to read entity on node1");
+            assertEquals(employeeName, "Tom Brady");
+            employeeName = executeUrlWithAnswer(client, xpc1_getempsecond_url, "1. xpc on node1, node1 should be able to read entity from second bean on node1");
+            assertEquals(employeeName, "Tom Brady");
+
+            start(CONTAINER_2);
+
+            System.out.println(new Date() + "2. started node2 + deployed, about to read entity on node1");
+
+            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "2. started node2, xpc on node1, node1 should be able to read entity on node1");
+            assertEquals(employeeName, "Tom Brady");
+            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "2. started node2, xpc on node1, node1 should be able to read entity from second bean on node1");
+            assertEquals(employeeName, "Tom Brady");
+
+            // failover to deployment2
+            stop(CONTAINER_1); // failover #1 to node 2
+
+            System.out.println(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
+
+            employeeName = executeUrlWithAnswer(client, xpc2_get_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc");
+            assertEquals(employeeName, "Tom Brady");
+            employeeName = executeUrlWithAnswer(client, xpc2_getempsecond_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc that is on node2 (second bean)");
+            assertEquals(employeeName, "Tom Brady");
+
+            String destroyed = executeUrlWithAnswer(client, xpc2_getdestroy_url, "4. destroy the bean on node2");
+            assertEquals(destroyed, "destroy");
+            System.out.println(new Date() + "4. test is done");
+
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    @InSequence(3)
+    public void testCleanup() {
+        // node-1 was last shutdown, lets bring it up and remove deployments
+        start(CONTAINER_1);
+        undeploy(DEPLOYMENTS);
     }
 
     private String executeUrlWithAnswer(HttpClient client, String url, String message) throws IOException, InterruptedException {
@@ -319,39 +286,15 @@ public class StatefulWithXPCFailoverTestCase {
             Assert.assertNotNull(message, header);
             return header.getValue();
         } finally {
-            HttpClientUtils.closeQuietly(response);
-        }
-    }
+            org.apache.http.client.utils.HttpClientUtils.closeQuietly(response);
+     }}
 
     private void assertExecuteUrl(HttpClient client, String url) throws IOException {
         HttpResponse response = client.execute(new HttpGet(url));
         try {
             assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
         } finally {
-            HttpClientUtils.closeQuietly(response);
-        }
-    }
-
-    private void stop(String deployment, String container) {
-        try {
-            System.out.println(new Date() + "stopping deployment="+deployment+", container="+container);
-            deployer.undeploy(deployment);
-            controller.stop(container);
-            System.out.println(new Date() + "stopped deployment="+deployment+", container="+container);
-
-        } catch (Throwable e) {
-            e.printStackTrace(System.err);
-        }
-    }
-
-    private void start(String deployment, String container) {
-        try {
-            System.out.println(new Date() + "starting deployment="+deployment+", container="+ container);
-            controller.start(container);
-            deployer.deploy(deployment);
-            System.out.println(new Date() + "started deployment="+deployment+", container=" + container);
-        } catch (Throwable e) {
-            e.printStackTrace(System.err);
+            org.apache.http.client.utils.HttpClientUtils.closeQuietly(response);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
@@ -106,7 +106,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         war.addAsResource(new StringAsset(persistence_xml), "META-INF/persistence.xml");
         war.addClasses(ViewChangeListener.class, ViewChangeListenerBean.class, ViewChangeListenerServlet.class);
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 
@@ -163,7 +163,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
             String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity in node1 in memory db");                           //
             assertEquals(employeeName, "Tom Brady");
-            System.out.println(new Date() + "about to read entity on node1 (from xpc queue)");
+            log.info(new Date() + "about to read entity on node1 (from xpc queue)");
 
             employeeName = executeUrlWithAnswer(client, xpc1_get_url, "on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
@@ -231,11 +231,11 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         try {
             // extended persistence context is available on node1
 
-            System.out.println(new Date() + "create employee entity ");
+            log.info(new Date() + "create employee entity ");
             String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity that lives in the extended persistence context that this test will verify is always available");
             assertEquals(employeeName, "Tom Brady");
 
-            System.out.println(new Date() + "1. about to read entity on node1");
+            log.info(new Date() + "1. about to read entity on node1");
             // ensure that we can get it from node 1
             employeeName = executeUrlWithAnswer(client, xpc1_get_url, "1. xpc on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
@@ -244,7 +244,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
             start(CONTAINER_2);
 
-            System.out.println(new Date() + "2. started node2 + deployed, about to read entity on node1");
+            log.info(new Date() + "2. started node2 + deployed, about to read entity on node1");
 
             employeeName = executeUrlWithAnswer(client, xpc2_get_url, "2. started node2, xpc on node1, node1 should be able to read entity on node1");
             assertEquals(employeeName, "Tom Brady");
@@ -254,7 +254,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
             // failover to deployment2
             stop(CONTAINER_1); // failover #1 to node 2
 
-            System.out.println(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
+            log.info(new Date() + "3. stopped node1 to force failover, about to read entity on node2");
 
             employeeName = executeUrlWithAnswer(client, xpc2_get_url, "3. stopped deployment on node1, xpc should failover to node2, node2 should be able to read entity from xpc");
             assertEquals(employeeName, "Tom Brady");
@@ -263,7 +263,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
 
             String destroyed = executeUrlWithAnswer(client, xpc2_getdestroy_url, "4. destroy the bean on node2");
             assertEquals(destroyed, "destroy");
-            System.out.println(new Date() + "4. test is done");
+            log.info(new Date() + "4. test is done");
 
         } finally {
             client.getConnectionManager().shutdown();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/SecondBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/SecondBean.java
@@ -41,7 +41,7 @@ import org.jboss.ejb3.annotation.Clustered;
 @javax.ejb.Stateful
 public class SecondBean {
     @PersistenceContext(unitName = "mypc", type = PersistenceContextType.EXTENDED)
-        EntityManager em;
+    EntityManager em;
 
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public Employee getEmployee(int id) {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/Stateful.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/Stateful.java
@@ -29,7 +29,7 @@ import javax.ejb.TransactionAttributeType;
 /**
  * Interface to see if that helps avoid the
  * error:
- *
+ * <p/>
  * JBAS014134: EJB Invocation failed on component StatefulBean for method
  * public org.jboss.as.test.clustering.unmanaged.ejb3.xpc.bean.Employee
  * org.jboss.as.test.clustering.unmanaged.ejb3.xpc.bean.StatefulBean.getEmployee(int):

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
@@ -103,14 +103,14 @@ public class StatefulBean implements Stateful {
     }
 
     @Override
-        @TransactionAttribute(TransactionAttributeType.REQUIRED)
-        public void deleteEmployee(int id) {
-            Employee employee = em.find(Employee.class, id, LockModeType.NONE);
-            em.remove(employee);
-            logStats("deleteEmployee");
-            version = "deletedEmployee";
-            valueBag.put("version",version);
-        }
+    @TransactionAttribute(TransactionAttributeType.REQUIRED)
+    public void deleteEmployee(int id) {
+        Employee employee = em.find(Employee.class, id, LockModeType.NONE);
+        em.remove(employee);
+        logStats("deleteEmployee");
+        version = "deletedEmployee";
+        valueBag.put("version", version);
+    }
 
 
     @Override

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
@@ -34,6 +34,7 @@ import javax.sql.DataSource;
 import org.hibernate.Session;
 import org.hibernate.stat.SecondLevelCacheStatistics;
 import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.logging.Logger;
 
 import java.sql.Connection;
 import java.util.HashMap;
@@ -46,6 +47,8 @@ import java.util.HashMap;
 @javax.ejb.Stateful(name = "StatefulBean")
 
 public class StatefulBean implements Stateful {
+
+    private static final Logger log = Logger.getLogger(StatefulBean.class);
 
     @PersistenceContext(unitName = "mypc", type = PersistenceContextType.EXTENDED)
     EntityManager em;
@@ -132,9 +135,9 @@ public class StatefulBean implements Stateful {
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     @Override
     public void echo(String message) {
-        System.out.println("echo entered for " + message);
+        log.info("echo entered for " + message);
         logStats("echo " + message);
-        System.out.println("echo completed for " + message);
+        log.info("echo completed for " + message);
     }
 
 
@@ -166,14 +169,14 @@ public class StatefulBean implements Stateful {
 
     private void logStats(String methodName) {
         Session session = em.unwrap(Session.class);
-        System.out.println(methodName + "(version="+version+", HashMap version="+valueBag.get("version")+") logging statistics for session = " + session);
+        log.info(methodName + "(version="+version+", HashMap version="+valueBag.get("version")+") logging statistics for session = " + session);
         session.getSessionFactory().getStatistics().setStatisticsEnabled(true);
         session.getSessionFactory().getStatistics().logSummary();
         String entityRegionNames[] =  session.getSessionFactory().getStatistics().getSecondLevelCacheRegionNames();
         for (String name: entityRegionNames) {
-            System.out.println("cache entity region name = " + name);
+            log.info("cache entity region name = " + name);
             SecondLevelCacheStatistics stats = session.getSessionFactory().getStatistics().getSecondLevelCacheStatistics(name);
-            System.out.println("2lc for " + name+ ": " + stats.toString());
+            log.info("2lc for " + name+ ": " + stats.toString());
 
         }
         // we will want to return the SecondLevelCacheStatistics for Employee

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulBean.java
@@ -56,10 +56,6 @@ public class StatefulBean implements Stateful {
     String version = "initial";
     HashMap valueBag = new HashMap();
 
-//     @EJB
-//     SecondBean secondBean;
-
-
     /**
      * Create the employee but don't commit the change to the database, instead keep it in the
      * extended persistence context.
@@ -79,7 +75,7 @@ public class StatefulBean implements Stateful {
         em.persist(emp);
         logStats("createEmployee");
         version = "created";
-        valueBag.put("version","created");
+        valueBag.put("version", "created");
     }
 
     @Override
@@ -102,7 +98,7 @@ public class StatefulBean implements Stateful {
     public void destroy() {
         logStats("destroy");
         version = "destroyed";
-        valueBag.put("version",version);
+        valueBag.put("version", version);
     }
 
     @Override
@@ -121,7 +117,7 @@ public class StatefulBean implements Stateful {
     public void flush() {
         logStats("flush");
         version = "flushed";
-        valueBag.put("version",version);
+        valueBag.put("version", version);
     }
 
     @Override
@@ -129,7 +125,7 @@ public class StatefulBean implements Stateful {
         em.clear();
         logStats("clear");
         version = "cleared";
-        valueBag.put("version",version);
+        valueBag.put("version", version);
     }
 
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
@@ -156,8 +152,8 @@ public class StatefulBean implements Stateful {
     @Override
     public long getEmployeesInMemory() {
         Session session = em.unwrap(Session.class);
-        String entityRegionNames[] =  session.getSessionFactory().getStatistics().getSecondLevelCacheRegionNames();
-        for (String name: entityRegionNames) {
+        String entityRegionNames[] = session.getSessionFactory().getStatistics().getSecondLevelCacheRegionNames();
+        for (String name : entityRegionNames) {
             if (name.contains(Employee.class.getName())) {
                 SecondLevelCacheStatistics stats = session.getSessionFactory().getStatistics().getSecondLevelCacheStatistics(name);
                 return stats.getElementCountInMemory();
@@ -169,14 +165,14 @@ public class StatefulBean implements Stateful {
 
     private void logStats(String methodName) {
         Session session = em.unwrap(Session.class);
-        log.info(methodName + "(version="+version+", HashMap version="+valueBag.get("version")+") logging statistics for session = " + session);
+        log.info(methodName + "(version=" + version + ", HashMap version=" + valueBag.get("version") + ") logging statistics for session = " + session);
         session.getSessionFactory().getStatistics().setStatisticsEnabled(true);
         session.getSessionFactory().getStatistics().logSummary();
-        String entityRegionNames[] =  session.getSessionFactory().getStatistics().getSecondLevelCacheRegionNames();
-        for (String name: entityRegionNames) {
+        String entityRegionNames[] = session.getSessionFactory().getStatistics().getSecondLevelCacheRegionNames();
+        for (String name : entityRegionNames) {
             log.info("cache entity region name = " + name);
             SecondLevelCacheStatistics stats = session.getSessionFactory().getStatistics().getSecondLevelCacheStatistics(name);
-            log.info("2lc for " + name+ ": " + stats.toString());
+            log.info("2lc for " + name + ": " + stats.toString());
 
         }
         // we will want to return the SecondLevelCacheStatistics for Employee

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulServlet.java
@@ -38,6 +38,7 @@ import javax.sql.DataSource;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.test.clustering.LocalEJBDirectory;
+import org.jboss.logging.Logger;
 
 /**
  * @author Paul Ferraro
@@ -46,6 +47,8 @@ import org.jboss.as.test.clustering.LocalEJBDirectory;
 @WebServlet(urlPatterns = { "/count" })
 public class StatefulServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
+
+    private static final Logger log = Logger.getLogger(StatefulServlet.class);
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -60,7 +63,7 @@ public class StatefulServlet extends HttpServlet {
         }
 
         String command = req.getParameter("command");
-        System.out.println(StatefulServlet.class.getName() + ": command = " + command);
+        log.info(StatefulServlet.class.getName() + ": command = " + command);
         String answer = null;
 
         if("createEmployee".equals(command)) {
@@ -118,6 +121,6 @@ public class StatefulServlet extends HttpServlet {
         }
         resp.getWriter().write("Success");
         session.setAttribute("bean", bean);
-        System.out.println(StatefulServlet.class.getName() + ": command = " + command + " finished");
+        log.info(StatefulServlet.class.getName() + ": command = " + command + " finished");
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/StatefulServlet.java
@@ -42,9 +42,8 @@ import org.jboss.logging.Logger;
 
 /**
  * @author Paul Ferraro
- *
  */
-@WebServlet(urlPatterns = { "/count" })
+@WebServlet(urlPatterns = {"/count"})
 public class StatefulServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
 
@@ -53,7 +52,7 @@ public class StatefulServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         HttpSession session = req.getSession(true);
-        Stateful bean = (Stateful)session.getAttribute("bean");
+        Stateful bean = (Stateful) session.getAttribute("bean");
         if (bean == null) {
             try {
                 bean = new LocalEJBDirectory("stateful").lookupStateful(StatefulBean.class, Stateful.class);
@@ -66,57 +65,47 @@ public class StatefulServlet extends HttpServlet {
         log.info(StatefulServlet.class.getName() + ": command = " + command);
         String answer = null;
 
-        if("createEmployee".equals(command)) {
-            bean.createEmployee("Tom Brady","New England Patriots", 1);
+        if ("createEmployee".equals(command)) {
+            bean.createEmployee("Tom Brady", "New England Patriots", 1);
             answer = bean.getEmployee(1).getName();
-        }
-        else if("getEmployee".equals(command)) {
+        } else if ("getEmployee".equals(command)) {
             Employee employee = bean.getEmployee(1);
             if (employee == null) {
                 throw new ServletException("couldn't load Employee entity (with id=1) from database");
             }
             answer = employee.getName();
-        }
-        else if("deleteEmployee".equals(command)) {
+        } else if ("deleteEmployee".equals(command)) {
             bean.deleteEmployee(1);
             answer = command;
-        }
-        else if ("getEmployeesInSecondLevelCache".equals(command)) {
+        } else if ("getEmployeesInSecondLevelCache".equals(command)) {
             long count = bean.getEmployeesInMemory();
-            if(count == -1) {
+            if (count == -1) {
                 throw new ServletException("couldn't get number of employees in second level cache");
             }
             answer = "" + count;
-        }
-        else if("getSecondBeanEmployee".equals(command)) {
+        } else if ("getSecondBeanEmployee".equals(command)) {
             Employee employee = bean.getSecondBeanEmployee(1);
             answer = employee.getName();
-        }
-        else if("destroy".equals(command)) {
+        } else if ("destroy".equals(command)) {
             bean.destroy();
             answer = command;
-        }
-        else if("flush".equals(command)) {
+        } else if ("flush".equals(command)) {
             bean.flush();
-        }
-        else if("echo".equals(command)) {
+        } else if ("echo".equals(command)) {
             bean.echo(req.getParameter("message"));
-        }
-        else if("clear".equals(command)) {
+        } else if ("clear".equals(command)) {
             bean.clear();
-        }
-        else if("deleteEmployeeViaJDBC".equals(command)) {
+        } else if ("deleteEmployeeViaJDBC".equals(command)) {
             // delete all employees in db
             int deleted = bean.executeNativeSQL("delete from Employee where id=1");
             if (deleted < 1) {
                 throw new ServletException("couldn't delete entity in database, deleted row count =" + deleted);
             }
-        }
-        else {
-            throw new ServletException("unknown command name=" +command );
+        } else {
+            throw new ServletException("unknown command name=" + command);
         }
 
-        if( answer != null) {
+        if (answer != null) {
             resp.setHeader("answer", answer);
         }
         resp.getWriter().write("Success");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/web.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/bean/web.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -129,8 +129,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         if (setCookie != null) {
             String setCookieValue = setCookie.getValue();
             state.sessionId = setCookieValue.substring(setCookieValue.indexOf('=') + 1, setCookieValue.indexOf(';'));
-        }
-        else if (sessionId != null) {
+        } else if (sessionId != null) {
             // We don't get a cookie back if we have sent it, so just set it to whatever we had before
             state.sessionId = sessionId;
         }
@@ -160,6 +159,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
 
     /**
      * Creates an HTTP POST request with a number guess.
+     *
      * @param url
      * @param sessionId
      * @param viewState
@@ -170,7 +170,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
     private static HttpUriRequest buildPostRequest(String url, String sessionId, String viewState, String guess) throws UnsupportedEncodingException {
         HttpPost post = new HttpPost(url);
 
-        List<NameValuePair> list = new LinkedList<NameValuePair> ();
+        List<NameValuePair> list = new LinkedList<NameValuePair>();
 
         list.add(new BasicNameValuePair("javax.faces.ViewState", viewState));
         list.add(new BasicNameValuePair("numberGuess", "numberGuess"));
@@ -187,6 +187,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
 
     /**
      * Creates an HTTP GET request, with a potential JSESSIONID cookie.
+     *
      * @param url
      * @param sessionId
      * @return
@@ -212,7 +213,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
      *
      * @throws java.io.IOException
      * @throws InterruptedException
-     * @throws URISyntaxException 
+     * @throws URISyntaxException
      */
     @Test
     @InSequence(1)
@@ -240,7 +241,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             // We get a cookie!
             String sessionId = state.sessionId;
 
@@ -257,7 +258,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals("2", state.smallest);
             Assert.assertEquals("100", state.biggest);
             Assert.assertEquals("9", state.remainingGuesses);
@@ -275,7 +276,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             // If the state would not be replicated, we would have 9 remaining guesses.
             Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", "8", state.remainingGuesses);
 
@@ -292,7 +293,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals("7", state.remainingGuesses);
             Assert.assertEquals("2", state.smallest);
             Assert.assertEquals("98", state.biggest);
@@ -309,7 +310,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals("Session failed to replicate after container 1 was brought up.", "6", state.remainingGuesses);
             Assert.assertEquals(sessionId, state.sessionId);
             Assert.assertEquals("3", state.smallest);
@@ -323,7 +324,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals(sessionId, state.sessionId);
             Assert.assertEquals("5", state.remainingGuesses);
             Assert.assertEquals("3", state.smallest);
@@ -347,7 +348,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
      *
      * @throws java.io.IOException
      * @throws InterruptedException
-     * @throws URISyntaxException 
+     * @throws URISyntaxException
      */
     @Test
     @InSequence(2)
@@ -373,7 +374,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             // We get a cookie!
             String sessionId = state.sessionId;
 
@@ -390,7 +391,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals("2", state.smallest);
             Assert.assertEquals("100", state.biggest);
             Assert.assertEquals("9", state.remainingGuesses);
@@ -399,7 +400,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             undeploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_2);
-            
+
             // Now we do a JSF POST request with a cookie on to the second node, guessing 100, expecting to find a replicated state.
             response = client.execute(buildPostRequest(url2, state.sessionId, state.jsfViewState, "100"));
             try {
@@ -408,7 +409,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             // If the state would not be replicated, we would have 9 remaining guesses.
             Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", "8", state.remainingGuesses);
 
@@ -425,7 +426,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals("7", state.remainingGuesses);
             Assert.assertEquals("2", state.smallest);
             Assert.assertEquals("98", state.biggest);
@@ -443,7 +444,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals("Session failed to replicate after container 1 was brought up.", "6", state.remainingGuesses);
             Assert.assertEquals(sessionId, state.sessionId);
             Assert.assertEquals("3", state.smallest);
@@ -457,7 +458,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-            
+
             Assert.assertEquals(sessionId, state.sessionId);
             Assert.assertEquals("5", state.remainingGuesses);
             Assert.assertEquals("3", state.smallest);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -226,7 +226,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         String url1 = baseURL1.toString() + "home.jsf";
         String url2 = baseURL2.toString() + "home.jsf";
 
-        System.out.println("URLs are: " + url1 + ", " + url2);
+        log.info("URLs are: " + url1 + ", " + url2);
 
         try {
             HttpResponse response;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/faces-config.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/faces-config.xml
@@ -1,11 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
 <faces-config version="2.0"
-   xmlns="http://java.sun.com/xml/ns/javaee"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="
+              xmlns="http://java.sun.com/xml/ns/javaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="
       http://java.sun.com/xml/ns/javaee
       http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
-      
-      <name>numberguess</name>
-      
+
+    <name>numberguess</name>
+
 </faces-config>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/management/CacheTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/management/CacheTestCase.java
@@ -53,7 +53,7 @@ import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 
 /**
- * @author Dominik Pospisil <dpospisi@redhat.com>
+ * @author <a href="mailto:dpospisi@redhat.com>Dominik Pospisil</a>
  */
 @RunWith(Arquillian.class)
 @RunAsClient

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/management/CacheTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/management/CacheTestCase.java
@@ -22,8 +22,12 @@
 package org.jboss.as.test.clustering.cluster.management;
 
 import java.net.URL;
-import org.junit.Assert;
-import org.jboss.arquillian.container.test.api.*;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -32,19 +36,23 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.common.JndiServlet;
 import org.jboss.as.test.integration.management.util.ModelUtil;
+
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+
 import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 
 /**
- *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
 @RunWith(Arquillian.class)
@@ -101,11 +109,12 @@ public class CacheTestCase extends AbstractMgmtTestBase {
 
         NodeUtil.stop(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
     }
+
     @Test
     public void testLocalCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/local-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/local-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("jndi-name").set("java:jboss/caches/TestCache");
@@ -121,7 +130,7 @@ public class CacheTestCase extends AbstractMgmtTestBase {
                     ModelDescriptionConstants.REMOVE);
             executeOperation(op);
         }
-        
+
         // check that it is unregistered
         String jndiClass = JndiServlet.lookup(url.toString(), "java:jboss/caches/TestCache");
         Assert.assertEquals(JndiServlet.NOT_FOUND, jndiClass);
@@ -129,10 +138,10 @@ public class CacheTestCase extends AbstractMgmtTestBase {
 
 
     @Test
-    public void testDistributedCache(@ArquillianResource ManagementClient managementClient,  @ArquillianResource URL url) throws Exception {
+    public void testDistributedCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/distributed-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/distributed-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("mode").set("ASYNC");
@@ -149,17 +158,17 @@ public class CacheTestCase extends AbstractMgmtTestBase {
                     ModelDescriptionConstants.REMOVE);
             executeOperation(op);
         }
-        
+
         // check that it is unregistered
         String jndiClass = JndiServlet.lookup(url.toString(), "java:jboss/caches/TestCache");
         Assert.assertEquals(JndiServlet.NOT_FOUND, jndiClass);
     }
 
     @Test
-    public void testReplicatedCache(@ArquillianResource ManagementClient managementClient,  @ArquillianResource URL url) throws Exception {
+    public void testReplicatedCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/replicated-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/replicated-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("mode").set("ASYNC");
@@ -183,10 +192,10 @@ public class CacheTestCase extends AbstractMgmtTestBase {
     }
 
     @Test
-    public void testInvalidationCache(@ArquillianResource ManagementClient managementClient,  @ArquillianResource URL url) throws Exception {
+    public void testInvalidationCache(@ArquillianResource ManagementClient managementClient, @ArquillianResource URL url) throws Exception {
         this.managementClient = managementClient;
         // add local cache
-        ModelNode  op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/invalidation-cache=" + TEST_CACHE,
+        ModelNode op = createOpNode("subsystem=infinispan/cache-container=" + TEST_CONTAINER + "/invalidation-cache=" + TEST_CACHE,
                 ModelDescriptionConstants.ADD);
         op.get("start").set("EAGER");
         op.get("mode").set("ASYNC");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
@@ -100,6 +100,8 @@ public class SingletonTestCase extends ClusterAbstractTestCase {
         URI defaultURI1 = MyServiceServlet.createURI(baseURL1, MyService.DEFAULT_SERVICE_NAME);
         URI defaultURI2 = MyServiceServlet.createURI(baseURL2, MyService.DEFAULT_SERVICE_NAME);
 
+        log.info("URLs are: " + defaultURI1 + ", " + defaultURI2);
+
         URI quorumURI1 = MyServiceServlet.createURI(baseURL1, MyService.QUORUM_SERVICE_NAME);
         URI quorumURI2 = MyServiceServlet.createURI(baseURL2, MyService.QUORUM_SERVICE_NAME);
         

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
@@ -104,7 +104,7 @@ public class SingletonTestCase extends ClusterAbstractTestCase {
 
         URI quorumURI1 = MyServiceServlet.createURI(baseURL1, MyService.QUORUM_SERVICE_NAME);
         URI quorumURI2 = MyServiceServlet.createURI(baseURL2, MyService.QUORUM_SERVICE_NAME);
-        
+
         try {
             this.establishView(client, baseURL1, NODE_1);
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/Environment.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/Environment.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 
 /**
  * @author Paul Ferraro
- *
  */
 public class Environment implements Serializable {
     private static final long serialVersionUID = -7845251073515304583L;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceActivator.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceActivator.java
@@ -32,6 +32,7 @@ import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
@@ -40,6 +41,8 @@ import org.jboss.msc.value.InjectedValue;
  * @author Paul Ferraro
  */
 public class MyServiceActivator implements ServiceActivator {
+
+    private static final Logger log = Logger.getLogger(MyServiceActivator.class);
 
     public static final String PREFERRED_NODE = NODE_2;
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceActivator.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceActivator.java
@@ -58,9 +58,9 @@ public class MyServiceActivator implements ServiceActivator {
         SingletonService<Environment> singleton = new SingletonService<Environment>(service, name, quorum);
         singleton.setElectionPolicy(new PreferredSingletonElectionPolicy(new SimpleSingletonElectionPolicy(), new NamePreference(PREFERRED_NODE + "/" + SingletonService.DEFAULT_CONTAINER)));
         singleton.build(context.getServiceTarget())
-            .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, env)
-            .setInitialMode(ServiceController.Mode.ACTIVE)
-            .install()
+                .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, env)
+                .setInitialMode(ServiceController.Mode.ACTIVE)
+                .install()
         ;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceServlet.java
@@ -35,13 +35,13 @@ import javax.servlet.http.HttpServletResponse;
 import org.jboss.as.server.CurrentServiceContainer;
 import org.jboss.msc.service.ServiceName;
 
-@WebServlet(urlPatterns = { MyServiceServlet.SERVLET_PATH })
+@WebServlet(urlPatterns = {MyServiceServlet.SERVLET_PATH})
 public class MyServiceServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
     private static final String SERVLET_NAME = "service";
     static final String SERVLET_PATH = "/" + SERVLET_NAME;
     private static final String SERVICE = "service";
-    
+
     public static URI createURI(URL baseURL, ServiceName serviceName) throws URISyntaxException {
         return baseURL.toURI().resolve(new StringBuilder(SERVLET_NAME).append('?').append(SERVICE).append('=').append(serviceName.getCanonicalName()).toString());
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/sso/ClusteredSingleSignOnTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/sso/ClusteredSingleSignOnTestCase.java
@@ -47,8 +47,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- *
- * @author Dominik Pospisil <dpospisi@redhat.com>
+ * @author <a href="mailto:dpospisi@redhat.com">Dominik Pospisil</a>
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -128,7 +127,7 @@ public class ClusteredSingleSignOnTestCase {
             @ArquillianResource(LogoutServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(LogoutServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2) throws Exception {
         log.info("+++ testFormAuthSingleSignOn");
-        SSOTestBase.executeFormAuthSingleSignOnTest(new URL(baseURL1, "/"), new URL(baseURL2, "/"),  log);
+        SSOTestBase.executeFormAuthSingleSignOnTest(new URL(baseURL1, "/"), new URL(baseURL2, "/"), log);
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -62,7 +62,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
     /**
      * Test simple graceful shutdown failover:
-     *
+     * <p/>
      * 1/ Start 2 containers and deploy <distributable/> webapp.
      * 2/ Query first container creating a web session.
      * 3/ Shutdown first container.
@@ -72,7 +72,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
      *
      * @throws IOException
      * @throws InterruptedException
-     * @throws URISyntaxException 
+     * @throws URISyntaxException
      */
     @Test
     @InSequence(1)
@@ -88,7 +88,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
         try {
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             HttpResponse response = client.execute(new HttpGet(url1));
             try {
                 log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -112,7 +112,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             stop(CONTAINER_1);
 
             this.establishView(client, baseURL2, NODE_2);
-            
+
             // Now check on the 2nd server
 
             // Note that this DOES rely on the fact that both servers are running on the "same" domain,
@@ -140,7 +140,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             start(CONTAINER_1);
 
             this.establishView(client, baseURL2, NODE_1, NODE_2);
-            
+
             // Lets wait for the cluster to update membership and tranfer state.
 
             response = client.execute(new HttpGet(url1));
@@ -170,7 +170,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
     /**
      * Test simple undeploy failover:
-     *
+     * <p/>
      * 1/ Start 2 containers and deploy <distributable/> webapp.
      * 2/ Query first container creating a web session.
      * 3/ Undeploy application from the first container.
@@ -180,7 +180,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
      *
      * @throws IOException
      * @throws InterruptedException
-     * @throws URISyntaxException 
+     * @throws URISyntaxException
      */
     @Test
     @InSequence(2)
@@ -196,7 +196,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
         try {
             this.establishView(client, baseURL1, NODE_1, NODE_2);
-            
+
             HttpResponse response = client.execute(new HttpGet(url1));
             try {
                 log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -220,7 +220,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             undeploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_2);
-            
+
             // Now check on the 2nd server
 
             // Note that this DOES rely on the fact that both servers are running on the "same" domain,
@@ -248,7 +248,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             deploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_1, NODE_2);
-            
+
             response = client.execute(new HttpGet(url1));
             try {
                 log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -21,19 +21,10 @@
  */
 package org.jboss.as.test.clustering.cluster.web;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Properties;
 import java.util.concurrent.ExecutionException;
-
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
@@ -41,53 +32,32 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Test that failover and undeploy works.
+ * Test that HTTP session failover on shutdown and undeploy works.
  *
  * @author Radoslav Husar
+ * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public abstract class ClusteredWebFailoverAbstractCase {
+public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTestCase {
 
-    /** Controller for testing failover and undeploy **/
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
-
-    @BeforeClass
-    public static void printSysProps() {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
-
-    /**
-     * Workaround for Arquillian so that you can use "@ArquillianResource(C.class) @OperateOnDeployment(D)" because the
-     * containers need to be started beforehand.
-     */
-    @Test
-    @InSequence(1)
-    public void testStartContainersAndDeployments() {
-        // Container is unmanaged, need to start manually.
-        controller.start(CONTAINER_1);
-        deployer.deploy(DEPLOYMENT_1);
-        controller.start(CONTAINER_2);
-        deployer.deploy(DEPLOYMENT_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     /**
@@ -105,7 +75,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
      * @throws URISyntaxException 
      */
     @Test
-    @InSequence(2)
+    @InSequence(1)
     public void testGracefulSimpleFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -128,7 +98,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Lets do this twice to have more debug info if failover is slow.
+            // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             try {
                 System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -139,7 +109,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             }
 
             // Gracefully shutdown the 1st container.
-            controller.stop(CONTAINER_1);
+            stop(CONTAINER_1);
 
             this.establishView(client, baseURL2, NODE_2);
             
@@ -157,7 +127,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Lets do one more check.
+            // Let's do one more check.
             response = client.execute(new HttpGet(url2));
             try {
                 System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -167,7 +137,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            controller.start(CONTAINER_1);
+            start(CONTAINER_1);
 
             this.establishView(client, baseURL2, NODE_1, NODE_2);
             
@@ -182,7 +152,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Lets do this twice to have more debug info if failover is slow.
+            // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             try {
                 System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
@@ -195,24 +165,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             HttpClientUtils.closeQuietly(client);
         }
 
-        // Is would be done automatically, keep for 2nd test is added
-        deployer.undeploy(DEPLOYMENT_1);
-        controller.stop(CONTAINER_1);
-        deployer.undeploy(DEPLOYMENT_2);
-        controller.stop(CONTAINER_2);
-
         // Assert.fail("Show me the logs please!");
-    }
-
-    @Test
-    @InSequence(3)
-    public void testStartContainersAndDeploymentsForUndeployFailover() {
-        // Container is unmanaged, need to start manually.
-        controller.start(CONTAINER_1);
-        deployer.deploy(DEPLOYMENT_1);
-
-        controller.start(CONTAINER_2);
-        deployer.deploy(DEPLOYMENT_2);
     }
 
     /**
@@ -230,7 +183,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
      * @throws URISyntaxException 
      */
     @Test
-    @InSequence(4)
+    @InSequence(2)
     public void testGracefulUndeployFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -264,7 +217,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             }
 
             // Gracefully undeploy from the 1st container.
-            deployer.undeploy(DEPLOYMENT_1);
+            undeploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_2);
             
@@ -292,7 +245,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
             }
 
             // Redeploy
-            deployer.deploy(DEPLOYMENT_1);
+            deploy(DEPLOYMENT_1);
 
             this.establishView(client, baseURL2, NODE_1, NODE_2);
             
@@ -318,16 +271,17 @@ public abstract class ClusteredWebFailoverAbstractCase {
             HttpClientUtils.closeQuietly(client);
         }
 
-        // Is would be done automatically, keep for when 3nd test is added
-        deployer.undeploy(DEPLOYMENT_1);
-        controller.stop(CONTAINER_1);
-        deployer.undeploy(DEPLOYMENT_2);
-        controller.stop(CONTAINER_2);
-
         // Assert.fail("Show me the logs please!");
+    }
+
+    @Test
+    @InSequence(3)
+    public void testCleanup() {
+        undeploy(DEPLOYMENTS);
     }
 
     private void establishView(HttpClient client, URL baseURL, String... members) throws URISyntaxException, IOException {
         ClusterHttpClientUtil.establishView(client, baseURL, "web", members);
     }
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -91,7 +91,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             
             HttpResponse response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -101,7 +101,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -120,7 +120,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             response = client.execute(new HttpGet(url2));
             try {
-                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -130,7 +130,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Let's do one more check.
             response = client.execute(new HttpGet(url2));
             try {
-                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -145,7 +145,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -155,7 +155,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -199,7 +199,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             
             HttpResponse response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -209,7 +209,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -227,7 +227,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // which is '127.0.0.1'. Otherwise you will have to spoof cookies. @Rado
             response = client.execute(new HttpGet(url2));
             try {
-                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -237,7 +237,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Lets do one more check.
             response = client.execute(new HttpGet(url2));
             try {
-                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -251,7 +251,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             
             response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -261,7 +261,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
             try {
-                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
@@ -94,7 +94,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 
@@ -111,7 +111,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
 
         // returns the URL of the deployment (http://127.0.0.1:8180/distributable)
         String url = baseURL.toString();
-        System.out.println("URL = " + url);
+        log.info("URL = " + url);
 
         try {
             HttpResponse response = client.execute(new HttpGet(url + "simple"));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
@@ -47,6 +47,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.as.test.http.util.HttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
@@ -60,6 +61,7 @@ import org.junit.runner.RunWith;
 import static org.jboss.as.test.clustering.ClusterTestUtil.waitForReplication;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENTS;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
 import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO_REPLICATE;
@@ -72,33 +74,23 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class ClusteredWebSimpleTestCase {
+public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
 
     private static final int REQUEST_DURATION = 10000;
-    @ArquillianResource
-    private ContainerController controller;
-    @ArquillianResource
-    private Deployer deployer;
-
-    @BeforeClass
-    public static void printSysProps() {
-        Properties sysprops = System.getProperties();
-        System.out.println("System properties:\n" + sysprops);
-    }
 
     @Deployment(name = DEPLOYMENT_1, managed = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
-        war.addClass(SimpleServlet.class);
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
-        return war;
+        return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
@@ -106,18 +98,10 @@ public class ClusteredWebSimpleTestCase {
         return war;
     }
 
-    @Test
-    @InSequence(-1)
-    public void testStartContainers() {
-        NodeUtil.start(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.start(controller, deployer, CONTAINER_2, DEPLOYMENT_2);
-    }
-
-    @Test
-    @InSequence(1)
-    public void testStopContainers() {
-        NodeUtil.stop(controller, deployer, CONTAINER_1, DEPLOYMENT_1);
-        NodeUtil.stop(controller, deployer, CONTAINER_2, DEPLOYMENT_2);
+    @Override
+    protected void setUp() {
+        super.setUp();
+        deploy(DEPLOYMENTS);
     }
 
     @Test
@@ -233,10 +217,10 @@ public class ClusteredWebSimpleTestCase {
 
         if (undeployOnly) {
             // Undeploy the app only.
-            deployer.undeploy(DEPLOYMENT_1);
+            undeploy(DEPLOYMENT_1);
         } else {
             // Shutdown server.
-            controller.stop(CONTAINER_1);
+            stop(CONTAINER_1);
         }
 
         // Get result of long request
@@ -262,10 +246,10 @@ public class ClusteredWebSimpleTestCase {
         // Cleanup after test.
         if (undeployOnly) {
             // Redeploy the app only.
-            deployer.deploy(DEPLOYMENT_1);
+            deploy(DEPLOYMENT_1);
         } else {
             // Startup server.
-            controller.start(CONTAINER_1);
+            start(CONTAINER_1);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
@@ -59,7 +59,7 @@ public class DistributionWebFailoverTestCase extends ClusteredWebFailoverAbstrac
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
         war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
@@ -21,6 +21,11 @@
  */
 package org.jboss.as.test.clustering.cluster.web;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.as.test.clustering.ViewChangeListener;
@@ -32,29 +37,24 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
 public class DistributionWebFailoverTestCase extends ClusteredWebFailoverAbstractCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
-        war.addClass(SimpleServlet.class);
-        // Take web.xml from the managed test.
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
-        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
-        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
-        return war;
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
+        // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
         war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -32,8 +32,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
 /**
  * @author Radoslav Husar
  * @version April 2012
@@ -43,22 +41,19 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "granular-distributable.war");
-        war.addClass(SimpleServlet.class);
-        // Take web.xml from the managed test.
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
-        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
-        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
-        return war;
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "granular-distributable.war");
         war.addClass(SimpleServlet.class);
+        // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
         war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -58,7 +58,7 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
         war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
@@ -45,6 +45,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -54,6 +55,7 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  * @version Oct 2012
  */
+@Ignore("Enable after rebase")
 @RunWith(Arquillian.class)
 @RunAsClient
 public class NonHaWebSessionPersistenceTestCase {
@@ -61,7 +63,7 @@ public class NonHaWebSessionPersistenceTestCase {
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_SINGLE)
     public static Archive<?> deployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "session-persistence.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(NonHaWebSessionPersistenceTestCase.class.getPackage(), "web.xml");
         return war;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
@@ -39,21 +39,19 @@ public class ReplicationWebFailoverTestCase extends ClusteredWebFailoverAbstract
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
-        war.addClass(SimpleServlet.class);
-        // Take web.xml from the managed test.
-        war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
-        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
-        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
-        return war;
+        return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
+        // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
@@ -55,7 +55,7 @@ public class ReplicationWebFailoverTestCase extends ClusteredWebFailoverAbstract
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/jboss-web_dist.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/jboss-web_dist.xml
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jboss-web version="6.0" xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<jboss-web version="6.0" xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
     <replication-config>
         <cache-name>web.dist</cache-name>
     </replication-config>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/jboss-web_granular.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/jboss-web_granular.xml
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jboss-web version="6.0" xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<jboss-web version="6.0" xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
     <replication-config>
         <replication-granularity>ATTRIBUTE</replication-granularity>
     </replication-config>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
@@ -29,28 +29,26 @@ import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 
 /**
  * @author Radoslav Husar
  * @version April 2012
  */
-@Ignore // AS7-5279
 public class AttributeBasedSessionPassivationTestCase extends SessionPassivationAbstractCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        return getDeployment();
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        return getDeployment();
+        return createDeployment();
     }
 
-    private static Archive<?> getDeployment() {
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "passivating-attribute.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
@@ -53,7 +53,7 @@ public class AttributeBasedSessionPassivationTestCase extends SessionPassivation
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(SessionPassivationAbstractCase.class.getPackage(), "jboss-web_passivation_attribute.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/AttributeBasedSessionPassivationTestCase.java
@@ -23,7 +23,9 @@ package org.jboss.as.test.clustering.cluster.web.passivation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+
 import org.jboss.as.test.clustering.cluster.web.ClusteredWebSimpleTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
@@ -53,7 +53,7 @@ public class SessionBasedSessionPassivationTestCase extends SessionPassivationAb
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(SessionPassivationAbstractCase.class.getPackage(), "jboss-web_passivation_session.xml", "jboss-web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
@@ -29,28 +29,26 @@ import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 
 /**
  * @author Radoslav Husar
  * @version April 2012
  */
-@Ignore // AS7-5279
 public class SessionBasedSessionPassivationTestCase extends SessionPassivationAbstractCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
-        return getDeployment();
+        return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> deployment1() {
-        return getDeployment();
+        return createDeployment();
     }
 
-    private static Archive<?> getDeployment() {
+    private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "passivating-session.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionBasedSessionPassivationTestCase.java
@@ -23,7 +23,9 @@ package org.jboss.as.test.clustering.cluster.web.passivation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+
 import org.jboss.as.test.clustering.cluster.web.ClusteredWebSimpleTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationAbstractCase.java
@@ -26,18 +26,11 @@ import org.junit.Assert;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.as.test.http.util.HttpClientUtils;
@@ -50,7 +43,7 @@ import org.junit.runner.RunWith;
  * <p/>
  * Tests: max-idle, min-idle, max-active-sessions
  * <p/>
- * To be extended with: passivation around fail-over events (restart, shutdown, deploy)
+ * TODO: extended with passivation around fail-over events (restart, shutdown, deploy)
  *
  * @author Radoslav Husar
  * @version April 2012

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/jboss-web_passivation_attribute.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/jboss-web_passivation_attribute.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <jboss-web version="6.0" xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
 
     <replication-config>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/jboss-web_passivation_session.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/jboss-web_passivation_session.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
 <jboss-web version="6.0" xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-web_6_0.xsd">
 
     <replication-config>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/web.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/web.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -52,7 +52,7 @@ import org.junit.BeforeClass;
 
 /**
  * Base class for passivation tests on EJB2 beans.
- * 
+ *
  * @author Ondrej Chaloupka
  */
 public abstract class ClusterPassivationTestBase {
@@ -104,7 +104,7 @@ public abstract class ClusterPassivationTestBase {
 
     /**
      * Start servers whether their are not started.
-     * 
+     *
      * @param client1 client for server1
      * @param client2 client for server2
      */
@@ -145,9 +145,9 @@ public abstract class ClusterPassivationTestBase {
         // A small hack - deleting node (by name) from cluster which this client knows
         // It means that the next request (ejb call) will be passed to the server #2
         EJBClientContext.requireCurrent().getClusterContext(CLUSTER_NAME).removeClusterNode(calledNodeFirst);
-        
+
         Assert.assertEquals("Supposing to get passivation node which was set", calledNodeFirst, statefulBean.getPassivatedBy());
-        
+
         String calledNodeSecond = statefulBean.incrementNumber(); // 42
         statefulBean.setPassivationNode(calledNodeSecond);
         log.info("Called node name second: " + calledNodeSecond);
@@ -170,7 +170,7 @@ public abstract class ClusterPassivationTestBase {
         Assert.assertEquals("It can't be node " + calledNodeSecond + " because is switched off", calledNodeFirst, calledNode);
 
         Assert.assertEquals("Supposing to get passivation node which was set", calledNodeSecond, statefulBean.getPassivatedBy());
-        
+
         Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
         Assert.assertEquals(++clientNumber, statefulBean.getNumber()); // 43
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
@@ -46,7 +46,7 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 
 /**
  * Clustering ejb passivation of EJB2 beans defined by annotation.
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
@@ -58,7 +58,7 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
     private ContainerController controller;
     @ArquillianResource
     private Deployer deployer;
-    
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
@@ -80,7 +80,7 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
         log.info(war.toString(true));
         return war;
     }
-    
+
     @Override
     protected void startServers(ManagementClient client1, ManagementClient client2) {
         if (client1 == null || !client1.isServerInRunningState()) {
@@ -93,9 +93,9 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
             controller.start(CONTAINER_2);
             deployer.deploy(DEPLOYMENT_2);
         }
-    }    
+    }
 
-    
+
     @Test
     @InSequence(-2)
     public void arquillianStartServers() {
@@ -109,11 +109,11 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
     @Test
     @InSequence(-1)
     public void defineMaps(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
+                           @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
+                           @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
+                           @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
 
-        String nodeName1 = HttpRequest.get(baseURL1.toString() + NodeInfoServlet.URL , HTTP_REQUEST_WAIT_TIME_S, TimeUnit.SECONDS);
+        String nodeName1 = HttpRequest.get(baseURL1.toString() + NodeInfoServlet.URL, HTTP_REQUEST_WAIT_TIME_S, TimeUnit.SECONDS);
         node2deployment.put(nodeName1, DEPLOYMENT_1);
         node2container.put(nodeName1, CONTAINER_1);
         log.info("URL1 nodename: " + nodeName1);
@@ -124,7 +124,7 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
         node2container.put(nodeName2, CONTAINER_2);
         log.info("URL2 nodename: " + nodeName2);
     }
-    
+
     @Ignore("JBPAPP-8774")
     @Test
     @InSequence(1)
@@ -133,10 +133,10 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
         setPassivationAttributes(client1.getControllerClient());
         setPassivationAttributes(client2.getControllerClient());
-        
+
         // Setting context from .properties file to get ejb:/ remote context
         setupEJBClientContextSelector();
-        
+
         StatefulRemoteHome home = directory.lookupHome(StatefulBean.class, StatefulRemoteHome.class);
         StatefulRemote statefulBean = home.create();
 
@@ -157,12 +157,12 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
         }
 
         // unset & undeploy & stop
-        if(client1.isServerInRunningState()) {
+        if (client1.isServerInRunningState()) {
             unsetPassivationAttributes(client1.getControllerClient());
             deployer.undeploy(DEPLOYMENT_1);
             controller.stop(CONTAINER_1);
         }
-        if(client2.isServerInRunningState()) {
+        if (client2.isServerInRunningState()) {
             unsetPassivationAttributes(client2.getControllerClient());
             deployer.undeploy(DEPLOYMENT_2);
             controller.stop(CONTAINER_2);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulBean.java
@@ -28,6 +28,7 @@ import javax.ejb.EJBException;
 import javax.ejb.RemoteHome;
 import javax.ejb.SessionBean;
 import javax.ejb.Stateful;
+
 import org.jboss.ejb3.annotation.Clustered;
 
 /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulBeanBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulBeanBase.java
@@ -35,13 +35,13 @@ import org.jboss.logging.Logger;
  */
 public abstract class StatefulBeanBase {
     private static Logger log = Logger.getLogger(StatefulBeanBase.class);
-    
+
     protected int number;
     protected String passivatedBy = "unknown";
     protected String actIfIsNode;
     protected int postActivateCalled = 0;
     protected int prePassivateCalled = 0;
-       
+
     /**
      * Getting number.
      */
@@ -71,22 +71,22 @@ public abstract class StatefulBeanBase {
     public void setPassivationNode(String nodeName) {
         this.actIfIsNode = nodeName;
     }
-    
-    /** 
+
+    /**
      * Creating method for home interface...
      */
     public void ejbCreate() throws java.rmi.RemoteException, javax.ejb.CreateException {
     }
-    
-    /** 
+
+    /**
      * @Override on SessionBean
      */
     public void ejbActivate() throws EJBException, RemoteException {
         postActivateCalled++;
-        log.info("Activating with number: " + number + " and was passivated by " + getPassivatedBy() + ", postActivate method called " + postActivateCalled + " times");        
+        log.info("Activating with number: " + number + " and was passivated by " + getPassivatedBy() + ", postActivate method called " + postActivateCalled + " times");
     }
 
-    /** 
+    /**
      * @Override on SessionBean
      */
     public void ejbPassivate() throws EJBException, RemoteException {
@@ -97,20 +97,20 @@ public abstract class StatefulBeanBase {
         if (NodeNameGetter.getNodeName().equals(actIfIsNode)) {
             passivatedBy = NodeNameGetter.getNodeName();
             log.info("I'm node " + actIfIsNode + " => changing passivatedBy to " + passivatedBy);
-        }        
+        }
     }
 
-    /** 
+    /**
      * @Override on SessionBean
      */
     public void ejbRemove() throws EJBException, RemoteException {
-        
+
     }
 
-    /** 
+    /**
      * @Override on SessionBean
      */
     public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {
-        
+
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulRemote.java
@@ -27,8 +27,12 @@ package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation;
  */
 public interface StatefulRemote extends javax.ejb.EJBObject {
     int getNumber();
+
     String setNumber(int number);
+
     String incrementNumber();
+
     void setPassivationNode(String node);
+
     String getPassivatedBy();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulRemoteHome.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/StatefulRemoteHome.java
@@ -24,7 +24,10 @@ package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation;
 
 import javax.ejb.EJBHome;
 
+/**
+ * @author Ondrej Chaloupka
+ */
 public interface StatefulRemoteHome extends EJBHome {
-    public StatefulRemote create() throws java.rmi.RemoteException, javax.ejb.CreateException;    
-    
+    public StatefulRemote create() throws java.rmi.RemoteException, javax.ejb.CreateException;
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
@@ -50,7 +50,7 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 
 /**
  * Clustering ejb passivation of EJB2 bean defined by descriptor.
- * 
+ *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
@@ -62,7 +62,7 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
     private ContainerController controller;
     @ArquillianResource
     private Deployer deployer;
-    
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> deployment0() {
@@ -86,7 +86,7 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
         log.info(war.toString(true));
         return war;
     }
-    
+
     @Override
     protected void startServers(ManagementClient client1, ManagementClient client2) {
         if (client1 == null || !client1.isServerInRunningState()) {
@@ -99,24 +99,24 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
             controller.start(CONTAINER_2);
             deployer.deploy(DEPLOYMENT_2);
         }
-    }  
-    
+    }
+
     @Test
     @InSequence(-1)
     public void startServersForTests() {
         startServers(null, null);
     }
-    
+
     /**
      * Associtation of node names to deployment,container names and client context
      */
     @Test
     @InSequence(-1)
     public void defineMaps(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
-            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
-        String nodeName1 = HttpRequest.get(baseURL1.toString() + NodeInfoServlet.URL , HTTP_REQUEST_WAIT_TIME_S, TimeUnit.SECONDS);
+                           @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
+                           @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
+                           @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
+        String nodeName1 = HttpRequest.get(baseURL1.toString() + NodeInfoServlet.URL, HTTP_REQUEST_WAIT_TIME_S, TimeUnit.SECONDS);
         node2deployment.put(nodeName1, DEPLOYMENT_1);
         node2container.put(nodeName1, CONTAINER_1);
         log.info("URL1 nodename: " + nodeName1);
@@ -125,7 +125,7 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
         node2container.put(nodeName2, CONTAINER_2);
         log.info("URL2 nodename: " + nodeName2);
     }
-    
+
     @Ignore("JBPAPP-8774")
     @Test
     @InSequence(1)
@@ -134,17 +134,16 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
         setPassivationAttributes(client1.getControllerClient());
         setPassivationAttributes(client2.getControllerClient());
-        
+
         // Setting context from .properties file to get ejb:/ remote context
         setupEJBClientContextSelector();
-        
+
         StatefulRemoteHome home = directory.lookupHome(StatefulBeanDD.class, StatefulRemoteHome.class);
         StatefulRemote statefulBean = home.create();
 
         runPassivation(statefulBean, controller, deployer);
         startServers(client1, client2);
     }
-
 
 
     @Test
@@ -160,12 +159,12 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
         }
 
         // unset & undeploy & stop
-        if(client1.isServerInRunningState()) {
+        if (client1.isServerInRunningState()) {
             unsetPassivationAttributes(client1.getControllerClient());
             deployer.undeploy(DEPLOYMENT_1);
             controller.stop(CONTAINER_1);
         }
-        if(client2.isServerInRunningState()) {
+        if (client2.isServerInRunningState()) {
             unsetPassivationAttributes(client2.getControllerClient());
             deployer.undeploy(DEPLOYMENT_2);
             controller.stop(CONTAINER_2);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/StatefulBeanDD.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/StatefulBeanDD.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation.dd;
 
-import java.rmi.RemoteException;
-
-import javax.ejb.EJBException;
 import javax.ejb.SessionBean;
 
 import org.jboss.as.test.clustering.extended.ejb2.stateful.passivation.StatefulBeanBase;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ejb-jar.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ejb-jar.xml
@@ -1,6 +1,27 @@
 <?xml version='1.0' ?>
 <!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" 
                          "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <ejb-jar>
 	<enterprise-beans>
 		<session>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterBaseBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterBaseBean.java
@@ -7,11 +7,11 @@ import org.jboss.as.test.clustering.NodeNameGetter;
  */
 public abstract class CounterBaseBean {
     private int count;
-    
+
     public void ejbCreate() throws java.rmi.RemoteException, javax.ejb.CreateException {
         // Creating method for home interface...
     }
-    
+
     public CounterResult increment() {
         this.count++;
         return new CounterResult(this.count, getNodeName());

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterBean.java
@@ -29,6 +29,7 @@ import javax.ejb.RemoteHome;
 import javax.ejb.SessionBean;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateful;
+
 import org.jboss.ejb3.annotation.Clustered;
 import org.jboss.logging.Logger;
 
@@ -41,24 +42,24 @@ import org.jboss.logging.Logger;
 public class CounterBean extends CounterBaseBean implements SessionBean {
     private static final long serialVersionUID = 1L;
     private static final Logger log = Logger.getLogger(CounterBean.class);
-        
+
     public void ejbRemove() throws EJBException, RemoteException {
         log.info("ejbRemove called...");
-        CounterSingleton.destroyCounter.incrementAndGet();        
+        CounterSingleton.destroyCounter.incrementAndGet();
     }
 
     @Override
     public void ejbActivate() throws EJBException, RemoteException {
-        
+
     }
 
     @Override
     public void ejbPassivate() throws EJBException, RemoteException {
-        
+
     }
 
     @Override
     public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {
-        
+
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterRemote.java
@@ -27,6 +27,8 @@ package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
  */
 public interface CounterRemote extends javax.ejb.EJBObject {
     CounterResult increment();
+
     CounterResult decrement();
-    CounterResult getCount();   
+
+    CounterResult getCount();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterRemoteHome.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterRemoteHome.java
@@ -22,12 +22,12 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
 
-import javax.ejb.*;
+import javax.ejb.EJBHome;
 
 /**
  * @author Ondrej Chaloupka
  */
 public interface CounterRemoteHome extends EJBHome {
     public CounterRemote create() throws java.rmi.RemoteException, javax.ejb.CreateException;
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterSingleton.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterSingleton.java
@@ -34,12 +34,12 @@ import org.apache.log4j.Logger;
 public class CounterSingleton implements CounterSingletonRemote {
     public static AtomicInteger destroyCounter = new AtomicInteger(0);
     private static final Logger log = Logger.getLogger(CounterSingleton.class);
-    
+
     public int getDestroyCount() {
         log.info("destroyCounter: " + destroyCounter.get());
         return destroyCounter.get();
     }
-    
+
     public void resetDestroyCount() {
         destroyCounter.set(0);
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterSingletonRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterSingletonRemote.java
@@ -28,7 +28,8 @@ import javax.ejb.Remote;
  * @author Ondrej Chaloupka
  */
 @Remote
-public interface CounterSingletonRemote {   
+public interface CounterSingletonRemote {
     int getDestroyCount();
-    void resetDestroyCount() ;
+
+    void resetDestroyCount();
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -55,7 +55,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClientStatefulFaliloverTestBase {
-    // private static final Logger log = Logger.getLogger(RemoteEJBClientStatefulBeanFailoverTestCase.class);
 
     @ArquillianResource
     private ContainerController container;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFaliloverTestBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFaliloverTestBase.java
@@ -30,17 +30,17 @@ import org.junit.BeforeClass;
  * @author Ondrej Chaloupka
  */
 public abstract class RemoteEJBClientStatefulFaliloverTestBase {
-       private static final Logger log = Logger.getLogger(RemoteEJBClientStatefulFaliloverTestBase.class);
-    
+    private static final Logger log = Logger.getLogger(RemoteEJBClientStatefulFaliloverTestBase.class);
+
     protected static final String PROPERTIES_FILE = "cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties";
     protected static final String ARCHIVE_NAME = "ejb2-failover-test";
     protected static final String ARCHIVE_NAME_SINGLE = ARCHIVE_NAME + "-single";
     protected static final String DEPLOYMENT_1_SINGLE = DEPLOYMENT_1 + "-single";
     protected static final String DEPLOYMENT_2_SINGLE = DEPLOYMENT_2 + "-single";
-    
+
     protected static EJBDirectory singletonDirectory;
     protected static EJBDirectory directory;
-    
+
     protected static Archive<?> createDeploymentSingleton() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME_SINGLE + ".jar");
         jar.addClasses(CounterSingleton.class, CounterSingletonRemote.class);
@@ -68,16 +68,16 @@ public abstract class RemoteEJBClientStatefulFaliloverTestBase {
      * @throws Exception
      */
     public abstract void testFailoverFromRemoteClientWhenOneNodeGoesDown() throws Exception;
-    
+
     /**
      * Same as above, but application gets undeployed while the server keeps running.
      *
      * @throws Exception
      */
     public abstract void testFailoverFromRemoteClientWhenOneNodeUndeploys() throws Exception;
-    
+
     /**
-     * Implementation of defined abstract tests above.  
+     * Implementation of defined abstract tests above.
      */
     protected void failoverFromRemoteClient(ContainerController container, Deployer deployer, boolean undeployOnly) throws Exception {
         // Container is unmanaged, so start it ourselves
@@ -96,16 +96,16 @@ public abstract class RemoteEJBClientStatefulFaliloverTestBase {
         boolean container2Stopped = false;
         try {
             ViewChangeListener listener = directory.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODE_1, NODE_2);
-            
+
             CounterRemoteHome home = directory.lookupHome(CounterBean.class, CounterRemoteHome.class);
             CounterRemote remoteCounter = home.create();
             Assert.assertNotNull(remoteCounter);
-            
+
             final CounterSingletonRemote destructionCounter = singletonDirectory.lookupSingleton(CounterSingleton.class, CounterSingletonRemote.class);
             destructionCounter.resetDestroyCount();
-            
+
             // invoke on the bean a few times
             final int NUM_TIMES = 25;
             for (int i = 0; i < NUM_TIMES; i++) {
@@ -128,9 +128,9 @@ public abstract class RemoteEJBClientStatefulFaliloverTestBase {
                 } else {
                     container.stop(CONTAINER_1);
                 }
-                
+
                 this.establishView(listener, NODE_2);
-                
+
                 container1Stopped = true;
             } else {
                 if (undeployOnly) {
@@ -139,9 +139,9 @@ public abstract class RemoteEJBClientStatefulFaliloverTestBase {
                 } else {
                     container.stop(CONTAINER_2);
                 }
-                
+
                 this.establishView(listener, NODE_1);
-                
+
                 container2Stopped = true;
             }
             // invoke again

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/CounterBeanDD.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/CounterBeanDD.java
@@ -38,15 +38,15 @@ import org.jboss.logging.Logger;
 public class CounterBeanDD extends CounterBaseBean implements SessionBean {
     private static final Logger log = Logger.getLogger(CounterBeanDD.class);
     private static final long serialVersionUID = 1L;
-    
+
     @Override
     public void ejbActivate() throws EJBException, RemoteException {
-        
+
     }
 
     @Override
     public void ejbPassivate() throws EJBException, RemoteException {
-        
+
     }
 
     @Override
@@ -57,6 +57,6 @@ public class CounterBeanDD extends CounterBaseBean implements SessionBean {
 
     @Override
     public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {
-        
+
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBClientStatefulFaliloverTestBase {
     private static final Logger log = Logger.getLogger(RemoteEJB2ClientStatefulBeanFailoverDDTestCase.class);
-    
+
     @ArquillianResource
     private ContainerController container;
     @ArquillianResource
@@ -71,7 +71,7 @@ public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBCli
     public static Archive<?> createDeploymentForContainer2Singleton() {
         return createDeploymentSingleton();
     }
-    
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> createDeploymentForContainer1() {
@@ -93,8 +93,8 @@ public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBCli
         jar.addAsManifestResource(new StringAsset("Dependencies: deployment." + ARCHIVE_NAME_SINGLE + ".jar\n"), "MANIFEST.MF");
         log.info(jar.toString(true));
         return jar;
-    }   
-    
+    }
+
     @Ignore("JBPAPP-8726")
     @Override
     @InSequence(1)

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/ejb-jar.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/ejb-jar.xml
@@ -1,6 +1,27 @@
 <?xml version='1.0' ?>
 <!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" 
                          "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <ejb-jar>
 	<enterprise-beans>
 		<session>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -65,10 +65,10 @@ import org.junit.runner.RunWith;
 
 /**
  * EJB2 stateless bean - basic cluster tests - failover and load balancing.
- * @see  org.jboss.as.test.clustering.cluster.ejb3.stateless.RemoteStatelessFailoverTestCase
- * 
+ *
  * @author Paul Ferraro
  * @author Ondrej Chaloupka
+ * @see org.jboss.as.test.clustering.cluster.ejb3.stateless.RemoteStatelessFailoverTestCase
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -85,14 +85,14 @@ public class RemoteStatelessFailoverTestCase {
     private static final String HOST_2 = System.getProperty("node1");
     private static final String REMOTE_PORT_PROPERTY_NAME = "remote.connection.default.port";
     private static final String REMOTE_HOST_PROPERTY_NAME = "remote.connection.default.host";
-    
+
     private static final String DEPLOYMENT_1_DD = DEPLOYMENT_1 + "-descriptor";
     private static final String DEPLOYMENT_2_DD = DEPLOYMENT_2 + "-descriptor";
-    
+
     private static final Map<String, Boolean> deployed = new HashMap<String, Boolean>();
     private static final Map<String, Boolean> started = new HashMap<String, Boolean>();
     private static final Map<String, List<String>> container2deployment = new HashMap<String, List<String>>();
-    
+
     @BeforeClass
     public static void init() throws NamingException {
         directoryAnnotation = new RemoteEJBDirectory(ARCHIVE_NAME);
@@ -104,7 +104,7 @@ public class RemoteStatelessFailoverTestCase {
         deployed.put(DEPLOYMENT_2_DD, false);
         started.put(CONTAINER_1, false);
         started.put(CONTAINER_2, false);
-        
+
         List<String> deployments1 = new ArrayList<String>();
         deployments1.add(DEPLOYMENT_1);
         deployments1.add(DEPLOYMENT_1_DD);
@@ -137,7 +137,7 @@ public class RemoteStatelessFailoverTestCase {
     public static Archive<?> createDeploymentForContainer2() {
         return createDeployment();
     }
-    
+
     @Deployment(name = DEPLOYMENT_1_DD, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> createDeploymentOnDescriptorForContainer1() {
@@ -159,7 +159,7 @@ public class RemoteStatelessFailoverTestCase {
         log.info(jar.toString(true));
         return jar;
     }
-    
+
     private static Archive<?> createDeploymentOnDescriptor() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME_DD + ".jar");
         jar.addClasses(StatelessBeanBase.class, StatelessBeanDD.class, StatelessRemote.class, StatelessRemoteHome.class);
@@ -173,7 +173,7 @@ public class RemoteStatelessFailoverTestCase {
     }
 
     @Test
-    public void testFailoverOnStopAnnotatedBean() throws Exception {        
+    public void testFailoverOnStopAnnotatedBean() throws Exception {
         doFailover(true, directoryAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);
     }
 
@@ -184,25 +184,25 @@ public class RemoteStatelessFailoverTestCase {
 
     @Test
     public void testFailoverOnUndeployAnnotatedBean() throws Exception {
-        doFailover(false, directoryAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);     
+        doFailover(false, directoryAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);
     }
-    
+
     @Test
     public void testFailoverOnUndeploySpecifiedByDescriptor() throws Exception {
         doFailover(false, directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
     }
-    
+
     private void doFailover(boolean isStop, EJBDirectory directory, String deployment1, String deployment2) throws Exception {
         this.start(CONTAINER_1);
         this.deploy(CONTAINER_1, deployment1);
-        
+
         final ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try {
             ViewChangeListener listener = directory.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
-            
+
             this.establishView(listener, NODES[0]);
-            
+
             StatelessRemoteHome home = directory.lookupHome(StatelessBean.class, StatelessRemoteHome.class);
             StatelessRemote bean = home.create();
 
@@ -210,17 +210,17 @@ public class RemoteStatelessFailoverTestCase {
 
             this.start(CONTAINER_2);
             this.deploy(CONTAINER_2, deployment2);
-            
+
             this.establishView(listener, NODES);
-            
-            if(isStop) {
+
+            if (isStop) {
                 this.stop(CONTAINER_1);
             } else {
                 this.undeploy(CONTAINER_1, deployment1);
             }
-            
+
             this.establishView(listener, NODES[1]);
-            
+
             assertEquals("Only " + NODES[1] + " is active. The bean had to be invoked on it but it wasn't.", NODES[1], bean.getNodeName());
         } finally {
             // reset the selector
@@ -233,7 +233,7 @@ public class RemoteStatelessFailoverTestCase {
             undeployAll();
             shutdownAll();
         }
-    }    
+    }
 
     @Test
     public void testLoadbalanceAnnotatedBean() throws Exception {
@@ -244,7 +244,7 @@ public class RemoteStatelessFailoverTestCase {
     public void testLoadbalanceSpecifiedByDescriptor() throws Exception {
         loadbalance(directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
     }
-    
+
     /**
      * Basic load balance testing. A random distribution is used amongst nodes for client now.
      */
@@ -307,28 +307,28 @@ public class RemoteStatelessFailoverTestCase {
             count = count == null ? 1 : ++count;
             callCount.put(nodeName, count);
         }
-        Assert.assertEquals("It was running " + expectedServers + " servers but not all of them were used for loadbalancing.", 
-                   expectedServers, callCount.size());
+        Assert.assertEquals("It was running " + expectedServers + " servers but not all of them were used for loadbalancing.",
+                expectedServers, callCount.size());
 
         for (Integer count : callCount.values()) {
             maxNumOfProcessedCalls = count > maxNumOfProcessedCalls ? count : maxNumOfProcessedCalls;
             minNumOfProcessedCalls = count < minNumOfProcessedCalls ? count : minNumOfProcessedCalls;
         }
-        Assert.assertTrue("Minimal number of calls done to all servers have to be " + minPercentage * numCalls + " but was " + minNumOfProcessedCalls, 
+        Assert.assertTrue("Minimal number of calls done to all servers have to be " + minPercentage * numCalls + " but was " + minNumOfProcessedCalls,
                 minPercentage * numCalls <= minNumOfProcessedCalls);
         log.info("All " + expectedServers + " servers processed at least " + minNumOfProcessedCalls + " of calls");
     }
-    
+
     private void undeployAll() {
-        for(String container: container2deployment.keySet()) {
-            for(String deployment: container2deployment.get(container)) {
+        for (String container : container2deployment.keySet()) {
+            for (String deployment : container2deployment.get(container)) {
                 undeploy(container, deployment);
             }
         }
     }
-    
+
     private void shutdownAll() {
-        for(String container: container2deployment.keySet()) {
+        for (String container : container2deployment.keySet()) {
             stop(container);
         }
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessBean.java
@@ -26,17 +26,17 @@ import javax.ejb.Remote;
 import javax.ejb.RemoteHome;
 import javax.ejb.SessionBean;
 import javax.ejb.Stateless;
+
 import org.jboss.ejb3.annotation.Clustered;
 
 /**
  * @author Ondrej Chaloupka
- *
  */
 @Stateless
 @Clustered
 @RemoteHome(StatelessRemoteHome.class)
 @Remote(StatelessRemote.class)
-public class StatelessBean extends StatelessBeanBase implements SessionBean  {
+public class StatelessBean extends StatelessBeanBase implements SessionBean {
     private static final long serialVersionUID = 1L;
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessBeanBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessBeanBase.java
@@ -27,18 +27,19 @@ import java.rmi.RemoteException;
 import javax.ejb.EJBException;
 import javax.ejb.SessionContext;
 import javax.ejb.TransactionAttributeType;
+
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.logging.Logger;
 
 /**
  * @author Ondrej Chaloupka
- *
  */
 public abstract class StatelessBeanBase {
     private static final Logger log = Logger.getLogger(StatelessBeanBase.class);
 
     /**
      * {@inheritDoc}
+     *
      * @see org.jboss.as.test.clustering.cluster.ejb3.stateless.bean.Stateless#getNodeName()
      */
     @javax.ejb.TransactionAttribute(TransactionAttributeType.SUPPORTS)
@@ -47,36 +48,36 @@ public abstract class StatelessBeanBase {
         log.info("StatelessBean.getNodeName() was called on node: " + nodeName);
         return nodeName;
     }
-    
+
     public void ejbCreate() throws EJBException, RemoteException {
         // creating ejb2 bean
     }
 
     /**
-     * Overrides SessionBean method 
+     * Overrides SessionBean method
      */
     public void ejbActivate() throws EJBException, RemoteException {
-        
+
     }
 
     /**
-     * Overrides SessionBean method 
+     * Overrides SessionBean method
      */
     public void ejbPassivate() throws EJBException, RemoteException {
-        
+
     }
 
     /**
-     * Overrides SessionBean method 
+     * Overrides SessionBean method
      */
     public void ejbRemove() throws EJBException, RemoteException {
-        
+
     }
 
     /**
-     * Overrides SessionBean method 
+     * Overrides SessionBean method
      */
     public void setSessionContext(SessionContext arg0) throws EJBException, RemoteException {
-        
+
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessBeanDD.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessBeanDD.java
@@ -26,9 +26,8 @@ import javax.ejb.SessionBean;
 
 /**
  * @author Ondrej Chaloupka
- *
  */
-public class StatelessBeanDD extends StatelessBeanBase implements SessionBean  {
+public class StatelessBeanDD extends StatelessBeanBase implements SessionBean {
     private static final long serialVersionUID = 1L;
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessRemote.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessRemote.java
@@ -26,7 +26,6 @@ import javax.ejb.EJBObject;
 
 /**
  * @author Ondrej Chaloupka
- *
  */
 public interface StatelessRemote extends EJBObject {
     String getNodeName();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessRemoteHome.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/StatelessRemoteHome.java
@@ -22,12 +22,12 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateless;
 
-import javax.ejb.*;
+import javax.ejb.EJBHome;
 
 /**
  * @author Ondrej Chaloupka
  */
 public interface StatelessRemoteHome extends EJBHome {
     public StatelessRemote create() throws java.rmi.RemoteException, javax.ejb.CreateException;
-    
+
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/ejb-jar.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/ejb-jar.xml
@@ -1,6 +1,27 @@
 <?xml version='1.0' ?>
 <!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" 
                          "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <ejb-jar>
 	<enterprise-beans>
 		<session>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/ejb/remotecall/RemoteLocalCallsTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/ejb/remotecall/RemoteLocalCallsTestCase.java
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Calling clustered annotated beans on one (local) machine plus testing remote calls for that single node.
- * 
+ *
  * @author Kabir Khan, Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
@@ -81,30 +81,30 @@ public class RemoteLocalCallsTestCase {
         ejbInitialContext = new InitialContext(props);
 
     }
-    
+
     @AfterClass
     public static void tearDown() throws Exception {
-        if(initalContext != null) { 
+        if (initalContext != null) {
             initalContext.close();
         }
-        if(ejbInitialContext != null) { 
+        if (ejbInitialContext != null) {
             ejbInitialContext.close();
         }
     }
 
     private InitialContext getInitialContext(String remoteProviderUrl) throws Exception {
-        if(initalContext == null) {
+        if (initalContext == null) {
             final Properties env = new Properties();
             env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
             env.put(Context.PROVIDER_URL, remoteProviderUrl);
             env.put("jboss.naming.client.ejb.context", true);
             env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
-            env.put("jboss.naming.client.security.callback.handler.class",  org.jboss.as.test.shared.integration.ejb.security.CallbackHandler.class.getName());
+            env.put("jboss.naming.client.security.callback.handler.class", org.jboss.as.test.shared.integration.ejb.security.CallbackHandler.class.getName());
             initalContext = new InitialContext(env);
-        } 
+        }
         return initalContext;
     }
-    
+
     private ContextSelector<EJBClientContext> setupEJBClientContextSelector() throws IOException {
         return EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties");
 
@@ -115,33 +115,33 @@ public class RemoteLocalCallsTestCase {
     public void testRemoteIfLocalCallsEJBctx() throws Exception {
         final ContextSelector<EJBClientContext> previousSelector = this.setupEJBClientContextSelector();
         InitialContext ctx = ejbInitialContext;
-        
+
         try {
             String lookupStr = "ejb:/" + ARCHIVE_NAME + "//" + StatefulBean.class.getSimpleName() + "!"
                     + RemoteInterface.class.getName() + "?stateful";
             RemoteInterface stateful1 = (RemoteInterface) ctx.lookup(lookupStr);
             RemoteInterface stateful2 = (RemoteInterface) ctx.lookup(lookupStr);
-    
-            lookupStr = "ejb:/" +  ARCHIVE_NAME + "//" + StatefulClusteredBean.class.getSimpleName() + "!"
+
+            lookupStr = "ejb:/" + ARCHIVE_NAME + "//" + StatefulClusteredBean.class.getSimpleName() + "!"
                     + RemoteInterface.class.getName() + "?stateful";
             RemoteInterface statefulClustered1 = (RemoteInterface) ctx.lookup(lookupStr);
             RemoteInterface statefulClustered2 = (RemoteInterface) ctx.lookup(lookupStr);
-    
-            lookupStr = "ejb:/" +  ARCHIVE_NAME + "//" + StatelessBean.class.getSimpleName() + "!"
+
+            lookupStr = "ejb:/" + ARCHIVE_NAME + "//" + StatelessBean.class.getSimpleName() + "!"
                     + RemoteInterface.class.getName();
             RemoteInterface stateless1 = (RemoteInterface) ctx.lookup(lookupStr);
             RemoteInterface stateless2 = (RemoteInterface) ctx.lookup(lookupStr);
-    
-            lookupStr = "ejb:/" +  ARCHIVE_NAME + "//" + StatelessClusteredBean.class.getSimpleName() + "!"
+
+            lookupStr = "ejb:/" + ARCHIVE_NAME + "//" + StatelessClusteredBean.class.getSimpleName() + "!"
                     + RemoteInterface.class.getName();
             RemoteInterface statelessClustered1 = (RemoteInterface) ctx.lookup(lookupStr);
             RemoteInterface statelessClustered2 = (RemoteInterface) ctx.lookup(lookupStr);
-    
-            lookupStr = "ejb:/" +  ARCHIVE_NAME + "//" + ServiceBean.class.getSimpleName() + "!"
+
+            lookupStr = "ejb:/" + ARCHIVE_NAME + "//" + ServiceBean.class.getSimpleName() + "!"
                     + ServiceRemoteInterface.class.getName();
             ServiceRemoteInterface service1 = (ServiceRemoteInterface) ctx.lookup(lookupStr);
             ServiceRemoteInterface service2 = (ServiceRemoteInterface) ctx.lookup(lookupStr);
-    
+
             stateful1.test();
             stateful2.test();
             statefulClustered1.test();
@@ -152,13 +152,13 @@ public class RemoteLocalCallsTestCase {
             statelessClustered2.test();
             service1.test();
             service2.test();
-    
+
             Assert.assertFalse(stateful1.hashCode() == stateful2.hashCode());
             Assert.assertFalse(statefulClustered1.hashCode() == statefulClustered2.hashCode());
             Assert.assertTrue(stateless1.hashCode() == stateless2.hashCode());
             Assert.assertTrue(statelessClustered1.hashCode() == statelessClustered2.hashCode());
             Assert.assertTrue(service1.hashCode() == service2.hashCode());
-    
+
             Assert.assertFalse(stateful1.equals(stateful2));
             Assert.assertFalse(statefulClustered1.equals(statefulClustered2));
             Assert.assertTrue(stateless1.equals(stateless2));
@@ -171,7 +171,7 @@ public class RemoteLocalCallsTestCase {
             }
         }
     }
-    
+
     @Test
     @OperateOnDeployment("localcall")
     public void testRemoteIfLocalCalls(@ArquillianResource ManagementClient mngmtClient) throws Exception {
@@ -256,7 +256,7 @@ public class RemoteLocalCallsTestCase {
         InitialContext ctx = getInitialContext(remoteStringUrl);
         SynchronizationSingletonInterface synchro = (SynchronizationSingletonInterface) ctx.lookup(
                 ARCHIVE_NAME + "/" + SynchronizationSingleton.class.getSimpleName() + "!"
-                + SynchronizationSingletonInterface.class.getName());
+                        + SynchronizationSingletonInterface.class.getName());
 
         synchro.resetLatches();
         asyncClusteredBean.resetMethodCalled();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/ejb/remotecall/StatelessAsyncClusteredBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/ejb/remotecall/StatelessAsyncClusteredBean.java
@@ -32,7 +32,8 @@ import javax.ejb.Stateless;
 import org.jboss.ejb3.annotation.Clustered;
 
 /**
- * @author Kabir Khan, Ondrej Chaloupka
+ * @author Kabir Khan
+ * @author Ondrej Chaloupka
  */
 @Stateless
 @Clustered

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalInfinispanManagedBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalInfinispanManagedBean.java
@@ -32,6 +32,7 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 import javax.transaction.UserTransaction;
+
 import org.infinispan.Cache;
 
 /**
@@ -157,7 +158,7 @@ public class TransactionalInfinispanManagedBean {
         }
         return rowCount;
     }
-    
+
     private void initializeCache() throws Exception {
         try {
             tx.begin();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalJdbcStoreTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalJdbcStoreTestCase.java
@@ -44,6 +44,7 @@ import javax.naming.NamingException;
  * @author Martin Gencur
  */
 @RunWith(Arquillian.class)
+@Ignore("https://issues.jboss.org/browse/ISPN-604")
 public class TransactionalJdbcStoreTestCase {
 
     @Deployment
@@ -55,37 +56,31 @@ public class TransactionalJdbcStoreTestCase {
         return war;
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxPutCommit() throws Exception {
         getIspnBeanFromJndi().testTxPutCommit();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxPutRollback() throws Exception {
         getIspnBeanFromJndi().testTxPutRollback();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxRemoveCommit() throws Exception {
         getIspnBeanFromJndi().testTxRemoveCommit();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxRemoveRollback() throws Exception {
         getIspnBeanFromJndi().testTxRemoveRollback();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxAlterCommit() throws Exception {
         getIspnBeanFromJndi().testTxAlterCommit();
     }
 
-    @Ignore("ISPN-604")
     @Test
     public void testTxAlterRollback() throws Exception {
         getIspnBeanFromJndi().testTxAlterRollback();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalJdbcStoreTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/jdbcstore/TransactionalJdbcStoreTestCase.java
@@ -31,16 +31,17 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 /**
- * Verify the integration between JdbcCacheStore and XADataSource. XADataSource's 
- * connection should be properly enlisted with the ongoing transaction when 
+ * Verify the integration between JdbcCacheStore and XADataSource. XADataSource's
+ * connection should be properly enlisted with the ongoing transaction when
  * Infinispan internally calls its getConnection() method.
- * 
+ * <p/>
  * These tests should be failing until ISPN-604 is resolved.
- * 
+ *
  * @author Martin Gencur
  */
 @RunWith(Arquillian.class)

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpSession;
 /**
  * @author Paul Ferraro
  */
-@WebServlet(urlPatterns = { "/simple" })
+@WebServlet(urlPatterns = {"/simple"})
 public class SimpleServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
     public static final String REQUEST_DURATION_PARAM = "requestduration";

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -51,12 +52,14 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class SimpleWebTestCase {
 
+    private static final Logger log = Logger.getLogger(SimpleWebTestCase.class);
+
     @Deployment(name = "deployment-single")
     public static Archive<?> deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(SimpleWebTestCase.class.getPackage(), "web.xml");
-        System.out.println(war.toString(true));
+        log.info(war.toString(true));
         return war;
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Validate the <distributable/> works for single node.
- * 
+ *
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/web.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/web.xml
@@ -1,4 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"

--- a/testsuite/integration/clust/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/integration/clust/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.jboss.as.test.clustering.arquillian.StopCustomContainersOnAfterSuiteExtension

--- a/testsuite/integration/clust/src/test/resources/logging.properties
+++ b/testsuite/integration/clust/src/test/resources/logging.properties
@@ -21,7 +21,8 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.ejb.client
+loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.ejb.client,org.jboss.arquillian
+logger.org.jboss.arquillian.level=INFO
 logger.org.jboss.shrinkwrap.level=INFO
 logger.org.jboss.ejb.client.level=DEBUG
 logger.sun.rmi.level=WARNING


### PR DESCRIPTION
Features
- 2x speed up -> clustering ts now runs in ~8 minutes
- introduced abstract cluster test significantly reducing repetitive code
- leveraging ARQ custom container mode
- no more starting and stopping on every test
- replaced system outs with logger
- less intermittent issues
- reenabled most tests
- disabled consistently failing tests
