### PR TITLE
[AS7-6058] Deprecate operations and added new add-handler/remove-handler

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/AbstractFileHandlerDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AbstractFileHandlerDefinition.java
@@ -25,8 +25,10 @@ package org.jboss.as.logging;
 import java.util.logging.Handler;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
@@ -36,6 +38,12 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 abstract class AbstractFileHandlerDefinition extends AbstractHandlerDefinition {
 
     public static final String CHANGE_FILE_OPERATION_NAME = "change-file";
+
+    static final SimpleOperationDefinition CHANGE_FILE = new SimpleOperationDefinitionBuilder(CHANGE_FILE_OPERATION_NAME, HANDLER_RESOLVER)
+            .setDeprecated(ModelVersion.create(1, 2, 0))
+            .setParameters(CommonAttributes.FILE)
+            .build();
+
     private final ResolvePathHandler resolvePathHandler;
 
     protected AbstractFileHandlerDefinition(final PathElement path, final Class<? extends Handler> type,
@@ -48,8 +56,7 @@ abstract class AbstractFileHandlerDefinition extends AbstractHandlerDefinition {
     @Override
     public void registerOperations(final ManagementResourceRegistration registration) {
         super.registerOperations(registration);
-        registration.registerOperationHandler(new SimpleOperationDefinition(CHANGE_FILE_OPERATION_NAME, getResourceDescriptionResolver(), CommonAttributes.FILE),
-                HandlerOperations.CHANGE_FILE);
+        registration.registerOperationHandler(CHANGE_FILE, HandlerOperations.CHANGE_FILE);
         if (resolvePathHandler != null)
             registration.registerOperationHandler(resolvePathHandler.getOperationDefinition(), resolvePathHandler);
     }

--- a/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
@@ -22,15 +22,15 @@
 
 package org.jboss.as.logging;
 
-import static org.jboss.as.logging.CommonAttributes.HANDLER_NAME;
 import static org.jboss.as.logging.CommonAttributes.OVERFLOW_ACTION;
 import static org.jboss.as.logging.CommonAttributes.QUEUE_LENGTH;
 import static org.jboss.as.logging.CommonAttributes.SUBHANDLERS;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleOperationDefinition;
-import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.logmanager.handlers.AsyncHandler;
 
@@ -43,6 +43,23 @@ class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
     public static final String REMOVE_SUBHANDLER_OPERATION_NAME = "unassign-subhandler";
     static final PathElement ASYNC_HANDLER_PATH = PathElement.pathElement(CommonAttributes.ASYNC_HANDLER);
 
+    static final SimpleOperationDefinition ADD_HANDLER = new SimpleOperationDefinitionBuilder(CommonAttributes.ADD_HANDLER_OPERATION_NAME, HANDLER_RESOLVER)
+            .setParameters(CommonAttributes.HANDLER_NAME)
+            .build();
+
+    static final SimpleOperationDefinition REMOVE_HANDLER = new SimpleOperationDefinitionBuilder(CommonAttributes.REMOVE_HANDLER_OPERATION_NAME, HANDLER_RESOLVER)
+            .setParameters(CommonAttributes.HANDLER_NAME)
+            .build();
+
+    static final SimpleOperationDefinition LEGACY_ADD_HANDLER = new SimpleOperationDefinitionBuilder(ADD_SUBHANDLER_OPERATION_NAME, HANDLER_RESOLVER)
+            .setDeprecated(ModelVersion.create(1, 2, 0))
+            .setParameters(CommonAttributes.HANDLER_NAME)
+            .build();
+
+    static final SimpleOperationDefinition LEGACY_REMOVE_HANDLER = new SimpleOperationDefinitionBuilder(REMOVE_SUBHANDLER_OPERATION_NAME, HANDLER_RESOLVER)
+            .setDeprecated(ModelVersion.create(1, 2, 0))
+            .setParameters(CommonAttributes.HANDLER_NAME)
+            .build();
 
     static final AttributeDefinition[] ATTRIBUTES = Logging.join(DEFAULT_ATTRIBUTES, QUEUE_LENGTH, OVERFLOW_ACTION, SUBHANDLERS);
 
@@ -54,8 +71,10 @@ class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
     @Override
     public void registerOperations(final ManagementResourceRegistration registration) {
         super.registerOperations(registration);
-        final ResourceDescriptionResolver resolver = getResourceDescriptionResolver();
-        registration.registerOperationHandler(new SimpleOperationDefinition(ADD_SUBHANDLER_OPERATION_NAME, resolver, HANDLER_NAME), HandlerOperations.ADD_SUBHANDLER);
-        registration.registerOperationHandler(new SimpleOperationDefinition(REMOVE_SUBHANDLER_OPERATION_NAME, resolver, HANDLER_NAME), HandlerOperations.REMOVE_SUBHANDLER);
+
+        registration.registerOperationHandler(LEGACY_ADD_HANDLER, HandlerOperations.ADD_SUBHANDLER);
+        registration.registerOperationHandler(LEGACY_REMOVE_HANDLER, HandlerOperations.REMOVE_SUBHANDLER);
+        registration.registerOperationHandler(ADD_HANDLER, HandlerOperations.ADD_SUBHANDLER);
+        registration.registerOperationHandler(REMOVE_HANDLER, HandlerOperations.REMOVE_SUBHANDLER);
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -342,4 +342,8 @@ public interface CommonAttributes {
             .setDeprecated(ModelVersion.create(1, 2, 0))
             .setAllowNull(true)
             .build();
+
+    String ADD_HANDLER_OPERATION_NAME = "add-handler";
+
+    String REMOVE_HANDLER_OPERATION_NAME = "remove-handler";
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -356,7 +356,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
 
         final ModelNode node = new ModelNode();
-        node.get(OP).set(RootLoggerResourceDefinition.ROOT_LOGGER_ADD_OPERATION_NAME);
+        node.get(OP).set(ADD);
         node.get(OP_ADDR).set(address.toModelNode()).add(ROOT_LOGGER, ROOT_LOGGER_ATTRIBUTE_NAME);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
         final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -12,13 +12,22 @@ logging.logging-profile.remove=Removes the logging profile and all associated lo
 logging.root-logger=Defines the root logger for this log context.
 logging.root-logger.remove=Remove the root logger.
 logging.root-logger.remove-root-logger=Remove the root logger.
+logging.root-logger.remove-root-logger.deprecated=Use the remove operation.
 logging.root-logger.add=Adds the root logger.
+logging.root-logger.add-handler=Adds a handler to the logger.
+logging.root-logger.add-handler.name=The name of the handler to add.
+logging.root-logger.remove-handler=Removes a handler from the logger.
+logging.root-logger.remove-handler.name=The name of the logger to remove.
 logging.root-logger.change-root-log-level=Change the root logger level.
+logging.root-logger.change-root-log-level.deprecated=Use the write-attribute operation.
+logging.root-logger.root-logger-assign-handler.deprecated=Use the add-handler operation.
 logging.root-logger.root-logger-assign-handler=Assign a Handler to the root logger.
 logging.root-logger.root-logger-assign-handler.name=The name of the handler to add.
 logging.root-logger.root-logger-unassign-handler=Unassign a Handler from the root logger.
+logging.root-logger.root-logger-unassign-handler.deprecated=Use the remove-handler operation.
 logging.root-logger.root-logger-unassign-handler.name=The name of the handler to remove.
 logging.root-logger.set-root-logger=Same as add operation
+logging.root-logger.set-root-logger.deprecated=Use the add operation.
 
 # Logger definitions
 logging.logger=Defines a logger category.
@@ -27,10 +36,17 @@ logging.logger.remove=Remove an existing logger category.
 logging.logger.name=Name of the logger
 logging.logger.use-parent-handlers=Specifies whether or not this logger should send its output to it's parent Logger.
 logging.logger.category=Specifies the category for the logger.
+logging.logger.add-handler=Adds a handler to the logger.
+logging.logger.add-handler.name=The name of the handler to add.
+logging.logger.remove-handler=Removes a handler from the logger.
+logging.logger.remove-handler.name=The name of the logger to remove.
 logging.logger.change-log-level=Change the logging level for a logger category.
+logging.logger.change-log-level.deprecated=Use the write-attribute operation.
 logging.logger.assign-handler=Assign a Handler to a Logger.
+logging.logger.assign-handler.deprecated=Use the add-handler operation.
 logging.logger.assign-handler.name=The name of the handler to add.
 logging.logger.unassign-handler=Unassign a Handler from a Logger.
+logging.logger.unassign-handler.deprecated=Use the remove-handler operation.
 logging.logger.unassign-handler.name=The name of the handler to remove.
 
 # Logger handler definitions
@@ -42,13 +58,21 @@ logging.handler.name.deprecated=The name attribute should not be used as the han
 logging.handler.enable=Enable a logging handler.
 logging.handler.disable=Disable a logging handler.
 logging.handler.change-log-level=Change the logging level for a handler.
+logging.handler.change-log-level.deprecated=Use the write-attribute operation.
 logging.handler.change-file=Change the file for a handler.
+logging.handler.change-file.deprecated=Use the write-attribute operation.
 logging.handler.change-file.file=Change the file for a handler.
 logging.handler.update-properties=Update the properties on the existing handler.
-logging.handler.update-properties.file=File for updated properties
+logging.handler.update-properties.deprecated=Use the write-attribute operation.
+logging.handler.add-handler=Adds a handler to the AsyncHandler.
+logging.handler.add-handler.name=The name of the handler to add.
+logging.handler.remove-handler=Removes a handler from the AsyncHandler.
+logging.handler.remove-handler.name=The name of the handler to remove.
 logging.handler.assign-subhandler=Assign a subhandler to the handler.
+logging.handler.assign-subhandler.deprecated=Use the add-handler operation.
 logging.handler.assign-subhandler.name=The name of the handler to add.
 logging.handler.unassign-subhandler=Unassign a subhandler from the handler.
+logging.handler.unassign-subhandler.deprecated=Use the remove-handler operation.
 logging.handler.unassign-subhandler.name=The name of the handler to remove.
 
 # Async handler definitions
@@ -58,8 +82,6 @@ logging.async-handler.overflow-action=Specify what action to take when the overf
 logging.async-handler.add=Add a new ASYNC handler.
 logging.async-handler.subhandlers=The Handlers associated with this async handler.
 logging.async-handler.subhandlers.handler=The subhandler associated with this async handler.
-logging.async-handler.assign-subhandler=Assign a subhandler to the ASYNC handler.
-logging.async-handler.unassign-subhandler=Unassign a subhandler from the ASYNC handler.
 
 # Console handler definitions
 logging.console-handler=Defines a handler which writes to the console.

--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -125,6 +125,14 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
         return createAddress(profileName, CommonAttributes.LOGGER, name);
     }
 
+    static PathAddress createAsyncHandlerAddress(final String name) {
+        return createAddress(CommonAttributes.ASYNC_HANDLER, name);
+    }
+
+    static PathAddress createAsyncHandlerAddress(final String profileName, final String name) {
+        return createAddress(profileName, CommonAttributes.ASYNC_HANDLER, name);
+    }
+
     static PathAddress createConsoleHandlerAddress(final String name) {
         return createAddress(CommonAttributes.CONSOLE_HANDLER, name);
     }

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
@@ -186,7 +186,7 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
 
         // Add the handler to a logger
         final PathAddress loggerAddress = createLoggerAddress("org.jboss.as.logging");
-        op = Operations.createOperation(LoggerResourceDefinition.ADD_HANDLER_OPERATION_NAME, loggerAddress.toModelNode());
+        op = Operations.createOperation(CommonAttributes.ADD_HANDLER_OPERATION_NAME, loggerAddress.toModelNode());
         op.get(CommonAttributes.HANDLER_NAME.getName()).set(consoleHandler.getLastElement().getValue());
         result = kernelServices.executeOperation(op);
         Assert.assertTrue(Operations.getFailureDescription(result), Operations.successful(result));
@@ -252,7 +252,7 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
 
         // Add the handler to a logger
         final PathAddress loggerAddress = createLoggerAddress("org.jboss.as.logging");
-        op = Operations.createOperation(LoggerResourceDefinition.ADD_HANDLER_OPERATION_NAME, loggerAddress.toModelNode());
+        op = Operations.createOperation(CommonAttributes.ADD_HANDLER_OPERATION_NAME, loggerAddress.toModelNode());
         op.get(CommonAttributes.HANDLER_NAME.getName()).set(consoleHandler.getLastElement().getValue());
         result = kernelServices.executeOperation(op);
         Assert.assertTrue(Operations.getFailureDescription(result), Operations.successful(result));


### PR DESCRIPTION
Deprecates unneeded operations like `update-properties`. Added new operations to add handlers to loggers and the async-handler, deprecated the old operation names.
