### PR TITLE
[7.1] [AS7-5922] Allow expressions for grouping-handler's type

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -583,7 +583,7 @@ public interface CommonAttributes {
     SimpleAttributeDefinition TRANSFORMER_CLASS_NAME = new SimpleAttributeDefinition("transformer-class-name", ModelType.STRING, true);
 
     SimpleAttributeDefinition TYPE = new SimpleAttributeDefinition("type", "type",
-            null, ModelType.STRING,  true, false, MeasurementUnit.NONE, GroupingHandlerTypeValidator.INSTANCE);
+            null, ModelType.STRING,  true, true, MeasurementUnit.NONE, GroupingHandlerTypeValidator.INSTANCE);
 
     SimpleAttributeDefinition CONNECTION_FACTORY_TYPE = new SimpleAttributeDefinition("factory-type", "factory-type",
             null, ModelType.STRING,  true, false, MeasurementUnit.NONE, ConnectionFactoryTypeValidator.INSTANCE);

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -109,7 +109,7 @@ public class MessagingExtension implements Extension {
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
     private static final int MANAGEMENT_API_MINOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MICRO_VERSION = 0;
+    private static final int MANAGEMENT_API_MICRO_VERSION = 1;
 
     static ResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
         return new StandardResourceDescriptionResolver(keyPrefix, RESOURCE_NAME, MessagingExtension.class.getClassLoader(), true, true);

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_2.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_2.xml
@@ -172,7 +172,7 @@
                 </cluster-connection>
             </cluster-connections>
             <grouping-handler name="grouping-handler">
-                <type>LOCAL</type>
+                <type>${grouping.type:LOCAL}</type>
                 <address>handler-address</address>
                 <timeout>5000</timeout>
             </grouping-handler>


### PR DESCRIPTION
- let grouping-handler's type attribute support expressions.
  In a cluster, only one node could be of LOCAL type (all the others are
  REMOTE)
