### PR TITLE
[7.1] [AS7-6055] support multiple entries for pooled cf

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
@@ -106,8 +106,10 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
         }
 
         // We validated that jndiName part of the model in populateModel
-        // TODO we only use a single jndi name here but the xsd indicates support for many
-        final String jndiName = resolvedModel.get(CommonAttributes.ENTRIES.getName()).asList().get(0).asString();
+        final List<String> jndiNames = new ArrayList<String>();
+        for (ModelNode node : resolvedModel.get(CommonAttributes.ENTRIES.getName()).asList()) {
+            jndiNames.add(node.asString());
+        }
 
         final int minPoolSize = resolvedModel.get(MIN_POOL_SIZE.getName()).asInt();
         final int maxPoolSize = resolvedModel.get(MAX_POOL_SIZE.getName()).asInt();
@@ -136,7 +138,7 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
 
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(address);
         ServiceName hornetQResourceAdapterService = JMSServices.getPooledConnectionFactoryBaseServiceName(hqServiceName).append(name);
-        PooledConnectionFactoryService resourceAdapterService = new PooledConnectionFactoryService(name, connectors, discoveryGroupName, adapterParams, jndiName, txSupport, minPoolSize, maxPoolSize);
+        PooledConnectionFactoryService resourceAdapterService = new PooledConnectionFactoryService(name, connectors, discoveryGroupName, adapterParams, jndiNames, txSupport, minPoolSize, maxPoolSize);
         ServiceBuilder serviceBuilder = serviceTarget
                 .addService(hornetQResourceAdapterService, resourceAdapterService)
                 .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, resourceAdapterService.getTransactionManager())


### PR DESCRIPTION
- use the 1st JNDI name to create the RA service
- If there are more than 1 JNDI names, creates JNDI aliases to the first
