### PR TITLE
AS7-5184 Add re-entrancy checking to EJB3 singleton creation

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -2131,4 +2131,7 @@ public interface EjbMessages {
     @Message(id = 14231, value = "EJB client context selector failed due to unavailability of %s service")
     IllegalStateException ejbClientContextSelectorUnableToFunctionDueToMissingService(ServiceName serviceName);
 
+    @Message(id = 14232, value = "@PostConstruct method of EJB singleton %s of type %s has been recursively invoked")
+    IllegalStateException reentrantSingletonCreation(String componentName, String componentClassName);
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/creation/SingletonBeanOne.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/creation/SingletonBeanOne.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.singleton.creation;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.SessionContext;
+import javax.ejb.Singleton;
+
+import org.jboss.logging.Logger;
+
+/**
+ * The test fixture for {@link SingletonReentrantPostConstructTestCase}.
+ *
+ * @author steve.coy
+ *
+ */
+@Singleton
+public class SingletonBeanOne {
+
+    private static final Logger logger = Logger.getLogger(SingletonBeanOne.class);
+
+    @EJB
+    private SingletonBeanTwo beanTwo;
+
+    @Resource
+    private SessionContext sessionContext;
+
+    public SingletonBeanOne() {
+    }
+
+    /**
+     * Grabs a reference to it's own business interface and passes it to {@link #beanTwo}.
+     */
+    @PostConstruct
+    void initialise() {
+        logger.info("Initialising");
+        SingletonBeanOne thisBO = sessionContext.getBusinessObject(SingletonBeanOne.class);
+        beanTwo.useBeanOne(thisBO);
+    }
+
+    /**
+     * Stub method to start the bean life-cycle.
+     */
+    public void start() {
+    }
+
+    /**
+     * A business method for {@link SingletonBeanTwo} to call.
+     */
+    public void performSomething() {
+        logger.info("Doing something");
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/creation/SingletonBeanTwo.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/creation/SingletonBeanTwo.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.singleton.creation;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Part of the test fixture for {@link SingletonReentrantPostConstructTestCase}.
+ *
+ * @author steve.coy
+ *
+ */
+@Singleton
+public class SingletonBeanTwo {
+
+    private static final Logger logger = Logger.getLogger(SingletonBeanTwo.class);
+
+    @PostConstruct
+    void initialise() {
+        logger.info("initialised");
+    }
+
+    /**
+     * Performs a callback on beanOne. This method is called from {@link SingletonBeanOne#initialise()}, so the SingletonBeanOne
+     * instance is not yet in the "method-ready" state, making the callback illegal. <p>
+     * This resulted in a stack overflow prior to the AS7-5184 fix.
+     *
+     * @param beanOne
+     */
+    public void useBeanOne(SingletonBeanOne beanOne) {
+        beanOne.performSomething();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/creation/SingletonReentrantPostConstructTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/creation/SingletonReentrantPostConstructTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.singleton.creation;
+
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests the fix to {@link org.jboss.as.ejb3.component.singleton.SingletonComponent#getComponentInstance())} that was made to
+ * prevent stack overflows as described in <a href="https://issues.jboss.org/browse/AS7-5184">AS7-5184</a>.
+ * <p>
+ * The scenario itself is illegal because the business method {@link SingletonBeanOne#performSomething()} is being invoked from
+ * {@link SingletonBeanTwo#initialise()} before SingletonBeanOne is "method-ready" - it's PostConstruct method is not yet
+ * completed.
+ * 
+ * @author steve.coy
+ */
+@RunWith(Arquillian.class)
+public class SingletonReentrantPostConstructTestCase {
+    private static final Logger log = Logger.getLogger(SingletonReentrantPostConstructTestCase.class.getName());
+
+    @EJB(mappedName = "java:module/SingletonBeanOne")
+    private SingletonBeanOne singletonBean;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb3-reentrantly-created-singleton.jar");
+        jar.addPackage(SingletonReentrantPostConstructTestCase.class.getPackage());
+        log.info(jar.toString(true));
+        return jar;
+    }
+
+    /**
+     * Indirectly invokes the {@link PostConstruct} annotated {@link SingletonBeanOne#initialise()} method.
+     *
+     * @throws Exception
+     */
+    @Test(expected = javax.ejb.EJBException.class)
+    public void testReentrantPostConstruction() throws Exception {
+        // trigger the bean creation life-cycle
+        singletonBean.start();
+        Assert.fail("Expected an EJBException");
+    }
+
+}


### PR DESCRIPTION
Includes a unit test in integration/basic as requested by Jaikiran.

```
mvn clean install -DallTests -Dtest=SingletonReentrantPostConstructTestCase -pl testsuite/integration/basic
```
