### PR TITLE
[AS7-5246] Allow the outbound LDAP connection to be associated with a se...

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
@@ -215,18 +215,27 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <!-- TODO - Later will be optional if we support GSSAPI to connect to LDAP -->
-        <xs:attribute name="search-dn" type="xs:string" use="required">
+        <xs:attribute name="search-dn" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The distinguished name to use when connecting to LDAP to perform searches.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="search-credential" type="xs:string" use="required">
+        <xs:attribute name="search-credential" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The credential to use when connecting to perform a search.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a 
+                    connection to the LDAP server.
+                    
+                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.                
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -420,7 +429,7 @@
             </xs:documentation>
         </xs:annotation>
 	    <xs:complexContent>
-		    <xs:extension base="keyStoreType">
+            <xs:extension base="keyStoreType">
                 <xs:attribute name="alias" type="xs:string" use="optional">
                     <xs:annotation>
                         <xs:documentation>

--- a/build/src/main/resources/modules/org/jboss/as/domain-management/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/domain-management/main/module.xml
@@ -40,5 +40,6 @@
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.staxmapper"/>
         <module name="javax.api"/>
+        <module name="sun.jdk" export="true" />        
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/server/main/module.xml
@@ -36,7 +36,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
-	<module name="org.jboss.common-beans" services="export"/>
+        <module name="org.jboss.common-beans" services="export"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.jandex"/>

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -102,6 +102,7 @@ core.management.ldap-connection.remove=Removes a connection factory that was usa
 core.management.ldap-connection.url=The URL to use to connect to the LDAP server.
 core.management.ldap-connection.search-dn=The distinguished name to use when connecting to the LDAP server to perform searches.
 core.management.ldap-connection.search-credential=The credential to use when connecting to perform a search.
+core.management.ldap-connection.security-realm=The security realm to reference to obtain a configured SSLContext to use when establishing the connection.
 core.management.ldap-connection.initial-context-factory=The initial context factory to establish the LdapContext.
 core.management.management-interface=Interfaces exposed by the management services to allow external callers to perform management tasks.
 core.management.native-interface=Configuration of the server's native management interface

--- a/domain-management/src/main/java/org/jboss/as/domain/management/SSLIdentity.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/SSLIdentity.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.domain.management;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Interface for services providing SSL identities through pre-configured SSLContexts.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface SSLIdentity {
+
+    /**
+     * Obtain the full SSLContext comprising of both any defined key and trust stores.
+     *
+     * @return The SSLContext.
+     */
+    SSLContext getFullContext();
+
+    /**
+     * Obtain the SSLContext but only comprising the trust store definitions.
+     *
+     * @return The SSLContext.
+     */
+    SSLContext getTrustOnlyContext();
+
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/SecurityRealm.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/SecurityRealm.java
@@ -66,7 +66,6 @@ public interface SecurityRealm {
      * Used to obtain the SSLContext as configured for this security realm.
      *
      * @return the SSLContext server identity for this realm.
-     * @throws IllegalStateException - If no SSL server-identity has been defined.
      */
     SSLContext getSSLContext();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/LdapConnectionResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/LdapConnectionResourceDefinition.java
@@ -53,16 +53,19 @@ public class LdapConnectionResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition URL = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.URL, ModelType.STRING, false)
             .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true)).build();
 
-    public static final SimpleAttributeDefinition SEARCH_DN = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SEARCH_DN, ModelType.STRING, false)
-            .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true)).build();
+    public static final SimpleAttributeDefinition SEARCH_DN = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SEARCH_DN, ModelType.STRING, true)
+            .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true)).build();
 
-    public static final SimpleAttributeDefinition SEARCH_CREDENTIAL = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SEARCH_CREDENTIAL, ModelType.STRING, false)
-            .setAllowExpression(true).setValidator(new StringLengthValidator(0, Integer.MAX_VALUE, false, true)).build();
+    public static final SimpleAttributeDefinition SEARCH_CREDENTIAL = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SEARCH_CREDENTIAL, ModelType.STRING, true)
+            .setAllowExpression(true).setValidator(new StringLengthValidator(0, Integer.MAX_VALUE, true, true)).build();
+
+    public static final SimpleAttributeDefinition SECURITY_REALM = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURITY_REALM, ModelType.STRING, true)
+            .setAllowExpression(false).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true)).build();
 
     public static final SimpleAttributeDefinition INITIAL_CONTEXT_FACTORY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INITIAL_CONTEXT_FACTORY, ModelType.STRING, true)
             .setAllowExpression(true).setDefaultValue(new ModelNode(DEFAULT_INITIAL_CONTEXT)).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true)).build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {URL, SEARCH_DN, SEARCH_CREDENTIAL, INITIAL_CONTEXT_FACTORY};
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {URL, SEARCH_DN, SEARCH_CREDENTIAL, SECURITY_REALM, INITIAL_CONTEXT_FACTORY};
 
     public static final LdapConnectionResourceDefinition INSTANCE = new LdapConnectionResourceDefinition();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/ThreadLocalSSLSocketFactory.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/ThreadLocalSSLSocketFactory.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.domain.management.connections.ldap;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * An SSLSocketFactory that delegates to a SSLSocketFactory set on a ThreadLocal, if the SSLSocketFactory is not set then the
+ * default implementation is used.
+ *
+ * The purpose of this class is to allow custom configuration to be used when only the name of the SSLSocketFactory to be
+ * instantiated later can be specified - this does assume that the SSLSocketFactory is not instantiated in a different thread.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ThreadLocalSSLSocketFactory extends SSLSocketFactory {
+
+    private static final ThreadLocal<SSLSocketFactory> socketFactory = new ThreadLocal<SSLSocketFactory>();
+
+    private final SSLSocketFactory delegate;
+
+    public ThreadLocalSSLSocketFactory() {
+        SSLSocketFactory socketFactory = ThreadLocalSSLSocketFactory.socketFactory.get();
+        if (socketFactory == null) {
+            socketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        }
+        delegate = socketFactory;
+    }
+
+    /**
+     * Set the SSLSocketFactory to be used when an instance of this class is created on this thread.
+     *
+     * This method has the default level of access to prevent it's use from other packages, should this need to be opened up
+     * appropriate permissions should be set to prevent code in other packages from changing the SSLSocketFactory in use.
+     *
+     * @param factory - The SSLSocketFactory to set.
+     */
+    static void setSSLSocketFactory(final SSLSocketFactory factory) {
+        socketFactory.set(factory);
+    }
+
+    /**
+     * Remove the previously set SSLSocketFactory.
+     *
+     * As with setSSLSocketFactory visibility of this method is reduced to prevent modification from other packages.
+     */
+    static void removeSSLSocketFactory() {
+        socketFactory.remove();
+    }
+
+    public static SocketFactory getDefault() {
+        return new ThreadLocalSSLSocketFactory();
+    }
+
+    @Override
+    public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException {
+        return delegate.createSocket(socket, host, port, autoClose);
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return delegate.createSocket(host, port);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port) throws IOException {
+        return delegate.createSocket(address, port);
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localAddress, int localPort) throws IOException {
+        return delegate.createSocket(host, port, localAddress, localPort);
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return delegate.createSocket(address, port, localAddress, localPort);
+    }
+
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml.java
@@ -173,14 +173,24 @@ public class ManagementXml {
         }
     }
 
-    private void parseConnections(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list)
-            throws XMLStreamException {
+    private void parseConnections(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs,
+            final List<ModelNode> list) throws XMLStreamException {
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
             final Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 case LDAP: {
-                    parseLdapConnection(reader, address, list);
+                    switch (expectedNs) {
+                        case DOMAIN_1_0:
+                        case DOMAIN_1_1:
+                        case DOMAIN_1_2:
+                        case DOMAIN_1_3:
+                            parseLdapConnection_1_0(reader, address, list);
+                            break;
+                        default:
+                            parseLdapConnection_1_4(reader, address, list);
+                            break;
+                    }
                     break;
                 }
                 default: {
@@ -190,7 +200,7 @@ public class ManagementXml {
         }
     }
 
-    private void parseLdapConnection(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
+    private void parseLdapConnection_1_0(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
             throws XMLStreamException {
 
         final ModelNode add = new ModelNode();
@@ -222,6 +232,62 @@ public class ManagementXml {
                     }
                     case SEARCH_CREDENTIAL: {
                         LdapConnectionResourceDefinition.SEARCH_CREDENTIAL.parseAndSetParameter(value, add, reader);
+                        break;
+                    }
+                    case INITIAL_CONTEXT_FACTORY: {
+                        LdapConnectionResourceDefinition.INITIAL_CONTEXT_FACTORY.parseAndSetParameter(value, add, reader);
+                        break;
+                    }
+                    default: {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                }
+            }
+        }
+
+        if (required.size() > 0) {
+            throw missingRequired(reader, required);
+        }
+
+        requireNoContent(reader);
+    }
+
+    private void parseLdapConnection_1_4(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list)
+            throws XMLStreamException {
+
+        final ModelNode add = new ModelNode();
+        add.get(OP).set(ADD);
+
+        list.add(add);
+
+        Set<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.URL);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final String value = reader.getAttributeValue(i);
+            if (!isNoNamespaceAttribute(reader, i)) {
+                throw unexpectedAttribute(reader, i);
+            } else {
+                final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+                required.remove(attribute);
+                switch (attribute) {
+                    case NAME: {
+                        add.get(OP_ADDR).set(address).add(LDAP_CONNECTION, value);
+                        break;
+                    }
+                    case URL: {
+                        LdapConnectionResourceDefinition.URL.parseAndSetParameter(value, add, reader);
+                        break;
+                    }
+                    case SEARCH_DN: {
+                        LdapConnectionResourceDefinition.SEARCH_DN.parseAndSetParameter(value,  add, reader);
+                        break;
+                    }
+                    case SEARCH_CREDENTIAL: {
+                        LdapConnectionResourceDefinition.SEARCH_CREDENTIAL.parseAndSetParameter(value, add, reader);
+                        break;
+                    }
+                    case SECURITY_REALM: {
+                        LdapConnectionResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, add, reader);
                         break;
                     }
                     case INITIAL_CONTEXT_FACTORY: {
@@ -542,7 +608,7 @@ public class ManagementXml {
                         break;
                     case PASSWORD: {
                         // TODO - Support for this attribute can later be removed, would suggest removing at the
-                        //        start of AS 7.2.x development.
+                        //        start of AS 8 development.
                         ROOT_LOGGER.passwordAttributeDeprecated();
                         required.remove(Attribute.KEYSTORE_PASSWORD);
                         KeystoreAttributes.KEYSTORE_PASSWORD.parseAndSetParameter(value, addOperation, reader);
@@ -1563,6 +1629,7 @@ public class ManagementXml {
             LdapConnectionResourceDefinition.URL.marshallAsAttribute(connection, writer);
             LdapConnectionResourceDefinition.SEARCH_DN.marshallAsAttribute(connection, writer);
             LdapConnectionResourceDefinition.SEARCH_CREDENTIAL.marshallAsAttribute(connection, writer);
+            LdapConnectionResourceDefinition.SECURITY_REALM.marshallAsAttribute(connection, writer);
             LdapConnectionResourceDefinition.INITIAL_CONTEXT_FACTORY.marshallAsAttribute(connection, writer);
         }
         writer.writeEndElement();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInLoaderService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInLoaderService.java
@@ -24,7 +24,6 @@ package org.jboss.as.domain.management.security;
 
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -34,8 +33,6 @@ import org.jboss.as.domain.management.plugin.AuthenticationPlugIn;
 import org.jboss.as.domain.management.plugin.AuthorizationPlugIn;
 import org.jboss.as.domain.management.plugin.Credential;
 import org.jboss.as.domain.management.plugin.PlugInProvider;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -55,6 +55,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.domain.management.AuthenticationMechanism;
 import org.jboss.as.domain.management.CallbackHandlerFactory;
+import org.jboss.as.domain.management.SSLIdentity;
 import org.jboss.as.domain.management.connections.ConnectionManager;
 import org.jboss.as.domain.management.connections.ldap.LdapConnectionManagerService;
 import org.jboss.dmr.ModelNode;
@@ -178,7 +179,7 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
 
         if (ssl != null || authTruststore != null) {
             ServiceName sslServiceName = addSSLService(context, ssl, authTruststore, realmServiceName, serviceTarget, newControllers);
-            realmBuilder.addDependency(sslServiceName, SSLIdentityService.class, securityRealmService.getSSLIdentityInjector());
+            realmBuilder.addDependency(sslServiceName, SSLIdentity.class, securityRealmService.getSSLIdentityInjector());
         }
 
         realmBuilder.setInitialMode(Mode.ACTIVE);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmService.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.security.SubjectUserInfo;
 import org.jboss.as.domain.management.AuthenticationMechanism;
 import org.jboss.as.domain.management.AuthorizingCallbackHandler;
 import org.jboss.as.domain.management.CallbackHandlerFactory;
+import org.jboss.as.domain.management.SSLIdentity;
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -65,7 +66,7 @@ public class SecurityRealmService implements Service<SecurityRealm>, SecurityRea
     public static final ServiceName BASE_SERVICE_NAME = ServiceName.JBOSS.append("server", "controller", "management", "security_realm");
 
     private final InjectedValue<SubjectSupplementalService> subjectSupplemental = new InjectedValue<SubjectSupplementalService>();
-    private final InjectedValue<SSLIdentityService> sslIdentity = new InjectedValue<SSLIdentityService>();
+    private final InjectedValue<SSLIdentity> sslIdentity = new InjectedValue<SSLIdentity>();
     private final InjectedValue<CallbackHandlerFactory> secretCallbackFactory = new InjectedValue<CallbackHandlerFactory>();
     private final InjectedSetValue<CallbackHandlerService> callbackHandlerServices = new InjectedSetValue<CallbackHandlerService>();
 
@@ -215,7 +216,7 @@ public class SecurityRealmService implements Service<SecurityRealm>, SecurityRea
         return subjectSupplemental;
     }
 
-    public InjectedValue<SSLIdentityService> getSSLIdentityInjector() {
+    public InjectedValue<SSLIdentity> getSSLIdentityInjector() {
         return sslIdentity;
     }
 
@@ -228,17 +229,12 @@ public class SecurityRealmService implements Service<SecurityRealm>, SecurityRea
     }
 
     public SSLContext getSSLContext() {
-        SSLIdentityService service = sslIdentity.getOptionalValue();
+        SSLIdentity service = sslIdentity.getOptionalValue();
         if (service != null) {
-            return service.getSSLContext();
+            return service.getFullContext();
         }
 
         return null;
-    }
-
-    public boolean hasTrustStore() {
-        SSLIdentityService service;
-        return ((service = sslIdentity.getOptionalValue()) != null && service.hasTrustStore());
     }
 
     public CallbackHandlerFactory getSecretCallbackHandlerFactory() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/UserLdapCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/UserLdapCallbackHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.domain.management.security;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADVANCED_FILTER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USERNAME_ATTRIBUTE;
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
+import static org.jboss.as.domain.management.DomainManagementLogger.ROOT_LOGGER;
 import static org.jboss.as.domain.management.RealmConfigurationConstants.VERIFY_PASSWORD_CALLBACK_SUPPORTED;
 
 import java.io.IOException;
@@ -219,6 +220,7 @@ public class UserLdapCallbackHandler implements Service<CallbackHandlerService>,
             }
 
         } catch (Exception e) {
+            ROOT_LOGGER.trace("Unable to verify identity.", e);
             throw MESSAGES.cannotPerformVerification(e);
         } finally {
             safeClose(searchEnumeration);


### PR DESCRIPTION
...curity realm to pull in keystore and truststore definitions to use when communicating with LDAP.

As one aspect of connecting is also to verify the remote user has supplied a valid password the keystore portion can be ommitted when the step to authenticate as the remote user takes place to prevent authenticating as the server again.
