### PR TITLE
AS7-4894 HA Singleton deployer for applications

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ArchiveDeployer.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ArchiveDeployer.java
@@ -43,11 +43,15 @@ public class ArchiveDeployer {
     }
 
     public String deploy(Archive<?> archive) throws DeploymentException {
-        return deployInternal(archive);
+        return this.deploy(archive, null);
+    }
+
+    public String deploy(Archive<?> archive, String policy) throws DeploymentException {
+        return deployInternal(archive, policy);
     }
 
     public String deploy(String name, InputStream input) throws DeploymentException {
-        return deployInternal(name, input);
+        return deployInternal(name, null, input);
     }
 
     public void undeploy(String runtimeName) throws DeploymentException {
@@ -58,10 +62,10 @@ public class ArchiveDeployer {
         }
     }
 
-    private String deployInternal(Archive<?> archive) throws DeploymentException {
+    private String deployInternal(Archive<?> archive, String policy) throws DeploymentException {
         final InputStream input = archive.as(ZipExporter.class).exportAsInputStream();
         try {
-            return deployInternal(archive.getName(), input);
+            return deployInternal(archive.getName(), policy, input);
         } finally {
             if (input != null)
                 try {
@@ -72,9 +76,9 @@ public class ArchiveDeployer {
         }
     }
 
-    private String deployInternal(String name, InputStream input) throws DeploymentException {
+    private String deployInternal(String name, String policy, InputStream input) throws DeploymentException {
         try {
-            return deployer.deploy(name, input);
+            return deployer.deploy(name, policy, input);
         } catch (Exception ex) {
             Throwable rootCause = ex.getCause();
             while (null != rootCause && rootCause.getCause() != null) {

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -139,10 +139,14 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
         return getManagementClient().getControllerClient();
     }
 
+    public ProtocolMetaData deploy(Archive<?> archive, String policy) throws DeploymentException {
+        String runtimeName = archiveDeployer.get().deploy(archive, policy);
+        return getManagementClient().getProtocolMetaData(runtimeName);
+    }
+
     @Override
     public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
-        String runtimeName = archiveDeployer.get().deploy(archive);
-        return getManagementClient().getProtocolMetaData(runtimeName);
+        return this.deploy(archive, null);
     }
 
     @Override

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/DeployManagedDeployment.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/DeployManagedDeployment.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.event.DeploymentEvent;
+import org.jboss.as.arquillian.container.CommonDeployableContainer;
+
+public class DeployManagedDeployment extends DeploymentEvent {
+    private final String policy;
+
+    public DeployManagedDeployment(Container container, Deployment deployment, String policy) {
+        super(container, deployment);
+        this.policy = policy;
+    }
+
+    @Override
+    public CommonDeployableContainer<?> getDeployableContainer() {
+        return (CommonDeployableContainer<?>) super.getDeployableContainer();
+    }
+
+    public String getDeploymentPolicy() {
+        return this.policy;
+    }
+}

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedClientDeployer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedClientDeployer.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.Container.State;
+import org.jboss.arquillian.container.spi.ContainerRegistry;
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentScenario;
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentTargetDescription;
+import org.jboss.arquillian.container.spi.event.DeploymentEvent;
+import org.jboss.arquillian.container.test.impl.client.deployment.ClientDeployer;
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+public class ManagedClientDeployer extends ClientDeployer implements ManagedDeployer {
+    @Inject
+    private Event<DeploymentEvent> event;
+
+    @Inject
+    private Instance<ContainerRegistry> containerRegistry;
+
+    @Inject
+    private Instance<DeploymentScenario> deploymentScenario;
+
+    @Override
+    public void deploy(String name, String policy) {
+        DeploymentScenario scenario = deploymentScenario.get();
+        if (scenario == null) {
+            throw new IllegalArgumentException("No deployment scenario in context");
+        }
+        ContainerRegistry registry = containerRegistry.get();
+        if (registry == null) {
+            throw new IllegalArgumentException("No container registry in context");
+        }
+
+        Deployment deployment = scenario.deployment(new DeploymentTargetDescription(name));
+        if (deployment == null) {
+            throw new IllegalArgumentException("No deployment in context found with name " + name);
+        }
+
+        if (deployment.getDescription().managed()) {
+            throw new IllegalArgumentException("Could not deploy " + name
+                    + " deployment. The deployment is controlled by Arquillian");
+        }
+
+        Container container = registry.getContainer(deployment.getDescription().getTarget());
+
+        if (!container.getState().equals(State.STARTED)) {
+            throw new IllegalArgumentException("Deployment with name " + name + " could not be deployed. Container "
+                    + container.getName() + " must be started first.");
+        }
+
+        event.fire(new DeployManagedDeployment(container, deployment, policy));
+    }
+}

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedClientDeployerCreator.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedClientDeployerCreator.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+
+public class ManagedClientDeployerCreator {
+
+    @Inject @ApplicationScoped
+    private InstanceProducer<ManagedDeployer> deployer;
+
+    @Inject
+    private Instance<Injector> injector;
+
+    public void createClientSideDeployer(@Observes BeforeSuite event) {
+       deployer.set(injector.get().inject(new ManagedClientDeployer()));
+    }
+}

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerDeployController.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerDeployController.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.util.concurrent.Callable;
+
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.client.deployment.DeploymentDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.context.annotation.DeploymentScoped;
+import org.jboss.arquillian.container.spi.event.container.AfterDeploy;
+import org.jboss.arquillian.container.spi.event.container.BeforeDeploy;
+import org.jboss.arquillian.container.spi.event.container.DeployerEvent;
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.as.arquillian.container.CommonDeployableContainer;
+
+public class ManagedContainerDeployController {
+    @Inject
+    private Instance<Injector> injector;
+
+    public void deploy(@Observes final DeployManagedDeployment event) throws Exception {
+        executeOperation(new Callable<Void>() {
+            @Inject
+            private Event<DeployerEvent> deployEvent;
+
+            @Inject
+            @DeploymentScoped
+            private InstanceProducer<DeploymentDescription> deploymentDescriptionProducer;
+
+            @Inject
+            @DeploymentScoped
+            private InstanceProducer<Deployment> deploymentProducer;
+
+            @Inject
+            @DeploymentScoped
+            private InstanceProducer<ProtocolMetaData> protocolMetadata;
+
+            @Override
+            public Void call() throws Exception {
+                CommonDeployableContainer<?> deployableContainer = event.getDeployableContainer();
+                Deployment deployment = event.getDeployment();
+                DeploymentDescription deploymentDescription = deployment.getDescription();
+                String policy = event.getDeploymentPolicy();
+                /*
+                 * TODO: should the DeploymentDescription producer some how be automatically registered ? Or should we just
+                 * 'know' who is the first one to create the context
+                 */
+                deploymentDescriptionProducer.set(deploymentDescription);
+                deploymentProducer.set(deployment);
+
+                deployEvent.fire(new BeforeDeploy(deployableContainer, deploymentDescription));
+
+                try {
+                    if (deploymentDescription.isArchiveDeployment()) {
+                        protocolMetadata
+                                .set(deployableContainer.deploy(deploymentDescription.getTestableArchive() != null ? deploymentDescription
+                                        .getTestableArchive() : deploymentDescription.getArchive(), policy));
+                    } else {
+                        deployableContainer.deploy(deploymentDescription.getDescriptor());
+                    }
+                    deployment.deployed();
+                } catch (Exception e) {
+                    deployment.deployedWithError(e);
+                    throw e;
+                }
+
+                deployEvent.fire(new AfterDeploy(deployableContainer, deploymentDescription));
+                return null;
+            }
+        });
+    }
+
+    private void executeOperation(Callable<Void> operation) throws Exception {
+        injector.get().inject(operation);
+        operation.call();
+    }
+}

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerExtension.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerExtension.java
@@ -17,6 +17,8 @@
 package org.jboss.as.arquillian.container.managed;
 
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.test.impl.enricher.resource.DeployerProvider;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.jboss.as.arquillian.container.CommonContainerExtension;
 
 /**
@@ -32,5 +34,8 @@ public class ManagedContainerExtension extends CommonContainerExtension {
     public void register(ExtensionBuilder builder) {
         super.register(builder);
         builder.service(DeployableContainer.class, ManagedDeployableContainer.class);
+        builder.override(ResourceProvider.class, DeployerProvider.class, ManagedDeployerProvider.class);
+        builder.observer(ManagedClientDeployerCreator.class);
+        builder.observer(ManagedContainerDeployController.class);
     }
 }

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployer.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+
+public interface ManagedDeployer extends Deployer {
+    /**
+     * Deploy the named deployment using the specified policy.<br/>
+     * The operation will block until deploy is complete.
+     * @param name The name of the deployment
+     * @param policy the deployment policy.
+     */
+    void deploy(String name, String policy);
+}

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployerProvider.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployerProvider.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.arquillian.container.managed;
+
+import java.lang.annotation.Annotation;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+public class ManagedDeployerProvider implements ResourceProvider {
+    @Inject
+    private Instance<ManagedDeployer> deployer;
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers)
+    {
+       return deployer.get();
+    }
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return Deployer.class.isAssignableFrom(type);
+    }
+}

--- a/build/build.xml
+++ b/build/build.xml
@@ -809,6 +809,10 @@
             <maven-resource group="org.jboss.as" artifact="jboss-as-clustering-singleton"/>
         </module-def>
 
+        <module-def name="org.jboss.as.clustering.singleton.deployment">
+            <maven-resource group="org.jboss.as" artifact="jboss-as-clustering-singleton-deployment"/>
+        </module-def>
+
         <module-def name="org.jboss.as.clustering.web.infinispan">
             <maven-resource group="org.jboss.as" artifact="jboss-as-clustering-web-infinispan"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -843,6 +843,11 @@
 
                 <dependency>
                     <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-clustering-singleton-deployment</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-clustering-web-infinispan</artifactId>
                 </dependency>
 

--- a/build/src/main/resources/configuration/domain/subsystems.xml
+++ b/build/src/main/resources/configuration/domain/subsystems.xml
@@ -53,6 +53,7 @@
       <subsystem>configuration/subsystems/resource-adapters.xml</subsystem>
       <subsystem>configuration/subsystems/sar.xml</subsystem>
       <subsystem supplement="domain">configuration/subsystems/security.xml</subsystem>
+      <subsystem>configuration/subsystems/singleton-deployment.xml</subsystem>
       <subsystem>configuration/subsystems/threads.xml</subsystem>
       <subsystem>configuration/subsystems/transactions.xml</subsystem>
       <subsystem supplement="ha">configuration/subsystems/web.xml</subsystem>
@@ -121,6 +122,7 @@
       <subsystem>configuration/subsystems/resource-adapters.xml</subsystem>
       <subsystem>configuration/subsystems/sar.xml</subsystem>
       <subsystem supplement="domain">configuration/subsystems/security.xml</subsystem>
+      <subsystem>configuration/subsystems/singleton-deployment.xml</subsystem>
       <subsystem>configuration/subsystems/threads.xml</subsystem>
       <subsystem>configuration/subsystems/transactions.xml</subsystem>
       <subsystem supplement="ha">configuration/subsystems/web.xml</subsystem>

--- a/build/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/build/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -30,6 +30,7 @@
       <subsystem>configuration/subsystems/resource-adapters.xml</subsystem>
       <subsystem>configuration/subsystems/sar.xml</subsystem>
       <subsystem supplement="standalone">configuration/subsystems/security.xml</subsystem>
+      <subsystem>configuration/subsystems/singleton-deployment.xml</subsystem>
       <subsystem>configuration/subsystems/threads.xml</subsystem>
       <subsystem>configuration/subsystems/transactions.xml</subsystem>
       <subsystem supplement="ha">configuration/subsystems/web.xml</subsystem>

--- a/build/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/build/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -25,6 +25,7 @@
       <subsystem>configuration/subsystems/resource-adapters.xml</subsystem>
       <subsystem>configuration/subsystems/sar.xml</subsystem>
       <subsystem supplement="standalone">configuration/subsystems/security.xml</subsystem>
+      <subsystem>configuration/subsystems/singleton-deployment.xml</subsystem>
       <subsystem>configuration/subsystems/threads.xml</subsystem>
       <subsystem>configuration/subsystems/transactions.xml</subsystem>
       <subsystem supplement="ha">configuration/subsystems/web.xml</subsystem>

--- a/build/src/main/resources/configuration/subsystems/infinispan.xml
+++ b/build/src/main/resources/configuration/subsystems/infinispan.xml
@@ -32,7 +32,7 @@
     </supplement>
     <supplement name="ha">
         <replacement placeholder="CACHE-CONTAINERS">
-            <cache-container name="cluster" aliases="ha-partition" default-cache="default">
+            <cache-container name="singleton" aliases="cluster ha-partition" default-cache="default">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="default" mode="SYNC" batching="true">
                     <locking isolation="REPEATABLE_READ"/>

--- a/build/src/main/resources/configuration/subsystems/singleton-deployment.xml
+++ b/build/src/main/resources/configuration/subsystems/singleton-deployment.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <extension-module>org.jboss.as.clustering.singleton.deployment</extension-module>
+    <subsystem xmlns="urn:jboss:domain:singleton-deployment:1.0">
+        <deployment-policy name="singleton" cache-container="singleton"/>
+    </subsystem>
+</config>

--- a/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
@@ -1174,6 +1174,11 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="policy" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Identifies the policy used to deploy this deployment.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -1244,6 +1249,11 @@
                         <xs:element name="fs-exploded" type="fs-explodedType"/>
                     </xs:choice>
                 </xs:sequence>
+                <xs:attribute name="policy" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>Identifies the policy used to deploy this deployment.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/build/src/main/resources/docs/schema/jboss-as-singleton-deployment.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-singleton-deployment.xsd
@@ -1,0 +1,48 @@
+<xs:schema targetNamespace="urn:jboss:domain:singleton-deployment:1.0"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            xmlns:tns="urn:jboss:domain:singleton-deployment:1.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <xs:element name="subsystem" type="tns:subsystem">
+        <xs:annotation>
+            <xs:documentation>Enumerates a set of singleton deployment policies.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="subsystem">
+        <xs:sequence>
+            <xs:element name="deployment-policy" type="tns:deployment-policy" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a singleton deployment policy.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-policy">
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Uniquely identifies this deployment policy.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cache-container" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Identifies the cache-container used to back the singleton deployment policy.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="preferred-nodes" type="tns:preferred-nodes" use="optional">
+            <xs:annotation>
+                <xs:documentation>Identifies a list of preferred node names used when determining which node should act as the singleton master.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="preferred-nodes">
+        <xs:annotation>
+            <xs:documentation>A list of preferred nodes.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+</xs:schema>

--- a/build/src/main/resources/modules/org/jboss/as/clustering/singleton/deployment/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/clustering/singleton/deployment/main/module.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.clustering.singleton.deployment">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.as.clustering.common"/>
+        <module name="org.jboss.as.clustering.singleton"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.staxmapper"/>
+    </dependencies>
+</module>

--- a/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
-	<module name="org.jboss.common-beans" services="export"/>
+        <module name="org.jboss.common-beans" services="export"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.jandex"/>

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -68,6 +68,7 @@ public class Util {
     public static final String DEPLOYMENT = "deployment";
     public static final String DEPLOYMENT_NAME = "deployment-name";
     public static final String DEPLOYMENT_OVERLAY = "deployment-overlay";
+    public static final String DEPLOYMENT_POLICY = "deployment-policy";
     public static final String DESCRIPTION = "description";
     public static final String DOMAIN_FAILURE_DESCRIPTION = "domain-failure-description";
     public static final String DOMAIN_RESULTS = "domain-results";

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -66,6 +66,7 @@ public class DeployHandler extends DeploymentHandler {
     private final ArgumentWithoutValue disabled;
     private final ArgumentWithoutValue unmanaged;
     private final ArgumentWithValue script;
+    private final ArgumentWithValue policy;
 
     public DeployHandler(CommandContext ctx) {
         super(ctx, "deploy", true);
@@ -182,6 +183,9 @@ public class DeployHandler extends DeploymentHandler {
 
         script = new ArgumentWithValue(this, "--script");
         script.addRequiredPreceding(path);
+
+        policy = new ArgumentWithValue(this, "--policy");
+        policy.addRequiredPreceding(path);
     }
 
     @Override
@@ -247,6 +251,7 @@ public class DeployHandler extends DeploymentHandler {
         final boolean disabled = this.disabled.isPresent(args);
         final String serverGroups = this.serverGroups.getValue(args);
         final boolean allServerGroups = this.allServerGroups.isPresent(args);
+        final String policy = this.policy.getValue(args);
 
         if(force) {
             if(f == null) {
@@ -327,7 +332,11 @@ public class DeployHandler extends DeploymentHandler {
                 steps.add(Util.configureDeploymentOperation(Util.ADD, name, serverGroup));
             }
             for (String serverGroup : sgList) {
-                steps.add(Util.configureDeploymentOperation(Util.DEPLOY, name, serverGroup));
+                ModelNode operation = Util.configureDeploymentOperation(Util.DEPLOY, name, serverGroup);
+                if (policy != null) {
+                    operation.get(Util.DEPLOYMENT_POLICY).set(policy);
+                }
+                steps.add(operation);
             }
         } else {
             if(serverGroups != null || allServerGroups) {
@@ -337,6 +346,9 @@ public class DeployHandler extends DeploymentHandler {
             deployRequest = new ModelNode();
             deployRequest.get(Util.OPERATION).set(Util.DEPLOY);
             deployRequest.get(Util.ADDRESS, Util.DEPLOYMENT).set(name);
+            if (policy != null) {
+                deployRequest.get(Util.DEPLOYMENT_POLICY).set(policy);
+            }
         }
 
         if(f != null) {
@@ -408,6 +420,7 @@ public class DeployHandler extends DeploymentHandler {
         final String serverGroups = this.serverGroups.getValue(args);
         final boolean allServerGroups = this.allServerGroups.isPresent(args);
         final boolean archive = isCliArchive(f);
+        final String policy = this.policy.getValue(args);
 
         if(force) {
             if(f == null) {
@@ -554,7 +567,11 @@ public class DeployHandler extends DeploymentHandler {
                 steps.add(Util.configureDeploymentOperation(Util.ADD, name, serverGroup));
             }
             for (String serverGroup : sgList) {
-                steps.add(Util.configureDeploymentOperation(Util.DEPLOY, name, serverGroup));
+                ModelNode operation = Util.configureDeploymentOperation(Util.DEPLOY, name, serverGroup);
+                if (policy != null) {
+                    operation.get(Util.DEPLOYMENT_POLICY).set(policy);
+                }
+                steps.add(operation);
             }
         } else {
             if(serverGroups != null || allServerGroups) {
@@ -564,6 +581,9 @@ public class DeployHandler extends DeploymentHandler {
             deployRequest = new ModelNode();
             deployRequest.get(Util.OPERATION).set(Util.DEPLOY);
             deployRequest.get(Util.ADDRESS, Util.DEPLOYMENT).set(name);
+            if (policy != null) {
+                deployRequest.get(Util.DEPLOYMENT_POLICY).set(policy);
+            }
         }
 
         final ModelNode addRequest;

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -65,5 +65,5 @@ ARGUMENTS
                        The deploy command will execute the script given by the --script argument. 
                        All paths in the scripts are relative to the root directory in the cli archive. 
                        The script is executed as a batch.
-                                 
-               
+
+ --policy            - optional, the policy used to deploy the application.

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/StringListAttributeMarshaller.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/StringListAttributeMarshaller.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Paul Ferraro
+ */
+public class StringListAttributeMarshaller extends AttributeMarshaller {
+
+    @Override
+    public void marshallAsElement(AttributeDefinition attribute, ModelNode model, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+        boolean exists = model.hasDefined(attribute.getName());
+        if (exists || marshallDefault) {
+            StringBuilder builder = new StringBuilder();
+            ModelNode value = exists ? model.get(attribute.getName()) : attribute.getDefaultValue();
+            for (ModelNode item: value.asList()) {
+                if (builder.length() > 0) {
+                    builder.append(' ');
+                }
+                builder.append(item.asString());
+            }
+            writer.writeAttribute(attribute.getXmlName(), builder.toString());
+        }
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/BatchServiceTargetFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/BatchServiceTargetFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import org.jboss.msc.service.BatchServiceTarget;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface BatchServiceTargetFactory {
+    BatchServiceTargetFactory SIMPLE = new BatchServiceTargetFactory() {
+        @Override
+        public BatchServiceTarget createBatchServiceTarget(BatchServiceTarget target) {
+            return target;
+        }
+    };
+
+    BatchServiceTarget createBatchServiceTarget(BatchServiceTarget target);
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingBatchServiceTarget.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingBatchServiceTarget.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import java.util.Collection;
+
+import org.jboss.msc.service.BatchServiceTarget;
+import org.jboss.msc.service.ServiceListener;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DelegatingBatchServiceTarget extends DelegatingServiceTarget implements BatchServiceTarget {
+    private final BatchServiceTarget target;
+
+    public DelegatingBatchServiceTarget(BatchServiceTarget target, ServiceTargetFactory factory, BatchServiceTargetFactory batchFactory, ServiceBuilderFactory builderFactory) {
+        super(target, factory, batchFactory, builderFactory);
+        this.target = target;
+    }
+
+    @Override
+    public BatchServiceTarget addListener(ServiceListener<Object> listener) {
+        this.target.addListener(listener);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget addListener(ServiceListener<Object>... listeners) {
+        this.target.addListener(listeners);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget addListener(Collection<ServiceListener<Object>> listeners) {
+        this.target.addListener(listeners);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget removeListener(ServiceListener<Object> listener) {
+        this.target.removeListener(listener);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget addDependency(ServiceName dependency) {
+        this.target.addDependency(dependency);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget addDependency(ServiceName... dependencies) {
+        this.target.addDependency(dependencies);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget addDependency(Collection<ServiceName> dependencies) {
+        this.target.addDependency(dependencies);
+        return this;
+    }
+
+    @Override
+    public BatchServiceTarget removeDependency(ServiceName dependency) {
+        this.target.removeDependency(dependency);
+        return this;
+    }
+
+    @Override
+    public void removeServices() {
+        this.target.removeServices();
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceBuilder.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceBuilder.java
@@ -1,0 +1,178 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import java.util.Collection;
+
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceListener;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceListener.Inheritance;
+import org.jboss.msc.value.Value;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DelegatingServiceBuilder<T> implements ServiceBuilder<T> {
+    private final ServiceBuilder<T> builder;
+    private final ServiceControllerFactory factory;
+
+    public DelegatingServiceBuilder(ServiceBuilder<T> builder, ServiceControllerFactory factory) {
+        this.builder = builder;
+        this.factory = factory;
+    }
+
+    @Override
+    public ServiceBuilder<T> addAliases(ServiceName... aliases) {
+        this.builder.addAliases(aliases);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> setInitialMode(Mode mode) {
+        this.builder.setInitialMode(mode);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependencies(ServiceName... dependencies) {
+        this.builder.addDependencies(dependencies);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependencies(ServiceBuilder.DependencyType dependencyType, ServiceName... dependencies) {
+        this.builder.addDependencies(dependencyType, dependencies);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependencies(Iterable<ServiceName> dependencies) {
+        this.builder.addDependencies(dependencies);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependencies(ServiceBuilder.DependencyType dependencyType, Iterable<ServiceName> dependencies) {
+        this.builder.addDependencies(dependencyType, dependencies);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependency(ServiceName dependency) {
+        this.builder.addDependency(dependency);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependency(ServiceBuilder.DependencyType dependencyType, ServiceName dependency) {
+        this.builder.addDependency(dependencyType, dependency);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependency(ServiceName dependency, Injector<Object> target) {
+        this.builder.addDependency(dependency, target);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addDependency(ServiceBuilder.DependencyType dependencyType, ServiceName dependency, Injector<Object> target) {
+        this.builder.addDependency(dependencyType, dependency, target);
+        return this;
+    }
+
+    @Override
+    public <I> ServiceBuilder<T> addDependency(ServiceName dependency, Class<I> type, Injector<I> target) {
+        this.builder.addDependency(dependency, type, target);
+        return this;
+    }
+
+    @Override
+    public <I> ServiceBuilder<T> addDependency(org.jboss.msc.service.ServiceBuilder.DependencyType dependencyType, ServiceName dependency, Class<I> type, Injector<I> target) {
+        this.builder.addDependency(dependencyType, dependency, type, target);
+        return this;
+    }
+
+    @Override
+    public <I> ServiceBuilder<T> addInjection(Injector<? super I> target, I value) {
+        this.builder.addInjection(target, value);
+        return this;
+    }
+
+    @Override
+    public <I> ServiceBuilder<T> addInjectionValue(Injector<? super I> target, Value<I> value) {
+        this.builder.addInjectionValue(target, value);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addInjection(Injector<? super T> target) {
+        this.builder.addInjection(target);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addListener(ServiceListener<? super T> listener) {
+        this.builder.addListener(listener);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addListener(ServiceListener<? super T>... listeners) {
+        this.builder.addListener(listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addListener(Collection<? extends ServiceListener<? super T>> listeners) {
+        this.builder.addListener(listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addListener(Inheritance inheritance, ServiceListener<? super T> listener) {
+        this.builder.addListener(inheritance, listener);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addListener(Inheritance inheritance, ServiceListener<? super T>... listeners) {
+        this.builder.addListener(inheritance, listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> addListener(Inheritance inheritance, Collection<? extends ServiceListener<? super T>> listeners) {
+        this.builder.addListener(inheritance, listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceController<T> install() {
+        return this.factory.createServiceController(this.builder.install());
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceContainer.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceContainer.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import java.io.PrintStream;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DelegatingServiceContainer extends DelegatingServiceTarget implements ServiceContainer {
+    private final ServiceContainer container;
+    private final ServiceControllerFactory controllerFactory;
+
+    public DelegatingServiceContainer(ServiceContainer container, ServiceTargetFactory factory, BatchServiceTargetFactory batchFactory, ServiceBuilderFactory builderFactory, ServiceControllerFactory controllerFactory) {
+        super(container, factory, batchFactory, builderFactory);
+        this.container = container;
+        this.controllerFactory = controllerFactory;
+    }
+
+    @Override
+    public ServiceController<?> getRequiredService(ServiceName serviceName) {
+        return this.controllerFactory.createServiceController(this.container.getRequiredService(serviceName));
+    }
+
+    @Override
+    public ServiceController<?> getService(ServiceName serviceName) {
+        return this.controllerFactory.createServiceController(this.container.getService(serviceName));
+    }
+
+    @Override
+    public List<ServiceName> getServiceNames() {
+        return this.container.getServiceNames();
+    }
+
+    @Override
+    public void shutdown() {
+        this.container.shutdown();
+    }
+
+    @Override
+    public boolean isShutdownComplete() {
+        return this.container.isShutdownComplete();
+    }
+
+    @Override
+    public void addTerminateListener(TerminateListener listener) {
+        this.container.addTerminateListener(listener);
+    }
+
+    @Override
+    public void awaitTermination() throws InterruptedException {
+        this.container.awaitTermination();
+    }
+
+    @Override
+    public void awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        this.container.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public void dumpServices() {
+        this.container.dumpServices();
+    }
+
+    @Override
+    public void dumpServices(PrintStream stream) {
+        this.container.dumpServices(stream);
+    }
+
+    @Override
+    public String getName() {
+        return this.container.getName();
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceController.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceController.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import java.util.Set;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceListener;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.ServiceListener.Inheritance;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DelegatingServiceController<T> implements ServiceController<T> {
+    private final ServiceController<T> controller;
+    private final ServiceControllerFactory factory;
+    private final ServiceContainerFactory containerFactory;
+
+    public DelegatingServiceController(ServiceController<T> controller, ServiceControllerFactory factory, ServiceContainerFactory containerFactory) {
+        this.controller = controller;
+        this.factory = factory;
+        this.containerFactory = containerFactory;
+    }
+
+    @Override
+    public ServiceController<?> getParent() {
+        return this.factory.createServiceController(this.controller.getParent());
+    }
+
+    @Override
+    public ServiceContainer getServiceContainer() {
+        return this.containerFactory.createServiceContainer(this.controller.getServiceContainer());
+    }
+
+    @Override
+    public ServiceController.Mode getMode() {
+        return this.controller.getMode();
+    }
+
+    @Override
+    public boolean compareAndSetMode(ServiceController.Mode expected, ServiceController.Mode newMode) {
+        return this.controller.compareAndSetMode(expected, newMode);
+    }
+
+    @Override
+    public void setMode(ServiceController.Mode mode) {
+        this.controller.setMode(mode);
+    }
+
+    @Override
+    public ServiceController.State getState() {
+        return this.controller.getState();
+    }
+
+    @Override
+    public ServiceController.Substate getSubstate() {
+        return this.controller.getSubstate();
+    }
+
+    @Override
+    public T getValue() {
+        return this.controller.getValue();
+    }
+
+    @Override
+    public Service<T> getService() {
+        return this.controller.getService();
+    }
+
+    @Override
+    public ServiceName getName() {
+        return this.controller.getName();
+    }
+
+    @Override
+    public ServiceName[] getAliases() {
+        return this.controller.getAliases();
+    }
+
+    @Override
+    public void addListener(ServiceListener<? super T> serviceListener) {
+        this.controller.addListener(serviceListener);
+    }
+
+    @Override
+    public void addListener(Inheritance inheritance, ServiceListener<Object> serviceListener) {
+        this.controller.addListener(inheritance, serviceListener);
+    }
+
+    @Override
+    public void removeListener(ServiceListener<? super T> serviceListener) {
+        this.controller.removeListener(serviceListener);
+    }
+
+    @Override
+    public StartException getStartException() {
+        return this.controller.getStartException();
+    }
+
+    @Override
+    public void retry() {
+        this.controller.retry();
+    }
+
+    @Override
+    public Set<ServiceName> getImmediateUnavailableDependencies() {
+        return this.controller.getImmediateUnavailableDependencies();
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceTarget.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/DelegatingServiceTarget.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.jboss.msc.service.BatchServiceTarget;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceListener;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.ServiceListener.Inheritance;
+import org.jboss.msc.value.Value;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DelegatingServiceTarget implements ServiceTarget {
+    private final ServiceTarget target;
+    private final ServiceTargetFactory factory;
+    private final BatchServiceTargetFactory batchFactory;
+    private final ServiceBuilderFactory builderFactory;
+
+    public DelegatingServiceTarget(ServiceTarget target, ServiceTargetFactory factory, BatchServiceTargetFactory batchFactory, ServiceBuilderFactory builderFactory) {
+        this.target = target;
+        this.builderFactory = builderFactory;
+        this.batchFactory = batchFactory;
+        this.factory = factory;
+    }
+
+    @Override
+    public <T> ServiceBuilder<T> addServiceValue(ServiceName name, Value<? extends Service<T>> value) {
+        return this.builderFactory.createServiceBuilder(this.target.addServiceValue(name, value));
+    }
+
+    @Override
+    public <T> ServiceBuilder<T> addService(ServiceName name, Service<T> service) {
+        return this.builderFactory.createServiceBuilder(this.target.addService(name, service));
+    }
+
+    @Override
+    public ServiceTarget addListener(ServiceListener<Object> listener) {
+        this.target.addListener(listener);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addListener(ServiceListener<Object>... listeners) {
+        this.target.addListener(listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addListener(Collection<ServiceListener<Object>> listeners) {
+        this.target.addListener(listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addListener(Inheritance inheritance, ServiceListener<Object> listener) {
+        this.target.addListener(inheritance, listener);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addListener(Inheritance inheritance, ServiceListener<Object>... listeners) {
+        this.target.addListener(inheritance, listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addListener(Inheritance inheritance, Collection<ServiceListener<Object>> listeners) {
+        this.target.addListener(inheritance, listeners);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget removeListener(ServiceListener<Object> listener) {
+        this.target.removeListener(listener);
+        return this;
+    }
+
+    @Override
+    public Set<ServiceListener<Object>> getListeners() {
+        return this.getListeners();
+    }
+
+    @Override
+    public ServiceTarget addDependency(ServiceName dependency) {
+        this.target.addDependency(dependency);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addDependency(ServiceName... dependencies) {
+        this.target.addDependency(dependencies);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget addDependency(Collection<ServiceName> dependencies) {
+        this.target.addDependency(dependencies);
+        return this;
+    }
+
+    @Override
+    public ServiceTarget removeDependency(ServiceName dependency) {
+        this.target.removeDependency(dependency);
+        return this;
+    }
+
+    @Override
+    public Set<ServiceName> getDependencies() {
+        return this.target.getDependencies();
+    }
+
+    @Override
+    public ServiceTarget subTarget() {
+        return this.factory.createServiceTarget(this.target.subTarget());
+    }
+
+    @Override
+    public BatchServiceTarget batchTarget() {
+        return this.batchFactory.createBatchServiceTarget(this.target.batchTarget());
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceBuilderFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceBuilderFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import org.jboss.msc.service.ServiceBuilder;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface ServiceBuilderFactory {
+    ServiceBuilderFactory SIMPLE = new ServiceBuilderFactory() {
+        @Override
+        public <T> ServiceBuilder<T> createServiceBuilder(ServiceBuilder<T> builder) {
+            return builder;
+        }
+    };
+
+    <T> ServiceBuilder<T> createServiceBuilder(ServiceBuilder<T> builder);
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceContainerFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceContainerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import org.jboss.msc.service.ServiceContainer;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface ServiceContainerFactory {
+    ServiceContainerFactory SIMPLE = new ServiceContainerFactory() {
+        @Override
+        public ServiceContainer createServiceContainer(ServiceContainer container) {
+            return container;
+        }
+    };
+
+    ServiceContainer createServiceContainer(ServiceContainer container);
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceControllerFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceControllerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import org.jboss.msc.service.ServiceController;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface ServiceControllerFactory {
+    ServiceControllerFactory SIMPLE = new ServiceControllerFactory() {
+        @Override
+        public <T> ServiceController<T> createServiceController(ServiceController<T> controller) {
+            return controller;
+        }
+    };
+
+    <T> ServiceController<T> createServiceController(ServiceController<T> controller);
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceTargetFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceTargetFactory.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.msc;
+
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface ServiceTargetFactory {
+    ServiceTargetFactory SIMPLE = new ServiceTargetFactory() {
+        @Override
+        public ServiceTarget createServiceTarget(ServiceTarget target) {
+            return target;
+        }
+    };
+
+    ServiceTarget createServiceTarget(ServiceTarget target);
+}

--- a/clustering/impl/src/main/java/org/jboss/as/clustering/impl/ClusterNodeImpl.java
+++ b/clustering/impl/src/main/java/org/jboss/as/clustering/impl/ClusterNodeImpl.java
@@ -108,14 +108,7 @@ public class ClusterNodeImpl implements ClusterNode {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-
-        if (!(obj instanceof ClusterNodeImpl))
-            return false;
-
-        ClusterNodeImpl other = (ClusterNodeImpl) obj;
-        return this.id.equals(other.id);
+        return (obj != null) && (obj instanceof ClusterNode) ? this.id.equals(((ClusterNode) obj).getName()) : false;
     }
 
     @Override

--- a/clustering/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/src/main/resources/jgroups-defaults.xml
@@ -28,7 +28,6 @@
         ucast_send_buf_size="640000"
         mcast_recv_buf_size="25000000"
         mcast_send_buf_size="640000"
-        discard_incompatible_packets="true"
         enable_bundling="false"
         max_bundle_size="64000"
         max_bundle_timeout="30"
@@ -51,7 +50,6 @@
     <TCP
         recv_buf_size="20000000"
         send_buf_size="640000"
-        discard_incompatible_packets="true"
         max_bundle_size="64000"
         max_bundle_timeout="30"
         enable_bundling="false"

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -46,6 +46,7 @@
         <module>registry</module>
         <module>service</module>
         <module>singleton</module>
+        <module>singleton-deployment</module>
         <module>web-spi</module>
         <module>web-infinispan</module>
         <module>ejb3-infinispan</module>

--- a/clustering/singleton-deployment/pom.xml
+++ b/clustering/singleton-deployment/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-clustering</artifactId>
+        <version>7.2.0.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jboss-as-clustering-singleton-deployment</artifactId>
+    <packaging>jar</packaging>
+
+    <name>JBoss Application Server: Clustered singleton deployments</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-clustering-singleton</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-clustering-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-subsystem-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <useManifestOnlyJar>false</useManifestOnlyJar>
+                    <parallel>false</parallel>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>
+                        -AgeneratedTranslationFilesPath=${project.basedir}/target/generated-translation-files
+                    </compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/SingletonDeploymentUnitPhaseServiceBuilder.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/SingletonDeploymentUnitPhaseServiceBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment;
+
+import org.jboss.as.clustering.singleton.SingletonElectionPolicy;
+import org.jboss.as.clustering.singleton.SingletonService;
+import org.jboss.as.server.deployment.DeploymentUnitPhaseServiceBuilder;
+import org.jboss.as.server.deployment.Phase;
+import org.jboss.as.server.deployment.Services;
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * @author paul
+ *
+ */
+public class SingletonDeploymentUnitPhaseServiceBuilder extends AbstractService<DeploymentUnitPhaseServiceBuilder> implements DeploymentUnitPhaseServiceBuilder {
+
+    private final String name;
+    private final String cluster;
+    private final SingletonElectionPolicy electionPolicy;
+
+    public ServiceBuilder<DeploymentUnitPhaseServiceBuilder> build(ServiceTarget target) {
+        return target.addService(Services.deploymentPolicyName(this.name), this);
+    }
+
+    public SingletonDeploymentUnitPhaseServiceBuilder(String name, String cluster, SingletonElectionPolicy electionPolicy) {
+        this.name = name;
+        this.cluster = cluster;
+        this.electionPolicy = electionPolicy;
+    }
+
+    @Override
+    public String getDeploymentPolicy() {
+        return this.name;
+    }
+
+    @Override
+    public DeploymentUnitPhaseServiceBuilder getValue() throws IllegalStateException {
+        return this;
+    }
+
+    @Override
+    public <T> ServiceBuilder<T> build(ServiceTarget target, ServiceName name, Service<T> service, Phase phase) {
+        return (phase == Phase.FIRST_MODULE_USE) ? this.createSingletonService(name, service).build(target, this.cluster) : target.addService(name, service);
+    }
+
+    private <T> SingletonService<T> createSingletonService(ServiceName name, Service<T> service) {
+        SingletonService<T> singleton = new SingletonService<T>(service, name);
+        singleton.setElectionPolicy(this.electionPolicy);
+        return singleton;
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/Attribute.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/Attribute.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Paul Ferraro
+ */
+enum Attribute {
+    UNKNOWN(null),
+
+    CACHE_CONTAINER(ModelKeys.CACHE_CONTAINER),
+    NAME(ModelKeys.NAME),
+    PREFERRED_NODES(ModelKeys.PREFERRED_NODES),
+    ;
+
+    private final String localName;
+
+    private Attribute(String localName) {
+        this.localName = localName;
+    }
+
+    public String getLocalName() {
+        return this.localName;
+    }
+
+    private static final Map<String, Attribute> attributes = new HashMap<String, Attribute>();
+
+    static {
+        for (Attribute attribute: values()) {
+            String localName = attribute.getLocalName();
+            if (localName != null) {
+                attributes.put(localName, attribute);
+            }
+        }
+    }
+
+    public static Attribute forName(String localName) {
+        Attribute attribute = attributes.get(localName);
+        return (attribute != null) ? attribute : Attribute.UNKNOWN;
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/DeploymentPolicyAddHandler.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/DeploymentPolicyAddHandler.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.clustering.singleton.SingletonElectionPolicy;
+import org.jboss.as.clustering.singleton.deployment.SingletonDeploymentUnitPhaseServiceBuilder;
+import org.jboss.as.clustering.singleton.election.NamePreference;
+import org.jboss.as.clustering.singleton.election.Preference;
+import org.jboss.as.clustering.singleton.election.PreferredSingletonElectionPolicy;
+import org.jboss.as.clustering.singleton.election.SimpleSingletonElectionPolicy;
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DeploymentPolicyAddHandler extends AbstractAddStepHandler {
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        for (AttributeDefinition attribute: DeploymentPolicyResourceDefinition.ATTRIBUTES) {
+            attribute.validateAndSet(operation, model);
+        }
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        newControllers.addAll(installRuntimeServices(context, operation, model, verificationHandler));
+    }
+
+    static Collection<ServiceController<?>> installRuntimeServices(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
+        String name = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+        final ServiceTarget target = context.getServiceTarget();
+
+        final String container = DeploymentPolicyResourceDefinition.CACHE_CONTAINER.resolveModelAttribute(context, model).asString();
+
+        SingletonElectionPolicy electionPolicy = new SimpleSingletonElectionPolicy();
+        ModelNode preferredNodes = DeploymentPolicyResourceDefinition.PREFERRED_NODES.resolveModelAttribute(context, model);
+        if (preferredNodes.isDefined()) {
+            final List<ModelNode> nodes = preferredNodes.asList();
+            final List<Preference> preferences = new ArrayList<Preference>(nodes.size());
+            for (ModelNode node: nodes) {
+                preferences.add(new NamePreference(node.asString()));
+            }
+            electionPolicy = new PreferredSingletonElectionPolicy(electionPolicy, preferences.toArray(new Preference[preferences.size()]));
+        }
+
+        final ServiceBuilder<?> builder = new SingletonDeploymentUnitPhaseServiceBuilder(name, container, electionPolicy).build(target);
+        if (verificationHandler != null) {
+            builder.addListener(verificationHandler);
+        }
+        return Collections.<ServiceController<?>>singleton(builder.install());
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/DeploymentPolicyRemoveHandler.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/DeploymentPolicyRemoveHandler.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.server.deployment.Services;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DeploymentPolicyRemoveHandler extends AbstractRemoveStepHandler {
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        if (context.isResourceServiceRestartAllowed()) {
+            final String name = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement().getValue();
+            final ServiceName serviceName = Services.deploymentPolicyName(name);
+            context.removeService(serviceName);
+        } else {
+            context.reloadRequired();
+        }
+    }
+
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        if (context.isResourceServiceRestartAllowed()) {
+            DeploymentPolicyAddHandler.installRuntimeServices(context, operation, model, null);
+        } else {
+            context.revertReloadRequired();
+        }
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/DeploymentPolicyResourceDefinition.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/DeploymentPolicyResourceDefinition.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.clustering.controller.StringListAttributeMarshaller;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ListAttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DeploymentPolicyResourceDefinition extends SimpleResourceDefinition {
+
+    static final SimpleAttributeDefinition CACHE_CONTAINER =  new SimpleAttributeDefinitionBuilder(ModelKeys.CACHE_CONTAINER, ModelType.STRING, false)
+            .setXmlName(Attribute.CACHE_CONTAINER.getLocalName())
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build()
+    ;
+
+    static final AttributeDefinition PREFERRED_NODE = new SimpleAttributeDefinitionBuilder(ModelKeys.PREFERRED_NODE, ModelType.STRING, true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build()
+    ;
+
+    static final ListAttributeDefinition PREFERRED_NODES = SimpleListAttributeDefinition.Builder.of(ModelKeys.PREFERRED_NODES, PREFERRED_NODE)
+            .setAllowExpression(true)
+            .setAllowNull(true)
+            .setAttributeMarshaller(new StringListAttributeMarshaller())
+            .build()
+    ;
+
+    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { CACHE_CONTAINER, PREFERRED_NODES };
+
+    public DeploymentPolicyResourceDefinition() {
+        super(PathElement.pathElement(ModelKeys.DEPLOYMENT_POLICY), new SingletonDeploymentResourceDescriptionResolver(ModelKeys.DEPLOYMENT_POLICY), new DeploymentPolicyAddHandler(), new DeploymentPolicyRemoveHandler());
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        ReloadRequiredWriteAttributeHandler handler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
+        for (AttributeDefinition attribute: ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(attribute, null, handler);
+        }
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/Element.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/Element.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Paul Ferraro
+ */
+public enum Element {
+    UNKNOWN(null),
+
+    DEPLOYMENT_POLICY(ModelKeys.DEPLOYMENT_POLICY),
+    ;
+
+    private final String localName;
+
+    private Element(String localName) {
+        this.localName = localName;
+    }
+
+    public String getLocalName() {
+        return this.localName;
+    }
+
+    private static final Map<String, Element> elements = new HashMap<String, Element>();
+
+    static {
+        for (Element element: values()) {
+            String localName = element.getLocalName();
+            if (localName != null) {
+                elements.put(localName, element);
+            }
+        }
+    }
+
+    public static Element forName(String localName) {
+        Element element = elements.get(localName);
+        return (element != null) ? element : Element.UNKNOWN;
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/ModelKeys.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/ModelKeys.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+/**
+ * @author Paul Ferraro
+ */
+final class ModelKeys {
+    public static final String DEPLOYMENT_POLICY = "deployment-policy";
+    public static final String CACHE_CONTAINER = "cache-container";
+    public static final String NAME = "name";
+    public static final String PREFERRED_NODE = "preferred-node";
+    public static final String PREFERRED_NODES = "preferred-nodes";
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/Namespace.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/Namespace.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import java.util.List;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+
+/**
+ * @author Paul Ferraro
+ */
+public enum Namespace {
+
+    VERSION_1_0(1, 0, new SingletonDeploymentSubsystemXMLReader_1_0())
+    ;
+
+    private static final String URN_PATTERN = "urn:jboss:domain:%s:%d.%d";
+
+    public static final Namespace CURRENT = VERSION_1_0;
+
+    private final int major;
+    private final int minor;
+    private final XMLElementReader<List<ModelNode>> reader;
+
+    Namespace(int major, int minor, XMLElementReader<List<ModelNode>> reader) {
+        this.major = major;
+        this.minor = minor;
+        this.reader = reader;
+    }
+
+    /**
+     * Get the URI of this namespace.
+     *
+     * @return the URI
+     */
+    public String getUri() {
+        return String.format(URN_PATTERN, SingletonDeploymentExtension.SUBSYSTEM_NAME, this.major, this.minor);
+    }
+
+    public XMLElementReader<List<ModelNode>> getXMLReader() {
+        return this.reader;
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentExtension.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentExtension.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+public class SingletonDeploymentExtension implements Extension {
+
+    public static final String SUBSYSTEM_NAME = "singleton-deployment";
+    static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
+
+    private static final int MAJOR_VERSION = 1;
+    private static final int MINOR_VERSION = 0;
+    private static final int MICRO_VERSION = 0;
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        final SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, MAJOR_VERSION, MINOR_VERSION, MICRO_VERSION);
+        registration.registerXMLElementWriter(new SingletonDeploymentSubsystemXMLWriter());
+
+        final ManagementResourceRegistration subsystem = registration.registerSubsystemModel(new SingletonDeploymentSubsystemResourceDefinition());
+        subsystem.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+        // subsystem=singleton-deployment/deployment-policy=*
+        subsystem.registerSubModel(new DeploymentPolicyResourceDefinition());
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        for (Namespace namespace: Namespace.values()) {
+            context.setSubsystemXmlMapping(SUBSYSTEM_NAME, namespace.getUri(), namespace.getXMLReader());
+        }
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentResourceDescriptionResolver.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentResourceDescriptionResolver.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SingletonDeploymentResourceDescriptionResolver extends StandardResourceDescriptionResolver {
+    private static String RESOURCE_NAME = SingletonDeploymentResourceDescriptionResolver.class.getPackage().getName() + ".LocalDescriptions";
+
+    public SingletonDeploymentResourceDescriptionResolver(String prefix) {
+        super(prefix, RESOURCE_NAME, SingletonDeploymentResourceDescriptionResolver.class.getClassLoader(), true, false);
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemAddHandler.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemAddHandler.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SingletonDeploymentSubsystemAddHandler extends AbstractAddStepHandler {
+
+    static ModelNode createOperation(ModelNode address, ModelNode existing) throws OperationFailedException {
+        ModelNode operation = Util.getEmptyOperation(ModelDescriptionConstants.ADD, address);
+        populate(existing, operation);
+        return operation;
+    }
+
+    private static void populate(ModelNode source, ModelNode target) throws OperationFailedException {
+
+        target.get(ModelKeys.DEPLOYMENT_POLICY).setEmptyObject();
+    }
+
+    @Override
+    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        populate(operation, model);
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemResourceDefinition.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemResourceDefinition.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SingletonDeploymentSubsystemResourceDefinition extends SimpleResourceDefinition {
+
+    public SingletonDeploymentSubsystemResourceDefinition() {
+        super(SingletonDeploymentExtension.SUBSYSTEM_PATH, new SingletonDeploymentResourceDescriptionResolver(SingletonDeploymentExtension.SUBSYSTEM_NAME), new SingletonDeploymentSubsystemAddHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemXMLReader_1_0.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemXMLReader_1_0.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SingletonDeploymentSubsystemXMLReader_1_0 implements XMLElementReader<List<ModelNode>> {
+
+    @Override
+    public void readElement(XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
+        PathAddress subsystemAddress = PathAddress.pathAddress(SingletonDeploymentExtension.SUBSYSTEM_PATH);
+        ModelNode subsystem = Util.createAddOperation(subsystemAddress);
+
+        operations.add(subsystem);
+
+        while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
+            Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case DEPLOYMENT_POLICY: {
+                    operations.add(readDeploymentPolicy(reader, subsystemAddress));
+                    break;
+                }
+                default: {
+                    throw ParseUtils.unexpectedElement(reader);
+                }
+            }
+        }
+    }
+
+    protected ModelNode readDeploymentPolicy(XMLExtendedStreamReader reader, PathAddress address) throws XMLStreamException {
+        ModelNode operation = Util.getEmptyOperation(ADD, null);
+        final Set<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.CACHE_CONTAINER);
+
+        for (int i = 0; i < reader.getAttributeCount(); i++) {
+            ParseUtils.requireNoNamespaceAttribute(reader, i);
+            String value = reader.getAttributeValue(i);
+            Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    operation.get(OP_ADDR).set(address.append(ModelKeys.DEPLOYMENT_POLICY, value).toModelNode());
+                    break;
+                }
+                case CACHE_CONTAINER: {
+                    DeploymentPolicyResourceDefinition.CACHE_CONTAINER.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                case PREFERRED_NODES: {
+                    for (String node: reader.getListAttributeValue(i)) {
+                        DeploymentPolicyResourceDefinition.PREFERRED_NODES.parseAndAddParameterElement(node, operation, reader);
+                    }
+                    break;
+                }
+                default: {
+                    throw ParseUtils.unexpectedAttribute(reader, i);
+                }
+            }
+        }
+
+        if (!required.isEmpty()) {
+            throw ParseUtils.missingRequired(reader, required);
+        }
+
+        ParseUtils.requireNoContent(reader);
+
+        return operation;
+    }
+}

--- a/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemXMLWriter.java
+++ b/clustering/singleton-deployment/src/main/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemXMLWriter.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import static org.jboss.as.clustering.singleton.deployment.subsystem.DeploymentPolicyResourceDefinition.CACHE_CONTAINER;
+import static org.jboss.as.clustering.singleton.deployment.subsystem.DeploymentPolicyResourceDefinition.PREFERRED_NODES;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SingletonDeploymentSubsystemXMLWriter implements XMLElementWriter<SubsystemMarshallingContext> {
+
+    @Override
+    public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
+        context.startSubsystemElement(Namespace.CURRENT.getUri(), false);
+        ModelNode model = context.getModelNode();
+        if (model.isDefined()) {
+            for (Property property: model.get(ModelKeys.DEPLOYMENT_POLICY).asPropertyList()) {
+                writer.writeStartElement(Element.DEPLOYMENT_POLICY.getLocalName());
+
+                String deploymentPolicyName = property.getName();
+                writer.writeAttribute(Attribute.NAME.getLocalName(), deploymentPolicyName);
+
+                ModelNode deploymentPolicy = property.getValue();
+
+                CACHE_CONTAINER.marshallAsAttribute(deploymentPolicy, writer);
+                PREFERRED_NODES.marshallAsElement(deploymentPolicy, false, writer);
+
+                writer.writeEndElement();
+            }
+        }
+        writer.writeEndElement();
+    }
+}

--- a/clustering/singleton-deployment/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
+++ b/clustering/singleton-deployment/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
@@ -1,0 +1,23 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2012, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+org.jboss.as.clustering.singleton.deployment.subsystem.SingletonDeploymentExtension

--- a/clustering/singleton-deployment/src/main/resources/org/jboss/as/clustering/singleton/deployment/subsystem/LocalDescriptions.properties
+++ b/clustering/singleton-deployment/src/main/resources/org/jboss/as/clustering/singleton/deployment/subsystem/LocalDescriptions.properties
@@ -1,0 +1,11 @@
+singleton-deployment = 
+singleton-deployment.deployment-policy = 
+singleton-deployment.add = 
+singleton-deployment.remove = 
+
+deployment-policy = 
+deployment-policy.add = 
+deployment-policy.remove = 
+deployment-policy.cache-container = 
+deployment-policy.preferred-nodes = 
+deployment-policy.preferred-nodes.preferred-node = 

--- a/clustering/singleton-deployment/src/test/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemTest.java
+++ b/clustering/singleton-deployment/src/test/java/org/jboss/as/clustering/singleton/deployment/subsystem/SingletonDeploymentSubsystemTest.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.singleton.deployment.subsystem;
+
+import org.jboss.as.clustering.subsystem.ClusteringSubsystemTest;
+import org.jboss.as.subsystem.test.ModelDescriptionValidator.ValidationConfiguration;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SingletonDeploymentSubsystemTest extends ClusteringSubsystemTest {
+
+    public SingletonDeploymentSubsystemTest() {
+        super(SingletonDeploymentExtension.SUBSYSTEM_NAME, new SingletonDeploymentExtension(), "subsystem-singleton-deployment.xml");
+    }
+
+    @Override
+    protected ValidationConfiguration getModelValidationConfiguration() {
+        return new ValidationConfiguration();
+    }
+}

--- a/clustering/singleton-deployment/src/test/resources/subsystem-singleton-deployment.xml
+++ b/clustering/singleton-deployment/src/test/resources/subsystem-singleton-deployment.xml
@@ -1,0 +1,4 @@
+<subsystem xmlns="urn:jboss:domain:singleton-deployment:1.0">
+    <deployment-policy name="singleton" cache-container="singleton"/>
+    <deployment-policy name="preferred" cache-container="singleton" preferred-nodes="node0 node1"/>
+</subsystem>

--- a/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/SingletonLogger.java
+++ b/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/SingletonLogger.java
@@ -22,12 +22,15 @@
 package org.jboss.as.clustering.singleton;
 
 import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.msc.service.StartException;
 
 @MessageLogger(projectCode = "JBAS")
 public interface SingletonLogger {
@@ -53,4 +56,8 @@ public interface SingletonLogger {
     @LogMessage(level = DEBUG)
     @Message(id = 10343, value = "No response received from master node of the %s service, retrying...")
     void noResponseFromMaster(String service);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 10344, value = "Failed to start %s service")
+    void serviceStartFailed(@Cause StartException e, String service);
 }

--- a/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/election/NamePreference.java
+++ b/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/election/NamePreference.java
@@ -35,4 +35,19 @@ public class NamePreference implements Preference {
     public boolean preferred(ClusterNode node) {
         return node.getName().equals(this.name);
     }
+
+    @Override
+    public boolean equals(Object object) {
+        return ((object != null) && (object instanceof NamePreference)) ? this.name.equals(((NamePreference) object).name) : false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
 }

--- a/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/election/SocketAddressPreference.java
+++ b/clustering/singleton/src/main/java/org/jboss/as/clustering/singleton/election/SocketAddressPreference.java
@@ -37,4 +37,19 @@ public class SocketAddressPreference implements Preference {
     public boolean preferred(ClusterNode node) {
         return node.getIpAddress().getHostAddress().equals(this.address.getAddress().getHostAddress()) && (node.getPort() == this.address.getPort());
     }
+
+    @Override
+    public boolean equals(Object object) {
+        return ((object != null) && (object instanceof SocketAddressPreference)) ? this.address.equals(((SocketAddressPreference) object).address) : false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.address.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.address.toString();
+    }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
@@ -31,6 +31,7 @@ public class ClientConstants {
     public static final String COMPOSITE = "composite";
     public static final String CONTENT = "content";
     public static final String DEPLOYMENT = "deployment";
+    public static final String DEPLOYMENT_POLICY = "deployment-policy";
     public static final String EXTENSION = "extension";
     public static final String INPUT_STREAM_INDEX = "input-stream-index";
     public static final String FAILURE_DESCRIPTION = "failure-description";
@@ -53,5 +54,4 @@ public class ClientConstants {
     public static final String DEPLOYMENT_REMOVE_OPERATION = "remove";
     public static final String DEPLOYMENT_REPLACE_OPERATION = "replace-deployment";
     public static final String DEPLOYMENT_UNDEPLOY_OPERATION = "undeploy";
-
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/AddDeploymentPlanBuilder.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/AddDeploymentPlanBuilder.java
@@ -40,6 +40,15 @@ public interface AddDeploymentPlanBuilder extends DeploymentActionsCompleteBuild
 
     /**
      * Indicates content that was added via an immediately preceding
+     * <code>add</code> operation should be deployed.
+     *
+     * @param indicates the deployment policy to use when deploying this content
+     * @return a builder that can continue building the overall deployment plan
+     */
+    DeployDeploymentPlanBuilder andDeploy(String policy);
+
+    /**
+     * Indicates content that was added via an immediately preceding
      * <code>add</code> operation should be deployed, replacing the specified
      * existing content in the runtime.
      *

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/DeploymentPlanBuilder.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/DeploymentPlanBuilder.java
@@ -205,6 +205,15 @@ public interface DeploymentPlanBuilder {
     DeployDeploymentPlanBuilder deploy(String deploymentName);
 
     /**
+     * Indicates the specified deployment content should be deployed.
+     *
+     * @param deploymentName unique identifier of the deployment content
+     * @param policy identifies the deployment policy used to deploy this content
+     * @return a builder that can continue building the overall deployment plan
+     */
+    DeployDeploymentPlanBuilder deploy(String deploymentName, String policy);
+
+    /**
      * Indicates the specified deployment content should be undeployed.
      *
      * @param deploymentName unique identifier of the deployment content

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/AddDeploymentPlanBuilderImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/AddDeploymentPlanBuilderImpl.java
@@ -47,11 +47,16 @@ class AddDeploymentPlanBuilderImpl extends DeploymentPlanBuilderImpl implements 
 
     @Override
     public DeployDeploymentPlanBuilder andDeploy() {
+        return this.andDeploy(null);
+    }
+
+    @Override
+    public DeployDeploymentPlanBuilder andDeploy(String policy) {
         DeploymentSetPlanImpl currentSet = getCurrentDeploymentSetPlan();
         if (currentSet.hasServerGroupPlans()) {
             throw MESSAGES.cannotAddDeploymentAction();
         }
-        DeploymentActionImpl mod = DeploymentActionImpl.getDeployAction(newContentKey);
+        DeploymentActionImpl mod = DeploymentActionImpl.getDeployAction(newContentKey, policy);
         DeploymentSetPlanImpl newSet = currentSet.addAction(mod);
         return new DeployDeploymentPlanBuilderImpl(this, newSet);
     }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentActionImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentActionImpl.java
@@ -40,36 +40,36 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
     public static DeploymentActionImpl getAddAction(String deploymentName, String fileName, byte[] hash) {
         assert fileName != null : "fileName is null";
         assert hash != null : "hash is null";
-        return new DeploymentActionImpl(Type.ADD, deploymentName, fileName, hash, null);
+        return new DeploymentActionImpl(Type.ADD, deploymentName, fileName, hash, null, null);
     }
 
-    public static DeploymentActionImpl getDeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.DEPLOY, deploymentName, null, null, null);
+    public static DeploymentActionImpl getDeployAction(String deploymentName, String policy) {
+        return new DeploymentActionImpl(Type.DEPLOY, deploymentName, null, null, null, policy);
     }
 
     public static DeploymentActionImpl getRedeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.REDEPLOY, deploymentName, null, null, null);
+        return new DeploymentActionImpl(Type.REDEPLOY, deploymentName, null, null, null, null);
     }
 
     public static DeploymentActionImpl getUndeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.UNDEPLOY, deploymentName, null, null, null);
+        return new DeploymentActionImpl(Type.UNDEPLOY, deploymentName, null, null, null, null);
     }
 
     public static DeploymentActionImpl getReplaceAction(String deploymentName, String replacedName) {
         if (replacedName == null) {
             throw MESSAGES.nullVar("replacedName");
         }
-        return new DeploymentActionImpl(Type.REPLACE, deploymentName, null, null, replacedName);
+        return new DeploymentActionImpl(Type.REPLACE, deploymentName, null, null, replacedName, null);
     }
 
     public static DeploymentActionImpl getFullReplaceAction(String deploymentName, String fileName, byte[] hash) {
         assert fileName != null : "fileName is null";
         assert hash != null : "hash is null";
-        return new DeploymentActionImpl(Type.FULL_REPLACE, deploymentName, fileName, hash, null);
+        return new DeploymentActionImpl(Type.FULL_REPLACE, deploymentName, fileName, hash, null, null);
     }
 
     public static DeploymentActionImpl getRemoveAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.REMOVE, deploymentName, null, null, null);
+        return new DeploymentActionImpl(Type.REMOVE, deploymentName, null, null, null, null);
     }
 
     private final UUID uuid = UUID.randomUUID();
@@ -78,8 +78,9 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
     private final String oldDeploymentUnitName;
     private final String newContentFileName;
     private final byte[] newContentHash;
+    private final String policy;
 
-    private DeploymentActionImpl(Type type, String deploymentUnitName, String newContentFileName, byte[] newContentHash, String replacedDeploymentUnitName) {
+    private DeploymentActionImpl(Type type, String deploymentUnitName, String newContentFileName, byte[] newContentHash, String replacedDeploymentUnitName, String policy) {
         if (type == null) {
             throw MESSAGES.nullVar("type");
         }
@@ -91,6 +92,7 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
         this.newContentFileName = newContentFileName;
         this.newContentHash = newContentHash;
         this.oldDeploymentUnitName = replacedDeploymentUnitName;
+        this.policy = policy;
     }
 
     @Override
@@ -121,4 +123,7 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
         return newContentHash;
     }
 
+    public String getPolicy() {
+        return this.policy;
+    }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentPlanBuilderImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentPlanBuilderImpl.java
@@ -122,11 +122,16 @@ class DeploymentPlanBuilderImpl extends AbstractDeploymentPlanBuilder implements
 
     @Override
     public DeployDeploymentPlanBuilder deploy(String key) {
+        return this.deploy(key, null);
+    }
+
+    @Override
+    public DeployDeploymentPlanBuilder deploy(String key, String policy) {
         DeploymentSetPlanImpl currentSet = getCurrentDeploymentSetPlan();
         if (currentSet.hasServerGroupPlans()) {
             throw MESSAGES.cannotAddDeploymentAction();
         }
-        DeploymentActionImpl mod = DeploymentActionImpl.getDeployAction(key);
+        DeploymentActionImpl mod = DeploymentActionImpl.getDeployAction(key, policy);
         DeploymentSetPlanImpl newSet = currentSet.addAction(mod);
         return new DeployDeploymentPlanBuilderImpl(this, newSet);
     }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/AddDeploymentPlanBuilder.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/AddDeploymentPlanBuilder.java
@@ -39,6 +39,15 @@ public interface AddDeploymentPlanBuilder extends DeploymentPlanBuilder {
 
     /**
      * Indicates content that was added via an immediately preceding
+     * <code>add</code> operation should be deployed.
+     *
+     * @param indicates the deployment policy to use when deploying this content
+     * @return a builder that can continue building the overall deployment plan
+     */
+    DeploymentPlanBuilder andDeploy(String policy);
+
+    /**
+     * Indicates content that was added via an immediately preceding
      * <code>add</code> operation should be deployed, replacing the specified
      * existing content in the runtime.
      *
@@ -47,5 +56,4 @@ public interface AddDeploymentPlanBuilder extends DeploymentPlanBuilder {
      * @return a builder that can continue building the overall deployment plan
      */
     ReplaceDeploymentPlanBuilder andReplace(String toReplace);
-
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/DeploymentPlanBuilder.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/DeploymentPlanBuilder.java
@@ -222,6 +222,15 @@ public interface DeploymentPlanBuilder {
     DeploymentPlanBuilder deploy(String deploymentName);
 
     /**
+     * Indicates the specified deployment content should be deployed.
+     *
+     * @param deploymentName unique identifier of the deployment content
+     * @param indicates the deployment policy to use when deploying this content
+     * @return a builder that can continue building the overall deployment plan
+     */
+    DeploymentPlanBuilder deploy(String deploymentName, String policy);
+
+    /**
      * Indicates the specified deployment content should be undeployed.
      *
      * @param deploymentName unique identifier of the deployment content

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/ServerDeploymentHelper.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/ServerDeploymentHelper.java
@@ -40,10 +40,14 @@ public class ServerDeploymentHelper {
     }
 
     public String deploy(String runtimeName, InputStream input) throws ServerDeploymentException {
+        return this.deploy(runtimeName, null, input);
+    }
+
+    public String deploy(String runtimeName, String policy, InputStream input) throws ServerDeploymentException {
         ServerDeploymentActionResult actionResult;
         try {
             DeploymentPlanBuilder builder = deploymentManager.newDeploymentPlan();
-            builder = builder.add(runtimeName, input).andDeploy();
+            builder = builder.add(runtimeName, input).andDeploy(policy);
             DeploymentPlan plan = builder.build();
             DeploymentAction action = builder.getLastAction();
             Future<ServerDeploymentPlanResult> future = deploymentManager.execute(plan);

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/AbstractServerDeploymentManager.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/AbstractServerDeploymentManager.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.CONTENT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT_DEPLOY_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT_FULL_REPLACE_OPERATION;
+import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT_POLICY;
 import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT_REDEPLOY_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT_REMOVE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT_REPLACE_OPERATION;
@@ -109,6 +110,10 @@ public abstract class AbstractServerDeploymentManager implements ServerDeploymen
             }
             case DEPLOY: {
                 configureDeploymentOperation(step, DEPLOYMENT_DEPLOY_OPERATION, uniqueName);
+                String policy = action.getPolicy();
+                if (policy != null) {
+                    step.get(DEPLOYMENT_POLICY).set(action.getPolicy());
+                }
                 break;
             }
             case FULL_REPLACE: {

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentActionImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentActionImpl.java
@@ -36,31 +36,31 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
     private static final long serialVersionUID = 613098200977026475L;
 
     public static DeploymentActionImpl getAddAction(String deploymentName, String fileName, InputStream in, boolean internalStream) {
-        return new DeploymentActionImpl(Type.ADD, deploymentName, fileName, in, internalStream, null);
+        return new DeploymentActionImpl(Type.ADD, deploymentName, fileName, in, internalStream, null, null);
     }
 
-    public static DeploymentActionImpl getDeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.DEPLOY, deploymentName, null, null, false, null);
+    public static DeploymentActionImpl getDeployAction(String deploymentName, String policy) {
+        return new DeploymentActionImpl(Type.DEPLOY, deploymentName, null, null, false, null, policy);
     }
 
     public static DeploymentActionImpl getRedeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.REDEPLOY, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.REDEPLOY, deploymentName, null, null, false, null, null);
     }
 
     public static DeploymentActionImpl getUndeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.UNDEPLOY, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.UNDEPLOY, deploymentName, null, null, false, null, null);
     }
 
     public static DeploymentActionImpl getReplaceAction(String deploymentName, String replacedName) {
-        return new DeploymentActionImpl(Type.REPLACE, deploymentName, null, null, false, replacedName);
+        return new DeploymentActionImpl(Type.REPLACE, deploymentName, null, null, false, replacedName, null);
     }
 
     public static DeploymentActionImpl getFullReplaceAction(String deploymentName, String fileName, InputStream in, boolean internalStream) {
-        return new DeploymentActionImpl(Type.FULL_REPLACE, deploymentName, fileName, in, internalStream, null);
+        return new DeploymentActionImpl(Type.FULL_REPLACE, deploymentName, fileName, in, internalStream, null, null);
     }
 
     public static DeploymentActionImpl getRemoveAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.REMOVE, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.REMOVE, deploymentName, null, null, false, null, null);
     }
 
     private final UUID uuid = UUID.randomUUID();
@@ -70,14 +70,16 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
     private final InputStream contents;
     private final String newContentFileName;
     private final boolean internalStream;
+    private final String policy;
 
-    private DeploymentActionImpl(Type type, String deploymentUnitName, String newContentFileName, InputStream contents, boolean internalStream, String replacedDeploymentUnitName) {
+    private DeploymentActionImpl(Type type, String deploymentUnitName, String newContentFileName, InputStream contents, boolean internalStream, String replacedDeploymentUnitName, String policy) {
         this.type = type;
         this.deploymentUnitName = deploymentUnitName;
         this.newContentFileName = newContentFileName;
         this.contents = contents;
         this.oldDeploymentUnitName = replacedDeploymentUnitName;
         this.internalStream = internalStream;
+        this.policy = policy;
     }
 
     @Override
@@ -110,5 +112,9 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
 
     public boolean isInternalStream() {
         return internalStream;
+    }
+
+    public String getPolicy() {
+        return this.policy;
     }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentPlanBuilderImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentPlanBuilderImpl.java
@@ -198,8 +198,13 @@ class DeploymentPlanBuilderImpl
      */
     @Override
     public DeploymentPlanBuilder andDeploy() {
+        return this.andDeploy(null);
+    }
+
+    @Override
+    public DeploymentPlanBuilder andDeploy(String policy) {
         String addedKey = getAddedContentKey();
-        DeploymentActionImpl deployMod = DeploymentActionImpl.getDeployAction(addedKey);
+        DeploymentActionImpl deployMod = DeploymentActionImpl.getDeployAction(addedKey, policy);
         return new DeploymentPlanBuilderImpl(this, deployMod);
     }
 
@@ -214,7 +219,12 @@ class DeploymentPlanBuilderImpl
 
     @Override
     public DeploymentPlanBuilder deploy(String key) {
-        DeploymentActionImpl mod = DeploymentActionImpl.getDeployAction(key);
+        return this.deploy(key, null);
+    }
+
+    @Override
+    public DeploymentPlanBuilder deploy(String key, String policy) {
+        DeploymentActionImpl mod = DeploymentActionImpl.getDeployAction(key, policy);
         return new DeploymentPlanBuilderImpl(this, mod);
     }
 
@@ -361,7 +371,6 @@ class DeploymentPlanBuilderImpl
         }
         return new DeploymentPlanBuilderImpl(this, -1);
     }
-
 
     private String getAddedContentKey() {
         DeploymentAction last = getLastAction();

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -76,6 +76,7 @@ public class ModelDescriptionConstants {
     public static final String DEPLOY = "deploy";
     public static final String DEPLOYMENT = "deployment";
     public static final String DEPLOYMENT_OVERLAY = "deployment-overlay";
+    public static final String DEPLOYMENT_POLICY = "deployment-policy";
     public static final String DEPRECATED = "deprecated";
     public static final String DESCRIBE = "describe";
     public static final String DESCRIPTION = "description";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -56,6 +56,7 @@ public enum Attribute {
     DEBUG_OPTIONS("debug-options"),
     DEPLOYMENT("deployment"),
     DEPLOYMENT_OVERLAY("deployment-overlay"),
+    DEPLOYMENT_POLICY("policy"),
     DESTINATION_ADDRESS("destination-address"),
     DIRECTORY_GROUPING("directory-grouping"),
     DESTINATION_PORT("destination-port"),

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -701,7 +701,7 @@ public class DomainXml extends CommonXml {
                             throw MESSAGES.alreadyDefined(element.getLocalName(), reader.getLocation());
                         }
                         sawDeployments = true;
-                        parseDeployments(reader, groupAddress, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED), Collections.<Element>emptySet());
+                        parseDeployments(reader, groupAddress, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED, Attribute.DEPLOYMENT_POLICY), Collections.<Element>emptySet());
                         break;
                     }
                     case DEPLOYMENT_OVERLAYS: {

--- a/pom.xml
+++ b/pom.xml
@@ -827,6 +827,12 @@
 
             <dependency>
                 <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-clustering-singleton-deployment</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.as</groupId>
                 <artifactId>jboss-as-clustering-web-infinispan</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.server.deployment.DeploymentMountProvider;
+import org.jboss.as.server.deployment.DefaultDeploymentUnitPhaseServiceBuilder;
 import org.jboss.as.server.mgmt.domain.RemoteFileRepositoryService;
 import org.jboss.as.server.moduleservice.ExternalModuleService;
 import org.jboss.as.server.moduleservice.ModuleIndexService;
@@ -160,6 +161,8 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
 
         // Add server environment
         ServerEnvironmentService.addService(serverEnvironment, serviceTarget);
+        // Add standard deployment policy
+        new DefaultDeploymentUnitPhaseServiceBuilder().build(serviceTarget).install();
 
         //Add server path manager service
         ServerPathManagerService serverPathManagerService = new ServerPathManagerService();

--- a/server/src/main/java/org/jboss/as/server/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/ServerLogger.java
@@ -136,6 +136,10 @@ public interface ServerLogger extends BasicLogger {
     void undeploymentRolledBackWithNoMessage(String deployment);
 
     @LogMessage(level = INFO)
+    @Message(id = 15858, value = "Deployed \"%s\" using %s policy")
+    void deploymentDeployed(String deploymentUnitName, String policy);
+
+    @LogMessage(level = INFO)
     @Message(id = 18558, value = "Undeployed \"%s\"")
     void deploymentUndeployed(String deploymentName);
 

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -672,4 +672,6 @@ public interface ServerMessages {
     @Message(id = 18784, value = "Null '%s'")
     OperationFailedException nullParameter(String name);
 
+    @Message(id = 18785, value = "%s is not a valid deployment policy")
+    OperationFailedException invalidDeploymentPolicy(String policy);
 }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -47,6 +47,7 @@ import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
 import org.jboss.as.server.deployment.AbstractDeploymentUnitService;
@@ -63,8 +64,8 @@ public class DeploymentAttributes {
 
     //Top level attributes
     public static final SimpleAttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.NAME, ModelType.STRING, false)
-        .setValidator(new StringLengthValidator(1, false))
-        .build();
+            .setValidator(new StringLengthValidator(1, false))
+            .build();
     public static final AttributeDefinition TO_REPLACE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.TO_REPLACE, NAME).build();
 
     //For use in resources
@@ -77,13 +78,15 @@ public class DeploymentAttributes {
             .build();
 
     public static final SimpleAttributeDefinition ENABLED = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ENABLED, ModelType.BOOLEAN, true)
-         .setDefaultValue(new ModelNode(false))
-        .build();
-    public static final AttributeDefinition PERSISTENT = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.PERSISTENT, ModelType.BOOLEAN, false)
-        .build();
+            .setDefaultValue(new ModelNode(false))
+            .build();
+    public static final SimpleAttributeDefinition POLICY = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DEPLOYMENT_POLICY, ModelType.STRING, true)
+            .setXmlName(Attribute.DEPLOYMENT_POLICY.getLocalName())
+            .build();
+    public static final AttributeDefinition PERSISTENT = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.PERSISTENT, ModelType.BOOLEAN, false).build();
     public static final AttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.STATUS, ModelType.STRING, false)
-        .setValidator(new EnumValidator<AbstractDeploymentUnitService.DeploymentStatus>(AbstractDeploymentUnitService.DeploymentStatus.class, false))
-        .build();
+            .setValidator(new EnumValidator<AbstractDeploymentUnitService.DeploymentStatus>(AbstractDeploymentUnitService.DeploymentStatus.class, false))
+            .build();
 
     //Managed content value attributes
     public static final SimpleAttributeDefinition CONTENT_INPUT_STREAM_INDEX =
@@ -174,6 +177,7 @@ public class DeploymentAttributes {
     public static final Map<String, AttributeDefinition> UNMANAGED_CONTENT_ATTRIBUTES = createAttributeMap(CONTENT_PATH, CONTENT_RELATIVE_TO, CONTENT_ARCHIVE);
 
     /** All attributes of the content attribute */
+    @SuppressWarnings("unchecked")
     public static final Map<String, AttributeDefinition> ALL_CONTENT_ATTRIBUTES = createAttributeMap(MANAGED_CONTENT_ATTRIBUTES, UNMANAGED_CONTENT_ATTRIBUTES);
 
     public static OperationDefinition DEPLOY_DEFINITION = new SimpleOperationDefinition(ModelDescriptionConstants.DEPLOY, DEPLOYMENT_RESOLVER);

--- a/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUnitService.java
@@ -51,6 +51,7 @@ public abstract class AbstractDeploymentUnitService implements Service<Deploymen
 
     private static final String FIRST_PHASE_NAME = Phase.values()[0].name();
     private final InjectedValue<DeployerChains> deployerChainsInjector = new InjectedValue<DeployerChains>();
+    private final InjectedValue<DeploymentUnitPhaseServiceBuilder> builder = new InjectedValue<DeploymentUnitPhaseServiceBuilder>();
 
     private DeploymentUnit deploymentUnit;
     private volatile DeploymentServiceListener listener;
@@ -68,6 +69,7 @@ public abstract class AbstractDeploymentUnitService implements Service<Deploymen
         target.addListener(ServiceListener.Inheritance.ALL, listener);
         deploymentUnit = createAndInitializeDeploymentUnit(context.getController().getServiceContainer());
         deploymentUnit.putAttachment(Attachments.STATUS_LISTENER, listener);
+        deploymentUnit.putAttachment(Attachments.DEPLOYMENT_UNIT_PHASE_SERVICE_BUILDER, builder.getValue());
 
         final ServiceName serviceName = deploymentUnit.getServiceName().append(FIRST_PHASE_NAME);
         final Phase firstPhase = Phase.values()[0];
@@ -106,6 +108,10 @@ public abstract class AbstractDeploymentUnitService implements Service<Deploymen
 
     Injector<DeployerChains> getDeployerChainsInjector() {
         return deployerChainsInjector;
+    }
+
+    Injector<DeploymentUnitPhaseServiceBuilder> getBuilderInjector() {
+        return this.builder;
     }
 
     public enum DeploymentStatus {

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -103,6 +103,11 @@ public final class Attachments {
      */
     public static final AttachmentKey<ServiceVerificationHandler> SERVICE_VERIFICATION_HANDLER = AttachmentKey.create(ServiceVerificationHandler.class);
 
+    /**
+     * The deployment policy
+     */
+    public static final AttachmentKey<DeploymentUnitPhaseServiceBuilder> DEPLOYMENT_UNIT_PHASE_SERVICE_BUILDER = AttachmentKey.create(DeploymentUnitPhaseServiceBuilder.class);
+
     //
     // STRUCTURE
     //

--- a/server/src/main/java/org/jboss/as/server/deployment/DefaultDeploymentUnitPhaseServiceBuilder.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DefaultDeploymentUnitPhaseServiceBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.server.deployment;
+
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * @author Paul Ferraro
+ *
+ */
+public class DefaultDeploymentUnitPhaseServiceBuilder extends AbstractService<DeploymentUnitPhaseServiceBuilder> implements DeploymentUnitPhaseServiceBuilder {
+
+    public ServiceBuilder<DeploymentUnitPhaseServiceBuilder> build(ServiceTarget target) {
+        return target.addService(Services.deploymentPolicyName(this.getDeploymentPolicy()), this);
+    }
+
+    @Override
+    public String getDeploymentPolicy() {
+        return null;
+    }
+
+    @Override
+    public <T> ServiceBuilder<T> build(ServiceTarget target, ServiceName name, Service<T> service, Phase phase) {
+        return target.addService(name, service);
+    }
+
+    @Override
+    public DeploymentUnitPhaseServiceBuilder getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
@@ -27,6 +27,7 @@ import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONT
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_RELATIVE_TO;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.PERSISTENT;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.POLICY;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.SERVER_ADD_ATTRIBUTES;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.asString;
@@ -126,7 +127,9 @@ public class DeploymentAddHandler implements OperationStepHandler {
         newModel.get(CONTENT_ALL.getName()).set(content);
 
         if (ENABLED.resolveModelAttribute(context, newModel).asBoolean() && context.isNormalServer()) {
-            DeploymentHandlerUtil.deploy(context, runtimeName, name, vaultReader, contentItem);
+            final ModelNode policyModel = POLICY.resolveModelAttribute(context, newModel);
+            final String policy = policyModel.isDefined() ? policyModel.asString() : null;
+            DeploymentHandlerUtil.deploy(context, runtimeName, name, policy, vaultReader, contentItem);
         }
 
         if (contentRepository != null && contentItem.getHash() != null) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentDeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentDeployHandler.java
@@ -22,6 +22,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEP
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_ALL;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.POLICY;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getContents;
 
@@ -32,6 +33,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.server.services.security.AbstractVaultReader;
 import org.jboss.dmr.ModelNode;
+
 /**
  * Handles deployment into the runtime.
  *
@@ -55,12 +57,16 @@ public class DeploymentDeployHandler implements OperationStepHandler {
         ModelNode model = context.readModelForUpdate(PathAddress.EMPTY_ADDRESS);
         model.get(ENABLED.getName()).set(true);
 
+        POLICY.validateAndSet(operation, model);
+
         final ModelNode opAddr = operation.get(OP_ADDR);
         PathAddress address = PathAddress.pathAddress(opAddr);
         final String name = address.getLastElement().getValue();
         final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
+        final ModelNode policyModel = POLICY.resolveModelAttribute(context, model);
+        final String policy = policyModel.isDefined() ? policyModel.asString() : null;
         final DeploymentHandlerUtil.ContentItem[] contents = getContents(CONTENT_ALL.resolveModelAttribute(context, model));
-        DeploymentHandlerUtil.deploy(context, runtimeName, name, vaultReader, contents);
+        DeploymentHandlerUtil.deploy(context, runtimeName, name, policy, vaultReader, contents);
 
         context.stepCompleted();
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -27,6 +27,7 @@ import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONT
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_PATH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_RELATIVE_TO;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.POLICY;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.asString;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.createFailureException;
@@ -124,9 +125,10 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
         deployNode.get(CONTENT).set(content);
         ENABLED.validateAndSet(deployNode, replaceNode);
 
-
         if (ENABLED.resolveModelAttribute(context, replaceNode).asBoolean()) {
-            DeploymentHandlerUtil.replace(context, replaceNode, runtimeName, name, replacedRuntimeName, vaultReader, contentItem);
+            final ModelNode policyModel = POLICY.resolveModelAttribute(context, replaceNode);
+            final String policy = policyModel.isDefined() ? policyModel.asString() : null;
+            DeploymentHandlerUtil.replace(context, replaceNode, runtimeName, name, replacedRuntimeName, policy, vaultReader, contentItem);
         }
 
         ModelNode contentNode = replaceNode.get(CONTENT).get(0);

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
@@ -20,6 +20,7 @@ package org.jboss.as.server.deployment;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_POLICY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getContents;
@@ -42,7 +43,6 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.ServerLogger;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceListener;
@@ -87,7 +87,7 @@ public class DeploymentHandlerUtil {
     private DeploymentHandlerUtil() {
     }
 
-    public static void deploy(final OperationContext context, final String deploymentUnitName, final String managementName, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
+    public static void deploy(final OperationContext context, final String deploymentUnitName, final String managementName, final String policy, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
         assert contents != null : "contents is null";
 
         if (context.isNormalServer()) {
@@ -99,7 +99,7 @@ public class DeploymentHandlerUtil {
             DeploymentModelUtils.cleanup(deployment);
 
             context.addStep(new OperationStepHandler() {
-                public void execute(OperationContext context, ModelNode operation) {
+                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                     final ServiceName deploymentUnitServiceName = Services.deploymentUnitName(deploymentUnitName);
                     final ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
                     final ServiceController<?> deploymentController = serviceRegistry.getService(deploymentUnitServiceName);
@@ -117,7 +117,7 @@ public class DeploymentHandlerUtil {
                         });
                     } else {
                         final ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-                        final Collection<ServiceController<?>> controllers = doDeploy(context, deploymentUnitName, managementName, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
+                        final Collection<ServiceController<?>> controllers = doDeploy(context, deploymentUnitName, managementName, policy, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
 
                         context.addStep(verificationHandler, OperationContext.Stage.VERIFY);
 
@@ -134,7 +134,11 @@ public class DeploymentHandlerUtil {
                                         ServerLogger.ROOT_LOGGER.deploymentRolledBackWithNoMessage(deploymentUnitName);
                                     }
                                 } else {
-                                    ServerLogger.ROOT_LOGGER.deploymentDeployed(deploymentUnitName);
+                                    if (policy != null) {
+                                        ServerLogger.ROOT_LOGGER.deploymentDeployed(deploymentUnitName, policy);
+                                    } else {
+                                        ServerLogger.ROOT_LOGGER.deploymentDeployed(deploymentUnitName);
+                                    }
                                 }
                             }
                         });
@@ -144,8 +148,8 @@ public class DeploymentHandlerUtil {
         }
     }
 
-    public static Collection<ServiceController<?>> doDeploy(final OperationContext context, final String deploymentUnitName, final String managementName, final ServiceVerificationHandler verificationHandler,
-                                                             final Resource deploymentResource, final ImmutableManagementResourceRegistration registration, final ManagementResourceRegistration mutableRegistration, final AbstractVaultReader vaultReader, final ContentItem... contents) {
+    public static Collection<ServiceController<?>> doDeploy(final OperationContext context, final String deploymentUnitName, final String managementName, final String policy, final ServiceVerificationHandler verificationHandler,
+                                                             final Resource deploymentResource, final ImmutableManagementResourceRegistration registration, final ManagementResourceRegistration mutableRegistration, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
         final ServiceName deploymentUnitServiceName = Services.deploymentUnitName(deploymentUnitName);
         final List<ServiceController<?>> controllers = new ArrayList<ServiceController<?>>();
 
@@ -164,6 +168,7 @@ public class DeploymentHandlerUtil {
 
         final RootDeploymentUnitService service = new RootDeploymentUnitService(deploymentUnitName, managementName, null, registration, mutableRegistration, deploymentResource, verificationHandler, vaultReader);
         final ServiceController<DeploymentUnit> deploymentUnitController = serviceTarget.addService(deploymentUnitServiceName, service)
+                .addDependency(Services.deploymentPolicyName(policy), DeploymentUnitPhaseServiceBuilder.class, service.getBuilderInjector())
                 .addDependency(Services.JBOSS_DEPLOYMENT_CHAINS, DeployerChains.class, service.getDeployerChainsInjector())
                 .addDependency(DeploymentMountProvider.SERVICE_NAME, DeploymentMountProvider.class, service.getServerDeploymentRepositoryInjector())
                 .addDependency(contentsServiceName, VirtualFile.class, service.contentsInjector)
@@ -183,8 +188,8 @@ public class DeploymentHandlerUtil {
         return controllers;
     }
 
-    public static void redeploy(final OperationContext context, final String deploymentUnitName,
-                                final String managementName, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
+    public static void redeploy(final OperationContext context, final String deploymentUnitName, final String managementName, final String policy,
+                                final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
         assert contents != null : "contents is null";
 
         if (context.isNormalServer()) {
@@ -207,7 +212,7 @@ public class DeploymentHandlerUtil {
                         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                             ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
                             context.addStep(verificationHandler, OperationContext.Stage.VERIFY);
-                            doDeploy(context, deploymentUnitName, managementName, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
+                            doDeploy(context, deploymentUnitName, managementName, policy, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
                             context.completeStep(new OperationContext.ResultHandler() {
                                 @Override
                                 public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
@@ -231,7 +236,12 @@ public class DeploymentHandlerUtil {
                         @Override
                         public void handleRollback(OperationContext context, ModelNode operation) {
                             ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-                            doDeploy(context, deploymentUnitName, managementName, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
+                            try {
+                                doDeploy(context, deploymentUnitName, managementName, policy, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
+                            } catch (OperationFailedException e) {
+                                // If it deployed before, it'll deploy again...
+                                throw new IllegalStateException(e);
+                            }
                             if (!logged.get()) {
                                 if (context.hasFailureDescription()) {
                                     ServerLogger.ROOT_LOGGER.undeploymentRolledBack(deploymentUnitName, context.getFailureDescription().asString());
@@ -247,7 +257,7 @@ public class DeploymentHandlerUtil {
     }
 
     public static void replace(final OperationContext context, final ModelNode originalDeployment, final String deploymentUnitName, final String managementName,
-                               final String replacedDeploymentUnitName, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
+                               final String replacedDeploymentUnitName, final String policy, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
         assert contents != null : "contents is null";
 
         if (context.isNormalServer()) {
@@ -267,7 +277,7 @@ public class DeploymentHandlerUtil {
                     context.removeService(replacedDeploymentUnitServiceName);
 
                     ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-                    final Collection<ServiceController<?>> controllers = doDeploy(context, deploymentUnitName, managementName, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
+                    final Collection<ServiceController<?>> controllers = doDeploy(context, deploymentUnitName, managementName, policy, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
                     context.addStep(verificationHandler, OperationContext.Stage.VERIFY);
 
                     context.completeStep(new OperationContext.ResultHandler() {
@@ -281,10 +291,14 @@ public class DeploymentHandlerUtil {
                                 DeploymentModelUtils.cleanup(deployment);
                                 final String name = originalDeployment.require(NAME).asString();
                                 final String runtimeName = originalDeployment.require(RUNTIME_NAME).asString();
+                                final String policy = originalDeployment.hasDefined(DEPLOYMENT_POLICY) ? originalDeployment.get(DEPLOYMENT_POLICY).asString() : null;
                                 final DeploymentHandlerUtil.ContentItem[] contents = getContents(originalDeployment.require(CONTENT));
                                 final ServiceVerificationHandler svh = new ServiceVerificationHandler();
-                                doDeploy(context, runtimeName, name, svh, deployment, registration, mutableRegistration, vaultReader, contents);
-
+                                try {
+                                    doDeploy(context, runtimeName, name, policy, svh, deployment, registration, mutableRegistration, vaultReader, contents);
+                                } catch (OperationFailedException e) {
+                                    throw new IllegalStateException(e);
+                                }
                                 if (context.hasFailureDescription()) {
                                     ServerLogger.ROOT_LOGGER.replaceRolledBack(replacedDeploymentUnitName, deploymentUnitName, getFormattedFailureDescription(context));
                                 } else {
@@ -321,10 +335,15 @@ public class DeploymentHandlerUtil {
                                 final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
                                 final String name = model.require(NAME).asString();
                                 final String runtimeName = model.require(RUNTIME_NAME).asString();
+                                final String policy = model.hasDefined(DEPLOYMENT_POLICY) ? model.get(DEPLOYMENT_POLICY).asString() : null;
                                 final DeploymentHandlerUtil.ContentItem[] contents = getContents(model.require(CONTENT));
                                 final ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-                                doDeploy(context, runtimeName, name, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
-
+                                try {
+                                    doDeploy(context, runtimeName, name, policy, verificationHandler, deployment, registration, mutableRegistration, vaultReader, contents);
+                                } catch (OperationFailedException e) {
+                                    // If this depoloyed the 1st time, we assume it'll deploy again
+                                    throw new IllegalStateException(e);
+                                }
                                 if (context.hasFailureDescription()) {
                                     ServerLogger.ROOT_LOGGER.undeploymentRolledBack(deploymentUnitName, getFormattedFailureDescription(context));
                                 } else {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentRedeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentRedeployHandler.java
@@ -21,6 +21,7 @@ package org.jboss.as.server.deployment;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_ALL;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.POLICY;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.redeploy;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getContents;
@@ -56,8 +57,10 @@ public class DeploymentRedeployHandler implements OperationStepHandler{
         final ModelNode model = context.readModel(PathAddress.EMPTY_ADDRESS);
         final String name = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
         final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
+        final ModelNode policyModel = POLICY.resolveModelAttribute(context, model);
+        final String policy = policyModel.isDefined() ? policyModel.asString() : null;
         final DeploymentHandlerUtil.ContentItem[] contents = getContents(CONTENT_ALL.resolveModelAttribute(context, model));
-        redeploy(context, runtimeName, name, vaultReader, contents);
+        redeploy(context, runtimeName, name, policy, vaultReader, contents);
 
         context.stepCompleted();
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseService.java
@@ -90,7 +90,7 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
         if (nextPhase != null) {
             final ServiceName serviceName = DeploymentUtils.getDeploymentUnitPhaseServiceName(deploymentUnit, nextPhase);
             phaseService = DeploymentUnitPhaseService.create(deploymentUnit, nextPhase);
-            phaseServiceBuilder = serviceTarget.addService(serviceName, phaseService);
+            phaseServiceBuilder = this.deploymentUnit.getAttachment(Attachments.DEPLOYMENT_UNIT_PHASE_SERVICE_BUILDER).build(serviceTarget, serviceName, phaseService, nextPhase);
         } else {
             phaseServiceBuilder = null;
             phaseService = null;
@@ -141,7 +141,6 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
                     AttachedDependency result = new AttachedDependency(attachableDep.getAttachmentKey(), attachableDep.isDeploymentUnit());
                     phaseServiceBuilder.addDependency(attachableDep.getServiceName(), result.getValue());
                     phaseService.injectedAttachedDependencies.add(result);
-
                 }
             }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseServiceBuilder.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseServiceBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.server.deployment;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface DeploymentUnitPhaseServiceBuilder {
+    String getDeploymentPolicy();
+
+    <T> ServiceBuilder<T> build(ServiceTarget target, ServiceName name, Service<T> service, Phase phase);
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/Services.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Services.java
@@ -36,6 +36,10 @@ public final class Services {
      */
     public static final ServiceName JBOSS_DEPLOYMENT = ServiceName.JBOSS.append("deployment");
     /**
+     * The base name for deployment services.
+     */
+    public static final ServiceName JBOSS_DEPLOYMENT_POLICY = JBOSS_DEPLOYMENT.append("policy");
+    /**
      * The base name for deployment unit services and phase services.
      */
     public static final ServiceName JBOSS_DEPLOYMENT_UNIT = JBOSS_DEPLOYMENT.append("unit");
@@ -60,6 +64,16 @@ public final class Services {
      */
     public static ServiceName deploymentUnitName(String name) {
         return JBOSS_DEPLOYMENT_UNIT.append(name);
+    }
+
+    /**
+     * Get the service name of a deployment policy.
+     *
+     * @param name the simple name of the deployment policy
+     * @return the service name
+     */
+    public static ServiceName deploymentPolicyName(String policy) {
+        return (policy != null) ? JBOSS_DEPLOYMENT_POLICY.append(policy) : JBOSS_DEPLOYMENT_POLICY;
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentProcessor.java
@@ -59,6 +59,7 @@ public class SubDeploymentProcessor implements DeploymentUnitProcessor {
             final ManagementResourceRegistration mutableRegistration =  deploymentUnit.getAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT);
             final AbstractVaultReader vaultReader = deploymentUnit.getAttachment(Attachments.VAULT_READER_ATTACHMENT_KEY);
             final SubDeploymentUnitService service = new SubDeploymentUnitService(childRoot, deploymentUnit, registration, mutableRegistration, resource, serviceVerificationHandler, vaultReader);
+            service.getBuilderInjector().inject(deploymentUnit.getAttachment(Attachments.DEPLOYMENT_UNIT_PHASE_SERVICE_BUILDER));
 
             final ResourceRoot parentRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
             final String relativePath = childRoot.getRoot().getPathNameRelativeTo(parentRoot.getRoot());

--- a/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
@@ -33,6 +33,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CON
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_POLICY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESTINATION_ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESTINATION_PORT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
@@ -986,6 +987,7 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
             String uniqueName = null;
             String runtimeName = null;
             String startInput = null;
+            String policy = null;
             final int count = reader.getAttributeCount();
             for (int i = 0; i < count; i++) {
                 final String value = reader.getAttributeValue(i);
@@ -1010,6 +1012,10 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
                         }
                         case ENABLED: {
                             startInput = value;
+                            break;
+                        }
+                        case DEPLOYMENT_POLICY: {
+                            policy = value;
                             break;
                         }
                         default:
@@ -1051,6 +1057,9 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
             }
 
             deploymentAdd.get(RUNTIME_NAME).set(runtimeName);
+            if (allowedAttributes.contains(DEPLOYMENT_POLICY)) {
+                deploymentAdd.get(DEPLOYMENT_POLICY).set(policy);
+            }
             if (allowedAttributes.contains(Attribute.ENABLED)) {
                 deploymentAdd.get(ENABLED).set(enabled);
             }

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -351,7 +351,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
             element = nextElement(reader, namespace);
         }
         if (element == Element.DEPLOYMENTS) {
-            parseDeployments(reader, address, namespace, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED),
+            parseDeployments(reader, address, namespace, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED, Attribute.DEPLOYMENT_POLICY),
                     EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
             element = nextElement(reader, namespace);
         }
@@ -1048,6 +1048,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
 //                    writeAttribute(writer, Attribute.ENABLED, "false");
 //                }
                 DeploymentAttributes.ENABLED.marshallAsAttribute(deployment, false, writer);
+                DeploymentAttributes.POLICY.marshallAsAttribute(deployment, false, writer);
                 final List<ModelNode> contentItems = deployment.require(CONTENT).asList();
                 for (ModelNode contentItem : contentItems) {
                     writeContentItem(writer, contentItem);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ServiceListenerServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ServiceListenerServlet.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Transition;
+import org.jboss.msc.service.ServiceListener;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * Utility servlet that waits until a specified service reaches a specific state.
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { ServiceListenerServlet.SERVLET_PATH })
+public class ServiceListenerServlet extends HttpServlet {
+    private static final long serialVersionUID = -879311373457718598L;
+    public static final String SERVLET_NAME = "service-listener";
+    public static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    public static final String SERVICE = "service";
+    public static final String STATE = "state";
+    public static final String TIMEOUT = "timeout";
+    public static final long DEFAULT_TIMEOUT = 5000;
+
+    public static URI createURI(URL baseURL, ServiceName name, ServiceController.State state) throws UnsupportedEncodingException, URISyntaxException {
+        return baseURL.toURI().resolve(new StringBuilder(SERVLET_NAME).append('?').append(SERVICE).append('=').append(URLEncoder.encode(name.getCanonicalName(), "UTF-8")).append('&').append(STATE).append('=').append(state.name()).toString());
+    }
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        ServiceName name = ServiceName.parse(this.getRequiredParameter(req, SERVICE));
+        String timeoutParameter = req.getParameter(TIMEOUT);
+        long timeout = (timeoutParameter != null) ? Integer.parseInt(timeoutParameter) : DEFAULT_TIMEOUT;
+        ServiceController.State expectedState = ServiceController.State.valueOf(this.getRequiredParameter(req, STATE));
+        ServiceRegistry registry = ServiceContainerHelper.getCurrentServiceContainer();
+        long start = System.currentTimeMillis();
+        long now = start;
+        long stop = start + timeout;
+        ServiceController<?> controller = registry.getService(name);
+        // Potentially wait until specified service is registered
+        while ((controller == null) && (now < stop)) {
+            Thread.yield();
+            now = System.currentTimeMillis();
+            controller = registry.getService(name);
+        }
+        if (controller == null) {
+            throw new ServletException(String.format("Failed to locate %s within %d ms", name, timeout));
+        }
+        ServiceListener<Object> listener = new AbstractServiceListener<Object>() {
+            @Override
+            public void transition(ServiceController<? extends Object> controller, Transition transition) {
+                synchronized (ServiceListenerServlet.this) {
+                    ServiceListenerServlet.this.notify();
+                }
+            }
+            
+        };
+        try
+        {
+            controller.addListener(listener);
+            synchronized (this) {
+                ServiceController.State state = controller.getState();
+                while (state != expectedState) {
+                    this.wait(stop - now);
+                    now = System.currentTimeMillis();
+                    if (now >= stop) {
+                        throw new InterruptedException(String.format("%s failed to reach %s state in %s ms.  Current state is %s", name, expectedState, timeout, state));
+                    }
+                    state = controller.getState();
+                }
+                System.out.println(String.format("%s successfully reached %s state within %d ms.", name, expectedState, now - start));
+            }
+        } catch (InterruptedException e) {
+            throw new ServletException(e);
+        } finally {
+            controller.removeListener(listener);
+        }
+    }
+    
+    private String getRequiredParameter(HttpServletRequest request, String name) throws ServletException {
+        String value = request.getParameter(name);
+        if (value == null) {
+            throw new ServletException(String.format("No '%s' parameter specified", name));
+        }
+        return value;
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerServlet.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.StartException;
+
+/**
+ * Utility servlet that waits until the specified cluster establishes a specific cluster membership.
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { ViewChangeListenerServlet.SERVLET_PATH })
+@Listener(sync = false)
+public class ViewChangeListenerServlet extends HttpServlet {
+    public static final String SERVLET_NAME = "membership";
+    public static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    private static final long serialVersionUID = -4382952409558738642L;
+    public static final long TIMEOUT = 10000;
+    public static final String CLUSTER = "cluster";
+    public static final String MEMBERS = "members";
+    
+    public static URI createURI(URL baseURL, String cluster, String... members) throws URISyntaxException {
+        StringBuilder builder = new StringBuilder(baseURL.toURI().resolve(SERVLET_NAME).toString());
+        builder.append("?").append(CLUSTER).append("=").append(cluster);
+        for (String member: members) {
+            builder.append("&").append(MEMBERS).append("=").append(member);
+        }
+        return URI.create(builder.toString());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String cluster = req.getParameter(CLUSTER);
+        if (cluster == null) {
+            throw new ServletException(String.format("No '%s' parameter specified", CLUSTER));
+        }
+        String[] names = req.getParameterValues(MEMBERS);
+        Set<String> expectedMembers = new TreeSet<String>();
+        if (names != null) {
+            for (String name: names) {
+                expectedMembers.add(name + "/" + cluster);
+            }
+        }
+        ServiceRegistry registry = ServiceContainerHelper.getCurrentServiceContainer();
+        ServiceController<?> controller = registry.getService(ServiceName.JBOSS.append("infinispan", cluster));
+        if (controller == null) {
+            throw new ServletException(String.format("Failed to locate service for cluster '%s'", cluster));
+        }
+        try {
+            EmbeddedCacheManager manager = ServiceContainerHelper.getValue(controller, EmbeddedCacheManager.class);
+            manager.addListener(this);
+            try
+            {
+                long start = System.currentTimeMillis();
+                long now = start;
+                long timeout = start + TIMEOUT;
+                synchronized (this) {
+                    Set<String> members = this.getMembers(manager);
+                    while (!expectedMembers.equals(members)) {
+                        System.out.println(expectedMembers + " != " + members + ", waiting for a view change event...");
+                        this.wait(timeout - now);
+                        now = System.currentTimeMillis();
+                        if (now >= timeout) {
+                            throw new InterruptedException(String.format("Cluster '%s' failed to establish view %s within %d ms.  Current view is: %s", cluster, expectedMembers, TIMEOUT, members));
+                        }
+                        members = this.getMembers(manager);
+                    }
+                    System.out.println(String.format("Cluster '%s' successfully established view %s within %d ms.", cluster, expectedMembers, now - start));
+                }
+            } catch (InterruptedException e) {
+                throw new ServletException(e);
+            } finally {
+                manager.removeListener(this);
+            }
+        } catch (StartException e) {
+            throw new ServletException(e);
+        }
+    }
+
+    private Set<String> getMembers(EmbeddedCacheManager manager) {
+        Set<String> members = new TreeSet<String>();
+        for (Address address: manager.getMembers()) {
+            members.add(address.toString());
+        }
+        return members;
+    }
+
+    @ViewChanged
+    public void viewChanged(ViewChangedEvent event) {
+        System.out.println("View changed event received: " + event);
+        synchronized (this) {
+            this.notify();
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/deployment/SingletonDeploymentTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/deployment/SingletonDeploymentTestCase.java
@@ -1,0 +1,266 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.cluster.singleton.deployment;
+
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.managed.ManagedDeployer;
+import org.jboss.as.server.deployment.Phase;
+import org.jboss.as.test.clustering.ServiceListenerServlet;
+import org.jboss.as.test.clustering.ViewChangeListenerServlet;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.as.test.http.util.HttpClientUtils;
+import org.jboss.as.web.WebSubsystemServices;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SingletonDeploymentTestCase {
+
+    private static final String WEB_CONTEXT_NAME = "singleton-deployment";
+    private static final String WEB_CONTEXT_PATH = "/" + WEB_CONTEXT_NAME;
+    private static final String DEPLOYMENT_NAME = WEB_CONTEXT_NAME + ".war";
+    private static final String MONITOR_DEPLOYMENT_1 = "monitor-deployment-0";
+    private static final String MONITOR_DEPLOYMENT_2 = "monitor-deployment-1";
+
+    @ArquillianResource
+    private ContainerController controller;
+    @ArquillianResource
+    private ManagedDeployer deployer;
+
+    @BeforeClass
+    public static void printSysProps() {
+        Properties sysprops = System.getProperties();
+        System.out.println("System properties:\n" + sysprops);
+    }
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_1)
+    public static Archive<?> deployment0() {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_2)
+    public static Archive<?> deployment1() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
+                .addClass(SimpleServlet.class)
+        ;
+    }
+
+    @Deployment(name = MONITOR_DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_1)
+    public static Archive<?> monitorDeployment0() {
+        return createMonitorDeployment();
+    }
+
+    @Deployment(name = MONITOR_DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_2)
+    public static Archive<?> monitorDeployment1() {
+        return createMonitorDeployment();
+    }
+    
+    private static Archive<?> createMonitorDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "monitor.war")
+                .addClass(ViewChangeListenerServlet.class)
+                .addClass(ServiceListenerServlet.class)
+                .setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.infinispan, org.jboss.msc, org.jboss.as.clustering.common\n"))
+        ;
+    }
+
+    @Test
+    @InSequence(1)
+    public void testArquillianWorkaround() {
+        // Container is unmanaged, need to start manually.
+        controller.start(CONTAINER_1);
+        // We want the monitor application deployed on both nodes, so use standard policy
+        deployer.deploy(MONITOR_DEPLOYMENT_1);
+        // Deploy initially using standard policy, so arquillian can inject the correct base URL.
+        deployer.deploy(DEPLOYMENT_1);
+
+        controller.start(CONTAINER_2);
+        // We want the monitor application deployed on both nodes, so use standard policy
+        deployer.deploy(MONITOR_DEPLOYMENT_2);
+        // Deploy initially using standard policy, so arquillian can inject the correct base URL.
+        deployer.deploy(DEPLOYMENT_2);
+    }
+
+    @Test
+    @InSequence(2)
+    public void testSingletonService(
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL deploymentURL1,
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL deploymentURL2,
+            @ArquillianResource @OperateOnDeployment(MONITOR_DEPLOYMENT_1) URL url1,
+            @ArquillianResource @OperateOnDeployment(MONITOR_DEPLOYMENT_2) URL url2)
+            throws IOException, InterruptedException, URISyntaxException {
+        HttpClient client = HttpClientUtils.relaxedCookieHttpClient();
+
+        URI uri1 = SimpleServlet.createURI(deploymentURL1);
+        URI uri2 = SimpleServlet.createURI(deploymentURL2);
+        
+        try {
+            // Redeploy each deployment using the singleton policy
+            deployer.undeploy(DEPLOYMENT_1);
+            deployer.deploy(DEPLOYMENT_1, "singleton");
+            
+            this.waitForViewChange(client, url1, NODE_1);
+            
+            deployer.undeploy(DEPLOYMENT_2);
+            deployer.deploy(DEPLOYMENT_2, "singleton");
+            
+            this.waitForViewChange(client, url1, NODE_1, NODE_2);
+            this.waitForSingletonService(client, url1);
+            this.waitForWebContext(client, url1);
+            
+            // Deployment should be started on the coordinator
+            this.assertOK(client, uri1);
+            this.assertNotFound(client, uri2);
+            
+            deployer.undeploy(DEPLOYMENT_1);
+            this.waitForViewChange(client, url2, NODE_2);
+            this.waitForSingletonService(client, url2);
+            this.waitForWebContext(client, url2);
+            
+            // Deployment should failover to the new coordinator
+            this.assertNotFound(client, uri1);
+            this.assertOK(client, uri2);
+
+            deployer.deploy(DEPLOYMENT_1, "singleton");
+            this.waitForViewChange(client, url2, NODE_1, NODE_2);
+            
+            // Deployment should still use the new coordinator
+            this.assertNotFound(client, uri1);
+            this.assertOK(client, uri2);
+            
+            deployer.undeploy(DEPLOYMENT_2);
+            this.waitForViewChange(client, url1, NODE_1);
+            this.waitForSingletonService(client, url1);
+            this.waitForWebContext(client, url1);
+            
+            // Deployment should fail-back to the new coordinator
+            this.assertOK(client, uri1);
+            this.assertNotFound(client, uri2);
+
+            deployer.deploy(DEPLOYMENT_2, "singleton");
+            this.waitForViewChange(client, url1, NODE_1, NODE_2);
+            
+            // Deployment should still use the new coordinator
+            this.assertOK(client, uri1);
+            this.assertNotFound(client, uri2);
+            
+            deployer.undeploy(DEPLOYMENT_1);
+            this.waitForViewChange(client, url2, NODE_2);
+            this.waitForSingletonService(client, url2);
+            this.waitForWebContext(client, url2);
+            
+            this.assertNotFound(client, uri1);
+            this.assertOK(client, uri2);
+
+            // Verify that we can redeploy the same deployment using the standard policy
+            deployer.deploy(DEPLOYMENT_1);
+            this.waitForViewChange(client, url2, NODE_2);
+            
+            this.assertOK(client, uri1);
+            this.assertOK(client, uri2);
+            
+            deployer.undeploy(DEPLOYMENT_2);
+            deployer.deploy(DEPLOYMENT_2);
+            
+            this.assertOK(client, uri1);
+            this.assertOK(client, uri2);
+        } finally {
+            client.getConnectionManager().shutdown();
+
+            deployer.undeploy(DEPLOYMENT_1);
+            deployer.undeploy(MONITOR_DEPLOYMENT_1);
+            controller.stop(CONTAINER_1);
+            deployer.undeploy(MONITOR_DEPLOYMENT_2);
+            deployer.undeploy(DEPLOYMENT_2);
+            controller.stop(CONTAINER_2);
+        }
+    }
+
+    // Validate the cluster membership
+    private void waitForViewChange(HttpClient client, URL baseURL, String... nodes) throws IOException, URISyntaxException {
+        this.assertOK(client, ViewChangeListenerServlet.createURI(baseURL, "singleton", nodes));
+    }
+
+    // Ensure that the singleton service is started
+    private void waitForSingletonService(HttpClient client, URL baseURL) throws IOException, URISyntaxException {
+        this.assertOK(client, ServiceListenerServlet.createURI(baseURL, org.jboss.as.server.deployment.Services.deploymentUnitName(DEPLOYMENT_NAME, Phase.FIRST_MODULE_USE).append("service"), ServiceController.State.UP));
+    }
+    
+    private void waitForWebContext(HttpClient client, URL baseURL) throws IOException, URISyntaxException {
+        this.assertOK(client, ServiceListenerServlet.createURI(baseURL, WebSubsystemServices.deploymentServiceName("default-host", WEB_CONTEXT_PATH), ServiceController.State.UP));
+    }
+
+    private void assertOK(HttpClient client, URI uri) throws IOException {
+        Assert.assertEquals(HttpServletResponse.SC_OK, this.invoke(client, uri));
+    }
+
+    private void assertNotFound(HttpClient client, URI uri) throws IOException {
+        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND, this.invoke(client, uri));
+    }
+    
+    private int invoke(HttpClient client, URI uri) throws IOException {
+        HttpResponse response = client.execute(new HttpGet(uri));
+        int status = response.getStatusLine().getStatusCode();
+        response.getEntity().getContent().close();
+        return status;
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -24,6 +24,8 @@ package org.jboss.as.test.clustering.single.web;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -35,13 +37,24 @@ import javax.servlet.http.HttpSession;
 /**
  * @author Paul Ferraro
  */
-@WebServlet(urlPatterns = { "/simple" })
+@WebServlet(urlPatterns = { SimpleServlet.SERVLET_PATH })
 public class SimpleServlet extends HttpServlet {
+    public static final String SERVLET_NAME = "simple";
+    public static final String SERVLET_PATH = "/" + SERVLET_NAME;
     private static final long serialVersionUID = -592774116315946908L;
     public static final String REQUEST_DURATION_PARAM = "requestduration";
     public static final String HEADER_SERIALIZED = "serialized";
-    public static final String URL = "simple";
+    public static final String VALUE = "value";
+    public static final String URL = SERVLET_NAME;
 
+    public static final URI createURI(java.net.URL baseURL) throws URISyntaxException {
+        return baseURL.toURI().resolve(SERVLET_NAME);
+    }
+
+    public static final URI createURI(java.net.URL baseURL, int duration) throws URISyntaxException {
+        return baseURL.toURI().resolve(new StringBuilder(SERVLET_NAME).append("?").append(REQUEST_DURATION_PARAM).append(duration).toString());
+    }
+    
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         HttpSession session = req.getSession(true);
@@ -52,7 +65,7 @@ public class SimpleServlet extends HttpServlet {
         } else {
             custom.increment();
         }
-        resp.setIntHeader("value", custom.getValue());
+        resp.setIntHeader(VALUE, custom.getValue());
         resp.setHeader(HEADER_SERIALIZED, Boolean.toString(custom.wasSerialized()));
 
         // Long running request?

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/redeployment/ReDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/redeployment/ReDeploymentTestCase.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import javax.naming.Context;
 
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -33,6 +32,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.arquillian.container.managed.ManagedDeployer;
 import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
@@ -67,7 +67,7 @@ public class ReDeploymentTestCase extends ContainerResourceMgmtTestBase {
     private Context context;
 
     @ArquillianResource
-    private Deployer deployer;
+    private ManagedDeployer deployer;
 
     static class ReDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
 


### PR DESCRIPTION
OK - here's a 2nd draft...

I've made the following changes:
- The singleton service now wraps a specific Service&lt;DeploymentUnitPhase&gt;, instead of the whole Service&lt;DeploymentUnit&gt;.
- A new "singleton-deployment" subsystem that allows the user to configure 1 or more deployment policies.  This addresses the concern that the management API cannot determine the possible values for deployment-policy.
- You can now configure the cache-container and singleton election policy for each deployment-policy.
- SingletonService will rollback the deployment installation if deployment fails
- DeploymentUnitPhaseServiceBuilders are now installed as services - replacing the ServiceLoader mechanism used previously.  Consequently, the jboss-as-server module no longer requires an optional dependency on the jboss-as-clustering-singleton-deployment module.
