### PR TITLE
[master] org.jboss.ejb3 module (a.k.a jboss-ejb3-ext-api) should be public 

### DIFF
--- a/build/src/main/resources/modules/org/jboss/ejb3/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/ejb3/main/module.xml
@@ -21,9 +21,6 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.1" name="org.jboss.ejb3">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
 
     <resources>
         <!-- Insert resources here -->


### PR DESCRIPTION
The org.jboss.ejb3 module which exposes publicly consumable annotations (like @SecurityDomain, @Clustered) isn't meant to be marked as private since the users are allowed to depend on the APIs exposed by this module.
