### PR TITLE
AS7 4610 Add a unit test to prove the scenario and provide a code fix

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ViewInterfaces.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ViewInterfaces.java
@@ -34,6 +34,7 @@ import java.util.Set;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 class ViewInterfaces {
+
     /**
      * Returns all interfaces implemented by a bean that are eligible to be view interfaces
      *
@@ -41,19 +42,17 @@ class ViewInterfaces {
      * @return A collection of all potential view interfaces
      */
     static Set<Class<?>> getPotentialViewInterfaces(Class<?> beanClass) {
-        Class<?>[] interfaces = beanClass.getInterfaces();
-        if (interfaces == null) {
-            return Collections.emptySet();
-        }
         final Set<Class<?>> potentialBusinessInterfaces = new HashSet<Class<?>>();
-        for (Class<?> klass : interfaces) {
-            // EJB 3.1 FR 4.9.7 bullet 5.3
-            if (klass.equals(Serializable.class) ||
-                    klass.equals(Externalizable.class) ||
-                    klass.getName().startsWith("javax.ejb.")) {
-                continue;
+        while (beanClass != null) {
+            for (Class<?> klass : beanClass.getInterfaces()) {
+                // EJB 3.1 FR 4.9.7 bullet 5.3
+                if (klass.equals(Serializable.class) || klass.equals(Externalizable.class)
+                        || klass.getName().startsWith("javax.ejb.")) {
+                    continue;
+                }
+                potentialBusinessInterfaces.add(klass);
             }
-            potentialBusinessInterfaces.add(klass);
+            beanClass = beanClass.getSuperclass();
         }
         return potentialBusinessInterfaces;
     }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/deployment/processors/ViewInterfacesTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/deployment/processors/ViewInterfacesTestCase.java
@@ -1,0 +1,153 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ejb3.deployment.processors;
+
+import java.io.Serializable;
+import java.rmi.RemoteException;
+import java.util.Set;
+
+import javax.ejb.EJBException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ViewInterfaces}.
+ *
+ * @author steve.coy
+ *
+ */
+public class ViewInterfacesTestCase {
+
+    interface InterfaceOne {
+    }
+
+    interface InterfaceTwo {
+    }
+
+    interface InterfaceThree {
+    }
+
+    static class NoSuperClassesNoInterfaces {
+    }
+
+    @Test
+    public void testNoSuperClassesNoInterfaces() {
+        Assert.assertEquals(0, ViewInterfaces.getPotentialViewInterfaces(NoSuperClassesNoInterfaces.class).size());
+    }
+
+    static class NoSuperClassesOneInterface implements InterfaceOne {
+    }
+
+    @Test
+    public void testNoSuperClassesOneInterface() {
+        Set<Class<?>> potentialViewInterfaces = ViewInterfaces.getPotentialViewInterfaces(NoSuperClassesOneInterface.class);
+        Assert.assertEquals(1, potentialViewInterfaces.size());
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceOne.class));
+    }
+
+    static class NoSuperClassesTwoInterfaces implements InterfaceOne, InterfaceTwo {
+    }
+
+    @Test
+    public void testNoSuperClassesTwoInterfaces() {
+        Set<Class<?>> potentialViewInterfaces = ViewInterfaces
+                .getPotentialViewInterfaces(NoSuperClassesTwoInterfaces.class);
+        Assert.assertEquals(2, potentialViewInterfaces.size());
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceOne.class));
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceTwo.class));
+    }
+
+    @SuppressWarnings("serial")
+    static class SerializableNoSuperClassesTwoInterfaces implements InterfaceOne, InterfaceTwo, Serializable {
+    }
+
+    @Test
+    public void testSerializableNoSuperClassesTwoInterfaces() {
+        Set<Class<?>> potentialViewInterfaces = ViewInterfaces
+                .getPotentialViewInterfaces(SerializableNoSuperClassesTwoInterfaces.class);
+        Assert.assertEquals(2, potentialViewInterfaces.size());
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceOne.class));
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceTwo.class));
+    }
+
+    @SuppressWarnings("serial")
+    static class SessionBeanNoSuperClassesTwoInterfaces implements InterfaceOne, InterfaceTwo,
+            SessionBean {
+
+        @Override
+        public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+        }
+
+        @Override
+        public void ejbRemove() throws EJBException, RemoteException {
+        }
+
+        @Override
+        public void ejbActivate() throws EJBException, RemoteException {
+        }
+
+        @Override
+        public void ejbPassivate() throws EJBException, RemoteException {
+        }
+    }
+
+    @Test
+    public void testSessionBeanNoSuperClassesTwoInterfaces() {
+        Set<Class<?>> potentialViewInterfaces = ViewInterfaces
+                .getPotentialViewInterfaces(SessionBeanNoSuperClassesTwoInterfaces.class);
+        Assert.assertEquals(2, potentialViewInterfaces.size());
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceOne.class));
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceTwo.class));
+    }
+
+    @SuppressWarnings("serial")
+    static class SessionBeanWithMultiInterfacedSuperClass extends
+            SessionBeanNoSuperClassesTwoInterfaces {
+    }
+
+    @Test
+    public void testSessionBeanWithMultiInterfacedSuperClass() {
+        Set<Class<?>> potentialViewInterfaces = ViewInterfaces
+                .getPotentialViewInterfaces(SessionBeanWithMultiInterfacedSuperClass.class);
+        Assert.assertEquals(2, potentialViewInterfaces.size());
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceOne.class));
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceTwo.class));
+    }
+
+    static class PojoWithOneInterfaceAndMultiInterfacedSuperClass extends NoSuperClassesTwoInterfaces implements InterfaceThree {
+    }
+
+    @Test
+    public void testPojoWithOneInterfaceAndMultiInterfacedSuperClass() {
+        Set<Class<?>> potentialViewInterfaces = ViewInterfaces
+                .getPotentialViewInterfaces(PojoWithOneInterfaceAndMultiInterfacedSuperClass.class);
+        Assert.assertEquals(3, potentialViewInterfaces.size());
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceOne.class));
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceTwo.class));
+        Assert.assertTrue(potentialViewInterfaces.contains(InterfaceThree.class));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/BusinessViewAnnotationProcessorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/BusinessViewAnnotationProcessorTestCase.java
@@ -93,4 +93,12 @@ public class BusinessViewAnnotationProcessorTestCase {
         assertNotNull("View " + MyInterface.class.getName() + " not found", noInterfaceBean);
     }
 
+    @Test
+    public void testExtendedPojoBean() throws Exception {
+        final Context ctx = new InitialContext();
+
+        final MyInterface myInterfaceView = (MyInterface) ctx.lookup("java:module/" + MyExtendedBean.class.getSimpleName());
+        assertNotNull("View " + MyExtendedBean.class.getName() + " not found", myInterfaceView);
+
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MyExtendedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MyExtendedBean.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.view.basic;
+
+import javax.ejb.Local;
+import javax.ejb.Stateless;
+
+/**
+ * @author steve.coy
+ *
+ */
+@Local
+@Stateless
+public class MyExtendedBean extends MyPojo {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MyPojo.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MyPojo.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.view.basic;
+
+/**
+ * @author steve.coy
+ *
+ */
+public class MyPojo implements MyInterface {
+
+}


### PR DESCRIPTION
This PR resolves https://issues.jboss.org/browse/AS7-4610.

It consists of:
- a basic integration test that was used to replicate the problem
- a code fix for ViewInterfaces.getPotentialViewInterfaces(Class<?>)
- some unit tests to prove the behaviour of ViewInterfaces.getPotentialViewInterfaces(Class<?>)
##### Note

---

As it stands, this means that the behaviour of this method and ViewInterfaces.getPotentialViewInterfaces(ClassInfo) is no longer symmetrical. The single call site of the second method follows up with super-class scanning. Changing the second method may not be considered "in scope" for this issue.
