### PR TITLE
[JBOSGI-615] VFSAdaptor30 uses non-thread-safe Map, which may result in deadlock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <version.org.jboss.osgi.resolver>3.0.0.Final</version.org.jboss.osgi.resolver>
         <version.org.jboss.osgi.repository>2.1.0.Final</version.org.jboss.osgi.repository>
         <version.org.jboss.osgi.spi>3.2.0.Final</version.org.jboss.osgi.spi>
-        <version.org.jboss.osgi.vfs>1.2.0.Final</version.org.jboss.osgi.vfs>
+        <version.org.jboss.osgi.vfs>1.2.1.Final</version.org.jboss.osgi.vfs>
         <version.org.jboss.remote-naming>1.0.5.Final</version.org.jboss.remote-naming>
         <version.org.jboss.remoting3>3.2.13.GA</version.org.jboss.remoting3>
         <version.org.jboss.remotingjmx.remoting-jmx>1.1.0.Beta1</version.org.jboss.remotingjmx.remoting-jmx>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBOSGI-615
