### PR TITLE
Setting the jmx-management attribute explicitly

### DIFF
--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -17,6 +17,9 @@
                <in-vm-connector name="in-vm" server-id="0"/>
            </connectors>
 
+           <!-- jmx-management is disabled as on AS7 it's preferred to use the AS7's management style -->
+           <jmx-management-enabled>false</jmx-management-enabled>
+
            <acceptors>
                <netty-acceptor name="netty" socket-binding="messaging"/>
                <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">


### PR DESCRIPTION
I have had a few cases where I had to tell users to enable this attribute.

Making it false would make more clear to users where to re-enable jmx management as a few users and customers have written management interfaces in top of our JMX management.
