### PR TITLE
AS7-5992, AS7-5874, AS7-5993 JGroups upgrade, default stack updates

### DIFF
--- a/build/src/main/resources/configuration/subsystems/jgroups.xml
+++ b/build/src/main/resources/configuration/subsystems/jgroups.xml
@@ -6,7 +6,7 @@
        <stack name="udp">
            <transport type="UDP" socket-binding="jgroups-udp"/>
            <protocol type="PING"/>
-           <protocol type="MERGE2"/>
+           <protocol type="MERGE3"/>
            <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
            <protocol type="FD"/>
            <protocol type="VERIFY_SUSPECT"/>

--- a/build/src/main/resources/configuration/subsystems/jgroups.xml
+++ b/build/src/main/resources/configuration/subsystems/jgroups.xml
@@ -10,7 +10,6 @@
            <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
            <protocol type="FD"/>
            <protocol type="VERIFY_SUSPECT"/>
-           <protocol type="BARRIER"/>
            <protocol type="pbcast.NAKACK2"/>
            <protocol type="UNICAST2"/>
            <protocol type="pbcast.STABLE"/>
@@ -27,7 +26,6 @@
            <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
            <protocol type="FD"/>
            <protocol type="VERIFY_SUSPECT"/>
-           <protocol type="BARRIER"/>
            <protocol type="pbcast.NAKACK2"/>
            <protocol type="UNICAST2"/>
            <protocol type="pbcast.STABLE"/>

--- a/clustering/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/src/main/resources/jgroups-defaults.xml
@@ -28,7 +28,6 @@
         ucast_send_buf_size="640000"
         mcast_recv_buf_size="25000000"
         mcast_send_buf_size="640000"
-        discard_incompatible_packets="true"
         enable_bundling="false"
         max_bundle_size="64000"
         max_bundle_timeout="30"
@@ -51,7 +50,6 @@
     <TCP
         recv_buf_size="20000000"
         send_buf_size="640000"
-        discard_incompatible_packets="true"
         max_bundle_size="64000"
         max_bundle_timeout="30"
         enable_bundling="false"
@@ -75,6 +73,7 @@
     <PING timeout="2000" num_initial_members="3"/>
     <MPING timeout="3000" num_initial_members="3" ip_ttl="2"/>
     <MERGE2 max_interval="100000" min_interval="20000"/>
+    <MERGE3 max_interval="100000" min_interval="20000"/>
     <FD_SOCK/>
     <FD timeout="6000" max_tries="5"/>
     <VERIFY_SUSPECT timeout="1500"/>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <version.org.jboss.xnio>3.0.7.GA</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
-        <version.org.jgroups>3.2.0.Final</version.org.jgroups>
+        <version.org.jgroups>3.2.1.Final</version.org.jgroups>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.8.5</version.org.mockito>
         <version.org.opensaml.opensaml>2.5.1-1</version.org.opensaml.opensaml>


### PR DESCRIPTION
N.B. MERGE3 is an optimized merge protocol for stacks using a multicast transport (hence it is only used in the "udp" stack).
