### PR TITLE
AS7-1103 Prevent transition in ControlledProcessState.setRunning() if current state isn't  STARTING

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ControlledProcessState.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControlledProcessState.java
@@ -100,13 +100,21 @@ public class ControlledProcessState {
     }
 
     public void setRunning() {
-        synchronized (service) {
-            if (restartRequiredFlag) {
-                state.set(State.RESTART_REQUIRED, stamp.incrementAndGet());
-                service.stateChanged(State.RESTART_REQUIRED);
-            } else {
-                state.set(State.RUNNING, stamp.incrementAndGet());
-                service.stateChanged(State.RUNNING);
+        AtomicStampedReference<State> stateRef = state;
+        int newStamp = stamp.incrementAndGet();
+        int[] receiver = new int[1];
+        // Keep trying until stateRef is set with our stamp
+        for (;;) {
+            State was = stateRef.get(receiver);
+            if (was != State.STARTING) { // AS7-1103 only transition to running from STARTING
+                break;
+            }
+            synchronized (service) {
+                State newState = restartRequiredFlag ? State.RESTART_REQUIRED : State.RUNNING;
+                if (state.compareAndSet(was, newState, receiver[0], newStamp)) {
+                    service.stateChanged(newState);
+                    break;
+                }
             }
         }
     }

--- a/controller/src/test/java/org/jboss/as/controller/CompositeOperationHandlerUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CompositeOperationHandlerUnitTestCase.java
@@ -39,7 +39,6 @@ import org.jboss.msc.service.ServiceTarget;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -47,7 +46,6 @@ import org.junit.Test;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-//@Ignore("Composite ops not working yet")
 public class CompositeOperationHandlerUnitTestCase {
 
     private ServiceContainer container;
@@ -63,17 +61,16 @@ public class CompositeOperationHandlerUnitTestCase {
 
         container = ServiceContainer.Factory.create("test");
         ServiceTarget target = container.subTarget();
-        ControlledProcessState processState = new ControlledProcessState(true);
-        ModelControllerImplUnitTestCase.ModelControllerService svc = new ModelControllerImplUnitTestCase.ModelControllerService(processState);
+        TestModelControllerService svc = new ModelControllerImplUnitTestCase.ModelControllerService();
         ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
         builder.install();
-        sharedState = svc.state;
-        svc.latch.await();
+        sharedState = svc.getSharedState();
+        svc.awaitStartup(30, TimeUnit.SECONDS);
         controller = svc.getValue();
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
 
-        assertEquals(ControlledProcessState.State.RUNNING, svc.processState.getState());
+        assertEquals(ControlledProcessState.State.RUNNING, svc.getCurrentProcessState());
     }
 
     @After
@@ -588,7 +585,6 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequired() throws Exception {
         ModelNode step1 = getOperation("reload-required", "attr1", 5);
         ModelNode step2 = getOperation("good", "attr2", 1);
@@ -606,14 +602,12 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredNonRecursive() throws Exception {
         useNonRecursive = true;
         testReloadRequired();
     }
 
     @Test
-//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequired() throws Exception {
         ModelNode step1 = getOperation("restart-required", "attr1", 5);
         ModelNode step2 = getOperation("good", "attr2", 1);
@@ -631,7 +625,6 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredNonRecursive() throws Exception {
         useNonRecursive = true;
         testRestartRequired();

--- a/controller/src/test/java/org/jboss/as/controller/CompositeOperationHandlerUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CompositeOperationHandlerUnitTestCase.java
@@ -57,6 +57,10 @@ public class CompositeOperationHandlerUnitTestCase {
     @Before
     public void setupController() throws InterruptedException {
         System.out.println("=========  New Test \n");
+
+        // restore default
+        useNonRecursive = false;
+
         container = ServiceContainer.Factory.create("test");
         ServiceTarget target = container.subTarget();
         ControlledProcessState processState = new ControlledProcessState(true);
@@ -68,7 +72,8 @@ public class CompositeOperationHandlerUnitTestCase {
         controller = svc.getValue();
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
-        processState.setRunning();
+
+        assertEquals(ControlledProcessState.State.RUNNING, svc.processState.getState());
     }
 
     @After
@@ -583,7 +588,7 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequired() throws Exception {
         ModelNode step1 = getOperation("reload-required", "attr1", 5);
         ModelNode step2 = getOperation("good", "attr2", 1);
@@ -601,14 +606,14 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredNonRecursive() throws Exception {
         useNonRecursive = true;
         testReloadRequired();
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequired() throws Exception {
         ModelNode step1 = getOperation("restart-required", "attr1", 5);
         ModelNode step2 = getOperation("good", "attr2", 1);
@@ -626,14 +631,13 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredNonRecursive() throws Exception {
         useNonRecursive = true;
         testRestartRequired();
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredTxRollback() throws Exception {
         ModelNode step1 = getOperation("reload-required", "attr1", 5);
         ModelNode step2 = getOperation("good", "attr2", 1);
@@ -652,14 +656,12 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredTxRollbackNonRecursive() throws Exception {
         useNonRecursive = true;
         testReloadRequiredTxRollback();
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredTxRollback() throws Exception {
         ModelNode step1 = getOperation("restart-required", "attr1", 5);
         ModelNode step2 = getOperation("good", "attr2", 1);
@@ -678,7 +680,6 @@ public class CompositeOperationHandlerUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredTxRollbackNonRecursive() throws Exception {
         useNonRecursive = true;
         testRestartRequiredTxRollback();

--- a/controller/src/test/java/org/jboss/as/controller/ControlledProcessStateUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ControlledProcessStateUnitTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests of {@link ControlledProcessState}.
+ *
+ * @author Brian Stansberry (c) 2012 Red Hat Inc.
+ */
+public class ControlledProcessStateUnitTestCase {
+
+    /** Test the AS7-1103 scenario */
+    @Test
+    public void testSetRunningRequiresStarting() {
+
+        ControlledProcessState state = new ControlledProcessState(true);
+        state.setRunning();
+        Assert.assertEquals(ControlledProcessState.State.RUNNING, state.getState());
+        Object stamp = state.setRestartRequired();
+        Assert.assertEquals(ControlledProcessState.State.RESTART_REQUIRED, state.getState());
+        state.setRunning(); // in AS7-1103 bug, another thread did this
+        Assert.assertEquals(ControlledProcessState.State.RESTART_REQUIRED, state.getState());
+        state.revertRestartRequired(stamp);
+        Assert.assertEquals(ControlledProcessState.State.RUNNING, state.getState());
+
+        state = new ControlledProcessState(true);
+        state.setRunning();
+        Assert.assertEquals(ControlledProcessState.State.RUNNING, state.getState());
+        stamp = state.setReloadRequired();
+        Assert.assertEquals(ControlledProcessState.State.RELOAD_REQUIRED, state.getState());
+        state.setRunning();
+        Assert.assertEquals(ControlledProcessState.State.RELOAD_REQUIRED, state.getState());
+        state.revertReloadRequired(stamp);
+        Assert.assertEquals(ControlledProcessState.State.RUNNING, state.getState());
+    }
+
+    /** Test the AS7-5929 scenario -- a reload should not clear RESTART_REQUIRED state */
+    @Test
+    public void testRestartRequiredRequiresRestart() {
+
+        ControlledProcessState state = new ControlledProcessState(true);
+        state.setRunning();
+        Assert.assertEquals(ControlledProcessState.State.RUNNING, state.getState());
+        state.setRestartRequired();
+        Assert.assertEquals(ControlledProcessState.State.RESTART_REQUIRED, state.getState());
+
+        // Now simulate a :reload
+        state.setStopping();
+        state.setStarting();
+        state.setRunning();
+
+        // Validate the RESTART_REQUIRED state still pertains
+        Assert.assertEquals(ControlledProcessState.State.RESTART_REQUIRED, state.getState());
+
+    }
+
+}

--- a/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
@@ -91,14 +91,11 @@ public class InterleavedSubsystemTestCase {
     public void testInterleavedOps() throws Exception {
         container = ServiceContainer.Factory.create("test");
         ServiceTarget target = container.subTarget();
-        ControlledProcessState processState = new ControlledProcessState(true);
-        ModelControllerImplUnitTestCase.ModelControllerService svc =
-                new InterleavedSubsystemModelControllerService(processState);
+        TestModelControllerService svc = new InterleavedSubsystemModelControllerService();
         ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
         builder.install();
-        svc.latch.await();
+        svc.awaitStartup(30, TimeUnit.SECONDS);
         ModelController controller = svc.getValue();
-        processState.setRunning();
 
         final ModelNode op = Util.getEmptyOperation(READ_RESOURCE_OPERATION, new ModelNode());
         op.get(RECURSIVE).set(true);
@@ -130,10 +127,10 @@ public class InterleavedSubsystemTestCase {
 
     }
 
-    public static class InterleavedSubsystemModelControllerService extends ModelControllerImplUnitTestCase.ModelControllerService {
+    public static class InterleavedSubsystemModelControllerService extends TestModelControllerService {
 
-        InterleavedSubsystemModelControllerService(final ControlledProcessState processState) {
-            super(processState, InterleavedConfigurationPersister.INSTANCE);
+        InterleavedSubsystemModelControllerService() {
+            super(InterleavedConfigurationPersister.INSTANCE, new ControlledProcessState(true));
         }
 
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -105,7 +105,6 @@ public class ModelControllerImplUnitTestCase {
 
     @Before
     public void setupController() throws InterruptedException {
-
         // restore default
         useNonRecursive = false;
 
@@ -120,7 +119,8 @@ public class ModelControllerImplUnitTestCase {
         controller = svc.getValue();
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
-        processState.setRunning();
+
+        assertEquals(ControlledProcessState.State.RUNNING, svc.processState.getState());
     }
 
     @After
@@ -140,8 +140,9 @@ public class ModelControllerImplUnitTestCase {
 
     public static class ModelControllerService extends AbstractControllerService {
 
+        final ControlledProcessState processState;
         final AtomicBoolean state = new AtomicBoolean(true);
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch = new CountDownLatch(2);
 
         ModelControllerService(final ControlledProcessState processState) {
             this(processState, new NullConfigurationPersister());
@@ -149,6 +150,13 @@ public class ModelControllerImplUnitTestCase {
 
         ModelControllerService(final ControlledProcessState processState, final ConfigurationPersister configurationPersister) {
             super(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, DESC_PROVIDER, null, ExpressionResolver.DEFAULT);
+            this.processState = processState;
+        }
+
+        @Override
+        public void start(StartContext context) throws StartException {
+            super.start(context);
+            latch.countDown();
         }
 
         @Override
@@ -180,8 +188,8 @@ public class ModelControllerImplUnitTestCase {
         }
 
         @Override
-        protected void finishBoot() throws ConfigurationPersistenceException {
-            super.finishBoot();
+        protected void bootThreadDone()  {
+            super.bootThreadDone();
             latch.countDown();
         }
     }
@@ -522,7 +530,7 @@ public class ModelControllerImplUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequired() throws Exception {
         ModelNode result = controller.execute(getOperation("reload-required", "attr1", 5), null, null, null);
         System.out.println(result);
@@ -537,14 +545,14 @@ public class ModelControllerImplUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredNonRecursive() throws Exception {
         useNonRecursive = true;
         testReloadRequired();
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequired() throws Exception {
         ModelNode result = controller.execute(getOperation("restart-required", "attr1", 5), null, null, null);
         System.out.println(result);
@@ -559,14 +567,13 @@ public class ModelControllerImplUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
+//    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredNonRecursive() throws Exception {
         useNonRecursive = true;
         testRestartRequired();
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredTxRollback() throws Exception {
         ModelNode result = controller.execute(getOperation("reload-required", "attr1", 5), null, RollbackTransactionControl.INSTANCE, null);
         System.out.println(result);
@@ -582,14 +589,12 @@ public class ModelControllerImplUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testReloadRequiredTxRollbackNonRecursive() throws Exception {
         useNonRecursive = true;
         testReloadRequiredTxRollback();
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredTxRollback() throws Exception {
         ModelNode result = controller.execute(getOperation("restart-required", "attr1", 5), null, RollbackTransactionControl.INSTANCE, null);
         System.out.println(result);
@@ -605,7 +610,6 @@ public class ModelControllerImplUnitTestCase {
     }
 
     @Test
-    @Ignore("AS7-1103 Fails intermittently for unknown reasons")
     public void testRestartRequiredTxRollbackNonRecursive() throws Exception {
         useNonRecursive = true;
         testRestartRequiredTxRollback();

--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.ControlledProcessState.State;
+
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.persistence.ConfigurationPersister;
+import org.jboss.as.controller.persistence.NullConfigurationPersister;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+
+/**
+* A simple {@code Service<ModelController>} base class for use in unit tests.
+*
+* @author Brian Stansberry (c) 2012 Red Hat Inc.
+*/
+public abstract class TestModelControllerService extends AbstractControllerService {
+
+    private final ControlledProcessState processState;
+    final AtomicBoolean state = new AtomicBoolean(true);
+    private final CountDownLatch latch = new CountDownLatch(2);
+
+    protected TestModelControllerService() {
+        this(new NullConfigurationPersister(), new ControlledProcessState(true));
+    }
+
+    protected TestModelControllerService(final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
+        this(ProcessType.EMBEDDED_SERVER, configurationPersister, processState, DESC_PROVIDER);
+    }
+
+    protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+                                         final DescriptionProvider rootDescriptionProvider) {
+        super(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootDescriptionProvider, null, ExpressionResolver.DEFAULT);
+        this.processState = processState;
+    }
+
+    public AtomicBoolean getSharedState() {
+        return state;
+    }
+
+    public State getCurrentProcessState() {
+        return processState.getState();
+    }
+
+    public void awaitStartup(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        if (!latch.await(timeout, timeUnit)) {
+            throw new RuntimeException("Failed to boot in timely fashion");
+        }
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        super.start(context);
+        latch.countDown();
+    }
+
+    @Override
+    protected void bootThreadDone()  {
+        super.bootThreadDone();
+        latch.countDown();
+    }
+
+    public static final DescriptionProvider DESC_PROVIDER = new DescriptionProvider() {
+        @Override
+        public ModelNode getModelDescription(Locale locale) {
+            return new ModelNode();
+        }
+    };
+}

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
@@ -43,8 +43,6 @@ import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
-import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -72,15 +70,13 @@ public class PlatformMBeanResourceUnitTestCase {
     public static void setupController() throws InterruptedException {
         container = ServiceContainer.Factory.create("test");
         ServiceTarget target = container.subTarget();
-        ControlledProcessState processState = new ControlledProcessState(true);
-        PlatformMBeanTestModelControllerService svc = new PlatformMBeanTestModelControllerService(processState);
+        PlatformMBeanTestModelControllerService svc = new PlatformMBeanTestModelControllerService();
         ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
         builder.install();
-        svc.latch.await();
+        svc.latch.await(30, TimeUnit.SECONDS);
         controller = svc.getValue();
         ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
         controller.execute(setup, null, null, null);
-        processState.setRunning();
 
         client = controller.createClient(Executors.newSingleThreadExecutor());
     }

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
@@ -55,15 +55,14 @@ public class PlatformMBeanTestModelControllerService extends AbstractControllerS
         }
     };
 
-    final CountDownLatch latch = new CountDownLatch(1);
+    final CountDownLatch latch = new CountDownLatch(2);
 
     /**
      * Construct a new instance.
      *
-     * @param processState   the state of the controlled process
      */
-    protected PlatformMBeanTestModelControllerService(final ControlledProcessState processState) {
-        super(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), new NullConfigurationPersister(), processState, DESC_PROVIDER, null, ExpressionResolver.DEFAULT);
+    protected PlatformMBeanTestModelControllerService() {
+        super(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), new NullConfigurationPersister(), new ControlledProcessState(true), DESC_PROVIDER, null, ExpressionResolver.DEFAULT);
     }
 
     @Override
@@ -80,6 +79,12 @@ public class PlatformMBeanTestModelControllerService extends AbstractControllerS
     @Override
     public void start(StartContext context) throws StartException {
         super.start(context);
+        latch.countDown();
+    }
+
+    @Override
+    protected void bootThreadDone() {
+        super.bootThreadDone();
         latch.countDown();
     }
 }


### PR DESCRIPTION
Flaws in unit tests were resulting in 2 separate threads (test thread and Controller Boot Thread) calling setRunning() during creation of test ModelControllers. This was leading to the intermittent failures in AS7-1103.

The tests have been cleaned up so only Controller Boot Thread calls setRunning() and ControlledProcessState.setRunning() has been fixed so even if this crept back in, an invalid state transition would not occur.

I also added a test case method for AS7-5929 to complement the integration test Bartosz created.
