### PR TITLE
[AS7-5850] AS7 resources for HornetQ API-create core queues

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -629,6 +629,7 @@ public interface CommonAttributes {
     String RESOURCE_ADAPTER = "resource-adapter";
     String ROLE = "role";
     String ROLES_ATTR_NAME = "roles";
+    String RUNTIME_QUEUE = "runtime-queue";
     String SECURITY_ROLE = "security-role";
     String SECURITY_SETTING = "security-setting";
     String SECURITY_SETTINGS = "security-settings";

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerResource.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerResource.java
@@ -22,18 +22,23 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.messaging.CommonAttributes.CORE_ADDRESS;
+import static org.jboss.as.messaging.CommonAttributes.RUNTIME_QUEUE;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.jboss.as.messaging.CommonAttributes.CORE_ADDRESS;
-
 import org.hornetq.api.core.management.AddressControl;
+import org.hornetq.api.core.management.QueueControl;
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.management.ManagementService;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.PlaceholderResource;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
@@ -83,6 +88,8 @@ public class HornetQServerResource implements Resource {
     public boolean hasChild(PathElement element) {
         if (CORE_ADDRESS.equals(element.getKey())) {
             return hasAddressControl(element);
+        } else if (RUNTIME_QUEUE.equals(element.getKey())) {
+            return hasQueueControl(element.getValue());
         } else {
             return delegate.hasChild(element);
         }
@@ -92,6 +99,8 @@ public class HornetQServerResource implements Resource {
     public Resource getChild(PathElement element) {
         if (CORE_ADDRESS.equals(element.getKey())) {
             return hasAddressControl(element) ? new CoreAddressResource(element.getValue(), getManagementService()) : null;
+        } else if (RUNTIME_QUEUE.equals(element.getKey())) {
+            return hasQueueControl(element.getValue()) ? PlaceholderResource.INSTANCE : null;
         } else {
             return delegate.getChild(element);
         }
@@ -104,6 +113,11 @@ public class HornetQServerResource implements Resource {
                 return new CoreAddressResource(element.getValue(), getManagementService());
             }
             throw new NoSuchResourceException(element);
+        } else if (RUNTIME_QUEUE.equals(element.getKey())) {
+            if (hasQueueControl(element.getValue())) {
+                return PlaceholderResource.INSTANCE;
+            }
+            throw new NoSuchResourceException(element);
         } else {
             return delegate.requireChild(element);
         }
@@ -113,6 +127,8 @@ public class HornetQServerResource implements Resource {
     public boolean hasChildren(String childType) {
         if (CORE_ADDRESS.equals(childType)) {
             return getChildrenNames(CORE_ADDRESS).size() > 0;
+        } else if (RUNTIME_QUEUE.equals(childType)) {
+            return getChildrenNames(RUNTIME_QUEUE).size() > 0;
         } else {
             return delegate.hasChildren(childType);
         }
@@ -125,6 +141,11 @@ public class HornetQServerResource implements Resource {
                 throw new NoSuchResourceException(address.getElement(1));
             }
             return new CoreAddressResource(address.getElement(0).getValue(), getManagementService());
+        } else if (address.size() > 0 && RUNTIME_QUEUE.equals(address.getElement(0).getKey())) {
+            if (address.size() > 1) {
+                throw new NoSuchResourceException(address.getElement(1));
+            }
+            return PlaceholderResource.INSTANCE;
         } else {
             return delegate.navigate(address);
         }
@@ -134,6 +155,7 @@ public class HornetQServerResource implements Resource {
     public Set<String> getChildTypes() {
         Set<String> result = new HashSet<String>(delegate.getChildTypes());
         result.add(CORE_ADDRESS);
+        result.add(RUNTIME_QUEUE);
         return result;
     }
 
@@ -141,6 +163,8 @@ public class HornetQServerResource implements Resource {
     public Set<String> getChildrenNames(String childType) {
         if (CORE_ADDRESS.equals(childType)) {
             return getCoreAddressNames();
+        } else if (RUNTIME_QUEUE.equals(childType)) {
+            return getCoreQueueNames();
         } else {
             return delegate.getChildrenNames(childType);
         }
@@ -154,6 +178,12 @@ public class HornetQServerResource implements Resource {
                 result.add(new CoreAddressResource.CoreAddressResourceEntry(name, getManagementService()));
             }
             return result;
+        } else if (RUNTIME_QUEUE.equals(childType)) {
+            Set<ResourceEntry> result = new LinkedHashSet<ResourceEntry>();
+            for (String name : getCoreQueueNames()) {
+                result.add(new PlaceholderResource.PlaceholderResourceEntry(RUNTIME_QUEUE, name));
+            }
+            return result;
         } else {
             return delegate.getChildren(childType);
         }
@@ -161,8 +191,10 @@ public class HornetQServerResource implements Resource {
 
     @Override
     public void registerChild(PathElement address, Resource resource) {
-        if (CORE_ADDRESS.equals(address.getKey())) {
-            throw new UnsupportedOperationException(String.format("Resources of type %s cannot be registered", CORE_ADDRESS));
+        String type = address.getKey();
+        if (CORE_ADDRESS.equals(type) ||
+                RUNTIME_QUEUE.equals(type)) {
+            throw MESSAGES.canNotRegisterResourceOfType(type);
         } else {
             delegate.registerChild(address, resource);
         }
@@ -170,8 +202,10 @@ public class HornetQServerResource implements Resource {
 
     @Override
     public Resource removeChild(PathElement address) {
-        if (CORE_ADDRESS.equals(address.getKey())) {
-            throw new UnsupportedOperationException(String.format("Resources of type %s cannot be removed", CORE_ADDRESS));
+        String type = address.getKey();
+        if (CORE_ADDRESS.equals(type) ||
+                RUNTIME_QUEUE.equals(type)) {
+            throw MESSAGES.canNotRemoveResourceOfType(type);
         } else {
             return delegate.removeChild(address);
         }
@@ -179,12 +213,12 @@ public class HornetQServerResource implements Resource {
 
     @Override
     public boolean isRuntime() {
-        return false;
+        return delegate.isRuntime();
     }
 
     @Override
     public boolean isProxy() {
-        return false;
+        return delegate.isProxy();
     }
 
     @Override
@@ -199,6 +233,11 @@ public class HornetQServerResource implements Resource {
         return managementService == null ? false : managementService.getResource(ResourceNames.CORE_ADDRESS + element.getValue()) != null;
     }
 
+    private boolean hasQueueControl(String name) {
+        final ManagementService managementService = getManagementService();
+        return managementService == null ? false : managementService.getResource(ResourceNames.CORE_QUEUE + name) != null;
+    }
+
     private Set<String> getCoreAddressNames() {
         final ManagementService managementService = getManagementService();
         if (managementService == null) {
@@ -208,6 +247,20 @@ public class HornetQServerResource implements Resource {
             for (Object obj : managementService.getResources(AddressControl.class)) {
                 AddressControl ac = AddressControl.class.cast(obj);
                 result.add(ac.getAddress());
+            }
+            return result;
+        }
+    }
+
+    private Set<String> getCoreQueueNames() {
+        final ManagementService managementService = getManagementService();
+        if (managementService == null) {
+            return Collections.emptySet();
+        } else {
+            Set<String> result = new HashSet<String>();
+            for (Object obj : managementService.getResources(QueueControl.class)) {
+                QueueControl qc = QueueControl.class.cast(obj);
+                result.add(qc.getName());
             }
             return result;
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -178,8 +178,11 @@ public class MessagingExtension implements Extension {
         serverRegistration.registerSubModel(new DivertDefinition(registerRuntimeOnly));
 
         // Core queues
-        serverRegistration.registerSubModel(new QueueDefinition(registerRuntimeOnly));
+        serverRegistration.registerSubModel(QueueDefinition.newQueueDefinition(registerRuntimeOnly));
         // getExpiryAddress, setExpiryAddress, getDeadLetterAddress, setDeadLetterAddress  -- no -- just toggle the 'queue-address', make this a mutable attr of address-setting
+
+        // Runtime core queues
+        serverRegistration.registerSubModel(QueueDefinition.newRuntimeQueueDefinition(registerRuntimeOnly));
 
         // Acceptors
         serverRegistration.registerSubModel(GenericTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -23,7 +23,6 @@
 package org.jboss.as.messaging;
 
 import java.util.Collection;
-import java.util.List;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -508,4 +507,19 @@ public interface MessagingMessages {
     @Message(id = 11673, value = "The clustered attribute is deprecated. To create a clustered HornetQ server, define at least one cluster-connection")
     UnsupportedOperationException canNotWriteClusteredAttribute();
 
+    /**
+     * Create an failure description message indicating that the resource of given type can not be registered.
+     *
+     * @return an {@link UnsupportedOperationException} for the error.
+     */
+    @Message(id = 11674, value = "Resources of type %s cannot be registered")
+    UnsupportedOperationException canNotRegisterResourceOfType(String childType);
+
+    /**
+     * Create an failure description message indicating that the resource of given type can not be removed.
+     *
+     * @return an {@link UnsupportedOperationException} for the error.
+     */
+    @Message(id = 11675, value = "Resources of type %s cannot be removed")
+    UnsupportedOperationException canNotRemoveResourceOfType(String childType);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
@@ -47,15 +47,22 @@ public class MessagingServices {
        // We are a handler for requests related to a jms-topic resource. Those reside on level below the hornetq-server
         // resources in the resource tree. So we could look for the hornetq-server in the 2nd to last element
         // in the PathAddress. But to be more generic and future-proof, we'll walk the tree looking
-        String hornetQServerName = null;
-        for (int i = pathAddress.size() - 1; i >=0; i--) {
-            PathElement pe = pathAddress.getElement(i);
-            if (CommonAttributes.HORNETQ_SERVER.equals(pe.getKey())) {
-                hornetQServerName = pe.getValue();
-                break;
-            }
-        }
-      return JBOSS_MESSAGING.append(hornetQServerName);
+       String hornetQServerName = null;
+       PathAddress hornetQServerPathAddress = getHornetQServerPathAddress(pathAddress);
+       if (hornetQServerPathAddress != null) {
+           hornetQServerName = hornetQServerPathAddress.getLastElement().getValue();
+       }
+       return JBOSS_MESSAGING.append(hornetQServerName);
+   }
+
+   public static PathAddress getHornetQServerPathAddress(PathAddress pathAddress) {
+       for (int i = pathAddress.size() - 1; i >=0; i--) {
+           PathElement pe = pathAddress.getElement(i);
+           if (CommonAttributes.HORNETQ_SERVER.equals(pe.getKey())) {
+               return pathAddress.subAddress(0, i + 1);
+           }
+       }
+       return PathAddress.EMPTY_ADDRESS;
    }
 
    public static ServiceName getHornetQServiceName(String serverName) {

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueControlHandler.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.messaging;
 
+
+import static org.jboss.as.messaging.QueueDefinition.forwardToRuntimeQueue;
+
 import java.util.EnumSet;
 import java.util.Locale;
 
@@ -72,6 +75,15 @@ public class QueueControlHandler extends AbstractQueueControlHandler<QueueContro
                 return MessagingDescriptions.getNoArgSimpleReplyOperation(locale, LIST_SCHEDULED_MESSAGES_AS_JSON, "queue", ModelType.STRING, true);
             }
         }, flags);
+    }
+
+    @Override
+    protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if (forwardToRuntimeQueue(context, operation, INSTANCE)) {
+            context.stepCompleted();
+        } else {
+            super.executeRuntimeStep(context, operation);
+        }
     }
 
     @Override

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -219,6 +219,7 @@ core-address.binding-names=The names of all bindings (both queues and diverts) b
 core-address.get-roles-as-json=Returns the roles (name and permissions) associated to this address using JSON serialization.
 core-address.get-roles-as-json.reply=A string JSON format.
 
+runtime-queue=A runtime queue.
 queue=A Queue.
 queue.add=Operation adding a core queue.
 queue.remove=Operation removing an existing queue.


### PR DESCRIPTION
- add runtime-queue resource to be able to manage _any_
  core queues created by HornetQ (not only those in AS7 configuration,
  but also ones underneath JMS resources and ones created with HornetQ
  API)
- provides QueueDefinition with an equivalent runtime read-only
  definition used by the runtime-queue resouce
- for backwards compatibility, when reading attribute or invoking
  queue-specific operations on a queue resource that does not exist (ie
  not created with AS7 API), forward the operation to the corresponding
  runtime-queue. This is validated by CoreQueueManagementTestCase
