### PR TITLE
[AS7-5927] Minimal AS7 build pulls in many unecessary dependencies

### DIFF
--- a/arquillian/container-embedded/pom.xml
+++ b/arquillian/container-embedded/pom.xml
@@ -101,31 +101,19 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<systemProperties>
-						<property>
-							<name>java.util.logging.manager</name>
-							<value>org.jboss.logmanager.LogManager</value>
-						</property>
-						<property>
-							<name>jboss.home</name>
-							<value>${basedir}/target/jbossas</value>
-						</property>
-						<property>
-							<name>module.path</name>
-							<value>${jboss.home}/modules</value>
-						</property>
-						<property>
-							<name>bundle.path</name>
-							<value>${jboss.home}/bundles</value>
-						</property>
-					</systemProperties>
-					<redirectTestOutputToFile>true</redirectTestOutputToFile>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <jboss.home>${basedir}/target/jbossas</jboss.home>
+                        <module.path>${jboss.home}/modules</module.path>
+                        <bundle.path>${jboss.home}/modules</bundle.path>
+                    </systemPropertyVariables>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 </project>

--- a/build-modular/build-modular-config.xml
+++ b/build-modular/build-modular-config.xml
@@ -44,16 +44,11 @@
 	
 	<!-- See ServerDependenciesProcessor -->
 	<property name="common.dependencies" value="
-		sun.jdk,
-		ibm.jdk,
-		javaee.api,
-		javax.api,
 		org.jboss.logging,
 		org.jboss.vfs,
-		org.apache.commons.logging,
-		org.apache.log4j,
 		org.slf4j,
-		org.jboss.logging.jul-to-slf4j-stub"/>
+		org.jboss.logging.jul-to-slf4j-stub"
+	/>
 
 	<target name="all" depends="generate-standalone-configs,generate-domain-configs,build-standalone-server,build-domain-server" />
 

--- a/build/src/main/resources/modules/javax/activation/api/main/module.xml
+++ b/build/src/main/resources/modules/javax/activation/api/main/module.xml
@@ -25,11 +25,11 @@
 <module xmlns="urn:jboss:module:1.1" name="javax.activation.api">
     <dependencies>
         <module name="javax.api" />
-        <module name="javax.mail.api">
+        <module name="javax.mail.api" optional="true">
             <imports><include path="META-INF"/></imports>
         </module>
-        <module name="com.sun.xml.messaging.saaj"/>
-        <module name="org.jboss.ws.native.jbossws-native-core"/>
+        <module name="com.sun.xml.messaging.saaj" optional="true"/>
+        <module name="org.jboss.ws.native.jbossws-native-core" optional="true"/>
         <module name="org.apache.cxf" optional="true"/>
     </dependencies>
 

--- a/build/src/main/resources/modules/org/jboss/as/ee/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/ee/main/module.xml
@@ -37,10 +37,10 @@
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
         <module name="javax.xml.ws.api" optional="true"/>
-        <module name="org.hibernate.validator"/>
+        <module name="org.hibernate.validator" optional="true"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.as.naming"/>
+        <module name="org.jboss.as.naming" optional="true"/>
         <module name="org.jboss.as.server" />
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.jandex"/>

--- a/build/src/main/resources/modules/org/jboss/as/embedded/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/embedded/main/module.xml
@@ -33,9 +33,13 @@
 
     <dependencies>
         <module name="javax.ejb.api"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.controller-client"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
+        <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/org/jboss/as/logging/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/logging/main/module.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.apache.log4j" />
+        <module name="org.apache.log4j"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.common-core"/>

--- a/build/src/main/resources/modules/org/jboss/as/osgi/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/osgi/main/module.xml
@@ -34,12 +34,13 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
+        <module name="javax.inject.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.as.ee" optional="true"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
+        <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
-	<module name="org.jboss.common-beans" services="export"/>
+        <module name="org.jboss.common-beans" services="export"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.jandex"/>
@@ -56,7 +56,6 @@
         <module name="org.jboss.as.deployment-repository"/>
         <module name="org.jboss.as.domain-http-interface"/>
         <module name="org.jboss.as.domain-management"/>
-        <module name="org.jboss.as.embedded"/>
         <module name="org.jboss.as.jmx" services="import"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.platform-mbean"/>

--- a/build/src/main/resources/modules/org/jboss/metadata/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/metadata/main/module.xml
@@ -34,15 +34,15 @@
     <dependencies>
         <module name="javax.annotation.api"/>
         <module name="javax.api"/>
-        <module name="javax.ejb.api"/>
-        <module name="javax.interceptor.api"/>
-        <module name="javax.jws.api"/>
-        <module name="javax.persistence.api"/>
-        <module name="javax.servlet.api"/>
-        <module name="javax.servlet.jsp.api"/>
-        <module name="javax.xml.bind.api"/>
-        <module name="javax.xml.ws.api"/>
-        <module name="org.jboss.ejb3"/>
+        <module name="javax.ejb.api" optional="true"/>
+        <module name="javax.interceptor.api" optional="true"/>
+        <module name="javax.jws.api" optional="true"/>
+        <module name="javax.persistence.api" optional="true"/>
+        <module name="javax.servlet.api" optional="true"/>
+        <module name="javax.servlet.jsp.api" optional="true"/>
+        <module name="javax.xml.bind.api" optional="true"/>
+        <module name="javax.xml.ws.api" optional="true"/>
+        <module name="org.jboss.ejb3" optional="true"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -64,6 +64,10 @@
             <artifactId>jboss-as-controller-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-server</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jandex</artifactId>
         </dependency>

--- a/embedded/src/main/java/org/jboss/as/embedded/EmbeddedServerFactory.java
+++ b/embedded/src/main/java/org/jboss/as/embedded/EmbeddedServerFactory.java
@@ -32,8 +32,6 @@ import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.log.JDKModuleLogger;
 
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.LogManager;
@@ -65,27 +63,7 @@ public class EmbeddedServerFactory {
     }
 
     public static StandaloneServer create(final ModuleLoader moduleLoader, final File jbossHomeDir, final Properties systemProps, final Map<String, String> systemEnv) {
-        try {
-            // Load the server Module and get its ClassLoader
-            final ModuleIdentifier serverModuleId = ModuleIdentifier.create("org.jboss.as.server");
-            final Module serverModule = moduleLoader.loadModule(serverModuleId);
-            final ModuleClassLoader serverModuleClassLoader = serverModule.getClassLoader();
-
-            Class<?> embeddedStandAloneServerFactoryClass = serverModuleClassLoader.loadClass("org.jboss.as.server.EmbeddedStandAloneServerFactory");
-            Method createMethod = embeddedStandAloneServerFactoryClass.getMethod("create", File.class, ModuleLoader.class, Properties.class, Map.class);
-            final StandaloneServer standaloneServer = (StandaloneServer) createMethod.invoke(null, jbossHomeDir, moduleLoader, systemProps, systemEnv);
-            return standaloneServer;
-        } catch (ModuleLoadException e) {
-            throw MESSAGES.moduleLoaderError(e, e.getMessage(), moduleLoader);
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        return EmbeddedStandAloneServerFactory.create(jbossHomeDir, moduleLoader, systemProps, systemEnv);
     }
 
     public static StandaloneServer create(final File jbossHomeDir, final Properties systemProps, final Map<String, String> systemEnv, String...systemPackages) {

--- a/embedded/src/main/java/org/jboss/as/embedded/EmbeddedStandAloneServerFactory.java
+++ b/embedded/src/main/java/org/jboss/as/embedded/EmbeddedStandAloneServerFactory.java
@@ -20,12 +20,8 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.server;
+package org.jboss.as.embedded;
 
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.xml.namespace.QName;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -45,20 +41,28 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.jboss.as.controller.extension.ExtensionRegistry;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.xml.namespace.QName;
+
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.standalone.DeploymentPlan;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentPlanResult;
+import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.parsing.Namespace;
-import org.jboss.as.server.parsing.StandaloneXml;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
 import org.jboss.as.controller.persistence.TransientConfigurationPersister;
-import org.jboss.as.embedded.ServerStartException;
-import org.jboss.as.embedded.StandaloneServer;
 import org.jboss.as.protocol.StreamUtils;
+import org.jboss.as.server.Bootstrap;
+import org.jboss.as.server.Main;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.ServerMessages;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.client.ModelControllerServerDeploymentManager;
+import org.jboss.as.server.parsing.StandaloneXml;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.msc.service.ServiceActivator;
@@ -225,7 +229,7 @@ public class EmbeddedStandAloneServerFactory {
         return standaloneServer;
     }
 
-    public static void setupCleanDirectories(Properties props) {
+    static void setupCleanDirectories(Properties props) {
         File jbossHomeDir = new File(props.getProperty(ServerEnvironment.HOME_DIR));
         setupCleanDirectories(jbossHomeDir, props);
     }

--- a/embedded/src/test/java/org/jboss/as/embedded/EmbeddedServerFactorySetupUnitTestCase.java
+++ b/embedded/src/test/java/org/jboss/as/embedded/EmbeddedServerFactorySetupUnitTestCase.java
@@ -19,15 +19,17 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.server;
+package org.jboss.as.embedded;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.jboss.as.server.ServerEnvironment;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  *

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,10 +67,6 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-embedded</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-platform-mbean</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-5927

This patch reverses the dependency order from server => embedded to embedded => server
Additionally it makes a number of module dependencies optional such that a modular build does not pull in so many unnecessary deps.

It reduces the number of binary dependencies from 739 to 188 and the download size by 78% to 18MB
