### PR TITLE
AS7-5639 Run OSGi TCK with AS7

### DIFF
--- a/embedded/src/main/java/org/jboss/as/embedded/StandaloneServer.java
+++ b/embedded/src/main/java/org/jboss/as/embedded/StandaloneServer.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
  * The standalone server interface.
  *
  * @author Thomas.Diesler@jboss.com
+ * @author David Bosschaert
  * @since 17-Nov-2010
  */
 public interface StandaloneServer {
@@ -48,10 +49,25 @@ public interface StandaloneServer {
      */
     Context getContext();
 
+    /**
+     * Retrieve an MSC service and waits for the service to be active.
+     * @param timeout The amount to time (in milliseconds) to wait for the service
+     * @param nameSegments The ServiceName segments
+     * @return the service or null if not found
+     */
+    Object getService(long timeout, String ... nameSegments);
+
     ModelControllerClient getModelControllerClient();
 
+    /**
+     * Start the server. This method blocks until all services have been started or failed.
+     * @throws ServerStartException
+     */
     void start() throws ServerStartException;
 
+    /**
+     * Shuts down the server and wait for its termination.
+     */
     void stop();
 
     // TODO: use a DeploymentPlan

--- a/osgi/launcher/pom.xml
+++ b/osgi/launcher/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-osgi</artifactId>
+        <version>7.2.0.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jboss-as-osgi-launcher</artifactId>
+    <name>JBoss Application Server: OSGi Launcher</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-embedded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.osgi.framework</groupId>
+            <artifactId>jbosgi-framework-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <!-- Build -->
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${surefire.system.args}</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.manager</name>
+                            <value>org.jboss.logmanager.LogManager</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>
+                        -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
+                    </compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/EmbeddedOSGiFrameworkLauncher.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/EmbeddedOSGiFrameworkLauncher.java
@@ -1,0 +1,168 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.embedded.EmbeddedServerFactory;
+import org.jboss.as.embedded.ServerStartException;
+import org.jboss.as.embedded.StandaloneServer;
+import org.jboss.dmr.ModelNode;
+import org.osgi.framework.Constants;
+
+/**
+ * Launch the Application Server using its EmbeddedServerFactory and activate the
+ * OSGi subsystem.
+ *
+ * @author David Bosschaert
+ */
+public class EmbeddedOSGiFrameworkLauncher {
+    private static StandaloneServer server;
+
+    public void startServer(Map<String, String> configuration) throws ServerStartException, IOException {
+        String jbossHomeKey = "jboss.home";
+        String jbossHomeProp = System.getProperty(jbossHomeKey);
+        if (jbossHomeProp == null)
+            throw new IllegalStateException("Cannot find system property: " + jbossHomeKey);
+
+        File jbossHomeDir = new File(jbossHomeProp).getAbsoluteFile();
+
+        Properties sysprops = new Properties();
+        sysprops.putAll(System.getProperties());
+        setDefaultProperty(sysprops, "jboss.home.dir", jbossHomeDir.getAbsolutePath());
+        setDefaultProperty(sysprops, "jboss.home.dir", jbossHomeDir.getAbsolutePath());
+        setDefaultProperty(sysprops, "java.util.logging.manager", "org.jboss.logmanager.LogManager");
+        setDefaultProperty(sysprops, "logging.configuration", "file:" + jbossHomeDir + "/standalone/configuration/logging.properties");
+        setDefaultProperty(sysprops, "org.jboss.boot.log.file", jbossHomeDir + "/standalone/log/boot.log");
+
+        // Temporary code, can be removed as soon as Framework R5 is implemented
+        //
+        // The OSGi packages have to be shared between the caller and the framework. Note that also some OSGi 4.3/5.0 packages
+        // are included here because these are used by the resolver. When a package is picked up from the parent classloader
+        // JBoss Modules also expects all subpackages to be picked up from the parent classloader, therefore these need to be
+        // as well. This can probably be removed as soon as we support OSGi 4.3/5.0
+        // The following fixes up the OSGi packages, if they are specified on any of these properties.
+        String pkgs = fixOSGiPackages(configuration, Constants.FRAMEWORK_SYSTEMPACKAGES, false);
+        String pkgs1 = fixOSGiPackages(configuration, Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, false);
+        String pkgs2 = fixOSGiPackages(configuration, Constants.FRAMEWORK_BOOTDELEGATION, false);
+
+        String allPkgs;
+        if (pkgs.length() == 0 && pkgs1.length() == 0 && pkgs2.length() == 0) {
+            // Should add these packages to at least one of the above properties, add to FRAMEWORK_SYSTEMPACKAGES_EXTRA
+            allPkgs = fixOSGiPackages(configuration, Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, true);
+        } else {
+            allPkgs = pkgs + "," + pkgs1 + "," + pkgs2;
+        }
+        // End Temporary code.
+
+        // Set the launcher properties as system properties. Not the best approach, but we cannot
+        // use the DMR at this point yet, see AS7-5882.
+        for (Map.Entry<String, String> entry : configuration.entrySet()) {
+            System.setProperty(entry.getKey(), entry.getValue());
+        }
+
+        // Strip any attributes of the package information as only bare packages need to passed into create() below.
+        List<String> sysPgsNoAttrs = new ArrayList<String>();
+        sysPgsNoAttrs.add("org.jboss.logmanager");
+        for (String sp : allPkgs.split(",")) {
+            int idx = sp.indexOf(';');
+            if (idx >= 0)
+                sysPgsNoAttrs.add(sp.substring(0, idx));
+            else
+                sysPgsNoAttrs.add(sp);
+        }
+
+        server = EmbeddedServerFactory.create(jbossHomeDir, sysprops, System.getenv(), sysPgsNoAttrs.toArray(new String [] {}));
+        server.start();
+    }
+
+    private String fixOSGiPackages(Map<String, String> configuration, String property, boolean force) {
+        List<String> systemPackages = new ArrayList<String>();
+
+        String packages = configuration.get(property);
+        if ((packages != null && packages.contains("org.osgi.")) || force) {
+            systemPackages.add("org.osgi.framework");
+            systemPackages.add("org.osgi.framework.launch");
+            systemPackages.add("org.osgi.framework.namespace");
+            systemPackages.add("org.osgi.framework.wiring");
+            systemPackages.add("org.osgi.resource");
+            systemPackages.add("org.osgi.service.resolver");
+            systemPackages.add("org.osgi.util.tracker");
+            systemPackages.add("org.osgi.util.xml");
+
+            StringBuilder sb = new StringBuilder();
+            if (packages != null) {
+                sb.append(packages);
+                sb.append(',');
+            }
+
+            for (String sp : systemPackages) {
+                sb.append(sp);
+                sb.append(',');
+            }
+            configuration.put(property, sb.toString());
+            return sb.toString();
+        }
+        return "";
+    }
+
+    private void setDefaultProperty(Properties props, String key, String value) {
+        if (props.getProperty(key) == null)
+            props.setProperty(key, value);
+    }
+
+    Object getService(long timeout, String ... nameSegments) {
+        return server.getService(timeout, nameSegments);
+    }
+
+
+    public Object activateOSGiFramework() throws Exception {
+        activateOSGiSubsystem(server);
+
+        // ServiceName.toArray() does not produce the correct output for msc 1.0.2.GA.
+        // This issue is already fixed on 1.0.3
+        // return server.getService(10000, Services.FRAMEWORK_CREATE.toArray());
+        return server.getService(10000, "jbosgi", "framework", "CREATE");
+    }
+
+    public void stop() {
+        server.stop();
+    }
+
+    /**
+     * Uses the Management API to activate the OSGi subsystem.
+     */
+    private static void activateOSGiSubsystem(StandaloneServer server) throws IOException {
+        ModelControllerClient controllerClient = server.getModelControllerClient();
+        ModelNode activationOp = new ModelNode();
+        ModelNode opList = activationOp.get("address").setEmptyList();
+        opList.add("subsystem", "osgi");
+        activationOp.get("operation").set("activate");
+        controllerClient.execute(activationOp);
+    }
+}

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/FrameworkWrapper.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/FrameworkWrapper.java
@@ -1,0 +1,244 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+import org.osgi.framework.launch.Framework;
+
+/**
+ * Implements the standard OSGi Framework launch API.
+ *
+ * @author David Bosschaert
+ */
+public class FrameworkWrapper implements Framework {
+    private final EmbeddedOSGiFrameworkLauncher launcher;
+    private final AtomicInteger frameworkState = new AtomicInteger(Bundle.INSTALLED);
+    private Bundle systemBundle;
+
+    public FrameworkWrapper(EmbeddedOSGiFrameworkLauncher launcher) {
+        this.launcher = launcher;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Enumeration findEntries(String path, String filePattern, boolean recurse) {
+        return systemBundle.findEntries(path, filePattern, recurse);
+    }
+
+    @Override
+    public BundleContext getBundleContext() {
+        return systemBundle.getBundleContext();
+    }
+
+    @Override
+    public URL getEntry(String path) {
+        return systemBundle.getEntry(path);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Enumeration getEntryPaths(String path) {
+        return systemBundle.getEntryPaths(path);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Dictionary getHeaders() {
+        return systemBundle.getHeaders();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Dictionary getHeaders(String locale) {
+        return systemBundle.getHeaders(locale);
+    }
+
+    @Override
+    public long getLastModified() {
+        return systemBundle.getLastModified();
+    }
+
+    @Override
+    public ServiceReference[] getRegisteredServices() {
+        return systemBundle.getRegisteredServices();
+    }
+
+    @Override
+    public URL getResource(String name) {
+        return systemBundle.getResource(name);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Enumeration getResources(String name) throws IOException {
+        return systemBundle.getResources(name);
+    }
+
+    @Override
+    public ServiceReference[] getServicesInUse() {
+        return systemBundle.getServicesInUse();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Map getSignerCertificates(int signersType) {
+        return systemBundle.getSignerCertificates(signersType);
+    }
+
+    @Override
+    public int getState() {
+        return frameworkState.get();
+    }
+
+    @Override
+    public Version getVersion() {
+        return systemBundle.getVersion();
+    }
+
+    @Override
+    public boolean hasPermission(Object permission) {
+        return systemBundle.hasPermission(permission);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class loadClass(String name) throws ClassNotFoundException {
+        return systemBundle.loadClass(name);
+    }
+
+    @Override
+    public long getBundleId() {
+        return 0;
+    }
+
+    @Override
+    public String getLocation() {
+        return systemBundle.getLocation();
+    }
+
+    @Override
+    public String getSymbolicName() {
+        return systemBundle.getSymbolicName();
+    }
+
+    @Override
+    public void init() throws BundleException {
+        int state = frameworkState.get();
+        if (state == Bundle.STARTING || state == Bundle.ACTIVE || state == Bundle.STOPPING)
+            return;
+
+        frameworkState.set(Bundle.STARTING);
+
+        try {
+            Object sbc = launcher.activateOSGiFramework();
+            systemBundle = ((BundleContext) sbc).getBundle();
+        } catch (Exception e) {
+            throw new BundleException(e.getLocalizedMessage(), e);
+        }
+        awaitFrameworkInit();
+    }
+
+    private void awaitFrameworkInit() {
+        launcher.getService(30000, "jbosgi", "framework", "INIT");
+    }
+
+    @Override
+    public void start() throws BundleException {
+        start(0);
+    }
+
+    @Override
+    public void start(int options) throws BundleException {
+        if (frameworkState.get() != Bundle.STARTING)
+            init();
+
+        awaitFrameworkActive();
+        frameworkState.set(Bundle.ACTIVE);
+    }
+
+    private void awaitFrameworkActive() {
+        launcher.getService(30000, "jbosgi", "framework", "ACTIVE");
+    }
+
+    @Override
+    public void stop() throws BundleException {
+        stop(0);
+    }
+
+    @Override
+    public void stop(int options) throws BundleException {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    waitForStop(0);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }).start();
+    }
+
+    @Override
+    public void uninstall() throws BundleException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void update() throws BundleException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void update(InputStream in) throws BundleException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FrameworkEvent waitForStop(long timeout) throws InterruptedException {
+        frameworkState.set(Bundle.STOPPING);
+
+        try {
+            launcher.stop();
+        } catch (Throwable e) {
+            InterruptedException ie = new InterruptedException(e.getLocalizedMessage());
+            ie.initCause(e);
+            throw ie;
+        }
+        frameworkState.set(Bundle.RESOLVED);
+
+        return new FrameworkEvent(FrameworkEvent.STOPPED, this, null);
+    }
+}

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/JBossOSGiFrameworkFactory.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/JBossOSGiFrameworkFactory.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.util.Map;
+
+import org.osgi.framework.launch.Framework;
+import org.osgi.framework.launch.FrameworkFactory;
+
+/**
+ * This class implements the FrameworkFactory that is defined in the OSGi launcher specification.
+ * It allows other programs to launch OSGi framework in a standard way and is also required in
+ * order to run the OSGi TCK with the JBoss AS.
+ *
+ * @author David Bosschaert
+ */
+public class JBossOSGiFrameworkFactory implements FrameworkFactory {
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Framework newFramework(Map configuration) {
+        try {
+            EmbeddedOSGiFrameworkLauncher launcher = new EmbeddedOSGiFrameworkLauncher();
+            launcher.startServer(configuration);
+            return new FrameworkWrapper(launcher);
+        } catch (RuntimeException re) {
+            throw re;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/osgi/launcher/src/main/resources/META-INF/services/org.osgi.framework.launch.FrameworkFactory
+++ b/osgi/launcher/src/main/resources/META-INF/services/org.osgi.framework.launch.FrameworkFactory
@@ -1,0 +1,1 @@
+org.jboss.as.osgi.launcher.JBossOSGiFrameworkFactory

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -42,5 +42,6 @@
     <modules>
         <module>service</module>
         <module>integration</module>
+        <module>launcher</module>
     </modules>
 </project>

--- a/osgi/service/src/main/java/org/jboss/as/osgi/service/FrameworkBootstrapService.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/service/FrameworkBootstrapService.java
@@ -58,10 +58,10 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.osgi.framework.spi.FrameworkBuilderFactory;
 import org.jboss.osgi.framework.spi.FrameworkBuilder;
-import org.jboss.osgi.framework.spi.SystemPathsPlugin;
 import org.jboss.osgi.framework.spi.FrameworkBuilder.FrameworkPhase;
+import org.jboss.osgi.framework.spi.FrameworkBuilderFactory;
+import org.jboss.osgi.framework.spi.SystemPathsPlugin;
 import org.osgi.framework.Constants;
 
 /**
@@ -165,7 +165,7 @@ public class FrameworkBootstrapService implements Service<Void> {
     private void setupIntegrationProperties(StartContext context, Map<String, Object> props) {
 
         // Setup the Framework's storage area.
-        String storage = (String) props.get(Constants.FRAMEWORK_STORAGE);
+        String storage = getFrameworkProperty(Constants.FRAMEWORK_STORAGE, props);
         if (storage == null) {
             ServerEnvironment environment = injectedServerEnvironment.getValue();
             File dataDir = environment.getServerDataDir();
@@ -179,7 +179,7 @@ public class FrameworkBootstrapService implements Service<Void> {
             props.put(ModuleLogger.class.getName(), moduleLogger.getClass().getName());
 
         // Setup default system modules
-        String sysmodules = (String) props.get(PROP_JBOSS_OSGI_SYSTEM_MODULES);
+        String sysmodules = getFrameworkProperty(PROP_JBOSS_OSGI_SYSTEM_MODULES, props);
         if (sysmodules == null) {
             Set<String> sysModules = new LinkedHashSet<String>();
             sysModules.addAll(Arrays.asList(SystemPackagesIntegration.DEFAULT_SYSTEM_MODULES));
@@ -189,7 +189,7 @@ public class FrameworkBootstrapService implements Service<Void> {
         }
 
         // Setup default system packages
-        String syspackages = (String) props.get(Constants.FRAMEWORK_SYSTEMPACKAGES);
+        String syspackages = getFrameworkProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, props);
         if (syspackages == null) {
             Set<String> sysPackages = new LinkedHashSet<String>();
             sysPackages.addAll(Arrays.asList(SystemPackagesIntegration.JAVAX_API_PACKAGES));
@@ -200,9 +200,18 @@ public class FrameworkBootstrapService implements Service<Void> {
             props.put(Constants.FRAMEWORK_SYSTEMPACKAGES, syspackages);
         }
 
-        String extrapackages = (String) props.get(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA);
+        String extrapackages = getFrameworkProperty(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, props);
         if (extrapackages != null) {
             props.put(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, extrapackages);
         }
+    }
+
+    private String getFrameworkProperty(String name, Map<String, Object> props) {
+        Object p = props.get(name);
+        if (p instanceof String)
+            return (String) p;
+
+        // not set, revert to system properties
+        return SecurityActions.getSystemProperty(name);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -46,10 +46,10 @@ import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.server.services.security.VaultReaderException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.invocation.proxy.MethodIdentifier;
+import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
-import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Param;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -672,4 +672,6 @@ public interface ServerMessages {
     @Message(id = 18784, value = "Null '%s'")
     OperationFailedException nullParameter(String name);
 
+    @Message(id = 18785, value = "Cannot obtain service value: %s")
+    RuntimeException cannotGetServiceValue(@Cause Throwable cause, ServiceName name);
 }

--- a/testsuite/integration/osgi/pom.xml
+++ b/testsuite/integration/osgi/pom.xml
@@ -32,6 +32,12 @@
     </properties>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-osgi-launcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+  
 	    <dependency>
 	        <groupId>com.sun.xml.bind</groupId>
 	        <artifactId>jaxb-impl</artifactId>
@@ -93,7 +99,8 @@
                                 <goals><goal>test</goal></goals>
                                 <phase>none</phase>
                             </execution>
-                            <!-- Multi node clustering tests. -->
+                            
+                            <!-- OSGi integration tests. -->
                             <execution>
                                 <id>tests-osgi.surefire</id>
                                 <phase>test</phase>
@@ -103,15 +110,39 @@
                                     <includes>
                                         <include>org/jboss/as/test/integration/osgi/**/*TestCase.java</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/osgi/launch/*TestCase.java</exclude>
+                                    </excludes>
 
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <arquillian.launch>osgi</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
 
+                            <!-- OSGi launcher tests. -->
+                            <execution>
+                                <id>tests-osgi-launcher.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Fork every test because it will launch a separate AS instance -->
+                                    <forkMode>always</forkMode>
+
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/osgi/launch/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>osgi</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestBase.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestBase.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * @author David Bosschaert
+ */
+public abstract class EmbeddedOSGiFrameworkLauncherTestBase {
+    private Properties savedProps;
+
+    @Before
+    public void setUp() throws Exception {
+        URL classURL = getClass().getClassLoader().getResource(getClass().getName().replace('.', File.separatorChar) + ".class");
+        String classStr = new File(classURL.toURI()).getAbsolutePath();
+        String projectStr = classStr.substring(0, classStr.lastIndexOf("target"));
+        File projectDir = new File(projectStr);
+        File baseDir = projectDir.getParentFile().getParentFile().getParentFile();
+        File buildDir = new File(baseDir, "build/target");
+        File jbossDir = null;
+        for (File f : buildDir.listFiles()) {
+            if (f.getName().startsWith("jboss-as-")) {
+                jbossDir = f;
+                break;
+            }
+        }
+
+        // This can only be run once the build dir is there
+        if (jbossDir == null)
+            throw new IllegalStateException("Unable to find JBoss Build Dir, make sure that the ");
+
+        savedProps = new Properties();
+        savedProps.putAll(System.getProperties());
+        System.setProperty("jboss.home", jbossDir.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() {
+        System.setProperties(savedProps);
+    }
+}

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestCase.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch;
+
+import java.util.HashMap;
+
+import junit.framework.Assert;
+
+import org.jboss.as.osgi.launcher.EmbeddedOSGiFrameworkLauncher;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author David Bosschaert
+ */
+public class EmbeddedOSGiFrameworkLauncherTestCase extends EmbeddedOSGiFrameworkLauncherTestBase {
+    @Test
+    public void testLaunchFramework() throws Exception {
+        EmbeddedOSGiFrameworkLauncher launcher = new EmbeddedOSGiFrameworkLauncher();
+        try {
+            launcher.startServer(new HashMap<String, String>());
+            BundleContext systemBundleContext = (BundleContext) launcher.activateOSGiFramework();
+            Assert.assertEquals(0L, systemBundleContext.getBundle().getBundleId());
+        } finally {
+            try {
+                launcher.stop();
+            } catch (Throwable e) {
+            }
+        }
+    }
+}

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/JBossOSGiFrameworkFactoryTestCase.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/JBossOSGiFrameworkFactoryTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.jboss.as.osgi.launcher.JBossOSGiFrameworkFactory;
+import org.jboss.as.test.integration.osgi.launch.bundle.Activator;
+import org.jboss.osgi.metadata.OSGiManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.launch.Framework;
+
+/**
+ * @author David Bosschaert
+ */
+public class JBossOSGiFrameworkFactoryTestCase extends EmbeddedOSGiFrameworkLauncherTestBase {
+    @Test
+    public void testFrameworkFactory() throws Exception {
+        HashMap<String, String> fwProps = new HashMap<String, String>();
+        fwProps.put("foo", "bar");
+        Framework framework = new JBossOSGiFrameworkFactory().newFramework(fwProps);
+        framework.init();
+        Assert.assertEquals(Bundle.STARTING, framework.getState());
+
+        framework.start();
+        Assert.assertEquals(Bundle.ACTIVE, framework.getState());
+
+        Assert.assertEquals(0, framework.getBundleId());
+
+        BundleContext sctx = framework.getBundleContext();
+        Assert.assertEquals("bar", sctx.getProperty("foo"));
+
+        Bundle b = sctx.installBundle("myBundle1.jar", getTestBundle());
+        b.start();
+
+        ServiceReference[] refs = sctx.getServiceReferences(String.class.getName(), "(org.jboss.launch.test=testproperty)");
+        Assert.assertEquals(1, refs.length);
+        Assert.assertEquals("a string service", sctx.getService(refs[0]));
+
+        final List<String> events = Collections.synchronizedList(new ArrayList<String>());
+        BundleListener listener = new BundleListener() {
+            @Override
+            public void bundleChanged(BundleEvent event) {
+                events.add(event.getBundle().getSymbolicName() + event.getType());
+            }
+        };
+
+        framework.getBundleContext().addBundleListener(listener);
+
+        Assert.assertEquals(0, events.size());
+        FrameworkEvent event = framework.waitForStop(0);
+        Assert.assertEquals(FrameworkEvent.STOPPED, event.getType());
+
+        Assert.assertTrue("Bundle should have been stopped", events.contains(b.getSymbolicName() + BundleEvent.STOPPED));
+        Assert.assertEquals(Framework.RESOLVED, framework.getState());
+    }
+
+    private InputStream getTestBundle() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "bundle1.jar");
+        archive.addClasses(Activator.class);
+        archive.setManifest(new Asset() {
+            @Override
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addBundleManifestVersion(2);
+                builder.addImportPackages(BundleContext.class);
+                builder.addBundleActivator(Activator.class);
+                return builder.openStream();
+            }
+        });
+        ZipExporter ze = archive.as(ZipExporter.class);
+        return ze.exportAsInputStream();
+    }
+}

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/bundle/Activator.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/bundle/Activator.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch.bundle;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author David Bosschaert
+ */
+public class Activator implements BundleActivator {
+    private ServiceRegistration reg;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        String stringService = "a string service";
+        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put("org.jboss.launch.test", "testproperty");
+        reg = context.registerService(String.class.getName(), stringService, props);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        reg.unregister();
+    }
+}


### PR DESCRIPTION
This commit provides the start of an implementation of the OSGi launcher API, which is part of the OSGi Core Specification.
The launcher API is a prerequisite for running AS7 through the OSGi TCK.

This pull request should address the issues flagged in the earlier pull request: https://github.com/jbossas/jboss-as/pull/3490
