### PR TITLE
AS7-6085 SecurityManager permissions for core management layer access

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -239,7 +239,16 @@ public abstract class AbstractControllerService implements Service<ModelControll
         controller = null;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws SecurityException if the caller does not have {@link ModelController#ACCESS_PERMISSION}
+     */
     public ModelController getValue() throws IllegalStateException, IllegalArgumentException {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ModelController.ACCESS_PERMISSION);
+        }
         final ModelController controller = this.controller;
         if (controller == null) {
             throw new IllegalStateException();

--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2578,4 +2578,13 @@ public interface ControllerMessages {
      */
     @Message(id = 14884, value = "No operation named '%s' exists at address %s")
     String noHandlerForOperation(String operationName, PathAddress address);
+
+    /**
+     * Indicates {@code permissionName} is not a valid permission for use with permission class {@code permissionClass}
+     * @param permissionClass the class of the permission
+     * @param permissionName the name of the permission provided by the user
+     * @return the exception
+     */
+    @Message(id = 14885, value = "Invalid %s \"%s\"")
+    IllegalArgumentException invalidPermission(String permissionClass, String permissionName);
 }

--- a/controller/src/main/java/org/jboss/as/controller/ModelController.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelController.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.Service;
 
 /**
  * Controls reads of and modifications to a management model.
@@ -35,6 +36,12 @@ import org.jboss.dmr.ModelNode;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public interface ModelController {
+
+    /**
+     * A {@link RuntimePermission} needed to access a {@link ModelController} via {@link Service#getValue()} or
+     * to invoke its methods. The name of the necessary {@code RuntimePermission} is "{@code canAccessModelController}."
+     */
+    RuntimePermission ACCESS_PERMISSION = new RuntimePermission("canAccessModelController");
 
     /**
      * Execute an operation, sending updates to the given handler.  This method is not intended to be invoked directly
@@ -45,6 +52,8 @@ public interface ModelController {
      * @param control the transaction control for this operation
      * @param attachments the operation attachments
      * @return the operation result
+     *
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     ModelNode execute(ModelNode operation, OperationMessageHandler handler, OperationTransactionControl control, OperationAttachments attachments);
 
@@ -53,6 +62,8 @@ public interface ModelController {
      *
      * @param executor the executor to use for asynchronous operation execution
      * @return the client
+     *
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     ModelControllerClient createClient(Executor executor);
 

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -113,6 +113,12 @@ class ModelControllerImpl implements ModelController {
     }
 
     protected ModelNode internalExecute(final ModelNode operation, final OperationMessageHandler handler, final OperationTransactionControl control, final OperationAttachments attachments, final OperationStepHandler prepareStep) {
+
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ModelController.ACCESS_PERMISSION);
+        }
+
         final ModelNode headers = operation.has(OPERATION_HEADERS) ? operation.get(OPERATION_HEADERS) : null;
         final boolean rollbackOnFailure = headers == null || !headers.hasDefined(ROLLBACK_ON_RUNTIME_FAILURE) || headers.get(ROLLBACK_ON_RUNTIME_FAILURE).asBoolean();
         final EnumSet<OperationContextImpl.ContextFlag> contextFlags = rollbackOnFailure ? EnumSet.of(OperationContextImpl.ContextFlag.ROLLBACK_ON_FAIL) : EnumSet.noneOf(OperationContextImpl.ContextFlag.class);
@@ -299,6 +305,12 @@ class ModelControllerImpl implements ModelController {
     }
 
     public ModelControllerClient createClient(final Executor executor) {
+
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ModelController.ACCESS_PERMISSION);
+        }
+
         return new ModelControllerClient() {
 
             @Override

--- a/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
@@ -59,8 +59,16 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
     private RootInvocation rootInvocation;
 
     AbstractResourceRegistration(final String valueString, final NodeSubregistry parent) {
+        checkPermission();
         this.valueString = valueString;
         this.parent = parent;
+    }
+
+    static void checkPermission() {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ImmutableManagementResourceRegistration.ACCESS_PERMISSION);
+        }
     }
 
     NodeSubregistry getParent() {
@@ -80,6 +88,7 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
 
     @Override
     public boolean isAllowsOverride() {
+        checkPermission();
         return !isRemote() && parent != null && PathElement.WILDCARD_VALUE.equals(valueString);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -79,16 +79,19 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public boolean isRuntimeOnly() {
+        checkPermission();
         return runtimeOnly.get();
     }
 
     @Override
     public void setRuntimeOnly(final boolean runtimeOnly) {
+        checkPermission();
         this.runtimeOnly.set(runtimeOnly);
     }
 
     @Override
     public boolean isRemote() {
+        checkPermission();
         return false;
     }
 
@@ -142,6 +145,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             }
             return subregistry.getOperationEntry(iterator, next.getValue(), operationName, inheritance);
         } else {
+            checkPermission();
             final OperationEntry entry = operationsUpdater.get(this, operationName);
             return entry == null ? inherited : entry;
         }
@@ -149,6 +153,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     OperationEntry getInheritableOperationEntry(final String operationName) {
+        checkPermission();
         final OperationEntry entry = operationsUpdater.get(this, operationName);
         if (entry != null && entry.isInherited()) {
             return entry;
@@ -160,6 +165,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     void getOperationDescriptions(final ListIterator<PathElement> iterator, final Map<String, OperationEntry> providers, final boolean inherited) {
 
         if (!iterator.hasNext() ) {
+            checkPermission();
             providers.putAll(operationsUpdater.get(this));
             if (inherited) {
                 getInheritedOperations(providers, true);
@@ -181,6 +187,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     void getInheritedOperationEntries(final Map<String, OperationEntry> providers) {
+        checkPermission();
         for (final Map.Entry<String, OperationEntry> entry : operationsUpdater.get(this).entrySet()) {
             if (entry.getValue().isInherited() && !providers.containsKey(entry.getKey())) {
                 providers.put(entry.getKey(), entry.getValue());
@@ -190,6 +197,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerOperationHandler(final String operationName, final OperationStepHandler handler, final DescriptionProvider descriptionProvider, final boolean inherited, EntryType entryType) {
+        checkPermission();
         if (operationsUpdater.putIfAbsent(this, operationName, new OperationEntry(handler, descriptionProvider, inherited, entryType)) != null) {
             throw alreadyRegistered("operation handler", operationName);
         }
@@ -197,6 +205,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerOperationHandler(final String operationName, final OperationStepHandler handler, final DescriptionProvider descriptionProvider, final boolean inherited, EntryType entryType, EnumSet<OperationEntry.Flag> flags) {
+        checkPermission();
         if (operationsUpdater.putIfAbsent(this, operationName, new OperationEntry(handler, descriptionProvider, inherited, entryType, flags)) != null) {
             throw alreadyRegistered("operation handler", operationName);
         }
@@ -204,6 +213,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void unregisterOperationHandler(final String operationName) {
+        checkPermission();
         if (operationsUpdater.remove(this, operationName) == null) {
             throw operationNotRegisteredException(operationName, resourceDefinition.getPathElement());
         }
@@ -211,6 +221,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerReadWriteAttribute(final String attributeName, final OperationStepHandler readHandler, final OperationStepHandler writeHandler, AttributeAccess.Storage storage) {
+        checkPermission();
         AttributeAccess aa = new AttributeAccess(AccessType.READ_WRITE, storage, readHandler, writeHandler, null, null);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
             throw alreadyRegistered("attribute", attributeName);
@@ -219,6 +230,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerReadWriteAttribute(final String attributeName, final OperationStepHandler readHandler, final OperationStepHandler writeHandler, EnumSet<AttributeAccess.Flag> flags) {
+        checkPermission();
         AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? Storage.RUNTIME : Storage.CONFIGURATION;
         AttributeAccess aa = new AttributeAccess(AccessType.READ_WRITE, storage, readHandler, writeHandler, null, flags);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
@@ -228,6 +240,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerReadWriteAttribute(final AttributeDefinition definition, final OperationStepHandler readHandler, final OperationStepHandler writeHandler) {
+        checkPermission();
         final EnumSet<AttributeAccess.Flag> flags = definition.getFlags();
         final String attributeName = definition.getName();
         AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? Storage.RUNTIME : Storage.CONFIGURATION;
@@ -239,6 +252,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerReadOnlyAttribute(final String attributeName, final OperationStepHandler readHandler, AttributeAccess.Storage storage) {
+        checkPermission();
         AttributeAccess aa = new AttributeAccess(AccessType.READ_ONLY, storage, readHandler, null, null, null);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
             throw alreadyRegistered("attribute", attributeName);
@@ -247,6 +261,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerReadOnlyAttribute(final String attributeName, final OperationStepHandler readHandler, EnumSet<AttributeAccess.Flag> flags) {
+        checkPermission();
         AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? Storage.RUNTIME : Storage.CONFIGURATION;
         AttributeAccess aa = new AttributeAccess(AccessType.READ_ONLY, storage, readHandler, null, null, null);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
@@ -256,6 +271,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerReadOnlyAttribute(final AttributeDefinition definition, final OperationStepHandler readHandler) {
+        checkPermission();
         final EnumSet<AttributeAccess.Flag> flags = definition.getFlags();
         final String attributeName = definition.getName();
         AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? Storage.RUNTIME : Storage.CONFIGURATION;
@@ -272,6 +288,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerMetric(String attributeName, OperationStepHandler metricHandler, EnumSet<AttributeAccess.Flag> flags) {
+        checkPermission();
         AttributeAccess aa = new AttributeAccess(AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, null, flags);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
             throw alreadyRegistered("attribute", attributeName);
@@ -280,11 +297,13 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void unregisterAttribute(String attributeName) {
+        checkPermission();
         attributesUpdater.remove(this, attributeName);
     }
 
     @Override
     public void registerMetric(AttributeDefinition definition, OperationStepHandler metricHandler) {
+        checkPermission();
         AttributeAccess aa = new AttributeAccess(AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition, definition.getFlags());
         if (attributesUpdater.putIfAbsent(this, definition.getName(), aa) != null) {
             throw alreadyRegistered("attribute", definition.getName());
@@ -330,6 +349,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             if (subregistry != null) {
                 return subregistry;
             } else {
+                checkPermission();
                 final NodeSubregistry newRegistry = new NodeSubregistry(key, this);
                 final NodeSubregistry appearing = childrenUpdater.putAtomic(this, key, newRegistry, snapshot);
                 if (appearing == null) {
@@ -353,6 +373,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             }
             return subregistry.getModelDescription(iterator, next.getValue());
         } else {
+            checkPermission();
             return resourceDefinition.getDescriptionProvider(this);
         }
     }
@@ -367,6 +388,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             }
             return subregistry.getAttributeNames(iterator, next.getValue());
         } else {
+            checkPermission();
             final Map<String, AttributeAccess> snapshot = attributesUpdater.get(this);
             return snapshot.keySet();
         }
@@ -383,6 +405,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             }
             return subregistry.getAttributeAccess(iterator, next.getValue(), attributeName);
         } else {
+            checkPermission();
             final Map<String, AttributeAccess> snapshot = attributesUpdater.get(this);
             AttributeAccess access = snapshot.get(attributeName);
             if (access == null && hasNoAlternativeWildcardRegistration()) {
@@ -411,6 +434,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             }
             return subregistry.getChildNames(iterator, next.getValue());
         } else {
+            checkPermission();
             final Map<String, NodeSubregistry> children = this.children;
             if (children != null) {
                 return Collections.unmodifiableSet(children.keySet());
@@ -429,6 +453,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             }
             return subregistry.getChildAddresses(iterator, next.getValue());
         } else {
+            checkPermission();
             final Map<String, NodeSubregistry> children = this.children;
             if (children != null) {
                 final Set<PathElement> elements = new HashSet<PathElement>();
@@ -485,6 +510,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     @Override
     AbstractResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator) {
         if (! iterator.hasNext()) {
+            checkPermission();
             return this;
         } else {
             final PathElement address = iterator.next();
@@ -508,6 +534,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public AliasEntry getAliasEntry() {
+        checkPermission();
         return null;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
@@ -39,11 +39,19 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 public interface ImmutableManagementResourceRegistration {
 
     /**
+     * A {@link RuntimePermission} needed to create a {@link ImmutableManagementResourceRegistration} or invoke one
+     * of its methods. The name of the necessary {@code RuntimePermission} is "{@code canAccessManagementResourceRegistration}."
+     */
+    RuntimePermission ACCESS_PERMISSION = new RuntimePermission("canAccessManagementResourceRegistration");
+
+    /**
      * Gets whether this model node only exists in the runtime and has no representation in the
      * persistent configuration model.
      *
      * @return {@code true} if the model node has no representation in the
      * persistent configuration model; {@code false} otherwise
+     *
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     boolean isRuntimeOnly();
 
@@ -52,6 +60,7 @@ public interface ImmutableManagementResourceRegistration {
      * a remote process.
      *
      * @return {@code true} if this registration represents a remote resource; {@code false} otherwise
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     boolean isRemote();
 
@@ -59,6 +68,7 @@ public interface ImmutableManagementResourceRegistration {
      * Gets whether this resource registration is an alias to another resource.
      *
      * @return {@code true} if this registration represents an alias; {@code false} otherwise
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     boolean isAlias();
 
@@ -67,6 +77,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @return the alias entry if this registration represents an aliased resource; {@code null} otherwise
      * @throws IllegalStateException if {@link #isAlias()} returns {@code false}
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     AliasEntry getAliasEntry();
 
@@ -76,6 +87,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param address the address, relative to this node
      * @param operationName the operation name
      * @return the operation handler
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     OperationStepHandler getOperationHandler(PathAddress address, String operationName);
 
@@ -85,6 +97,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param address the address, relative to this node
      * @param operationName the operation name
      * @return the operation description
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     DescriptionProvider getOperationDescription(PathAddress address, String operationName);
 
@@ -95,6 +108,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param operationName the operation name
      * @return the operation entry flags or {@code null}
      *
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     Set<OperationEntry.Flag> getOperationFlags(PathAddress address, String operationName);
 
@@ -105,6 +119,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param operationName the operation name
      * @return the operation entry or {@code null}
      *
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     OperationEntry getOperationEntry(PathAddress address, String operationName);
 
@@ -113,6 +128,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address, relative to this node
      * @return the attribute names. If there are none an empty set is returned
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     Set<String> getAttributeNames(PathAddress address);
 
@@ -123,6 +139,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param attributeName the name of the attribute
      *
      * @return the handling information, or {@code null} if the attribute or address is unknown
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     AttributeAccess getAttributeAccess(PathAddress address, String attributeName);
 
@@ -131,6 +148,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address, relative to this node
      * @return the operation names. If there are none an empty set is returned
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     Set<String> getChildNames(PathAddress address);
 
@@ -139,6 +157,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address we want to find children for
      * @return the set of direct child elements
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     Set<PathElement> getChildAddresses(PathAddress address);
 
@@ -147,6 +166,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address, relative to this node
      * @return the model description
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     DescriptionProvider getModelDescription(PathAddress address);
 
@@ -156,6 +176,7 @@ public interface ImmutableManagementResourceRegistration {
      * @param address the address
      * @param inherited true to include inherited operations
      * @return the operation map
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     Map<String, OperationEntry> getOperationDescriptions(PathAddress address, boolean inherited);
 
@@ -166,6 +187,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address to look for a proxy under
      * @return the found proxy controller, or <code>null</code> if there is none
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     ProxyController getProxyController(PathAddress address);
 
@@ -178,6 +200,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address to start looking for proxies under
      * @return the found proxy controllers, or an empty set if there are none
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     Set<ProxyController> getProxyControllers(PathAddress address);
 
@@ -186,6 +209,7 @@ public interface ImmutableManagementResourceRegistration {
      *
      * @param address the address, relative to this node
      * @return the node registration, <code>null</code> if there is none
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     ImmutableManagementResourceRegistration getSubModel(PathAddress address);
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -50,9 +50,11 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param name the specific name of the resource. Cannot be {@code null} or {@link PathElement#WILDCARD_VALUE}
      *
      * @return the resource registration, <code>null</code> if there is none
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
-
     ManagementResourceRegistration getOverrideModel(String name);
+
     /**
      * Get a sub model registration.
      * <p>This method overrides the superinterface method of the same name in order to require
@@ -61,6 +63,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param address the address, relative to this node
      * @return the resource registration, <code>null</code> if there is none
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     @Override
     ManagementResourceRegistration getSubModel(PathAddress address);
@@ -75,6 +79,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @throws IllegalArgumentException if a submodel is already registered at {@code address}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+     *
      * @deprecated use {@link ManagementResourceRegistration#registerSubModel(org.jboss.as.controller.ResourceDefinition)}
      */
     @Deprecated
@@ -93,6 +99,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @throws IllegalArgumentException if a submodel is already registered at {@code address}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     ManagementResourceRegistration registerSubModel(ResourceDefinition resourceDefinition);
 
@@ -100,6 +107,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * Unregister the existence of an addressable sub-resource of this resource.
      *
      * @param address the child of this registry that should no longer be available
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void unregisterSubModel(PathElement address);
 
@@ -110,6 +119,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * {@link #isRemote() remote registrations}.
      *
      * @return {@code true} if an exception will not always be thrown; {@code false} if it will
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     boolean isAllowsOverride();
 
@@ -120,6 +131,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param runtimeOnly {@code true} if the model node will have no representation in the
      * persistent configuration model; {@code false} otherwise
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void setRuntimeOnly(final boolean runtimeOnly);
 
@@ -134,6 +147,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @throws IllegalArgumentException if either parameter is null or if there is already a registration under {@code name}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true} or if {@link #isAllowsOverride()} returns false
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     ManagementResourceRegistration registerOverrideModel(final String name, final OverrideDescriptionProvider descriptionProvider);
 
@@ -142,6 +156,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * by adding additional attributes, operations or child types.
      *
      * @param name the specific name of the resource. Cannot be {@code null} or {@link PathElement#WILDCARD_VALUE}
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void unregisterOverrideModel(final String name);
 
@@ -178,6 +194,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param descriptionProvider the description provider for this operation
      * @param inherited {@code true} if the operation is inherited to child nodes, {@code false} otherwise
      * @throws IllegalArgumentException if either parameter is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link #registerOperationHandler(org.jboss.as.controller.OperationDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -192,6 +209,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param inherited {@code true} if the operation is inherited to child nodes, {@code false} otherwise
      * @param entryType the operation entry type
      * @throws IllegalArgumentException if either parameter is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link #registerOperationHandler(org.jboss.as.controller.OperationDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -207,6 +225,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param inherited {@code true} if the operation is inherited to child nodes, {@code false} otherwise
      * @param flags operational modifier flags for this operation (e.g. read-only)
      * @throws IllegalArgumentException if either parameter is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link #registerOperationHandler(org.jboss.as.controller.OperationDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -222,6 +241,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param entryType the operation entry type
      * @param flags operational modifier flags for this operation (e.g. read-only)
      * @throws IllegalArgumentException if either parameter is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link #registerOperationHandler(org.jboss.as.controller.OperationDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -232,6 +252,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param definition the definition of operation
      * @param handler    the operation handler
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerOperationHandler(OperationDefinition definition, OperationStepHandler handler);
 
@@ -241,6 +262,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param definition the definition of operation
      * @param handler    the operation handler
      * @param inherited  {@code true} if the operation is inherited to child nodes, {@code false} otherwise
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerOperationHandler(OperationDefinition definition, OperationStepHandler handler, boolean inherited);
 
@@ -249,6 +271,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param operationName       the operation name
      * @throws IllegalArgumentException if operationName is not registered
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void unregisterOperationHandler(final String operationName);
 
@@ -263,6 +286,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param writeHandler the handler for attribute writes. Cannot be {@code null}
      * @param storage the storage type for this attribute
      * @throws IllegalArgumentException if {@code attributeName} or {@code writeHandler} are {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link ManagementResourceRegistration#registerReadWriteAttribute(org.jboss.as.controller.AttributeDefinition, org.jboss.as.controller.OperationStepHandler, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -280,6 +304,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param writeHandler the handler for attribute writes. Cannot be {@code null}
      * @param flags additional flags describing this attribute
      * @throws IllegalArgumentException if {@code attributeName} or {@code writeHandler} are {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link ManagementResourceRegistration#registerReadWriteAttribute(org.jboss.as.controller.AttributeDefinition, org.jboss.as.controller.OperationStepHandler, org.jboss.as.controller.OperationStepHandler)}
      */
      @Deprecated
@@ -298,6 +323,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param writeHandler the handler for attribute writes. Cannot be {@code null}
      *
      * @throws IllegalArgumentException if {@code definition} or {@code writeHandler} are {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerReadWriteAttribute(AttributeDefinition definition, OperationStepHandler readHandler, OperationStepHandler writeHandler);
 
@@ -311,6 +337,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *                    in which case the default handling is used
      * @param storage the storage type for this attribute
      * @throws IllegalArgumentException if {@code attributeName} is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link ManagementResourceRegistration#registerReadOnlyAttribute(org.jboss.as.controller.AttributeDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -327,6 +354,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *                    in which case the default handling is used
      * @param flags additional flags describing this attribute
      * @throws IllegalArgumentException if {@code attributeName} is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link ManagementResourceRegistration#registerReadOnlyAttribute(org.jboss.as.controller.AttributeDefinition, org.jboss.as.controller.OperationStepHandler)}
       */
     @Deprecated
@@ -343,6 +371,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *                    in which case the default handling is used
      *
      * @throws IllegalArgumentException if {@code definition} is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerReadOnlyAttribute(AttributeDefinition definition, OperationStepHandler readHandler);
 
@@ -353,6 +382,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param metricHandler the handler for attribute reads. Cannot be {@code null}
      *
      * @throws IllegalArgumentException if {@code attributeName} or {@code metricHandler} are {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link ManagementResourceRegistration#registerMetric(org.jboss.as.controller.AttributeDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     @Deprecated
@@ -365,6 +395,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param metricHandler the handler for attribute reads. Cannot be {@code null}
      *
      * @throws IllegalArgumentException if {@code definition} or {@code metricHandler} are {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerMetric(AttributeDefinition definition, OperationStepHandler metricHandler);
 
@@ -376,6 +407,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param flags additional flags describing this attribute
      *
      * @throws IllegalArgumentException if {@code attributeName} or {@code metricHandler} are {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      * @deprecated use {@link ManagementResourceRegistration#registerMetric(org.jboss.as.controller.AttributeDefinition, org.jboss.as.controller.OperationStepHandler)}
      */
     void registerMetric(String attributeName, OperationStepHandler metricHandler, EnumSet<AttributeAccess.Flag> flags);
@@ -386,6 +418,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param attributeName the name of the attribute. Cannot be {@code null}
      *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void unregisterAttribute(String attributeName);
 
@@ -394,6 +427,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param address the child of this registry that should be proxied
      * @param proxyController the proxy controller
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerProxyController(PathElement address, ProxyController proxyController);
 
@@ -401,6 +435,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * Unregister a proxy controller
      *
      * @param address the child of this registry that should no longer be proxied
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void unregisterProxyController(PathElement address);
 
@@ -409,6 +444,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      *
      * @param address the child of this registry that is an alias
      * @param aliasEntry the target model
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void registerAlias(PathElement address, AliasEntry aliasEntry);
 
@@ -416,6 +452,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * Unregister an alias
      *
      * @param address the child of this registry that is an alias
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
      */
     void unregisterAlias(PathElement address);
 
@@ -432,6 +469,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
          *
          * @param rootModelDescriptionProvider the model description provider for the root model node
          * @return the new root model node registration
+         *
+         * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
          */
         public static ManagementResourceRegistration create(final DescriptionProvider rootModelDescriptionProvider) {
             if (rootModelDescriptionProvider == null) {
@@ -472,6 +511,8 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
          *
          * @param resourceDefinition the facotry for the model description provider for the root model node
          * @return the new root model node registration
+         *
+         * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
          */
         public static ManagementResourceRegistration create(final ResourceDefinition resourceDefinition) {
             if (resourceDefinition == null) {

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -41,6 +41,13 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
  */
 final class NodeSubregistry {
 
+    private static void checkPermission() {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ImmutableManagementResourceRegistration.ACCESS_PERMISSION);
+        }
+    }
+
     private static final String WILDCARD_VALUE = PathElement.WILDCARD_VALUE;
 
     private final String keyName;
@@ -88,6 +95,7 @@ final class NodeSubregistry {
     }
 
     void unregisterProxyController(final String elementValue) {
+        checkPermission();
         childRegistriesUpdater.remove(this, elementValue);
     }
 
@@ -101,11 +109,13 @@ final class NodeSubregistry {
     }
 
     public void unregisterAlias(final String elementValue) {
+        checkPermission();
         childRegistriesUpdater.remove(this, elementValue);
     }
 
 
     void unregisterSubModel(final String elementValue) {
+        checkPermission();
         childRegistriesUpdater.remove(this, elementValue);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -59,27 +59,31 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     OperationEntry getOperationEntry(final ListIterator<PathElement> iterator, final String operationName, OperationEntry inherited) {
+        checkPermission();
         return operationEntry;
     }
 
     @Override
     OperationEntry getInheritableOperationEntry(String operationName) {
+        checkPermission();
         return null;
     }
 
     @Override
     public boolean isRuntimeOnly() {
+        checkPermission();
         return true;
     }
 
     @Override
     public void setRuntimeOnly(final boolean runtimeOnly) {
-
+        checkPermission();
     }
 
 
     @Override
     public boolean isRemote() {
+        checkPermission();
         return true;
     }
 
@@ -120,7 +124,7 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     public void unregisterOperationHandler(final String operationName) {
-
+        checkPermission();
     }
 
     @Override
@@ -195,45 +199,53 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     void getOperationDescriptions(final ListIterator<PathElement> iterator, final Map<String, OperationEntry> providers, final boolean inherited) {
-
+        checkPermission();
     }
 
     @Override
     void getInheritedOperationEntries(final Map<String, OperationEntry> providers) {
+        checkPermission();
     }
 
     @Override
     DescriptionProvider getModelDescription(final ListIterator<PathElement> iterator) {
+        checkPermission();
         return null;
     }
 
     @Override
     Set<String> getAttributeNames(final ListIterator<PathElement> iterator) {
+        checkPermission();
         return Collections.emptySet();
     }
 
     @Override
     Set<String> getChildNames(final ListIterator<PathElement> iterator) {
+        checkPermission();
         return Collections.emptySet();
     }
 
     @Override
     Set<PathElement> getChildAddresses(final ListIterator<PathElement> iterator) {
+        checkPermission();
         return Collections.emptySet();
     }
 
     @Override
     AttributeAccess getAttributeAccess(final ListIterator<PathElement> address, final String attributeName) {
+        checkPermission();
         return null;
     }
 
     @Override
     ProxyController getProxyController(ListIterator<PathElement> iterator) {
+        checkPermission();
         return proxyController;
     }
 
     @Override
     void getProxyControllers(ListIterator<PathElement> iterator, Set<ProxyController> controllers) {
+        checkPermission();
         controllers.add(proxyController);
     }
 
@@ -246,11 +258,13 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 //        throw new IllegalArgumentException("Can't get child registrations of a proxy");
         while (iterator.hasNext())
             iterator.next();
+        checkPermission();
         return this;
     }
 
     @Override
     public ModelNode getModelDescription(Locale locale) {
+        checkPermission();
         //TODO
         return new ModelNode();
     }
@@ -261,6 +275,7 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     public AliasEntry getAliasEntry() {
+        checkPermission();
         return null;
     }
 


### PR DESCRIPTION
Adds a RuntimePermission to restrict access to a process' ModelController.

Adds a RuntimePermission to restrict ability to read/write the definitions of resources. The effective use of this would be to block out unknown Extensions by preventing them from registering subsystems.

A valid permission is required to allow code to register OperationStepHandlers, so to keep things simple I treat OSHs as trusted, and haven't added other permissions related to details of operation execution (e.g. stuff that OperationContext would enforce.)
