### PR TITLE
AS7-1264 Add schema references to standalone.xml, domain.xml, host.xml. ...

### DIFF
--- a/build/src/main/resources/configuration/domain/template.xml
+++ b/build/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:1.4"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd" >
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/configuration/standalone/template-osgi.xml
+++ b/build/src/main/resources/configuration/standalone/template-osgi.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:1.4"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd" >
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:1.4"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd" >
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/configuration/subsystems/cmp.xml
+++ b/build/src/main/resources/configuration/subsystems/cmp.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.cmp</extension-module>
-   <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:cmp:1.0"
+        xsi:schemaLocation="urn:jboss:domain:cmp:1.0 http://www.jboss.org/j2ee/jboss-as-cmp_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/configadmin.xml
+++ b/build/src/main/resources/configuration/subsystems/configadmin.xml
@@ -1,7 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <extension-module>org.jboss.as.configadmin</extension-module>
-    <subsystem xmlns="urn:jboss:domain:configadmin:1.0">
+    <subsystem xmlns="urn:jboss:domain:configadmin:1.0"
+        xsi:schemaLocation="urn:jboss:domain:configadmin:1.0 http://www.jboss.org/j2ee/jboss-as-configadmin_1_0.xsd" >
     </subsystem>
 </config>

--- a/build/src/main/resources/configuration/subsystems/datasources.xml
+++ b/build/src/main/resources/configuration/subsystems/datasources.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.connector</extension-module>
-   <subsystem xmlns="urn:jboss:domain:datasources:1.1">
+   <subsystem xmlns="urn:jboss:domain:datasources:1.1"
+        xsi:schemaLocation="urn:jboss:domain:datasources:1.1 http://www.jboss.org/j2ee/jboss-as-datasources_1_1.xsd">
        <datasources>
            <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
                <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>

--- a/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
+++ b/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.deployment-scanner</extension-module>
-   <subsystem xmlns="urn:jboss:domain:deployment-scanner:1.1">
+   <subsystem xmlns="urn:jboss:domain:deployment-scanner:1.1"
+        xsi:schemaLocation="urn:jboss:domain:deployment-scanner:1.1 http://www.jboss.org/j2ee/jboss-as-deployment-scanner_1_1.xsd" >
        <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/configuration/subsystems/ee.xml
+++ b/build/src/main/resources/configuration/subsystems/ee.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.ee</extension-module>
-   <subsystem xmlns="urn:jboss:domain:ee:1.1">
+   <subsystem xmlns="urn:jboss:domain:ee:1.1"
+        xsi:schemaLocation="urn:jboss:domain:ee:1.1 http://www.jboss.org/j2ee/jboss-as-ee_1_1.xsd">
         <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
         <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
    </subsystem>

--- a/build/src/main/resources/configuration/subsystems/ejb3.xml
+++ b/build/src/main/resources/configuration/subsystems/ejb3.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config default-supplement="default">
+<config default-supplement="default" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.ejb3</extension-module>
-   <subsystem xmlns="urn:jboss:domain:ejb3:1.4">
+   <subsystem xmlns="urn:jboss:domain:ejb3:1.4"
+        xsi:schemaLocation="urn:jboss:domain:ejb3:1.4 http://www.jboss.org/j2ee/jboss-as-ejb3_1_4.xsd">
        <session-bean>
            <stateless>
                <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>

--- a/build/src/main/resources/configuration/subsystems/infinispan.xml
+++ b/build/src/main/resources/configuration/subsystems/infinispan.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config default-supplement="default">
+<config default-supplement="default" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <extension-module>org.jboss.as.clustering.infinispan</extension-module>
-    <subsystem xmlns="urn:jboss:domain:infinispan:1.4">
+    <subsystem xmlns="urn:jboss:domain:infinispan:1.4"
+        xsi:schemaLocation="urn:jboss:domain:infinispan:1.4 http://www.jboss.org/j2ee/jboss-as-infinispan_1_4.xsd" >
         <?CACHE-CONTAINERS?>
     </subsystem>
     <supplement name="default">

--- a/build/src/main/resources/configuration/subsystems/jacorb.xml
+++ b/build/src/main/resources/configuration/subsystems/jacorb.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jacorb</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+   <subsystem xmlns="urn:jboss:domain:jacorb:1.2"
+        xsi:schemaLocation="urn:jboss:domain:jacorb:1.2 http://www.jboss.org/j2ee/jboss-as-jacorb_1_2.xsd" >
        <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
            <initializers transactions="spec" security="on"/>
        </orb>

--- a/build/src/main/resources/configuration/subsystems/jaxr.xml
+++ b/build/src/main/resources/configuration/subsystems/jaxr.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jaxr</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+   <subsystem xmlns="urn:jboss:domain:jaxr:1.1"
+        xsi:schemaLocation="urn:jboss:domain:jaxr:1.1 http://www.jboss.org/j2ee/jboss-as-jaxr_1_1.xsd" >
        <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/configuration/subsystems/jaxrs.xml
+++ b/build/src/main/resources/configuration/subsystems/jaxrs.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jaxrs</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"
+        xsi:schemaLocation="urn:jboss:domain:jaxrs:1.0 http://www.jboss.org/j2ee/jboss-as-jaxrs_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/jca.xml
+++ b/build/src/main/resources/configuration/subsystems/jca.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.connector</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jca:1.1">
+   <subsystem xmlns="urn:jboss:domain:jca:1.1"
+        xsi:schemaLocation="urn:jboss:domain:jca:1.1 http://www.jboss.org/j2ee/jboss-as-jca_1_1.xsd" >
        <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
        <bean-validation enabled="true"/>
        <default-workmanager>

--- a/build/src/main/resources/configuration/subsystems/jdr.xml
+++ b/build/src/main/resources/configuration/subsystems/jdr.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jdr</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:jdr:1.0"
+        xsi:schemaLocation="urn:jboss:domain:jdr:1.0 http://www.jboss.org/j2ee/jboss-as-jdr_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/jgroups.xml
+++ b/build/src/main/resources/configuration/subsystems/jgroups.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.clustering.jgroups</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="udp">
+   <subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="udp"
+        xsi:schemaLocation="urn:jboss:domain:jgroups:1.1 http://www.jboss.org/j2ee/jboss-as-jgroups_1_1.xsd" >
        <stack name="udp">
            <transport type="UDP" socket-binding="jgroups-udp"/>
            <protocol type="PING"/>

--- a/build/src/main/resources/configuration/subsystems/jmx.xml
+++ b/build/src/main/resources/configuration/subsystems/jmx.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config default-supplement="default">
+<config default-supplement="default" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jmx</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jmx:1.2">
+   <subsystem xmlns="urn:jboss:domain:jmx:1.2"
+        xsi:schemaLocation="urn:jboss:domain:jmx:1.2 http://www.jboss.org/j2ee/jboss-as-jmx_1_2.xsd" >
        <expose-resolved-model/>
        <expose-expression-model/>
        <?REMOTING-CONNECTOR?>

--- a/build/src/main/resources/configuration/subsystems/jpa.xml
+++ b/build/src/main/resources/configuration/subsystems/jpa.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jpa</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+   <subsystem xmlns="urn:jboss:domain:jpa:1.1"
+        xsi:schemaLocation="urn:jboss:domain:jpa:1.1 http://www.jboss.org/j2ee/jboss-as-jpa_1_1.xsd" >
        <jpa default-datasource="" default-extended-persistence-inheritance="DEEP" default-vfs="true"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/configuration/subsystems/jsf.xml
+++ b/build/src/main/resources/configuration/subsystems/jsf.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jsf</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:jsf:1.0"
+        xsi:schemaLocation="urn:jboss:domain:jsf:1.0 http://www.jboss.org/j2ee/jboss-as-jsf_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/jsr77.xml
+++ b/build/src/main/resources/configuration/subsystems/jsr77.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.jsr77</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jsr77:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:jsr77:1.0"
+        xsi:schemaLocation="urn:jboss:domain:jsr77:1.0 http://www.jboss.org/j2ee/jboss-as-jsr77_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/logging.xml
+++ b/build/src/main/resources/configuration/subsystems/logging.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config default-supplement="default">
+<config default-supplement="default" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.logging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:logging:1.2">
+   <subsystem xmlns="urn:jboss:domain:logging:1.2"
+        xsi:schemaLocation="urn:jboss:domain:logging:1.2 http://www.jboss.org/j2ee/jboss-as-logging_1_2.xsd">
        <console-handler name="CONSOLE">
            <level name="INFO"/>
            <formatter>

--- a/build/src/main/resources/configuration/subsystems/mail.xml
+++ b/build/src/main/resources/configuration/subsystems/mail.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.mail</extension-module>
-   <subsystem xmlns="urn:jboss:domain:mail:1.0">
+   <subsystem xmlns="urn:jboss:domain:mail:1.1"
+        xsi:schemaLocation="urn:jboss:domain:mail:1.1 http://www.jboss.org/j2ee/jboss-as-mail_1_1.xsd">
        <mail-session jndi-name="java:jboss/mail/Default">
            <smtp-server outbound-socket-binding-ref="mail-smtp"/>
        </mail-session>

--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.3"
+        xsi:schemaLocation="urn:jboss:domain:messaging:1.3 http://www.jboss.org/j2ee/jboss-as-messaging_1_3.xsd">
        <hornetq-server>
            <?CLUSTERED?>
            <persistence-enabled>true</persistence-enabled>

--- a/build/src/main/resources/configuration/subsystems/modcluster.xml
+++ b/build/src/main/resources/configuration/subsystems/modcluster.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.modcluster</extension-module>
-   <subsystem xmlns="urn:jboss:domain:modcluster:1.1">
+   <subsystem xmlns="urn:jboss:domain:modcluster:1.1"
+        xsi:schemaLocation="urn:jboss:domain:modcluster:1.1 http://www.jboss.org/j2ee/jboss-as-mod-cluster_1_1.xsd">
        <mod-cluster-config advertise-socket="modcluster" connector="ajp">
            <dynamic-load-provider>
                <load-metric type="busyness"/>

--- a/build/src/main/resources/configuration/subsystems/naming.xml
+++ b/build/src/main/resources/configuration/subsystems/naming.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.naming</extension-module>
-   <subsystem xmlns="urn:jboss:domain:naming:1.2">
+   <subsystem xmlns="urn:jboss:domain:naming:1.2"
+        xsi:schemaLocation="urn:jboss:domain:naming:1.2 http://www.jboss.org/j2ee/jboss-as-naming_1_2.xsd">
        <remote-naming/>
    </subsystem>
 </config>

--- a/build/src/main/resources/configuration/subsystems/osgi.xml
+++ b/build/src/main/resources/configuration/subsystems/osgi.xml
@@ -1,10 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config default-supplement="default">
+<config default-supplement="default" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <extension-module>org.jboss.as.osgi</extension-module>
-    <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="@@activation@@">
-    <?PROPERTIES?>
-    <?CAPABILITIES?>
+    <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="@@activation@@"
+        xsi:schemaLocation="urn:jboss:domain:osgi:1.2 http://www.jboss.org/j2ee/jboss-as-osgi_1_2.xsd">
+        <?PROPERTIES?>
+        <?CAPABILITIES?>
     </subsystem>
     <supplement name="default">
         <replacement placeholder="@@activation@@" attributeValue="lazy" />

--- a/build/src/main/resources/configuration/subsystems/pojo.xml
+++ b/build/src/main/resources/configuration/subsystems/pojo.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.pojo</extension-module>
-   <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:pojo:1.0"
+        xsi:schemaLocation="urn:jboss:domain:pojo:1.0 http://www.jboss.org/j2ee/jboss-as-pojo_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/remoting.xml
+++ b/build/src/main/resources/configuration/subsystems/remoting.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.remoting</extension-module>
-   <subsystem xmlns="urn:jboss:domain:remoting:1.1">
+   <subsystem xmlns="urn:jboss:domain:remoting:1.1"
+        xsi:schemaLocation="urn:jboss:domain:remoting:1.1 http://www.jboss.org/j2ee/jboss-as-remoting_1_1.xsd">
        <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
    </subsystem>
    <socket-binding name="remoting" port="4447"/>

--- a/build/src/main/resources/configuration/subsystems/resource-adapters.xml
+++ b/build/src/main/resources/configuration/subsystems/resource-adapters.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.connector</extension-module>
-   <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"
+        xsi:schemaLocation="urn:jboss:domain:resource-adapters:1.0 http://www.jboss.org/j2ee/jboss-as-resource-adapters_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/sar.xml
+++ b/build/src/main/resources/configuration/subsystems/sar.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.sar</extension-module>
-   <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:sar:1.0"
+        xsi:schemaLocation="urn:jboss:domain:sar:1.0 http://www.jboss.org/j2ee/jboss-as-sar_1_0.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/security.xml
+++ b/build/src/main/resources/configuration/subsystems/security.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.security</extension-module>
-   <subsystem xmlns="urn:jboss:domain:security:1.2">
+   <subsystem xmlns="urn:jboss:domain:security:1.2"
+        xsi:schemaLocation="urn:jboss:domain:security:1.2 http://www.jboss.org/j2ee/jboss-as-security_1_2.xsd">
        <security-domains>
            <security-domain name="other" cache-type="default">
                <authentication>

--- a/build/src/main/resources/configuration/subsystems/threads.xml
+++ b/build/src/main/resources/configuration/subsystems/threads.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.threads</extension-module>
-   <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
+   <subsystem xmlns="urn:jboss:domain:threads:1.1"
+        xsi:schemaLocation="urn:jboss:domain:threads:1.1 http://www.jboss.org/j2ee/jboss-as-threads_1_1.xsd" />
 </config>

--- a/build/src/main/resources/configuration/subsystems/transactions.xml
+++ b/build/src/main/resources/configuration/subsystems/transactions.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.transactions</extension-module>
-   <subsystem xmlns="urn:jboss:domain:transactions:1.2">
+   <subsystem xmlns="urn:jboss:domain:transactions:1.2"
+        xsi:schemaLocation="urn:jboss:domain:transactions:1.2 http://www.jboss.org/j2ee/jboss-as-txn_1_2.xsd">
        <core-environment>
            <process-id>
                <uuid/>

--- a/build/src/main/resources/configuration/subsystems/web.xml
+++ b/build/src/main/resources/configuration/subsystems/web.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.web</extension-module>
-   <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+   <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false"
+        xsi:schemaLocation="urn:jboss:domain:web:1.2 http://www.jboss.org/j2ee/jboss-as-web_1_2.xsd">
        <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
        <?AJP?>
        <virtual-server name="default-host" enable-welcome-root="true">

--- a/build/src/main/resources/configuration/subsystems/webservices.xml
+++ b/build/src/main/resources/configuration/subsystems/webservices.xml
@@ -1,8 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.webservices</extension-module>
-   <subsystem xmlns="urn:jboss:domain:webservices:1.2">
+   <subsystem xmlns="urn:jboss:domain:webservices:1.2"
+        xsi:schemaLocation="urn:jboss:domain:webservices:1.2 http://www.jboss.org/j2ee/jboss-as-webservices_1_2.xsd">
        <modify-wsdl-address>true</modify-wsdl-address>
        <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
        <endpoint-config name="Standard-Endpoint-Config"/>

--- a/build/src/main/resources/configuration/subsystems/weld.xml
+++ b/build/src/main/resources/configuration/subsystems/weld.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <extension-module>org.jboss.as.weld</extension-module>
-   <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
+   <subsystem xmlns="urn:jboss:domain:weld:1.0"
+        xsi:schemaLocation="urn:jboss:domain:weld:1.0 http://www.jboss.org/j2ee/jboss-as-weld_1_0.xsd" />
 </config>

--- a/build/src/main/resources/domain/configuration/host-master.xml
+++ b/build/src/main/resources/domain/configuration/host-master.xml
@@ -4,7 +4,7 @@
    A simple configuration for a Host Controller that only acts as the master domain controller
    and does not itself directly control any servers.
 -->
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd">
 
     <management>
         <security-realms>

--- a/build/src/main/resources/domain/configuration/host-slave.xml
+++ b/build/src/main/resources/domain/configuration/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:1.4">
+<host xmlns="urn:jboss:domain:1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd">
 
     <management>
         <security-realms>

--- a/build/src/main/resources/domain/configuration/host.xml
+++ b/build/src/main/resources/domain/configuration/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd">
 
     <management>
         <security-realms>

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader_1_1.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader_1_1.java
@@ -22,11 +22,13 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -56,7 +58,6 @@ public class JGroupsSubsystemXMLReader_1_1 implements XMLElementReader<List<Mode
         ModelNode subsystem = Util.createAddOperation(subsystemAddress);
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
-            ParseUtils.requireNoNamespaceAttribute(reader, i);
             String value = reader.getAttributeValue(i);
             Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
@@ -65,7 +66,8 @@ public class JGroupsSubsystemXMLReader_1_1 implements XMLElementReader<List<Mode
                     break;
                 }
                 default: {
-                    throw ParseUtils.unexpectedAttribute(reader, i);
+                    if (!XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI.equals(reader.getAttributeNamespace(i)))
+                        throw ParseUtils.unexpectedAttribute(reader, i);
                 }
             }
         }

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/AttributeValue.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/AttributeValue.java
@@ -39,4 +39,10 @@ public class AttributeValue {
     void setValue(String value) {
         this.value = value;
     }
+
+    @Override
+    public String toString() {
+        return "AttributeValue [" + value + "]";
+    }
+
 }

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/ConfigurationAssembler.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/ConfigurationAssembler.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 
@@ -132,7 +133,7 @@ class ConfigurationAssembler {
             final ProcessingInstructionNode extensionNode = templateParser.getExtensionPlaceHolder();
             for (String extension : extensions) {
                 final ElementNode extensionElement = new ElementNode(null, "extension", templateParser.getRootNode().getNamespace());
-                extensionElement.addAttribute("module", new AttributeValue(extension));
+                extensionElement.addAttribute(QName.valueOf("module"), new AttributeValue(extension));
                 extensionNode.addDelegate(extensionElement);
             }
         } else {

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/GenerateModulesDefinition.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/GenerateModulesDefinition.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -172,12 +173,12 @@ public class GenerateModulesDefinition {
     private void processModuleDependency(List<ModuleIdentifier> dependencies, ElementNode parentNode, ModuleDependency dep) throws IOException, XMLStreamException {
         ModuleIdentifier moduleId = dep.getModuleId();
         ElementNode moduleNode = new ElementNode(parentNode, "module");
-        moduleNode.addAttribute("name", new AttributeValue(moduleId.toString()));
+        moduleNode.addAttribute(QName.valueOf("name"), new AttributeValue(moduleId.toString()));
         if (dep.isOptional()) {
-            moduleNode.addAttribute("optional", new AttributeValue("true"));
+            moduleNode.addAttribute(QName.valueOf("optional"), new AttributeValue("true"));
         }
         if (dependencies.contains(moduleId)) {
-            moduleNode.addAttribute("defined", new AttributeValue("true"));
+            moduleNode.addAttribute(QName.valueOf("defined"), new AttributeValue("true"));
             parentNode.addChild(moduleNode);
         } else {
             parentNode.addChild(moduleNode);

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/GenerateSubsystemsDefinition.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/GenerateSubsystemsDefinition.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -108,14 +109,14 @@ public class GenerateSubsystemsDefinition {
         for (String profile : profiles) {
             ElementNode subsystems = new ElementNode(config, "subsystems");
             if (!profile.isEmpty()) {
-                subsystems.addAttribute("name", new AttributeValue(profile));
+                subsystems.addAttribute(QName.valueOf("name"), new AttributeValue(profile));
             }
             config.addChild(subsystems);
 
             for (SubsystemConfig sub : configs) {
                 ElementNode subsystem = new ElementNode(config, "subsystem");
                 if (sub.getSupplement() != null) {
-                    subsystem.addAttribute("supplement", new AttributeValue(sub.getSupplement()));
+                    subsystem.addAttribute(QName.valueOf("supplement"), new AttributeValue(sub.getSupplement()));
                 }
                 subsystem.addChild(new TextNode(filePrefix + sub.getSubsystem() + ".xml"));
                 subsystems.addChild(subsystem);

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/NodeParser.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/NodeParser.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
@@ -48,6 +49,10 @@ class NodeParser {
 
     NodeParser(String namespaceURI){
         this.namespaceURI = namespaceURI;
+    }
+
+    QName localQNameOf(String name) {
+        return new QName(namespaceURI, name);
     }
 
     ElementNode parseNode(XMLStreamReader reader, String nodeName) throws XMLStreamException {
@@ -109,9 +114,12 @@ class NodeParser {
         ElementNode childNode = new ElementNode(parent, reader.getLocalName(), namespace);
         int count = reader.getAttributeCount();
         for (int i = 0 ; i < count ; i++) {
-            String name = reader.getAttributeLocalName(i);
+            QName name = reader.getAttributeName(i);
             String value = reader.getAttributeValue(i);
             childNode.addAttribute(name, createAttributeValue(value));
+        }
+        for (int i = 0; i < reader.getNamespaceCount(); ++i) {
+            childNode.addNamespace(reader.getNamespacePrefix(i), reader.getNamespaceURI(i));
         }
         return childNode;
     }

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/SubsystemParser.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/SubsystemParser.java
@@ -102,10 +102,10 @@ class SubsystemParser extends NodeParser {
                         parseSupplement(reader, ((ElementNode)subsystem).getNamespace());
                     } else if (reader.getLocalName().equals("socket-binding")) {
                         ElementNode socketBinding = new NodeParser(socketBindingNamespace).parseNode(reader, "socket-binding");
-                        socketBindings.put(socketBinding.getAttributeValue("name"), socketBinding);
+                        socketBindings.put(socketBinding.getAttributeValue(localQNameOf("name")), socketBinding);
                     } else if (reader.getLocalName().equals("outbound-socket-binding")) {
                         ElementNode socketBinding = new NodeParser(socketBindingNamespace).parseNode(reader, "outbound-socket-binding");
-                        outboundSocketBindings.put(socketBinding.getAttributeValue("name"), socketBinding);
+                        outboundSocketBindings.put(socketBinding.getAttributeValue(localQNameOf("name")), socketBinding);
                     }
                 }
             }

--- a/config-assembly/src/main/java/org/jboss/as/config/assembly/TemplateParser.java
+++ b/config-assembly/src/main/java/org/jboss/as/config/assembly/TemplateParser.java
@@ -117,7 +117,7 @@ public class TemplateParser extends NodeParser {
             if (data.size() > 1) {
                 throw new IllegalStateException("Only 'socket-binding-group' is valid <?" + TemplateParser.SUBSYSTEMS_PI + "?> data");
             }
-            String profileName = parent.getAttributeValue("name", "");
+            String profileName = parent.getAttributeValue(localQNameOf("name"), "");
             node = new ProcessingInstructionNode(profileName, data);
             subsystemPlaceHolders.put(profileName, node);
         } else if (pi.equals(TemplateParser.SOCKET_BINDINGS_PI)) {
@@ -128,7 +128,7 @@ public class TemplateParser extends NodeParser {
                 throw new IllegalStateException("<?" + TemplateParser.SOCKET_BINDINGS_PI + "?> should not take any data");
             }
 
-            String groupName = parent.getAttributeValue("name", "");
+            String groupName = parent.getAttributeValue(localQNameOf("name"), "");
             node = new ProcessingInstructionNode(TemplateParser.SOCKET_BINDINGS_PI, data);
             socketBindingsPlaceHolder.put(groupName, node);
         } else {

--- a/config-assembly/src/test/resources/org/jboss/as/config/assembly/domain-template.xml
+++ b/config-assembly/src/test/resources/org/jboss/as/config/assembly/domain-template.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.3">
+<server xmlns="urn:jboss:domain:1.4"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd" >
 
     <extensions>
         <?EXTENSIONS?>

--- a/config-assembly/src/test/resources/org/jboss/as/config/assembly/standalone-template.xml
+++ b/config-assembly/src/test/resources/org/jboss/as/config/assembly/standalone-template.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.3">
+<server xmlns="urn:jboss:domain:1.4"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:jboss:domain:1.4 http://www.jboss.org/j2ee/jboss-as-config_1_4.xsd" >
 
     <extensions>
         <?EXTENSIONS?>

--- a/controller/src/test/java/org/jboss/as/controller/parsing/ParseUtilsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/parsing/ParseUtilsTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.parsing;
+
+import java.io.InputStream;
+
+import javax.xml.stream.FactoryConfigurationError;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ParseUtils}.
+ * 
+ * @author steve.coy
+ */
+public class ParseUtilsTestCase {
+
+    @Test
+    public void testRequireNoAttributesWithoutSchemaLocation() throws XMLStreamException, FactoryConfigurationError {
+        InputStream xmlInput = ParseUtilsTestCase.class.getResourceAsStream("testRequireNoAttributesWithoutSchemaLocation.xml");
+        XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(xmlInput);
+        try {
+            xmlReader.nextTag();
+            ParseUtils.requireNoAttributes(xmlReader);
+        } finally {
+            xmlReader.close();
+        }
+    }
+
+    @Test
+    public void testRequireNoAttributesWithoutSchemaLocationFail() throws XMLStreamException, FactoryConfigurationError {
+        InputStream xmlInput = ParseUtilsTestCase.class.getResourceAsStream("testRequireNoAttributesWithoutSchemaLocationFail.xml");
+        XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(xmlInput);
+        try {
+            xmlReader.nextTag();
+            try {
+                ParseUtils.requireNoAttributes(xmlReader);
+                Assert.fail("XMLStreamException expected");
+            } catch (XMLStreamException e) {
+                Assert.assertTrue("Unexpected attribute", e.getMessage().contains("JBAS014788"));
+            }
+        } finally {
+            xmlReader.close();
+        }
+    }
+
+    @Test
+    public void testRequireNoAttributesWithSchemaLocation() throws XMLStreamException, FactoryConfigurationError {
+        InputStream xmlInput = ParseUtilsTestCase.class.getResourceAsStream("testRequireNoAttributesWithSchemaLocation.xml");
+        XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(xmlInput);
+        try {
+            xmlReader.nextTag();
+            ParseUtils.requireNoAttributes(xmlReader);
+        } finally {
+            xmlReader.close();
+        }
+    }
+
+    @Test
+    public void testRequireNoAttributesWithSchemaLocationFail() throws XMLStreamException, FactoryConfigurationError {
+        InputStream xmlInput = ParseUtilsTestCase.class.getResourceAsStream("testRequireNoAttributesWithSchemaLocationFail.xml");
+        XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(xmlInput);
+        try {
+            xmlReader.nextTag();
+            try {
+                ParseUtils.requireNoAttributes(xmlReader);
+                Assert.fail("XMLStreamException expected");
+            } catch (XMLStreamException e) {
+                Assert.assertTrue("Unexpected attribute", e.getMessage().contains("JBAS014788"));
+            }
+        } finally {
+            xmlReader.close();
+        }
+    }
+}

--- a/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithSchemaLocation.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithSchemaLocation.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test xmlns="urn:test:1.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="urn:test:1.0 http://somewhere.org/test_1_0.xsd">
+    
+    <nested foo='bar'>
+    </nested>
+</test>

--- a/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithSchemaLocationFail.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithSchemaLocationFail.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test xmlns="urn:test:1.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="urn:test:1.0 http://somewhere.org/test_1_0.xsd"
+    unexpected="attributeValue">
+    
+    <nested foo='bar'>
+    </nested>
+</test>

--- a/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithoutSchemaLocation.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithoutSchemaLocation.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test xmlns="urn:test:1.0" >
+    <nested foo='bar'>
+    </nested>
+</test>

--- a/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithoutSchemaLocationFail.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/parsing/testRequireNoAttributesWithoutSchemaLocationFail.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<test xmlns="urn:test:1.0"
+    unexpected="attributeValue">
+    
+    <nested foo='bar'>
+    </nested>
+</test>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -274,8 +275,8 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>>,
     }
 
     protected void readAttribute(final ModelNode subsystemAddOperation, final XMLExtendedStreamReader reader, final int i) throws XMLStreamException {
-        ParseUtils.requireNoNamespaceAttribute(reader, i);
-        throw ParseUtils.unexpectedAttribute(reader, i);
+        if (!XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI.equals(reader.getAttributeNamespace(i)))
+            throw unexpectedAttribute(reader, i);
     }
 
     protected void readAttributes(final ModelNode subsystemAddOperation, final XMLExtendedStreamReader reader) throws XMLStreamException {

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.readStringAttributeElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
@@ -117,10 +118,9 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
      */
     @Override
     public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> list) throws XMLStreamException {
-        // No attributes
-        if (reader.getAttributeCount() > 0) {
-            throw unexpectedAttribute(reader, 0);
-        }
+
+        requireNoAttributes(reader);
+
         final PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, LoggingExtension.SUBSYSTEM_NAME));
 
         list.add(Util.createAddOperation(address));

--- a/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiNamespace12Parser.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/parser/OSGiNamespace12Parser.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -98,7 +99,6 @@ class OSGiNamespace12Parser implements Namespace12, XMLStreamConstants, XMLEleme
                 // Handle attributes
                 int count = reader.getAttributeCount();
                 for (int i = 0; i < count; i++) {
-                    requireNoNamespaceAttribute(reader, i);
                     final String attrValue = reader.getAttributeValue(i);
                     final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
                     switch (attribute) {
@@ -107,7 +107,8 @@ class OSGiNamespace12Parser implements Namespace12, XMLStreamConstants, XMLEleme
                             break;
                         }
                         default:
-                            throw unexpectedAttribute(reader, i);
+                            if (!XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI.equals(reader.getAttributeNamespace(i)))
+                                throw unexpectedAttribute(reader, i);
                     }
                 }
                 break;

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem12Parser.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem12Parser.java
@@ -43,6 +43,7 @@ import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
 import static org.jboss.as.controller.parsing.ParseUtils.missingOneOf;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequiredElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
@@ -63,10 +64,7 @@ class TransactionSubsystem12Parser implements XMLStreamConstants, XMLElementRead
      */
     @Override
     public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
-        // no attributes
-        if (reader.getAttributeCount() > 0) {
-            throw unexpectedAttribute(reader, 0);
-        }
+        requireNoAttributes(reader);
 
         final ModelNode address = new ModelNode();
         address.add(ModelDescriptionConstants.SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME);

--- a/web/src/main/java/org/jboss/as/web/WebSubsystemParser.java
+++ b/web/src/main/java/org/jboss/as/web/WebSubsystemParser.java
@@ -63,6 +63,8 @@ import static org.jboss.as.web.WebExtension.SSO_PATH;
 
 import java.util.Collections;
 import java.util.List;
+
+import javax.xml.XMLConstants;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -315,7 +317,6 @@ class WebSubsystemParser implements XMLStreamConstants, XMLElementReader<List<Mo
         subsystem.get(OP_ADDR).set(address.toModelNode());
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
-            requireNoNamespaceAttribute(reader, i);
             final String value = reader.getAttributeValue(i);
             final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
@@ -325,7 +326,8 @@ class WebSubsystemParser implements XMLStreamConstants, XMLElementReader<List<Mo
                     subsystem.get(attribute.getLocalName()).set(value);
                     break;
                 default:
-                    throw unexpectedAttribute(reader, i);
+                    if (!XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI.equals(reader.getAttributeNamespace(i)))
+                        throw unexpectedAttribute(reader, i);
             }
         }
         list.add(subsystem);


### PR DESCRIPTION
...Modify code to cope with parsing of same.

This turned out be more than just adding schemaLocation hints to the various xml files.

Both standalone.xml and domain.xml are composed from template files. The code that performs this assembly needed to be modified to preserve the various namespace declarations and schemaLocations.

Additionally, the code that subsequently parses standalone.xml, et al was modified to ignore any xml element attributes that are in the "http://www.w3.org/2001/XMLSchema-instance" namespace that contains "schemaLocation".

Most of this was done by simply modifying org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes(XMLStreamReader) to ignore attributes in that namespace (thus not changing its fundamental semantics). Note that I took the liberty of changing XMLExtendedStreamReader arguments to the super-interface XMLStreamReader in ParseUtils where appropriate which is generally considered best practice.

A small number of parsers that could not make use of this method were modified individually.

**Before merging this you may want to consider whether or not http://www.jboss.org/j2ee is an appropriate physical location for the schema**
