### PR TITLE
[AS7-6109] Secured naming context

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/InMemoryNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/InMemoryNamingStore.java
@@ -97,7 +97,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
         if (isLastComponentEmpty(name)) {
             throw emptyNameException();
         }
-        checkPermissions(name, JndiPermission.Action.BIND);
 
         writeLock.lock();
         try {
@@ -117,7 +116,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
         if (isLastComponentEmpty(name)) {
             throw emptyNameException();
         }
-        checkPermissions(name, JndiPermission.Action.REBIND);
 
         writeLock.lock();
         try {
@@ -137,7 +135,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
         if (isLastComponentEmpty(name)) {
             throw emptyNameException();
         }
-        checkPermissions(name, JndiPermission.Action.UNBIND);
 
         writeLock.lock();
         try {
@@ -157,10 +154,8 @@ public class InMemoryNamingStore implements WritableNamingStore {
     public Object lookup(final Name name) throws NamingException {
         if (isEmpty(name)) {
             final Name emptyName = new CompositeName("");
-            checkPermissions(emptyName, JndiPermission.Action.LOOKUP);
             return new NamingContext(emptyName, this, new Hashtable<String, Object>());
         }
-        checkPermissions(name, JndiPermission.Action.LOOKUP);
         return root.accept(new LookupVisitor(name));
     }
 
@@ -179,7 +174,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
      */
     public List<NameClassPair> list(final Name name) throws NamingException {
         final Name nodeName = name.isEmpty() ? new CompositeName("") : name;
-        checkPermissions(nodeName, JndiPermission.Action.LIST);
         return root.accept(new ListVisitor(nodeName));
     }
 
@@ -192,7 +186,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
      */
     public List<Binding> listBindings(final Name name) throws NamingException {
         final Name nodeName = name.isEmpty() ? new CompositeName("") : name;
-        checkPermissions(nodeName, JndiPermission.Action.LIST_BINDINGS);
         return root.accept(new ListBindingsVisitor(name));
     }
 
@@ -200,7 +193,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
         if (isLastComponentEmpty(name)) {
             throw emptyNameException();
         }
-        checkPermissions(name, JndiPermission.Action.CREATE_SUBCONTEXT);
         return root.accept(new CreateSubContextVisitor(name));
     }
 
@@ -259,13 +251,6 @@ public class InMemoryNamingStore implements WritableNamingStore {
             if (((Reference) object).get("nns") != null) {
                 throw cannotProceedException(object, name);
             }
-        }
-    }
-
-    private void checkPermissions(final Name name, JndiPermission.Action permission) {
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new JndiPermission(name, permission));
         }
     }
 

--- a/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
+++ b/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
@@ -110,8 +110,8 @@ public final class JndiPermission extends Permission
         LIST_BINDINGS("listBindings", 32),
         CREATE_SUBCONTEXT("createSubcontext", 64),
         DESTROY_SUBCONTEXT("destroySubcontext", 128),
-        ADD_NAMING_LISTENER("addNamingListener", 256),        
-        ALL("all", BIND.mask | REBIND.mask | UNBIND.mask | LOOKUP.mask | LIST.mask | LIST_BINDINGS.mask | 
+        ADD_NAMING_LISTENER("addNamingListener", 256),
+        ALL("all", BIND.mask | REBIND.mask | UNBIND.mask | LOOKUP.mask | LIST.mask | LIST_BINDINGS.mask |
             CREATE_SUBCONTEXT.mask | DESTROY_SUBCONTEXT.mask | ADD_NAMING_LISTENER.mask);
 
         private String actionName;
@@ -257,9 +257,9 @@ public final class JndiPermission extends Permission
 
     /**
      * @see #JndiPermission(String, Action...)
-     * 
+     *
      * The default policy file parser ({@code sun.security.provider.PolicyFile}) requires this constructor.
-     * 
+     *
      * @param path the pathname to grant the permission
      * @param actions the comma separated string of actions granted
      */
@@ -267,7 +267,7 @@ public final class JndiPermission extends Permission
         super(path);
         init(getMask(actions));
     }
-    
+
     /**
      * Checks if this JndiPermission object "implies" the specified permission.
      * <p/>

--- a/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
+++ b/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
@@ -225,7 +225,6 @@ public final class JndiPermission extends Permission
      * @throws IllegalArgumentException If actions is <code>null</code>, empty or contains an action
      *                                  other than the specified possible actions.
      */
-
     public JndiPermission(String path, Action... actions) {
         super(path);
         init(getMask(actions));
@@ -235,6 +234,19 @@ public final class JndiPermission extends Permission
         this(path.toString(), actions);
     }
 
+    /**
+     * @see #JndiPermission(String, Action...)
+     * 
+     * The default policy file parser ({@code sun.security.provider.PolicyFile}) requires this constructor.
+     * 
+     * @param path the pathname to grant the permission
+     * @param actions the comma separated string of actions granted
+     */
+    public JndiPermission(String path, String actions) {
+        super(path);
+        init(getMask(actions));
+    }
+    
     /**
      * Checks if this JndiPermission object "implies" the specified permission.
      * <p/>
@@ -399,7 +411,7 @@ public final class JndiPermission extends Permission
 
         String[] sa = actions.split(",");
         for (String s : sa) {
-            String key = s.toLowerCase(Locale.ENGLISH);
+            String key = s.trim().toLowerCase(Locale.ENGLISH);
             action = Action.forName(key);
             if (action == null) {
                 throw MESSAGES.invalidPermissionAction(s);

--- a/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
+++ b/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
@@ -432,8 +432,9 @@ public final class JndiPermission extends Permission
         StringBuilder sb = new StringBuilder();
         boolean insertComma = false;
         final Action[] allActions = Action.values();
-        for (int n = 0; n < allActions.length; n++) {
-            int action = 1 << n;
+        //none is an illegal value, so we're skipping it
+        for (int n = 1; n < allActions.length; n++) {
+            int action = 1 << (n - 1);
             if ((mask & action) == action) {
                 if (insertComma)
                     sb.append(',');

--- a/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
+++ b/naming/src/main/java/org/jboss/as/naming/JndiPermission.java
@@ -69,6 +69,10 @@ import javax.naming.Name;
  * <DD> Context.listBindings permission.
  * <DT> createSubcontext
  * <DD> Context.createSubcontext permission.
+ * <DT> destroySubcontext
+ * <DD> Context.destroySubcontext permission.
+ * <DT> addNamingListener
+ * <DD> EventContext.addNamingListener permission.
  * </DL>
  * <p/>
  * Be careful when granting JndiPermissions. Think about the implications of
@@ -105,7 +109,10 @@ public final class JndiPermission extends Permission
         LIST("list", 16),
         LIST_BINDINGS("listBindings", 32),
         CREATE_SUBCONTEXT("createSubcontext", 64),
-        ALL("all", BIND.mask | REBIND.mask | UNBIND.mask | LOOKUP.mask | LIST.mask | LIST_BINDINGS.mask | CREATE_SUBCONTEXT.mask);
+        DESTROY_SUBCONTEXT("destroySubcontext", 128),
+        ADD_NAMING_LISTENER("addNamingListener", 256),        
+        ALL("all", BIND.mask | REBIND.mask | UNBIND.mask | LOOKUP.mask | LIST.mask | LIST_BINDINGS.mask | 
+            CREATE_SUBCONTEXT.mask | DESTROY_SUBCONTEXT.mask | ADD_NAMING_LISTENER.mask);
 
         private String actionName;
         private int mask;
@@ -121,6 +128,20 @@ public final class JndiPermission extends Permission
                     return action;
             }
             return null;
+        }
+    }
+
+    /**
+     * A utility method to check if the current access control context possesses
+     * the JndiPermission for given JNDI name and actions.
+     *
+     * @param name the JNDI name
+     * @param actions the actions to check the permission for
+     */
+    public static void check(Name name, Action... actions) {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(new JndiPermission(name, actions));
         }
     }
 
@@ -202,7 +223,7 @@ public final class JndiPermission extends Permission
      * is the pathname of a file or directory, and <i>actions</i> contains a
      * comma-separated list of the desired actions granted on the file or
      * directory. Possible actions are "bind", "rebind", "unbind", "lookup",
-     * "list", "listBindings", and "createSubcontext".
+     * "list", "listBindings", "createSubcontext", "destroySubcontext" and "addNamingListener".
      * <p/>
      * <p/>
      * A pathname that ends in "/*" (where "/" is the file separator character,

--- a/naming/src/main/java/org/jboss/as/naming/NamingContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingContext.java
@@ -198,9 +198,9 @@ public class NamingContext implements EventContext {
         } catch(CannotProceedException cpe) {
             final Context continuationContext = NamingManager.getContinuationContext(cpe);
             if (continuationContext instanceof NamingContext) {
-                result = SecurityActions.lookup((NamingContext)continuationContext, cpe.getRemainingName(), dereference);
+                result = ((NamingContext)continuationContext).lookup(cpe.getRemainingName(), dereference);
             } else {
-                result = SecurityActions.lookup(continuationContext, cpe.getRemainingName());
+                result = continuationContext.lookup(cpe.getRemainingName());
             }
         }
 
@@ -221,9 +221,9 @@ public class NamingContext implements EventContext {
             }
             final Context namingContext = (Context) context;
             if (namingContext instanceof NamingContext) {
-                return SecurityActions.lookup((NamingContext)namingContext, resolveResult.getRemainingName(), dereference);
+                return ((NamingContext)namingContext).lookup(resolveResult.getRemainingName(), dereference);
             } else {
-                return SecurityActions.lookup(namingContext, resolveResult.getRemainingName());
+                return namingContext.lookup(resolveResult.getRemainingName());
             }
         } else if (result instanceof LinkRef) {
             result = resolveLink(result,dereference);
@@ -322,11 +322,11 @@ public class NamingContext implements EventContext {
             return namingEnumeration(namingStore.list(getAbsoluteName(name)));
         } catch(CannotProceedException cpe) {
             final Context continuationContext = NamingManager.getContinuationContext(cpe);
-            return SecurityActions.list(continuationContext, cpe.getRemainingName());
+            return continuationContext.list(cpe.getRemainingName());
         }  catch (RequireResolveException r) {
-            final Object o = SecurityActions.lookup(this, r.getResolve());
+            final Object o = lookup(r.getResolve());
             if (o instanceof Context) {
-                return SecurityActions.list((Context)o, name.getSuffix(r.getResolve().size()));
+                return ((Context)o).list(name.getSuffix(r.getResolve().size()));
             }
 
             throw notAContextException(r.getResolve());
@@ -346,11 +346,11 @@ public class NamingContext implements EventContext {
             return namingEnumeration(namingStore.listBindings(getAbsoluteName(name)));
         } catch(CannotProceedException cpe) {
             final Context continuationContext = NamingManager.getContinuationContext(cpe);
-            return SecurityActions.listBindings(continuationContext, cpe.getRemainingName());
+            return continuationContext.listBindings(cpe.getRemainingName());
         } catch (RequireResolveException r) {
-            final Object o = SecurityActions.lookup(this, r.getResolve());
+            final Object o = lookup(r.getResolve());
             if (o instanceof Context) {
-                return SecurityActions.listBindings((Context)o, name.getSuffix(r.getResolve().size()));
+                return ((Context)o).listBindings(name.getSuffix(r.getResolve().size()));
             }
 
             throw notAContextException(r.getResolve());
@@ -528,9 +528,9 @@ public class NamingContext implements EventContext {
             final LinkRef linkRef = (LinkRef) result;
             final String referenceName = linkRef.getLinkName();
             if (referenceName.startsWith("./")) {
-                linkResult = SecurityActions.lookup(this, parseName(referenceName.substring(2)) ,dereference);
+                linkResult = lookup(parseName(referenceName.substring(2)) ,dereference);
             } else {
-                linkResult = SecurityActions.lookup(new InitialContext(), referenceName);
+                linkResult = new InitialContext().lookup(referenceName);
             }
         } catch (Throwable t) {
             throw MESSAGES.cannotDeferenceObject(t);

--- a/naming/src/main/java/org/jboss/as/naming/NamingContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingContext.java
@@ -297,7 +297,7 @@ public class NamingContext implements EventContext {
     /** {@inheritDoc} */
     public void rename(final Name oldName, final Name newName) throws NamingException {
         //check for appropriate permissions first so that no other info leaks from this context
-        //in case of insufficient perms (like the fact if it is readonly or not)        
+        //in case of insufficient perms (like the fact if it is readonly or not)
         check(oldName, Action.LOOKUP, Action.UNBIND);
         check(newName, Action.BIND);
 
@@ -341,7 +341,7 @@ public class NamingContext implements EventContext {
     /** {@inheritDoc} */
     public NamingEnumeration<Binding> listBindings(final Name name) throws NamingException {
         check(name, Action.LIST_BINDINGS);
-        
+
         try {
             return namingEnumeration(namingStore.listBindings(getAbsoluteName(name)));
         } catch(CannotProceedException cpe) {
@@ -365,7 +365,7 @@ public class NamingContext implements EventContext {
     /** {@inheritDoc} */
     public void destroySubcontext(final Name name) throws NamingException {
         check(name, Action.DESTROY_SUBCONTEXT);
-        
+
         if(!(namingStore instanceof WritableNamingStore)) {
             throw MESSAGES.readOnlyNamingContext();
         }
@@ -379,7 +379,7 @@ public class NamingContext implements EventContext {
     /** {@inheritDoc} */
     public Context createSubcontext(Name name) throws NamingException {
         check(name, Action.CREATE_SUBCONTEXT);
-        
+
         if(namingStore instanceof WritableNamingStore) {
             final Name absoluteName = getAbsoluteName(name);
             return getWritableNamingStore().createSubcontext(absoluteName);
@@ -396,7 +396,7 @@ public class NamingContext implements EventContext {
     /** {@inheritDoc} */
     public Object lookupLink(Name name) throws NamingException {
         check(name, Action.LOOKUP);
-        
+
         if (name.isEmpty()) {
             return lookup(name);
         }
@@ -540,10 +540,10 @@ public class NamingContext implements EventContext {
 
     private void check(Name name, Action... actions) throws NamingException {
         Name absoluteName = getAbsoluteName(name);
-        
+
         JndiPermission.check(absoluteName, actions);
     }
-    
+
     Name getPrefix() {
         return prefix;
     }

--- a/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
@@ -34,10 +34,10 @@ import javax.naming.spi.ObjectFactory;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.naming.deployment.JndiName;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
-import org.jboss.logging.Messages;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
 
@@ -456,5 +456,28 @@ public interface NamingMessages {
      */
     @Message(id = 11873, value = "Binding add operation for Object Factory With Environment not supported in Naming Subsystem model version %s")
     String failedToTransformObjectFactoryWithEnvironmentNameBindingAddOperation(String modelVersion);
+    
+    /**
+     * An unexpected checked exception was thrown when doing a lookup on a naming context during a privileged action.
+     * @param cause the cause of failure
+     * @return
+     */
+    @Message(id = 11874, value = "Unexpected exception thrown while doing privileged lookup")
+    IllegalStateException unexpectedExceptionDuringPrivilegedLookup(@Cause Throwable cause);
 
+    /**
+     * An unexpected checked exception was thrown when doing a list on a naming context during a privileged action.
+     * @param cause the cause of failure
+     * @return
+     */
+    @Message(id = 11875, value = "Unexpected exception thrown while doing privileged list")
+    IllegalStateException unexpectedExceptionDuringPrivilegedList(@Cause Throwable cause);
+
+    /**
+     * An unexpected checked exception was thrown when doing a listBindings on a naming context during a privileged action.
+     * @param cause the cause of failure
+     * @return
+     */
+    @Message(id = 11876, value = "Unexpected exception thrown while doing privileged listBindings")
+    IllegalStateException unexpectedExceptionDuringPrivilegedListBindings(@Cause Throwable cause);
 }

--- a/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
@@ -456,7 +456,7 @@ public interface NamingMessages {
      */
     @Message(id = 11873, value = "Binding add operation for Object Factory With Environment not supported in Naming Subsystem model version %s")
     String failedToTransformObjectFactoryWithEnvironmentNameBindingAddOperation(String modelVersion);
-    
+
     /**
      * An unexpected checked exception was thrown when doing a lookup on a naming context during a privileged action.
      * @param cause the cause of failure

--- a/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
@@ -456,28 +456,4 @@ public interface NamingMessages {
      */
     @Message(id = 11873, value = "Binding add operation for Object Factory With Environment not supported in Naming Subsystem model version %s")
     String failedToTransformObjectFactoryWithEnvironmentNameBindingAddOperation(String modelVersion);
-
-    /**
-     * An unexpected checked exception was thrown when doing a lookup on a naming context during a privileged action.
-     * @param cause the cause of failure
-     * @return
-     */
-    @Message(id = 11874, value = "Unexpected exception thrown while doing privileged lookup")
-    IllegalStateException unexpectedExceptionDuringPrivilegedLookup(@Cause Throwable cause);
-
-    /**
-     * An unexpected checked exception was thrown when doing a list on a naming context during a privileged action.
-     * @param cause the cause of failure
-     * @return
-     */
-    @Message(id = 11875, value = "Unexpected exception thrown while doing privileged list")
-    IllegalStateException unexpectedExceptionDuringPrivilegedList(@Cause Throwable cause);
-
-    /**
-     * An unexpected checked exception was thrown when doing a listBindings on a naming context during a privileged action.
-     * @param cause the cause of failure
-     * @return
-     */
-    @Message(id = 11876, value = "Unexpected exception thrown while doing privileged listBindings")
-    IllegalStateException unexpectedExceptionDuringPrivilegedListBindings(@Cause Throwable cause);
 }

--- a/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
+++ b/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
@@ -22,8 +22,19 @@
 
 package org.jboss.as.naming;
 
+import static org.jboss.as.naming.NamingMessages.MESSAGES;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import javax.naming.Binding;
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
 
 final class SecurityActions {
 
@@ -92,4 +103,105 @@ final class SecurityActions {
         }
     }
 
+    static Object lookup(final Context context, final Name name) throws NamingException {
+        if (System.getSecurityManager() == null) {
+            return context.lookup(name);
+        } else {
+            try {
+                return AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+                    @Override
+                    public Object run() throws Exception {
+                        return context.lookup(name);
+                    }
+                });
+            } catch (PrivilegedActionException e) {
+                Throwable cause = e.getCause();
+                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedLookup(cause));
+            }
+        }
+    }
+    
+    static Object lookup(final NamingContext context, final Name name, final boolean dereference) throws NamingException {
+        if (System.getSecurityManager() == null) {
+            return context.lookup(name, dereference);
+        } else {
+            try {
+                return AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+                    @Override
+                    public Object run() throws Exception {
+                        return context.lookup(name, dereference);
+                    }
+                });
+            } catch (PrivilegedActionException e) {
+                Throwable cause = e.getCause();
+                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedLookup(cause));
+            }
+        }
+    }
+    
+    static Object lookup(final javax.naming.InitialContext context, final String name) throws NamingException {
+        if (System.getSecurityManager() == null) {
+            return context.lookup(name);
+        } else {
+            try {
+                return AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+                    @Override
+                    public Object run() throws Exception {
+                        return context.lookup(name);
+                    }
+                });
+            } catch (PrivilegedActionException e) {
+                Throwable cause = e.getCause();
+                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedLookup(cause));
+            }
+        }
+    }
+    
+    static NamingEnumeration<NameClassPair> list(final Context context, final Name name) throws NamingException {
+        if (System.getSecurityManager() == null) {
+            return context.list(name);
+        } else {
+            try {
+                return AccessController.doPrivileged(new PrivilegedExceptionAction<NamingEnumeration<NameClassPair>>() {
+                    @Override
+                    public NamingEnumeration<NameClassPair> run() throws Exception {
+                        return context.list(name);
+                    }
+                });
+            } catch (PrivilegedActionException e) {
+                Throwable cause = e.getCause();
+                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedList(cause));
+            }
+        }
+    }
+    
+    static NamingEnumeration<Binding> listBindings(final Context context, final Name name) throws NamingException {
+        if (System.getSecurityManager() == null) {
+            return context.listBindings(name);
+        } else {
+            try {
+                return AccessController.doPrivileged(new PrivilegedExceptionAction<NamingEnumeration<Binding>>() {
+                    @Override
+                    public NamingEnumeration<Binding> run() throws Exception {
+                        return context.listBindings(name);
+                    }
+                });
+            } catch (PrivilegedActionException e) {
+                Throwable cause = e.getCause();
+                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedListBindings(cause));
+            }
+        }
+    }
+    
+    private static <T extends Throwable> RuntimeException rethrowTypedOrUnchecked(Class<T> exceptionType, Throwable exception, RuntimeException fallback) throws T {
+        if (exceptionType.isInstance(exception)) {
+            throw exceptionType.cast(exception);
+        } else if (exception instanceof RuntimeException) {
+            throw (RuntimeException) exception;
+        } else if (exception instanceof Error) {
+            throw (Error) exception;
+        } else {
+            throw fallback;
+        }
+    }
 }

--- a/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
+++ b/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
@@ -22,19 +22,8 @@
 
 package org.jboss.as.naming;
 
-import static org.jboss.as.naming.NamingMessages.MESSAGES;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-
-import javax.naming.Binding;
-import javax.naming.Context;
-import javax.naming.Name;
-import javax.naming.NameClassPair;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
 
 final class SecurityActions {
 
@@ -100,108 +89,6 @@ final class SecurityActions {
                     return null;
                 }
             });
-        }
-    }
-
-    static Object lookup(final Context context, final Name name) throws NamingException {
-        if (System.getSecurityManager() == null) {
-            return context.lookup(name);
-        } else {
-            try {
-                return AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                    @Override
-                    public Object run() throws Exception {
-                        return context.lookup(name);
-                    }
-                });
-            } catch (PrivilegedActionException e) {
-                Throwable cause = e.getCause();
-                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedLookup(cause));
-            }
-        }
-    }
-
-    static Object lookup(final NamingContext context, final Name name, final boolean dereference) throws NamingException {
-        if (System.getSecurityManager() == null) {
-            return context.lookup(name, dereference);
-        } else {
-            try {
-                return AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                    @Override
-                    public Object run() throws Exception {
-                        return context.lookup(name, dereference);
-                    }
-                });
-            } catch (PrivilegedActionException e) {
-                Throwable cause = e.getCause();
-                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedLookup(cause));
-            }
-        }
-    }
-
-    static Object lookup(final javax.naming.InitialContext context, final String name) throws NamingException {
-        if (System.getSecurityManager() == null) {
-            return context.lookup(name);
-        } else {
-            try {
-                return AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
-                    @Override
-                    public Object run() throws Exception {
-                        return context.lookup(name);
-                    }
-                });
-            } catch (PrivilegedActionException e) {
-                Throwable cause = e.getCause();
-                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedLookup(cause));
-            }
-        }
-    }
-
-    static NamingEnumeration<NameClassPair> list(final Context context, final Name name) throws NamingException {
-        if (System.getSecurityManager() == null) {
-            return context.list(name);
-        } else {
-            try {
-                return AccessController.doPrivileged(new PrivilegedExceptionAction<NamingEnumeration<NameClassPair>>() {
-                    @Override
-                    public NamingEnumeration<NameClassPair> run() throws Exception {
-                        return context.list(name);
-                    }
-                });
-            } catch (PrivilegedActionException e) {
-                Throwable cause = e.getCause();
-                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedList(cause));
-            }
-        }
-    }
-
-    static NamingEnumeration<Binding> listBindings(final Context context, final Name name) throws NamingException {
-        if (System.getSecurityManager() == null) {
-            return context.listBindings(name);
-        } else {
-            try {
-                return AccessController.doPrivileged(new PrivilegedExceptionAction<NamingEnumeration<Binding>>() {
-                    @Override
-                    public NamingEnumeration<Binding> run() throws Exception {
-                        return context.listBindings(name);
-                    }
-                });
-            } catch (PrivilegedActionException e) {
-                Throwable cause = e.getCause();
-                throw rethrowTypedOrUnchecked(NamingException.class, cause, MESSAGES.unexpectedExceptionDuringPrivilegedListBindings(cause));
-            }
-        }
-    }
-
-    private static <T extends Throwable> RuntimeException rethrowTypedOrUnchecked(Class<T> exceptionType, Throwable exception, RuntimeException fallback) throws T {
-        if (exceptionType.isInstance(exception)) {
-            throw exceptionType.cast(exception);
-        } else if (exception instanceof RuntimeException) {
-            throw (RuntimeException) exception;
-        } else if (exception instanceof Error) {
-            throw (Error) exception;
-        } else {
-            throw fallback;
         }
     }
 }

--- a/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
+++ b/naming/src/main/java/org/jboss/as/naming/SecurityActions.java
@@ -120,7 +120,7 @@ final class SecurityActions {
             }
         }
     }
-    
+
     static Object lookup(final NamingContext context, final Name name, final boolean dereference) throws NamingException {
         if (System.getSecurityManager() == null) {
             return context.lookup(name, dereference);
@@ -138,7 +138,7 @@ final class SecurityActions {
             }
         }
     }
-    
+
     static Object lookup(final javax.naming.InitialContext context, final String name) throws NamingException {
         if (System.getSecurityManager() == null) {
             return context.lookup(name);
@@ -156,7 +156,7 @@ final class SecurityActions {
             }
         }
     }
-    
+
     static NamingEnumeration<NameClassPair> list(final Context context, final Name name) throws NamingException {
         if (System.getSecurityManager() == null) {
             return context.list(name);
@@ -174,7 +174,7 @@ final class SecurityActions {
             }
         }
     }
-    
+
     static NamingEnumeration<Binding> listBindings(final Context context, final Name name) throws NamingException {
         if (System.getSecurityManager() == null) {
             return context.listBindings(name);
@@ -192,7 +192,7 @@ final class SecurityActions {
             }
         }
     }
-    
+
     private static <T extends Throwable> RuntimeException rethrowTypedOrUnchecked(Class<T> exceptionType, Throwable exception, RuntimeException fallback) throws T {
         if (exceptionType.isInstance(exception)) {
             throw exceptionType.cast(exception);

--- a/naming/src/test/java/org/jboss/as/naming/NamingContextTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/NamingContextTestCase.java
@@ -22,10 +22,16 @@
 
 package org.jboss.as.naming;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.jboss.as.naming.SecurityHelper.testActionPermission;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Set;
 
 import javax.naming.Binding;
 import javax.naming.CompositeName;
@@ -41,15 +47,12 @@ import javax.naming.Referenceable;
 import javax.naming.StringRefAddr;
 import javax.naming.spi.ObjectFactory;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.jboss.as.naming.JndiPermission.Action;
 
 /**
  * @author John E. Bailey
@@ -83,7 +86,11 @@ public class NamingContextTestCase {
         final Object object = new Object();
         namingStore.bind(name, object);
 
-        final Object result = namingContext.lookup(name);
+        Object result = namingContext.lookup(name);
+        assertEquals(object, result);
+        
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "test");
         assertEquals(object, result);
     }
 
@@ -93,7 +100,11 @@ public class NamingContextTestCase {
         final Reference reference = new Reference(String.class.getName(), new StringRefAddr("blah", "test"), TestObjectFactory.class.getName(), null);
         namingStore.bind(name, reference);
 
-        final Object result = namingContext.lookup(name);
+        Object result = namingContext.lookup(name);
+        assertEquals("test", result);
+        
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "test");
         assertEquals("test", result);
     }
 
@@ -104,7 +115,11 @@ public class NamingContextTestCase {
         final Reference reference = new Reference(String.class.getName(), new StringRefAddr("nns", "comp"), TestObjectFactoryWithNameResolution.class.getName(), null);
         namingStore.bind(new CompositeName("test"), reference);
 
-        final Object result = namingContext.lookup(new CompositeName("test/nested"));
+        Object result = namingContext.lookup(new CompositeName("test/nested"));
+        assertEquals("test", result);
+
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "test/nested");
         assertEquals("test", result);
     }
 
@@ -115,7 +130,11 @@ public class NamingContextTestCase {
         final Reference reference = new Reference(String.class.getName(), new StringRefAddr("blahh", "test"), TestObjectFactoryWithNameResolution.class.getName(), null);
         namingStore.bind(new CompositeName("comp"), reference);
 
-        final Object result = namingContext.lookup(new CompositeName("comp/nested"));
+        Object result = namingContext.lookup(new CompositeName("comp/nested"));
+        assertEquals("test", result);
+
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "comp/nested");
         assertEquals("test", result);
     }
 
@@ -128,9 +147,17 @@ public class NamingContextTestCase {
         Object result = namingContext.lookup(linkName);
         assertEquals("testValue", result);
 
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "link");
+        assertEquals("testValue", result);
+        
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, InitialContextFactory.class.getName());
         namingStore.rebind(linkName, new LinkRef(name));
         result = namingContext.lookup(linkName);
+        assertEquals("testValue", result);
+        
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "link");
         assertEquals("testValue", result);
     }
 
@@ -142,6 +169,10 @@ public class NamingContextTestCase {
         namingStore.bind(linkName, new LinkRef("./test"));
         Object result = namingContext.lookup("link/value");
         assertEquals("testValue", result);
+        
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, "link/value");
+        assertEquals("testValue", result);        
     }
 
 
@@ -152,6 +183,13 @@ public class NamingContextTestCase {
             fail("Should have thrown and NameNotFoundException");
         } catch (NameNotFoundException expected) {
         }
+
+        //the same with security permissions
+        try {
+            testActionPermission(Action.LOOKUP, namingContext, "test");
+            fail("Should have thrown and NameNotFoundException with appropriate permissions");
+        } catch (NameNotFoundException expected) {
+        }
     }
 
     @Test
@@ -160,22 +198,39 @@ public class NamingContextTestCase {
         assertTrue(result instanceof NamingContext);
         result = namingContext.lookup(new CompositeName(""));
         assertTrue(result instanceof NamingContext);
+        
+        //the same with security permissions
+        result = testActionPermission(Action.LOOKUP, namingContext, null);
+        assertTrue(result instanceof NamingContext);
+        result = testActionPermission(Action.LOOKUP, namingContext, "");
+        assertTrue(result instanceof NamingContext);
     }
 
     @Test
     public void testBind() throws Exception {
-        final Name name = new CompositeName("test");
+        Name name = new CompositeName("test");
         final Object value = new Object();
         namingContext.bind(name, value);
         assertEquals(value, namingStore.lookup(name));
+        
+        //the same with security permissions
+        name = new CompositeName("securitytest");
+        testActionPermission(Action.BIND, namingContext, "securitytest", value);
+        assertEquals(value, namingStore.lookup(name));        
     }
 
     @Test
     public void testBindReferenceable() throws Exception {
-        final Name name = new CompositeName("test");
+        Name name = new CompositeName("test");
         final TestObjectReferenceable referenceable = new TestObjectReferenceable("addr");
         namingContext.bind(name, referenceable);
-        final Object result = namingContext.lookup(name);
+        Object result = namingContext.lookup(name);
+        assertEquals(referenceable.addr, result);
+
+        //the same with security permissions
+        name = new CompositeName("securitytest");
+        testActionPermission(Action.BIND, namingContext, "securitytest", referenceable);
+        result = testActionPermission(Action.LOOKUP, namingContext, "securitytest");
         assertEquals(referenceable.addr, result);
     }
     
@@ -189,11 +244,22 @@ public class NamingContextTestCase {
             namingStore.lookup(name);
             fail("Should have thrown name not found");
         } catch (NameNotFoundException expect) {}
+
+        //the same with security permissions
+        testActionPermission(Action.BIND, namingContext, "test", value);
+        testActionPermission(Action.UNBIND, namingContext, "test");
+        try {
+            namingStore.lookup(name);
+            fail("Should have thrown name not found");
+        } catch (NameNotFoundException expect) {}
     }
 
     @Test
     public void testCreateSubcontext() throws Exception {
         assertTrue(namingContext.createSubcontext(new CompositeName("test")) instanceof NamingContext);
+        
+        //the same with security permissions
+        assertTrue(testActionPermission(Action.CREATE_SUBCONTEXT, namingContext, "securitytest") instanceof NamingContext);
     }
 
     @Test
@@ -201,8 +267,13 @@ public class NamingContextTestCase {
         final Name name = new CompositeName("test");
         final Object value = new Object();
         namingStore.bind(name, value);
-        final Object newValue = new Object();
+        Object newValue = new Object();
         namingContext.rebind(name, newValue);
+        assertEquals(newValue, namingStore.lookup(name));
+        
+        //the same with security permissions
+        newValue = new Object();
+        testActionPermission(Action.REBIND, namingContext, "test", newValue);
         assertEquals(newValue, namingStore.lookup(name));
     }
 
@@ -211,9 +282,15 @@ public class NamingContextTestCase {
         final Name name = new CompositeName("test");
         final TestObjectReferenceable referenceable = new TestObjectReferenceable("addr");
         namingContext.bind(name, referenceable);
-        final TestObjectReferenceable newReferenceable = new TestObjectReferenceable("newAddr");
+        TestObjectReferenceable newReferenceable = new TestObjectReferenceable("newAddr");
         namingContext.rebind(name, newReferenceable);
-        final Object result = namingContext.lookup(name);
+        Object result = namingContext.lookup(name);
+        assertEquals(newReferenceable.addr, result);
+        
+        //the same with security permissions
+        newReferenceable = new TestObjectReferenceable("yetAnotherNewAddr");
+        testActionPermission(Action.REBIND, namingContext, "test", newReferenceable);
+        result = namingContext.lookup(name);
         assertEquals(newReferenceable.addr, result);
     }
     
@@ -224,67 +301,39 @@ public class NamingContextTestCase {
             fail("Should have thrown and NameNotFoundException");
         } catch (NameNotFoundException expected) {
         }
+
+        //the same with security permissions
+        try {
+            testActionPermission(Action.LIST, namingContext, "test");
+            fail("Should have thrown and NameNotFoundException with appropriate permissions");
+        } catch (NameNotFoundException expected) {
+        }
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testList() throws Exception {
-        final Name name = new CompositeName("test");
-        final Object object = new Object();
-        namingStore.bind(name, object);
-        final Name nameTwo = new CompositeName("testTwo");
-        final Object objectTwo = new Object();
-        namingStore.bind(nameTwo, objectTwo);
-        final Name nameThree = new CompositeName("testThree");
-        final Object objectThree = new Object();
-        namingStore.bind(nameThree, objectThree);
+        bindList();
 
-        namingStore.bind(new CompositeName("testContext/test"), "testNested");
+        NamingEnumeration<NameClassPair> results = namingContext.list(new CompositeName());
+        checkListResults(results);
 
-        final NamingEnumeration<NameClassPair> results = namingContext.list(new CompositeName());
-        final Set<String> expected = new HashSet<String>(Arrays.asList("test", "testTwo", "testThree", "testContext"));
-        while (results.hasMore()) {
-            NameClassPair result = results.next();
-            final String resultName = result.getName();
-            if ("test".equals(resultName) || "testTwo".equals(resultName) || "testThree".equals(resultName)) {
-                assertEquals(Object.class.getName(), result.getClassName());
-            } else if ("testContext".equals(resultName)) {
-                assertEquals(Context.class.getName(), result.getClassName());
-            } else {
-                fail("Unknown result name: " + resultName);
-            }
-            expected.remove(resultName);
-        }
-        assertTrue("Not all expected results were returned", expected.isEmpty());
+        //the same with security permissions        
+        results = (NamingEnumeration<NameClassPair>) testActionPermission(Action.LIST, namingContext, null);
+        checkListResults(results);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testListWithContinuation() throws Exception {
-        final Name name = new CompositeName("test/test");
-        final Object object = new Object();
-        namingStore.bind(name, object);
-        final Name nameTwo = new CompositeName("test/testTwo");
-        final Object objectTwo = new Object();
-        namingStore.bind(nameTwo, objectTwo);
-        final Name nameThree = new CompositeName("test/testThree");
-        final Object objectThree = new Object();
-        namingStore.bind(nameThree, objectThree);
+        bindListWithContinuations();
 
-        final Reference reference = new Reference(String.class.getName(), new StringRefAddr("nns", "test"), TestObjectFactoryWithNameResolution.class.getName(), null);
-        namingStore.bind(new CompositeName("comp"), reference);
-
-        final NamingEnumeration<NameClassPair> results = namingContext.list(new CompositeName("comp"));
-        final Set<String> expected = new HashSet<String>(Arrays.asList("test", "testTwo", "testThree"));
-        while (results.hasMore()) {
-            NameClassPair result = results.next();
-            final String resultName = result.getName();
-            if ("test".equals(resultName) || "testTwo".equals(resultName) || "testThree".equals(resultName)) {
-                assertEquals(Object.class.getName(), result.getClassName());
-            } else {
-                fail("Unknown result name: " + resultName);
-            }
-            expected.remove(resultName);
-        }
-        assertTrue("Not all expected results were returned", expected.isEmpty());
+        NamingEnumeration<NameClassPair> results = namingContext.list(new CompositeName("comp"));
+        checkListWithContinuationsResults(results);
+        
+        //the same with security permissions        
+        results = (NamingEnumeration<NameClassPair>) testActionPermission(Action.LIST, namingContext, "comp");
+        checkListWithContinuationsResults(results);
     }
 
     @Test
@@ -294,74 +343,39 @@ public class NamingContextTestCase {
             fail("Should have thrown and NameNotFoundException");
         } catch (NameNotFoundException expected) {
         }
+
+        //the same with security permissions        
+        try {
+            testActionPermission(Action.LIST_BINDINGS, namingContext, "test");
+            fail("Should have thrown and NameNotFoundException with appropriate permissions");
+        } catch (NameNotFoundException expected) {
+        }
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testListBindings() throws Exception {
-        final Name name = new CompositeName("test");
-        final Object object = new Object();
-        namingStore.bind(name, object);
-        final Name nameTwo = new CompositeName("testTwo");
-        final Object objectTwo = new Object();
-        namingStore.bind(nameTwo, objectTwo);
-        final Name nameThree = new CompositeName("testThree");
-        final Object objectThree = new Object();
-        namingStore.bind(nameThree, objectThree);
+        bindList();
 
-        namingStore.bind(new CompositeName("testContext/test"), "test");
-
-        final NamingEnumeration<Binding> results = namingContext.listBindings(new CompositeName());
-        final Set<String> expected = new HashSet<String>(Arrays.asList("test", "testTwo", "testThree", "testContext"));
-        while (results.hasMore()) {
-            final Binding result = results.next();
-            final String resultName = result.getName();
-            if ("test".equals(resultName)) {
-                assertEquals(Object.class.getName(), result.getClassName());
-                assertEquals(object, result.getObject());
-            } else if ("testTwo".equals(resultName)) {
-                assertEquals(Object.class.getName(), result.getClassName());
-                assertEquals(objectTwo, result.getObject());
-            } else if ("testThree".equals(resultName)) {
-                assertEquals(Object.class.getName(), result.getClassName());
-                assertEquals(objectThree, result.getObject());
-            } else if ("testContext".equals(resultName)) {
-                assertEquals(Context.class.getName(), result.getClassName());
-            } else {
-                fail("Unknown result name: " + resultName);
-            }
-            expected.remove(resultName);
-        }
-        assertTrue("Not all expected results were returned", expected.isEmpty());
+        NamingEnumeration<Binding> results = namingContext.listBindings(new CompositeName());
+        checkListResults(results);
+        
+        //the same with security permissions
+        results = (NamingEnumeration<Binding>) testActionPermission(Action.LIST_BINDINGS, namingContext, null);
+        checkListResults(results);
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testListBindingsWithContinuation() throws Exception {
-        final Name name = new CompositeName("test/test");
-        final Object object = new Object();
-        namingStore.bind(name, object);
-        final Name nameTwo = new CompositeName("test/testTwo");
-        final Object objectTwo = new Object();
-        namingStore.bind(nameTwo, objectTwo);
-        final Name nameThree = new CompositeName("test/testThree");
-        final Object objectThree = new Object();
-        namingStore.bind(nameThree, objectThree);
+        bindListWithContinuations();
 
-        final Reference reference = new Reference(String.class.getName(), new StringRefAddr("nns", "test"), TestObjectFactoryWithNameResolution.class.getName(), null);
-        namingStore.bind(new CompositeName("comp"), reference);
-
-        final NamingEnumeration<Binding> results = namingContext.listBindings(new CompositeName("comp"));
-        final Set<String> expected = new HashSet<String>(Arrays.asList("test", "testTwo", "testThree"));
-        while (results.hasMore()) {
-            NameClassPair result = results.next();
-            final String resultName = result.getName();
-            if ("test".equals(resultName) || "testTwo".equals(resultName) || "testThree".equals(resultName)) {
-                assertEquals(Object.class.getName(), result.getClassName());
-            } else {
-                fail("Unknown result name: " + resultName);
-            }
-            expected.remove(resultName);
-        }
-        assertTrue("Not all expected results were returned", expected.isEmpty());
+        NamingEnumeration<Binding> results = namingContext.listBindings(new CompositeName("comp"));
+        checkListWithContinuationsResults(results);
+        
+        //the same with security permissions
+        results = (NamingEnumeration<Binding>) testActionPermission(Action.LIST_BINDINGS, namingContext, "comp");
+        checkListWithContinuationsResults(results);
     }
 
     public static class TestObjectFactory implements ObjectFactory {
@@ -397,4 +411,67 @@ public class NamingContextTestCase {
 
     }
 
+    private void bindList() throws NamingException {
+        final Name name = new CompositeName("test");
+        final Object object = new Object();
+        namingStore.bind(name, object);
+        final Name nameTwo = new CompositeName("testTwo");
+        final Object objectTwo = new Object();
+        namingStore.bind(nameTwo, objectTwo);
+        final Name nameThree = new CompositeName("testThree");
+        final Object objectThree = new Object();
+        namingStore.bind(nameThree, objectThree);
+
+        namingStore.bind(new CompositeName("testContext/test"), "testNested");
+    }
+    
+    private void bindListWithContinuations() throws NamingException {
+        final Name name = new CompositeName("test/test");
+        final Object object = new Object();
+        namingStore.bind(name, object);
+        final Name nameTwo = new CompositeName("test/testTwo");
+        final Object objectTwo = new Object();
+        namingStore.bind(nameTwo, objectTwo);
+        final Name nameThree = new CompositeName("test/testThree");
+        final Object objectThree = new Object();
+        namingStore.bind(nameThree, objectThree);
+
+        final Reference reference = new Reference(String.class.getName(), new StringRefAddr("nns", "test"), TestObjectFactoryWithNameResolution.class.getName(), null);
+        namingStore.bind(new CompositeName("comp"), reference);
+    }
+    
+    private void checkListResults(NamingEnumeration<? extends NameClassPair> results) throws NamingException {
+        final Set<String> expected = new HashSet<String>(Arrays.asList("test", "testTwo", "testThree", "testContext"));
+        
+        while (results.hasMore()) {
+            NameClassPair result = results.next();
+            final String resultName = result.getName();
+            if ("test".equals(resultName) || "testTwo".equals(resultName) || "testThree".equals(resultName)) {
+                assertEquals(Object.class.getName(), result.getClassName());
+            } else if ("testContext".equals(resultName)) {
+                assertEquals(Context.class.getName(), result.getClassName());
+            } else {
+                fail("Unknown result name: " + resultName);
+            }
+            expected.remove(resultName);
+        }
+        assertTrue("Not all expected results were returned", expected.isEmpty());
+    }
+        
+    private void checkListWithContinuationsResults(NamingEnumeration<? extends NameClassPair> results) throws NamingException {
+        final Set<String> expected = new HashSet<String>(Arrays.asList("test", "testTwo", "testThree"));
+        
+        while (results.hasMore()) {
+            NameClassPair result = results.next();
+            final String resultName = result.getName();
+            if ("test".equals(resultName) || "testTwo".equals(resultName) || "testThree".equals(resultName)) {
+                assertEquals(Object.class.getName(), result.getClassName());
+            } else {
+                fail("Unknown result name: " + resultName);
+            }
+            expected.remove(resultName);
+        }
+        assertTrue("Not all expected results were returned", expected.isEmpty());
+    }
+        
 }

--- a/naming/src/test/java/org/jboss/as/naming/NamingContextTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/NamingContextTestCase.java
@@ -119,7 +119,7 @@ public class NamingContextTestCase {
         assertEquals("test", result);
 
         //the same with security permissions
-        result = testActionPermission(Action.LOOKUP, namingContext, "test/nested");
+        result = testActionPermission(Action.LOOKUP, Arrays.asList(new JndiPermission("comp/nested",  "lookup")), namingContext, "test/nested");
         assertEquals("test", result);
     }
 
@@ -134,7 +134,7 @@ public class NamingContextTestCase {
         assertEquals("test", result);
 
         //the same with security permissions
-        result = testActionPermission(Action.LOOKUP, namingContext, "comp/nested");
+        result = testActionPermission(Action.LOOKUP, Arrays.asList(new JndiPermission("test/nested", "lookup")), namingContext, "comp/nested");
         assertEquals("test", result);
     }
 
@@ -148,7 +148,7 @@ public class NamingContextTestCase {
         assertEquals("testValue", result);
 
         //the same with security permissions
-        result = testActionPermission(Action.LOOKUP, namingContext, "link");
+        result = testActionPermission(Action.LOOKUP, Arrays.asList(new JndiPermission("test", "lookup")), namingContext, "link");
         assertEquals("testValue", result);
         
         System.setProperty(Context.INITIAL_CONTEXT_FACTORY, InitialContextFactory.class.getName());
@@ -157,7 +157,7 @@ public class NamingContextTestCase {
         assertEquals("testValue", result);
         
         //the same with security permissions
-        result = testActionPermission(Action.LOOKUP, namingContext, "link");
+        result = testActionPermission(Action.LOOKUP, Arrays.asList(new JndiPermission("test", "lookup")), namingContext, "link");
         assertEquals("testValue", result);
     }
 
@@ -171,7 +171,9 @@ public class NamingContextTestCase {
         assertEquals("testValue", result);
         
         //the same with security permissions
-        result = testActionPermission(Action.LOOKUP, namingContext, "link/value");
+        result = testActionPermission(Action.LOOKUP, Arrays.asList(new JndiPermission("test", "lookup"), 
+            new JndiPermission("test/value", "lookup")), namingContext, "link/value");
+        
         assertEquals("testValue", result);        
     }
 
@@ -332,7 +334,9 @@ public class NamingContextTestCase {
         checkListWithContinuationsResults(results);
         
         //the same with security permissions        
-        results = (NamingEnumeration<NameClassPair>) testActionPermission(Action.LIST, namingContext, "comp");
+        results = (NamingEnumeration<NameClassPair>) testActionPermission(Action.LIST, Arrays.asList(
+            new JndiPermission("test", "list")), namingContext, "comp");
+        
         checkListWithContinuationsResults(results);
     }
 
@@ -374,7 +378,9 @@ public class NamingContextTestCase {
         checkListWithContinuationsResults(results);
         
         //the same with security permissions
-        results = (NamingEnumeration<Binding>) testActionPermission(Action.LIST_BINDINGS, namingContext, "comp");
+        results = (NamingEnumeration<Binding>) testActionPermission(Action.LIST_BINDINGS, Arrays.asList(
+            new JndiPermission("test", "listBindings")), namingContext, "comp");
+        
         checkListWithContinuationsResults(results);
     }
 

--- a/naming/src/test/java/org/jboss/as/naming/SecurityHelper.java
+++ b/naming/src/test/java/org/jboss/as/naming/SecurityHelper.java
@@ -1,0 +1,226 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.naming;
+
+import static org.junit.Assert.fail;
+
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.CodeSource;
+import java.security.Permission;
+import java.security.Permissions;
+import java.security.Policy;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
+import java.util.concurrent.Callable;
+
+import javax.naming.CompositeName;
+import javax.naming.Name;
+import javax.naming.NamingException;
+
+/**
+ * @author Lukas Krejci
+ */
+public class SecurityHelper {
+
+    private SecurityHelper() {
+
+    }
+
+    public static Object testActionPermission(final JndiPermission.Action action, final NamingContext namingContext,
+        final String name, final Object... params) throws Exception {
+
+        Exception positiveTestCaseException = null;
+
+        try {
+            //positive test case
+            return testActionWithPermission(action, namingContext, name, params);
+        } catch (Exception e) {
+            positiveTestCaseException = e;
+            //this is just to satisfy the compiler... the finally clause should always throw an exception in this case
+            return null;
+        } finally {
+            //negative test case
+            try {
+                testActionWithoutPermission(action, namingContext, name, params);
+            } catch (Exception e) {
+                if (positiveTestCaseException == null) {
+                    throw e;
+                } else {
+                    throw new Exception("Both positive and negative permission test for JNDI action "
+                        + action
+                        + " failed. The negative test case (which should have resulted in a security exception)"
+                        + " failed with a message: "
+                        + "("
+                        + e.getClass().getName()
+                        + "): "
+                        + e.getMessage()
+                        + ". The exception of the positive testcase"
+                        + " is set up as the cause of this exception.", positiveTestCaseException);
+                }
+            }
+
+            if (positiveTestCaseException != null) {
+                throw positiveTestCaseException;
+            }
+        }
+    }
+
+    public static Object testActionWithPermission(final JndiPermission.Action action, final NamingContext namingContext,
+        final String name, final Object... params) throws Exception {
+
+        final CompositeName n = name == null ? new CompositeName() : new CompositeName(name);
+        final String sn = name == null ? "" : name;
+
+        return runWithSecurityManager(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                return performAction(action, namingContext, n, params);
+            }
+        }, getSecurityContextForJNDILookup(new JndiPermission(sn, action)));
+    }
+
+    public static void testActionWithoutPermission(final JndiPermission.Action action, final NamingContext namingContext,
+        final String name, final Object... params) throws Exception {
+
+        final CompositeName n = name == null ? new CompositeName() : new CompositeName(name);
+        final String sn = name == null ? "" : name;
+
+        try {
+            runWithSecurityManager(new Callable<Object>() {
+                @Override
+                public Object call() throws Exception {
+                    return performAction(action, namingContext, n, params);
+                }
+            }, getSecurityContextForJNDILookup(new JndiPermission(sn, not(action))));
+
+            fail("Naming operation " + action + " should not have been permitted");
+        } catch (SecurityException e) {
+            //expected
+        }
+    }
+
+    private static JndiPermission.Action not(JndiPermission.Action action) {
+        for (JndiPermission.Action a : JndiPermission.Action.values()) {
+            //none is considered an invalid value
+            if (a != action && a != JndiPermission.Action.NONE) {
+                return a;
+            }
+        }
+
+        return null;
+    }
+
+    private static Object performAction(JndiPermission.Action action, NamingContext namingContext, Name name,
+        Object... params) throws NamingException {
+        switch (action) {
+        case BIND:
+            if (params.length == 1) {
+                namingContext.bind(name, params[0]);
+            } else {
+                throw new IllegalArgumentException("Invalid number of arguments passed to bind()");
+            }
+            return null;
+        case CREATE_SUBCONTEXT:
+            return namingContext.createSubcontext(name);
+        case LIST:
+            return namingContext.list(name);
+        case LIST_BINDINGS:
+            return namingContext.listBindings(name);
+        case LOOKUP:
+            if (params.length == 0) {
+                return namingContext.lookup(name);
+            } else if (params.length == 1) {
+                return namingContext.lookup(name, (Boolean) params[0]);
+            } else {
+                throw new IllegalArgumentException("Invalid number of arguments passed to lookup()");
+            }
+        case REBIND:
+            if (params.length == 1) {
+                namingContext.rebind(name, params[0]);
+            } else {
+                throw new IllegalArgumentException("Invalid number of arguments passed to rebind()");
+            }
+            return null;
+        case UNBIND:
+            namingContext.unbind(name);
+            return null;
+        default:
+            throw new IllegalArgumentException("Action "
+                + action
+                + " not supported by the generic testActionPermission test");
+        }
+    }
+
+    public static <T> T runWithSecurityManager(final Callable<T> action, final AccessControlContext securityContext)
+        throws Exception {
+
+        Policy previousPolicy = Policy.getPolicy();
+        SecurityManager previousSM = System.getSecurityManager();
+
+        //let's be a bit brutal here and just allow any code do anything by default for the time this method executes.
+        Policy.setPolicy(new Policy() {
+            @Override
+            public boolean implies(ProtectionDomain domain, Permission permission) {
+                return true;
+            }
+        });
+
+        //with our new totally unsecure policy, let's install a new security manager
+        System.setSecurityManager(new SecurityManager());
+
+        try {
+            //run the code to test with limited privs defined by the securityContext
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<T>() {
+                @Override
+                public T run() throws Exception {
+                    return action.call();
+                }
+            }, securityContext);
+        } catch (PrivilegedActionException e) {
+            throw e.getException();
+        } finally {
+            //and reset back the previous security settings
+            System.setSecurityManager(previousSM);
+            Policy.setPolicy(previousPolicy);
+        }
+    }
+
+    public static AccessControlContext getSecurityContextForJNDILookup(JndiPermission... jndiPermissions) {
+        CodeSource src = new CodeSource(null, (Certificate[]) null);
+
+        Permissions perms = new Permissions();
+
+        for (JndiPermission p : jndiPermissions) {
+            perms.add(p);
+        }
+
+        ProtectionDomain domain = new ProtectionDomain(src, perms);
+
+        AccessControlContext ctx = new AccessControlContext(new ProtectionDomain[] { domain });
+
+        return ctx;
+    }
+}


### PR DESCRIPTION
Adds the ability to secure the access to the JNDI tree using the org.jboss.as.naming.JndiPermission.
Also makes that permission class usable from the policy files.
