### PR TITLE
[7.1] [AS7-5999] Update PicketLink module dependencies

### DIFF
--- a/build/src/main/resources/modules/org/picketlink/main/module.xml
+++ b/build/src/main/resources/modules/org/picketlink/main/module.xml
@@ -43,5 +43,8 @@
         <module name="org.apache.log4j"/>
         <module name="org.apache.santuario.xmlsec"/>
         <module name="javax.api"/>
+	<module name="org.jboss.ws.api" />
+	<module name="org.jboss.ws.spi" />
+	<module name="org.apache.cxf" />        
     </dependencies>
 </module>


### PR DESCRIPTION
PicketLink module needs some additional dependencies to properly support/secure WS endpoints.
