### PR TITLE
AS7-5761 EJB2 entity bean CMP collection toArray throws NPE

### DIFF
--- a/cmp/src/main/java/org/jboss/as/cmp/component/CmpEntityBeanComponent.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/component/CmpEntityBeanComponent.java
@@ -24,6 +24,7 @@ package org.jboss.as.cmp.component;
 
 import java.lang.reflect.Method;
 import java.rmi.RemoteException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -90,7 +91,11 @@ public class CmpEntityBeanComponent extends EntityBeanComponent {
     }
 
     public Collection<Object> getEntityLocalCollection(List<Object> idList) {
-        return null;
+       final List<Object> result = new ArrayList<Object>(idList.size());
+       for (Object id:idList) {
+           result.add(getEJBLocalObject(id));
+       }
+       return result;
     }
 
     public void synchronizeEntitiesWithinTransaction(Transaction transaction) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/cmp/relationship/oneToManyUnidirectional/ABTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/cmp/relationship/oneToManyUnidirectional/ABTestCase.java
@@ -309,6 +309,28 @@ public class ABTestCase extends AbstractCmpTest {
         assertTrue(!(b1.contains(b1x[b1x.length - 1])));
     }
 
+    @Test
+    public void Xtest_toArray() throws Exception {
+        AHome aHome = getFKAHome();
+        BHome bHome = getFKBHome();
+        // Before change:
+        A a1 = aHome.create(new Integer(1));        
+
+        Collection b1 = a1.getB();        
+
+        B[] b1x = new B[20];
+
+        for (int i = 0; i < b1x.length; i++) {
+            b1x[i] = bHome.create(new Integer(10000 + i));
+            b1.add(b1x[i]);
+        }
+
+        Object[] b1Array = a1.getB().toArray();
+        for(int i = 0; i < b1Array.length; i++) {
+            assertTrue(b1.contains(b1Array[i]));
+        }
+    }
+
     public void tearDownEjb() throws Exception {
         AHome aHome;
         BHome bHome;


### PR DESCRIPTION
This fixes the NullPointerException and implements the desired behaviour, including a test case.

This should be equally efficient as the iterator applied over all elements. I do not know if there is a more efficient way to get the whole array of entity objects, as I do not know the details of CMP queries and caching implementation. If there is, this patch can be improved. But at least it works now and no longer throws Exceptions.

This commit can also directly be applied to the 7.1 branch. I can create a separate pull request for that if required.
