### PR TITLE
AS7-5746 Keep the old serviceName() method signature

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/deployment/JndiNamingDependencyProcessor.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/JndiNamingDependencyProcessor.java
@@ -67,6 +67,10 @@ public class JndiNamingDependencyProcessor implements DeploymentUnitProcessor {
         return deploymentUnitServiceName.append(JNDI_DEPENDENCY_SERVICE);
     }
 
+    public static ServiceName serviceName(final DeploymentUnit deploymentUnit) {
+        return serviceName(deploymentUnit.getServiceName());
+    }
+
     @Override
     public void undeploy(final DeploymentUnit context) {
     }


### PR DESCRIPTION
af649d7d2ec032b60bdb3bca1ccacadcf7d4c8a2 breaks backward compatibility for no reason. This commit restores the method.
