### PR TITLE
[AS7-5884] Maintain a reference count for deployment hashes deployed to ...

### DIFF
--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
@@ -32,6 +32,10 @@ import java.io.InputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -56,7 +60,7 @@ public interface ContentRepository {
     ServiceName SERVICE_NAME = ServiceName.JBOSS.append("content-repository");
 
     /**
-     * Add the given content to the repository.
+     * Add the given content to the repository along with a reference tracked by {@code name}.
      *
      * @param stream stream from which the content can be read. Cannot be <code>null</code>
      * @return the hash of the content that will be used as an internal identifier
@@ -64,6 +68,14 @@ public interface ContentRepository {
      * @throws IOException if there is a problem reading the stream
      */
     byte[] addContent(InputStream stream) throws IOException;
+
+    /**
+     * Adds a reference to the content hash.
+     *
+     * @param hash the hash of the deployment
+     * @param reference An identifier which must honour the equals() and hashCode() contracts. In the case of a deployment, this will be the deployment name. This is also used in {@link #removeContent(byte[], String)}
+     */
+    void addContentReference(byte[] hash, Object reference);
 
     /**
      * Get the content as a virtual file.
@@ -95,9 +107,11 @@ public interface ContentRepository {
     /**
      * Remove the given content from the repository.
      *
+     * Remove the given content from the repository. The reference for {@code name} will be removed, and if there are no references left the deployment will be totally removed
      * @param hash the hash. Cannot be {@code null}
+     * @param reference An identifier which must honour the equals() and hashCode() contracts. In the case of a deployment, this will be the deployment name. This is also used in {@link #addContentReference(byte[], Object)}
      */
-    void removeContent(byte[] hash);
+    void removeContent(byte[] hash, Object reference);
 
     static class Factory {
 
@@ -119,6 +133,7 @@ public interface ContentRepository {
             protected static final String CONTENT = "content";
             private final File repoRoot;
             protected final MessageDigest messageDigest;
+            private final Map<String, Set<Object>> deploymentHashReferences = new HashMap<String, Set<Object>>();
 
             protected ContentRepositoryImpl(final File repoRoot) {
                 if (repoRoot == null)
@@ -181,6 +196,19 @@ public interface ContentRepository {
                 }
 
                 return sha1Bytes;
+            }
+
+            @Override
+            public void addContentReference(byte[] hash, Object reference) {
+                String hashString = HashUtil.bytesToHexString(hash);
+                synchronized (deploymentHashReferences) {
+                    Set<Object> references = deploymentHashReferences.get(hashString);
+                    if (references == null) {
+                        references = new HashSet<Object>();
+                        deploymentHashReferences.put(hashString, references);
+                    }
+                    references.add(reference);
+                }
             }
 
             @Override
@@ -297,7 +325,19 @@ public interface ContentRepository {
             }
 
             @Override
-            public void removeContent(byte[] hash) {
+            public void removeContent(byte[] hash, Object reference) {
+                String hashString = HashUtil.bytesToHexString(hash);
+                synchronized (deploymentHashReferences) {
+                    final Set<Object> references = deploymentHashReferences.get(hashString);
+                    if (references != null) {
+                        references.remove(reference);
+                        if (references.size() != 0) {
+                            return;
+                        }
+                        deploymentHashReferences.remove(hashString);
+                    }
+                }
+
                 File file = getDeploymentContentFile(hash, true);
                 if(!file.delete()) {
                     file.deleteOnExit();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.HashUtil;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.ResultAction;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -141,7 +142,18 @@ public class DeploymentAddHandler implements OperationStepHandler {
 
         newModel.get(CONTENT_ALL.getName()).set(content);
 
-        context.stepCompleted();
+        if (contentRepository != null && hash != null) {
+            final byte[] contentHash = hash;
+            context.completeStep(new OperationContext.ResultHandler() {
+                public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
+                    if (resultAction == ResultAction.KEEP) {
+                        contentRepository.addContentReference(contentHash, name);
+                    }
+                }
+            });
+        } else {
+            context.stepCompleted();
+        }
     }
 
     private static OperationFailedException createFailureException(String msg) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
@@ -83,7 +83,7 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
             def.validateOperation(operation);
         }
 
-        String name = DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.get(NAME).resolveModelAttribute(context, operation).asString();
+        final String name = DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.get(NAME).resolveModelAttribute(context, operation).asString();
         String runtimeName = operation.hasDefined(RUNTIME_NAME) ? DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.get(RUNTIME_NAME).resolveModelAttribute(context, operation).asString() : name;
         byte[] hash;
 
@@ -162,19 +162,18 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
                         if (deployNode.get(CONTENT).get(0).hasDefined(HASH)) {
                             byte[] newHash = deployNode.get(CONTENT).get(0).get(HASH).asBytes();
                             if (!Arrays.equals(originalHash, newHash)) {
-                                contentRepository.removeContent(originalHash);
+                                contentRepository.removeContent(originalHash, name);
                             }
                         }
                     }
                 } else {
                     if (contentRepository != null && operation.get(CONTENT).get(0).hasDefined(HASH)) {
                         byte[] newHash = operation.get(CONTENT).get(0).get(HASH).asBytes();
-                        contentRepository.removeContent(newHash);
+                        contentRepository.removeContent(newHash, name);
                     }
                 }
             }
         });
-
     }
 
     private static void removeAttributes(final ModelNode node, final Iterable<String> attributeNames) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -82,7 +82,7 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
             def.validateOperation(operation);
         }
 
-        String name = DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.get(NAME).resolveModelAttribute(context, operation).asString();
+        final String name = DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.get(NAME).resolveModelAttribute(context, operation).asString();
         final PathAddress address = PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(DEPLOYMENT, name));
 
         final Resource root = context.readResource(PathAddress.EMPTY_ADDRESS);
@@ -137,10 +137,13 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
             public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                 if (resultAction == ResultAction.KEEP) {
                     if (originalHash != null  && newHash != null && !Arrays.equals(originalHash, newHash)) {
-                        contentRepository.removeContent(originalHash);
+                        contentRepository.removeContent(originalHash, name);
+                        if (contentRepository != null && newHash != null) {
+                            contentRepository.addContentReference(newHash, name);
+                        }
                     }
                 } else if (newHash != null) {
-                    contentRepository.removeContent(newHash);
+                    contentRepository.removeContent(newHash, name);
                 }
             }
         });

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
@@ -19,6 +19,7 @@
 package org.jboss.as.server.deployment;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_ALL;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
@@ -60,6 +61,7 @@ public class DeploymentRemoveHandler implements OperationStepHandler {
     }
 
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final String name = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
         Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
         final List<byte[]> removedHashes = DeploymentUtils.getDeploymentHash(resource);
 
@@ -104,7 +106,7 @@ public class DeploymentRemoveHandler implements OperationStepHandler {
 
                                 for (byte[] hash : removedHashes) {
                                     try {
-                                        contentRepository.removeContent(hash);
+                                        contentRepository.removeContent(hash, name);
                                     } catch (Exception e) {
                                         //TODO
                                         ServerLogger.DEPLOYMENT_LOGGER.failedToRemoveDeploymentContent(e, HashUtil.bytesToHexString(hash));

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/RemoteFileRepositoryService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/RemoteFileRepositoryService.java
@@ -22,11 +22,16 @@
 
 package org.jboss.as.server.mgmt.domain;
 
+import static org.jboss.as.server.ServerMessages.MESSAGES;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.jboss.as.controller.HashUtil;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.repository.DeploymentFileRepository;
 import org.jboss.as.repository.LocalDeploymentFileRepository;
-import static org.jboss.as.server.ServerMessages.MESSAGES;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
@@ -35,10 +40,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.vfs.VirtualFile;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * @author Emanuel Muckenhuber
@@ -110,8 +111,8 @@ public class RemoteFileRepositoryService implements CompositeContentRepository, 
     }
 
     @Override
-    public void removeContent(byte[] hash) {
-        contentRepository.removeContent(hash);
+    public void removeContent(byte[] hash, Object reference) {
+        contentRepository.removeContent(hash, reference);
     }
 
     @Override
@@ -141,6 +142,11 @@ public class RemoteFileRepositoryService implements CompositeContentRepository, 
     @Override
     public void deleteDeployment(byte[] deploymentHash) {
         localRepository.deleteDeployment(deploymentHash);
+    }
+
+    @Override
+    public void addContentReference(byte[] hash, Object reference) {
+        contentRepository.addContentReference(hash, reference);
     }
 
 }

--- a/server/src/test/java/org/jboss/as/server/deployment/DeploymentAddHandlerTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/deployment/DeploymentAddHandlerTestCase.java
@@ -107,7 +107,7 @@ public class DeploymentAddHandlerTestCase {
     private ContentRepository contentRepository = new ContentRepository() {
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
         }
 
         @Override
@@ -128,6 +128,10 @@ public class DeploymentAddHandlerTestCase {
         @Override
         public byte[] addContent(InputStream stream) throws IOException {
             return null;
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
     };
 }

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -478,7 +478,11 @@ public class ServerControllerUnitTestCase {
         }
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
 
     }

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -160,7 +160,11 @@ class TestModelControllerService extends ModelTestModelControllerService {
         }
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentManagementTestCase.java
@@ -82,6 +82,7 @@ import org.junit.Test;
 public class DeploymentManagementTestCase {
 
     private static final String TEST = "test.war";
+    private static final String TEST2 = "test2.war";
     private static final String REPLACEMENT = "test.war.v2";
     private static final ModelNode ROOT_ADDRESS = new ModelNode();
     private static final ModelNode ROOT_DEPLOYMENT_ADDRESS = new ModelNode();
@@ -682,8 +683,6 @@ public class DeploymentManagementTestCase {
         // Chnage the runtime name in the sg op
         composite.get("steps").get(1).get(RUNTIME_NAME).set("test1.war");
 
-        System.out.println(composite);
-
         OperationBuilder builder = new OperationBuilder(composite, true);
         builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
 
@@ -707,6 +706,72 @@ public class DeploymentManagementTestCase {
             fail("Webapp deployed to unselected server group");
         } catch (IOException ioe) {
             // good
+        }
+    }
+
+    @Test
+    public void testDeploymentsWithSameHash() throws Exception {
+        final ModelNode rootDeploymentAddress2 = new ModelNode();
+        rootDeploymentAddress2.add(DEPLOYMENT, "test2");
+        rootDeploymentAddress2.protect();
+
+        final ModelNode otherServerGroupDeploymentAddress2 = new ModelNode();
+        otherServerGroupDeploymentAddress2.add(SERVER_GROUP, "other-server-group");
+        otherServerGroupDeploymentAddress2.add(DEPLOYMENT, "test2");
+        otherServerGroupDeploymentAddress2.protect();
+
+        class LocalMethods {
+            Operation createDeploymentOperation(ModelNode rootDeploymentAddress, ModelNode serverGroupDeploymentAddress) {
+                ModelNode composite = getEmptyOperation(COMPOSITE, ROOT_ADDRESS);
+                ModelNode steps = composite.get(STEPS);
+
+                ModelNode step = steps.add();
+                step.set(getEmptyOperation(ADD, rootDeploymentAddress));
+                ModelNode content = new ModelNode();
+                content.get(INPUT_STREAM_INDEX).set(0);
+                step.get(CONTENT).add(content);
+
+                step = steps.add();
+                step.set(getEmptyOperation(ADD, serverGroupDeploymentAddress));
+                step.get(ENABLED).set(true);
+
+                OperationBuilder builder = new OperationBuilder(composite, true);
+                builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
+                return builder.build();
+             }
+
+             ModelNode createRemoveOperation(ModelNode rootDeploymentAddress, ModelNode serverGroupDeploymentAddress) {
+                 ModelNode composite = getEmptyOperation(COMPOSITE, ROOT_ADDRESS);
+                 ModelNode steps = composite.get(STEPS);
+
+                 ModelNode step = steps.add();
+                 step.set(getEmptyOperation(REMOVE, serverGroupDeploymentAddress));
+
+                 step = steps.add();
+                 step.set(getEmptyOperation(REMOVE, rootDeploymentAddress));
+
+                 return composite;
+             }
+
+        };
+        LocalMethods localMethods = new LocalMethods();
+        try {
+            executeOnMaster(localMethods.createDeploymentOperation(ROOT_DEPLOYMENT_ADDRESS, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS));
+            try {
+                executeOnMaster(localMethods.createDeploymentOperation(rootDeploymentAddress2, otherServerGroupDeploymentAddress2));
+            } finally {
+                executeOnMaster(localMethods.createRemoveOperation(rootDeploymentAddress2, otherServerGroupDeploymentAddress2));
+            }
+
+            ModelNode undeploySg = getEmptyOperation(REMOVE, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+            executeOnMaster(undeploySg);
+
+            ModelNode deploySg = getEmptyOperation(ADD, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+            deploySg.get(ENABLED).set(true);
+            executeOnMaster(deploySg);
+
+        } finally {
+            executeOnMaster(localMethods.createRemoveOperation(ROOT_DEPLOYMENT_ADDRESS, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS));
         }
     }
 
@@ -761,6 +826,7 @@ public class DeploymentManagementTestCase {
 
         return composite;
     }
+
 
     private static ModelNode createDeploymentReplaceOperation(ModelNode content, ModelNode... serverGroupAddressses) {
         ModelNode composite = getEmptyOperation(COMPOSITE, ROOT_ADDRESS);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -1036,7 +1036,11 @@ public class ParseAndMarshalModelsTestCase {
         }
 
         @Override
-        public void removeContent(byte[] hash) {
+        public void removeContent(byte[] hash, Object reference) {
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
         }
 
     }


### PR DESCRIPTION
...the content repository.

This is to handle the case where the same deployment is deployed with the same name, to make sure
that a copy is kept in the repository if one is removed. Once all deployments are removed, the
content is removed.

THis has so far ONLY been done for deployments. No attempt has been made to handle this for deployment overlays
