### PR TITLE
AS7-5943 fixing jboss-common_6_0.xsd schema validation issue on IBM JDK

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
@@ -82,6 +82,7 @@ public class AbstractValidationUnitTest {
         NAMESPACE_MAP.put("http://java.sun.com/xml/ns/javaee/javaee_6.xsd", "schema/javaee_6.xsd");
         NAMESPACE_MAP.put("http://www.w3.org/2001/xml.xsd", "schema/xml.xsd");
         NAMESPACE_MAP.put("http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd", "schema/ejb-jar_3_1.xsd");
+        NAMESPACE_MAP.put("http://www.jboss.org/j2ee/schema/jboss-common_6_0.xsd", "jboss-common_6_0.xsd");
 
         String asDir = System.getProperty(JBOSS_DIST_PROP_NAME);
         if( null == asDir ){


### PR DESCRIPTION
Very simple one-line fix, see

https://issues.jboss.org/browse/AS7-5943
