### PR TITLE
[AS7-5922] Allow expressions for grouping-handler's type

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/GroupingHandlerDefinition.java
@@ -44,6 +44,8 @@ import org.jboss.dmr.ModelNode;
  */
 public class GroupingHandlerDefinition extends SimpleResourceDefinition {
 
+    static final PathElement PATH = PathElement.pathElement(CommonAttributes.GROUPING_HANDLER);
+
     public static final SimpleAttributeDefinition GROUPING_HANDLER_ADDRESS = create("grouping-handler-address", STRING)
             .setXmlName(CommonAttributes.ADDRESS)
             .setDefaultValue(null)
@@ -62,6 +64,7 @@ public class GroupingHandlerDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition TYPE = create("type", STRING)
             .setDefaultValue(null)
             .setAllowNull(true)
+            .setAllowExpression(true)
             .setValidator(GroupingHandlerTypeValidator.INSTANCE)
             .setFlags(RESTART_ALL_SERVICES)
             .build();
@@ -71,7 +74,7 @@ public class GroupingHandlerDefinition extends SimpleResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     public GroupingHandlerDefinition(final boolean registerRuntimeOnly) {
-        super(PathElement.pathElement(CommonAttributes.GROUPING_HANDLER),
+        super(PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.GROUPING_HANDLER),
                 GroupingHandlerAdd.INSTANCE,
                 GroupingHandlerRemove.INSTANCE);

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -23,11 +23,6 @@
 package org.jboss.as.messaging;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
@@ -49,6 +44,7 @@ import static org.jboss.as.messaging.CommonAttributes.JGROUPS_STACK;
 import static org.jboss.as.messaging.CommonAttributes.PARAM;
 import static org.jboss.as.messaging.CommonAttributes.POOLED_CONNECTION_FACTORY;
 import static org.jboss.as.messaging.CommonAttributes.REPLICATION_CLUSTERNAME;
+import static org.jboss.as.messaging.GroupingHandlerDefinition.TYPE;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_0;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_1;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_2;
@@ -79,7 +75,6 @@ import org.jboss.as.controller.transform.OperationTransformer;
 import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.TransformersSubRegistration;
-import org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Common;
 import org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Pooled;
 import org.jboss.as.messaging.jms.ConnectionFactoryDefinition;
 import org.jboss.as.messaging.jms.JMSQueueDefinition;
@@ -100,7 +95,7 @@ import org.jboss.dmr.Property;
  *       <li>Management model: 1.2.0
  *     </ul>
  *   </dd>
- *   <dt>AS 7.1.2<dt>
+ *   <dt>AS 7.1.2, 7.1.3<dt>
  *   <dd>
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging:1.2
@@ -374,5 +369,10 @@ public class MessagingExtension implements Extension {
             }
         });
         pooledConnectionFactory.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, new OperationTransformers.FailUnignoredAttributesOperationTransformer(transformerdPooledCFAttributes));
+
+        RejectExpressionValuesTransformer rejectTypeExpressionTransformer = new RejectExpressionValuesTransformer(TYPE);
+        TransformersSubRegistration groupingHandler = server.registerSubResource(GroupingHandlerDefinition.PATH);
+        groupingHandler.registerOperationTransformer(ADD, rejectTypeExpressionTransformer);
+        groupingHandler.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectTypeExpressionTransformer.getWriteAttributeTransformer());
     }
 }

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
@@ -198,7 +198,7 @@
                 </cluster-connection>
             </cluster-connections>
             <grouping-handler name="grouping-handler">
-                <type>LOCAL</type>
+                <type>${grouping.type:LOCAL}</type>
                 <address>handler-address</address>
                 <timeout>5000</timeout>
             </grouping-handler>


### PR DESCRIPTION
- let grouping-handler's type attribute support expressions.
  In a cluster, only one node could be of LOCAL type (all the others are REMOTE)
- Reject a type attribute with an expression for legacy version of the
  messaging  management model
