### PR TITLE
[AS7-5884] Maintain a reference count for deployment hashes deployed to ...

### DIFF
--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
@@ -32,6 +32,10 @@ import java.io.InputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -56,7 +60,7 @@ public interface ContentRepository {
     ServiceName SERVICE_NAME = ServiceName.JBOSS.append("content-repository");
 
     /**
-     * Add the given content to the repository.
+     * Add the given content to the repository along with a reference tracked by {@code name}.
      *
      * @param stream stream from which the content can be read. Cannot be <code>null</code>
      * @return the hash of the content that will be used as an internal identifier
@@ -64,6 +68,14 @@ public interface ContentRepository {
      * @throws IOException if there is a problem reading the stream
      */
     byte[] addContent(InputStream stream) throws IOException;
+
+    /**
+     * Adds a reference to the content hash.
+     *
+     * @param hash the hash of the deployment
+     * @param reference An identifier which must honour the equals() and hashCode() contracts. In the case of a deployment, this will be the deployment name. This is also used in {@link #removeContent(byte[], String)}
+     */
+    void addContentReference(byte[] hash, Object reference);
 
     /**
      * Get the content as a virtual file.
@@ -84,11 +96,11 @@ public interface ContentRepository {
     boolean hasContent(byte[] hash);
 
     /**
-     * Remove the given content from the repository.
-     *
+     * Remove the given content from the repository. The reference for {@code name} will be removed, and if there are no references left the deployment will be totally removed
      * @param hash the hash. Cannot be {@code null}
+     * @param reference An identifier which must honour the equals() and hashCode() contracts. In the case of a deployment, this will be the deployment name. This is also used in {@link #addContentReference(byte[], Object)}
      */
-    void removeContent(byte[] hash);
+    void removeContent(byte[] hash, Object reference);
 
     static class Factory {
 
@@ -110,6 +122,7 @@ public interface ContentRepository {
             protected static final String CONTENT = "content";
             private final File repoRoot;
             protected final MessageDigest messageDigest;
+            private final Map<String, Set<Object>> deploymentHashReferences = new HashMap<String, Set<Object>>();
 
             protected ContentRepositoryImpl(final File repoRoot) {
                 if (repoRoot == null)
@@ -172,6 +185,19 @@ public interface ContentRepository {
                 }
 
                 return sha1Bytes;
+            }
+
+            @Override
+            public void addContentReference(byte[] hash, Object reference) {
+                String hashString = HashUtil.bytesToHexString(hash);
+                synchronized (deploymentHashReferences) {
+                    Set<Object> references = deploymentHashReferences.get(hashString);
+                    if (references == null) {
+                        references = new HashSet<Object>();
+                        deploymentHashReferences.put(hashString, references);
+                    }
+                    references.add(reference);
+                }
             }
 
             @Override
@@ -283,7 +309,19 @@ public interface ContentRepository {
             }
 
             @Override
-            public void removeContent(byte[] hash) {
+            public void removeContent(byte[] hash, Object reference) {
+                String hashString = HashUtil.bytesToHexString(hash);
+                synchronized (deploymentHashReferences) {
+                    final Set<Object> references = deploymentHashReferences.get(hashString);
+                    if (references != null) {
+                        references.remove(reference);
+                        if (references.size() != 0) {
+                            return;
+                        }
+                        deploymentHashReferences.remove(hashString);
+                    }
+                }
+
                 File file = getDeploymentContentFile(hash, true);
                 if(!file.delete()) {
                     file.deleteOnExit();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
@@ -248,9 +248,10 @@ public class OperationCoordinatorStepHandler {
             }
             else if (address.size() == 1 && DEPLOYMENT.equals(address.getElement(0).getKey())
                     && ADD.equals(opNode.get(OP).asString()) && hasStorableContent(opNode)) {
+                String name = address.getElement(0).getValue();
                 byte[] hash = DeploymentUploadUtil.storeDeploymentContent(context, opNode, contentRepository);
-                    opNode.get(CONTENT).get(0).remove(INPUT_STREAM_INDEX);
-                    opNode.get(CONTENT).get(0).get(HASH).set(hash);
+                opNode.get(CONTENT).get(0).remove(INPUT_STREAM_INDEX);
+                opNode.get(CONTENT).get(0).get(HASH).set(hash);
             }
         } catch (IOException ioe) {
             throw MESSAGES.caughtExceptionStoringDeploymentContent(ioe.getClass().getSimpleName(), ioe);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/AbstractDeploymentUploadHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/AbstractDeploymentUploadHandler.java
@@ -20,14 +20,14 @@ package org.jboss.as.domain.controller.operations.deployment;
 
 import static org.jboss.as.domain.controller.DomainControllerLogger.DEPLOYMENT_LOGGER;
 
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.repository.ContentRepository;
-import org.jboss.dmr.ModelNode;
-
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Base class for operation handlers that can handle the upload of deployment content.

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
@@ -44,6 +44,7 @@ import java.util.Locale;
 
 import org.jboss.as.controller.HashUtil;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.ResultAction;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -185,7 +186,11 @@ public class DeploymentAddHandler implements OperationStepHandler, DescriptionPr
         subModel.get(RUNTIME_NAME).set(runtimeName);
         subModel.get(CONTENT).set(content);
 
-        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        if (context.completeStep() == ResultAction.KEEP) {
+            if (contentRepository != null && hash != null) {
+                contentRepository.addContentReference(hash, name);
+            }
+        }
     }
 
     private static InputStream getInputStream(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
@@ -184,7 +184,8 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler, Descr
             throw createFailureException(MESSAGES.noDeploymentContentWithName(name));
         }
 
-        final Resource deployment = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(DEPLOYMENT, name)));
+
+        final Resource deployment = context.readResourceForUpdate(PathAddress.pathAddress(deploymentPath));
         ModelNode deployNode = deployment.getModel();
         byte[] originalHash = deployNode.get(CONTENT).get(0).hasDefined(HASH) ? deployNode.get(CONTENT).get(0).get(HASH).asBytes() : null;
         deployNode.get(NAME).set(name);
@@ -207,14 +208,17 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler, Descr
                 if (deployNode.get(CONTENT).get(0).hasDefined(HASH)) {
                     byte[] newHash = deployNode.get(CONTENT).get(0).get(HASH).asBytes();
                     if (!Arrays.equals(originalHash, newHash)) {
-                        contentRepository.removeContent(originalHash);
+                        contentRepository.removeContent(originalHash, name);
+                    }
+                    if (contentRepository != null && newHash != null) {
+                        contentRepository.addContentReference(newHash, name);
                     }
                 }
             }
         } else {
             if (contentRepository != null && operation.get(CONTENT).get(0).hasDefined(HASH)) {
                 byte[] newHash = operation.get(CONTENT).get(0).get(HASH).asBytes();
-                contentRepository.removeContent(newHash);
+                contentRepository.removeContent(newHash, name);
             }
         }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -186,14 +186,17 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler, Descr
                 if (replaceNode.get(CONTENT).get(0).hasDefined(HASH)) {
                     byte[] newHash = replaceNode.get(CONTENT).get(0).get(HASH).asBytes();
                     if (!Arrays.equals(originalHash, newHash)) {
-                        contentRepository.removeContent(originalHash);
+                        contentRepository.removeContent(originalHash, name);
+                    }
+                    if (contentRepository != null && newHash != null) {
+                        contentRepository.addContentReference(newHash, name);
                     }
                 }
             }
         } else {
             if (replaceNode.get(CONTENT).get(0).hasDefined(HASH)) {
                 byte[] newHash = replaceNode.get(CONTENT).get(0).get(HASH).asBytes();
-                contentRepository.removeContent(newHash);
+                contentRepository.removeContent(newHash, name);
             }
         }
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
@@ -64,6 +64,7 @@ public class DeploymentRemoveHandler implements OperationStepHandler, Descriptio
     }
 
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final String name = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
         Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
         final List<byte[]> removedHashes = DeploymentUtils.getDeploymentHash(resource);
 
@@ -102,7 +103,7 @@ public class DeploymentRemoveHandler implements OperationStepHandler, Descriptio
 
                         for (byte[] hash : removedHashes) {
                             try {
-                                contentRepository.removeContent(hash);
+                                contentRepository.removeContent(hash, name);
                             } catch (Exception e) {
                                 //TODO
                                 ServerLogger.DEPLOYMENT_LOGGER.failedToRemoveDeploymentContent(e, HashUtil.bytesToHexString(hash));

--- a/server/src/test/java/org/jboss/as/server/deployment/DeploymentAddHandlerTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/deployment/DeploymentAddHandlerTestCase.java
@@ -104,7 +104,7 @@ public class DeploymentAddHandlerTestCase {
     private ContentRepository contentRepository = new ContentRepository() {
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
         }
 
         @Override
@@ -120,6 +120,10 @@ public class DeploymentAddHandlerTestCase {
         @Override
         public byte[] addContent(InputStream stream) throws IOException {
             return null;
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
     };
 }

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -431,7 +431,11 @@ public class ServerControllerUnitTestCase {
         }
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
 
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
@@ -82,6 +82,7 @@ import org.junit.Test;
 public class DeploymentManagementTestCase {
 
     private static final String TEST = "test.war";
+    private static final String TEST2 = "test2.war";
     private static final String REPLACEMENT = "test.war.v2";
     private static final ModelNode ROOT_ADDRESS = new ModelNode();
     private static final ModelNode ROOT_DEPLOYMENT_ADDRESS = new ModelNode();
@@ -682,8 +683,6 @@ public class DeploymentManagementTestCase {
         // Chnage the runtime name in the sg op
         composite.get("steps").get(1).get(RUNTIME_NAME).set("test1.war");
 
-        System.out.println(composite);
-
         OperationBuilder builder = new OperationBuilder(composite, true);
         builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
 
@@ -707,6 +706,72 @@ public class DeploymentManagementTestCase {
             fail("Webapp deployed to unselected server group");
         } catch (IOException ioe) {
             // good
+        }
+    }
+
+    @Test
+    public void testDeploymentsWithSameHash() throws Exception {
+        final ModelNode rootDeploymentAddress2 = new ModelNode();
+        rootDeploymentAddress2.add(DEPLOYMENT, "test2");
+        rootDeploymentAddress2.protect();
+
+        final ModelNode otherServerGroupDeploymentAddress2 = new ModelNode();
+        otherServerGroupDeploymentAddress2.add(SERVER_GROUP, "other-server-group");
+        otherServerGroupDeploymentAddress2.add(DEPLOYMENT, "test2");
+        otherServerGroupDeploymentAddress2.protect();
+
+        class LocalMethods {
+            Operation createDeploymentOperation(ModelNode rootDeploymentAddress, ModelNode serverGroupDeploymentAddress) {
+                ModelNode composite = getEmptyOperation(COMPOSITE, ROOT_ADDRESS);
+                ModelNode steps = composite.get(STEPS);
+
+                ModelNode step = steps.add();
+                step.set(getEmptyOperation(ADD, rootDeploymentAddress));
+                ModelNode content = new ModelNode();
+                content.get(INPUT_STREAM_INDEX).set(0);
+                step.get(CONTENT).add(content);
+
+                step = steps.add();
+                step.set(getEmptyOperation(ADD, serverGroupDeploymentAddress));
+                step.get(ENABLED).set(true);
+
+                OperationBuilder builder = new OperationBuilder(composite, true);
+                builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
+                return builder.build();
+             }
+
+             ModelNode createRemoveOperation(ModelNode rootDeploymentAddress, ModelNode serverGroupDeploymentAddress) {
+                 ModelNode composite = getEmptyOperation(COMPOSITE, ROOT_ADDRESS);
+                 ModelNode steps = composite.get(STEPS);
+
+                 ModelNode step = steps.add();
+                 step.set(getEmptyOperation(REMOVE, serverGroupDeploymentAddress));
+
+                 step = steps.add();
+                 step.set(getEmptyOperation(REMOVE, rootDeploymentAddress));
+
+                 return composite;
+             }
+
+        };
+        LocalMethods localMethods = new LocalMethods();
+        try {
+            executeOnMaster(localMethods.createDeploymentOperation(ROOT_DEPLOYMENT_ADDRESS, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS));
+            try {
+                executeOnMaster(localMethods.createDeploymentOperation(rootDeploymentAddress2, otherServerGroupDeploymentAddress2));
+            } finally {
+                executeOnMaster(localMethods.createRemoveOperation(rootDeploymentAddress2, otherServerGroupDeploymentAddress2));
+            }
+
+            ModelNode undeploySg = getEmptyOperation(REMOVE, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+            executeOnMaster(undeploySg);
+
+            ModelNode deploySg = getEmptyOperation(ADD, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+            deploySg.get(ENABLED).set(true);
+            executeOnMaster(deploySg);
+
+        } finally {
+            executeOnMaster(localMethods.createRemoveOperation(ROOT_DEPLOYMENT_ADDRESS, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS));
         }
     }
 
@@ -761,6 +826,7 @@ public class DeploymentManagementTestCase {
 
         return composite;
     }
+
 
     private static ModelNode createDeploymentReplaceOperation(ModelNode content, ModelNode... serverGroupAddressses) {
         ModelNode composite = getEmptyOperation(COMPOSITE, ROOT_ADDRESS);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -1041,7 +1041,11 @@ public class ParseAndMarshalModelsTestCase {
         }
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
 
     }


### PR DESCRIPTION
...the content repository.

This is to handle the case where the same deployment is deployed with the same name, to make sure
that a copy is kept in the repository if one is removed. Once all deployments are removed, the
content is removed.
