### PR TITLE
ARQ-638 Add "cleanBeforeRunning" configuration option

### DIFF
--- a/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedContainerConfiguration.java
+++ b/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedContainerConfiguration.java
@@ -19,6 +19,7 @@ package org.jboss.as.arquillian.container.embedded;
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.deployment.Validate;
 import org.jboss.as.arquillian.container.CommonContainerConfiguration;
+import org.jboss.as.embedded.EmbeddedStandAloneServerFactory;
 
 /**
  * {@link org.jboss.arquillian.container.spi.client.container.ContainerConfiguration} implementation for JBoss AS Embedded
@@ -33,6 +34,8 @@ public class EmbeddedContainerConfiguration extends CommonContainerConfiguration
     private String modulePath = System.getProperty("module.path");
 
     private String bundlePath = System.getProperty("bundle.path");
+
+    private String cleanServerBaseDir = System.getProperty(EmbeddedStandAloneServerFactory.JBOSS_EMBEDDED_ROOT);
 
     public EmbeddedContainerConfiguration() {
 
@@ -78,6 +81,14 @@ public class EmbeddedContainerConfiguration extends CommonContainerConfiguration
 
     public void setBundlePath(String bundlePath) {
         this.bundlePath = bundlePath;
+    }
+
+    public String getCleanServerBaseDir() {
+        return cleanServerBaseDir;
+    }
+
+    public void setCleanServerBaseDir(String cleanServerBaseDir) {
+        this.cleanServerBaseDir = cleanServerBaseDir;
     }
 
     /**

--- a/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedDeployableContainer.java
+++ b/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedDeployableContainer.java
@@ -19,6 +19,7 @@ package org.jboss.as.arquillian.container.embedded;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.as.arquillian.container.CommonDeployableContainer;
 import org.jboss.as.embedded.EmbeddedServerFactory;
+import org.jboss.as.embedded.EmbeddedStandAloneServerFactory;
 import org.jboss.as.embedded.StandaloneServer;
 
 /**
@@ -40,6 +41,9 @@ public final class EmbeddedDeployableContainer extends CommonDeployableContainer
     @Override
     public void setup(final EmbeddedContainerConfiguration config) {
         super.setup(config);
+        if (config.getCleanServerBaseDir() != null) {
+            SecurityActions.setSystemProperty(EmbeddedStandAloneServerFactory.JBOSS_EMBEDDED_ROOT, config.getCleanServerBaseDir());
+        }
         server = EmbeddedServerFactory.create(config.getJbossHome(), config.getModulePath(), config.getBundlePath());
     }
 

--- a/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/SecurityActions.java
+++ b/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/SecurityActions.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.arquillian.container.embedded;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Security actions to access system environment information.  No methods in
+ * this class are to be made public under any circumstances!
+ *
+ * @author <a href="g.grossetien@gmail.com">Guillaume Grossetie</a>
+ */
+class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    static void setSystemProperty(final String key, final String value) {
+        if (System.getSecurityManager() == null) {
+            System.setProperty(key, value);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                @Override
+                public Void run() {
+                    System.setProperty(key, value);
+                    return null;
+                }
+            });
+        }
+    }
+}

--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
@@ -53,6 +53,10 @@ public class ManagedDomainContainerConfiguration extends CommonDomainContainerCo
 
     private boolean enableAssertions = true;
 
+    private boolean setupCleanServerBaseDir = false;
+
+    private String cleanServerBaseDir;
+
     public ManagedDomainContainerConfiguration() {
         // if no javaHome is set use java.home of already running jvm
         if (javaHome == null || javaHome.isEmpty()) {
@@ -226,5 +230,21 @@ public class ManagedDomainContainerConfiguration extends CommonDomainContainerCo
 
     public void setEnableAssertions(final boolean enableAssertions) {
         this.enableAssertions = enableAssertions;
+    }
+
+    public boolean isSetupCleanServerBaseDir() {
+        return setupCleanServerBaseDir;
+    }
+
+    public void setSetupCleanServerBaseDir(boolean setupCleanServerBaseDir) {
+        this.setupCleanServerBaseDir = setupCleanServerBaseDir;
+    }
+
+    public String getCleanServerBaseDir() {
+        return cleanServerBaseDir;
+    }
+
+    public void setCleanServerBaseDir(String cleanServerBaseDir) {
+        this.cleanServerBaseDir = cleanServerBaseDir;
     }
 }

--- a/arquillian/container-managed-domain/src/test/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerSetupCleanServerUnitTestCase.java
+++ b/arquillian/container-managed-domain/src/test/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerSetupCleanServerUnitTestCase.java
@@ -1,0 +1,96 @@
+package org.jboss.as.arquillian.container.domain.managed;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author ggrossetie
+ * @since 11/02/13
+ */
+public class ManagedDomainContainerSetupCleanServerUnitTestCase {
+
+    private File jbossHome = new File(createRootDir(), "jboss-home");
+
+    private String defaultServerBaseDir = createServer(jbossHome, "domain", 1).getAbsolutePath();
+    private File alternativeServer = createServer(createRootDir(), "domain2", 2);
+
+    private File tempDir = new File(System.getProperty("java.io.tmpdir"));
+    private File cleanServerBaseDir = new File(tempDir, ManagedDomainDeployableContainer.TEMP_CONTAINER_DIRECTORY);
+
+    private File userCleanServerBaseDir = createUserCleanServerBaseDir();
+
+    @Test
+    public void testDefaultServerBaseDir() throws Exception {
+        ManagedDomainDeployableContainer.setupCleanServerDirectories(defaultServerBaseDir, jbossHome.getAbsolutePath(), null);
+        assertCleanServerBaseDir(cleanServerBaseDir, 1);
+    }
+
+    @Test
+    public void testAlternativeServerBaseDir() throws Exception {
+        ManagedDomainDeployableContainer.setupCleanServerDirectories(".." + File.separatorChar + alternativeServer.getName(), jbossHome.getAbsolutePath(), null);
+        assertCleanServerBaseDir(cleanServerBaseDir, 2);
+    }
+
+    @Test
+    public void testUserCleanServerBaseDir() throws Exception {
+        ManagedDomainDeployableContainer.setupCleanServerDirectories(defaultServerBaseDir, jbossHome.getAbsolutePath(), userCleanServerBaseDir.getAbsolutePath());
+        assertCleanServerBaseDir(userCleanServerBaseDir, 1);
+    }
+
+    private void assertCleanServerBaseDir(File cleanServerBaseDir, int id) {
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDomainDeployableContainer.SERVERS_DIR).exists());
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDomainDeployableContainer.DATA_DIR).exists());
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDomainDeployableContainer.CONFIG_DIR).exists());
+
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDomainDeployableContainer.SERVERS_DIR + File.separatorChar + id).exists());
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDomainDeployableContainer.DATA_DIR + File.separatorChar + id).exists());
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDomainDeployableContainer.CONFIG_DIR + File.separatorChar + id).exists());
+    }
+
+    private File createUserCleanServerBaseDir() {
+        File root = new File("target/user-clean-server-base-dir");
+        if (!root.exists()) {
+            root.mkdirs();
+        }
+        return root.getAbsoluteFile();
+    }
+
+    private File createRootDir() {
+        File root = new File("target/server-home");
+        if (!root.exists()) {
+            root.mkdirs();
+        }
+        return root.getAbsoluteFile();
+    }
+
+    private File createServer(File home, String serverName, int id) {
+        File server = new File(home, serverName);
+        if (!server.exists()) {
+            server.mkdirs();
+        }
+        createDirectoryWithFile(server, ManagedDomainDeployableContainer.DATA_DIR, id);
+        createDirectoryWithFile(server, ManagedDomainDeployableContainer.CONFIG_DIR, id);
+        createDirectoryWithFile(server, ManagedDomainDeployableContainer.SERVERS_DIR, id);
+        return server.getAbsoluteFile();
+    }
+
+    private File createDirectoryWithFile(File server, String name, int id) {
+        File dir = new File(server, name);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        File file = new File(dir, String.valueOf(id));
+        try {
+            file.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertTrue(file.exists());
+
+        return dir.getAbsoluteFile();
+    }
+}

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -58,6 +58,10 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
 
     private Integer waitForPortsTimeoutInSeconds;
 
+    private boolean setupCleanServerBaseDir = false;
+
+    private String cleanServerBaseDir;
+
     public ManagedContainerConfiguration() {
         super();
     }
@@ -189,4 +193,19 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
         this.adminOnly = adminOnly;
     }
 
+    public boolean isSetupCleanServerBaseDir() {
+        return setupCleanServerBaseDir;
+    }
+
+    public void setSetupCleanServerBaseDir(boolean setupCleanServerBaseDir) {
+        this.setupCleanServerBaseDir = setupCleanServerBaseDir;
+    }
+
+    public String getCleanServerBaseDir() {
+        return cleanServerBaseDir;
+    }
+
+    public void setCleanServerBaseDir(String cleanServerBaseDir) {
+        this.cleanServerBaseDir = cleanServerBaseDir;
+    }
 }

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -16,19 +16,28 @@
  */
 package org.jboss.as.arquillian.container.managed;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.DatagramSocket;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Logger;
 
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.as.arquillian.container.CommonDeployableContainer;
+import org.jboss.as.protocol.StreamUtils;
+import org.jboss.as.server.ServerMessages;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -39,9 +48,12 @@ import org.jboss.dmr.ModelNode;
  */
 public final class ManagedDeployableContainer extends CommonDeployableContainer<ManagedContainerConfiguration> {
 
-    private static final String CONFIG_DIR = "configuration";
-    private static final String SERVER_BASE_DIR = "standalone";
-    private static final String LOG_DIR = "log";
+    static final String TEMP_CONTAINER_DIRECTORY = "arquillian-temp-container";
+
+    static final String CONFIG_DIR = "configuration";
+    static final String SERVER_BASE_DIR = "standalone";
+    static final String LOG_DIR = "log";
+    static final String DATA_DIR = "data";
 
     private static final int PORT_RANGE_MIN = 1;
     private static final int PORT_RANGE_MAX = 65535;
@@ -115,7 +127,14 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
                 cmd.add("-ea");
             }
 
-            final String serverBaseDir = getSystemPropertyValue(cmd, "jboss.server.base.dir", jbossHome + File.separatorChar + SERVER_BASE_DIR);
+            String serverBaseDir = getSystemPropertyValue(cmd, "jboss.server.base.dir", jbossHome + File.separatorChar + SERVER_BASE_DIR);
+
+            // Create a clean server base to run the container; ARQ-638
+            if (config.isSetupCleanServerBaseDir() || config.getCleanServerBaseDir() != null) {
+                serverBaseDir = setupCleanServerDirectories(serverBaseDir, jbossHome, config.getCleanServerBaseDir()).getAbsolutePath();
+                replaceSystemPropertyValue(cmd, "jboss.server.base.dir", serverBaseDir);
+            }
+
             final String bootLogFileDefaultValue = serverBaseDir + File.separatorChar + LOG_DIR + File.separatorChar + "boot.log";
             final String loggingConfigurationDefaultValue = serverBaseDir + File.separatorChar + CONFIG_DIR + File.separatorChar + "logging.properties";
             cmd.add("-Djboss.home.dir=" + jbossHome);
@@ -130,10 +149,11 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             cmd.add("-server-config");
             cmd.add(config.getServerConfig());
             if (config.isAdminOnly())
-               cmd.add("--admin-only");
+                cmd.add("--admin-only");
 
             // Wait on ports before launching; AS7-4070
             this.waitOnPorts();
+
 
             log.info("Starting container with: " + cmd.toString());
             ProcessBuilder processBuilder = new ProcessBuilder(cmd);
@@ -183,6 +203,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
     /**
      * If specified in the configuration, waits on the specified ports to become
      * available for the specified time, else throws a {@link PortAcquisitionTimeoutException}
+     *
      * @throws PortAcquisitionTimeoutException
      */
     private void waitOnPorts() throws PortAcquisitionTimeoutException {
@@ -214,7 +235,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
 
                     // Log that we're waiting
                     log.warning("Waiting on port " + port + " to become available for "
-                        + (timeoutInSeconds - elapsedSeconds) + "s");
+                            + (timeoutInSeconds - elapsedSeconds) + "s");
                 }
             }
         }
@@ -358,18 +379,37 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             final InputStream stream = process.getInputStream();
             final boolean writeOutput = getContainerConfiguration().isOutputToConsole();
 
-           try {
-              byte[] buf = new byte[32];
-              int num;
-              // Do not try reading a line cos it considers '\r' end of line
-              while((num = stream.read(buf)) != -1){
-                 if (writeOutput)
-                    System.out.write(buf, 0, num);
-              }
-           } catch (IOException e) {
-           }
+            try {
+                byte[] buf = new byte[32];
+                int num;
+                // Do not try reading a line cos it considers '\r' end of line
+                while ((num = stream.read(buf)) != -1) {
+                    if (writeOutput)
+                        System.out.write(buf, 0, num);
+                }
+            } catch (IOException e) {
+            }
         }
 
+    }
+
+    /**
+     * Replace the value of the system property from a list of command line arguments.
+     *
+     * @param cmdArguments list of command line arguments
+     * @param systemPropertyName name of the system property
+     * @param newValue the new value
+     */
+    private void replaceSystemPropertyValue(List<String> cmdArguments, String systemPropertyName, String newValue) {
+        final String argument = "-D" + systemPropertyName + "=";
+        final Iterator<String> cmdArgumentsIterator = cmdArguments.iterator();
+        while(cmdArgumentsIterator.hasNext()) {
+            String cmdArgument = cmdArgumentsIterator.next();
+            if (cmdArgument.startsWith(argument)) {
+                cmdArgumentsIterator.remove();
+            }
+        }
+        cmdArguments.add(argument + newValue);
     }
 
     /**
@@ -400,7 +440,7 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
      * @param jbossHome the jboss home directory
      * @return the File form for the file pathname.
      */
-    private File getFile(final String filePathname, final String jbossHome) {
+    static File getFile(final String filePathname, final String jbossHome) {
         File result = new File(filePathname);
         // AS7-1752 see if a non-existent relative path exists relative to the home dir
         if (!result.exists() && !result.isAbsolute()) {
@@ -410,5 +450,124 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             }
         }
         return result;
+    }
+
+    /**
+     * Setup clean directories to run the container.
+     * @param serverBaseDir the server base directory
+     * @param jbossHome the JBoss home
+     * @param cleanServerBaseDirPath the clean server base directory
+     */
+    static File setupCleanServerDirectories(String serverBaseDir, String jbossHome, String cleanServerBaseDirPath) throws IOException {
+        final File cleanServerBaseDir;
+        if (cleanServerBaseDirPath != null) {
+            cleanServerBaseDir = new File(cleanServerBaseDirPath);
+        } else {
+            cleanServerBaseDir = createTempServerBaseDirectory();
+        }
+        if (!cleanServerBaseDir.exists()) {
+            throw ServerMessages.MESSAGES.serverBaseDirectoryDoesNotExist(cleanServerBaseDir);
+        }
+        if (!cleanServerBaseDir.isDirectory()) {
+            throw ServerMessages.MESSAGES.serverBaseDirectoryIsNotADirectory(cleanServerBaseDir);
+        }
+        copyOriginalDirectoryToCleanServerBaseDir(CONFIG_DIR, serverBaseDir, jbossHome, cleanServerBaseDir);
+        copyOriginalDirectoryToCleanServerBaseDir(DATA_DIR, serverBaseDir, jbossHome, cleanServerBaseDir);
+        // For jboss.server.deployment.scanner.default
+        File deploymentsDir = new File(cleanServerBaseDir, "deployments");
+        deploymentsDir.mkdir();
+        return cleanServerBaseDir;
+    }
+
+    /**
+     * Copy the original directory to the clean server base directory.
+     * @param originalDirName Name of the original directory
+     * @param cleanServerBaseDir the clean server base directories
+     * @param serverBaseDir the server base directory
+     * @param jbossHome the jboss home
+     * @throws IOException
+     */
+    static void copyOriginalDirectoryToCleanServerBaseDir(String originalDirName, String serverBaseDir, String jbossHome, File cleanServerBaseDir)
+            throws IOException {
+        final File originalDir = getFile(serverBaseDir + File.separatorChar + originalDirName, jbossHome);
+
+        File cleanDir = new File(cleanServerBaseDir, originalDirName);
+        cleanDir.mkdir();
+
+        if (originalDir.exists()) {
+            copyDirectory(originalDir, cleanDir);
+        }
+    }
+
+    /**
+     * Create a temporary directory to setup clean directories to run the container.
+     *
+     * @throws IOException
+     */
+    static File createTempServerBaseDirectory() throws IOException {
+        File tempDir = new File(System.getProperty("java.io.tmpdir"));
+        File tempContainer = new File(tempDir, TEMP_CONTAINER_DIRECTORY);
+        // Delete the previous directory if exists...
+        if (tempContainer.exists()) {
+            deleteRecursively(tempContainer);
+        }
+        if (!tempContainer.mkdir()) {
+            throw new IOException("Could not create temp directory: " + tempContainer.getAbsolutePath());
+        }
+        return tempContainer;
+    }
+
+    /**
+     * Copy directory from {@code src} to {@code dest}.
+     *
+     * @param src Source directory
+     * @param dest Destination directory
+     */
+    private static void copyDirectory(File src, File dest) {
+        for (String current : src.list()) {
+            final File srcFile = new File(src, current);
+            final File destFile = new File(dest, current);
+
+            if (srcFile.isDirectory()) {
+                destFile.mkdir();
+                copyDirectory(srcFile, destFile);
+            } else {
+                try {
+                    final InputStream in = new BufferedInputStream(new FileInputStream(srcFile));
+                    final OutputStream out = new BufferedOutputStream(new FileOutputStream(destFile));
+
+                    try {
+                        int i;
+                        while ((i = in.read()) != -1) {
+                            out.write(i);
+                        }
+                    } catch (IOException e) {
+                        throw ServerMessages.MESSAGES.errorCopyingFile(srcFile.getAbsolutePath(), destFile.getAbsolutePath(), e);
+                    } finally {
+                        StreamUtils.safeClose(in);
+                        StreamUtils.safeClose(out);
+                    }
+
+                } catch (FileNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Delete a file if exists.
+     *
+     * @param file the file to delete
+     */
+    static void deleteRecursively(File file) {
+        if (file.exists()) {
+            if (file.isDirectory()) {
+                for (String name : file.list()) {
+                    deleteRecursively(new File(file, name));
+                }
+            }
+            file.delete();
+        }
     }
 }

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedContainerSetupCleanServerUnitTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedContainerSetupCleanServerUnitTestCase.java
@@ -1,0 +1,95 @@
+package org.jboss.as.arquillian.container.managed;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * @author ggrossetie
+ * @since 11/02/13
+ */
+@Ignore
+public class ManagedContainerSetupCleanServerUnitTestCase {
+
+    private File jbossHome = new File(createRootDir(), "jboss-home");
+
+    private String defaultServerBaseDir = createServer(jbossHome, "standalone", 1).getAbsolutePath();
+    private File alternativeServer = createServer(createRootDir(), "standalone2", 2);
+
+    private File tempDir = new File(System.getProperty("java.io.tmpdir"));
+    private File cleanServerBaseDir = new File(tempDir, ManagedDeployableContainer.TEMP_CONTAINER_DIRECTORY);
+
+    private File userCleanServerBaseDir = createUserCleanServerBaseDir();
+
+    @Test
+    public void testDefaultServerBaseDir() throws Exception {
+        ManagedDeployableContainer.setupCleanServerDirectories(defaultServerBaseDir, jbossHome.toString(), null);
+        assertCleanServerBaseDir(cleanServerBaseDir, 1);
+    }
+
+    @Test
+    public void testAlternativeServerBaseDir() throws Exception {
+        ManagedDeployableContainer.setupCleanServerDirectories(".." + File.separatorChar + alternativeServer.getName(), jbossHome.toString(), null);
+        assertCleanServerBaseDir(cleanServerBaseDir, 2);
+    }
+
+    @Test
+    public void testUserCleanServerBaseDir() throws Exception {
+        ManagedDeployableContainer.setupCleanServerDirectories(defaultServerBaseDir, jbossHome.getAbsolutePath(), userCleanServerBaseDir.getAbsolutePath());
+        assertCleanServerBaseDir(userCleanServerBaseDir, 1);
+    }
+
+    private void assertCleanServerBaseDir(File cleanServerBaseDir, int id) {
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDeployableContainer.DATA_DIR).exists());
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDeployableContainer.CONFIG_DIR).exists());
+
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDeployableContainer.DATA_DIR + File.separatorChar + id).exists());
+        Assert.assertTrue(new File(cleanServerBaseDir, ManagedDeployableContainer.CONFIG_DIR + File.separatorChar + id).exists());
+    }
+
+    private File createUserCleanServerBaseDir() {
+        File root = new File("target/user-clean-server-base-dir");
+        if (!root.exists()) {
+            root.mkdirs();
+        }
+        return root.getAbsoluteFile();
+    }
+
+    private File createRootDir() {
+        File root = new File("target/server-home");
+        if (!root.exists()) {
+            root.mkdirs();
+        }
+        return root.getAbsoluteFile();
+    }
+
+    private File createServer(File home, String serverName, int id) {
+        File server = new File(home, serverName);
+        if (!server.exists()) {
+            server.mkdirs();
+        }
+        createDirectoryWithFile(server, ManagedDeployableContainer.DATA_DIR, id);
+        createDirectoryWithFile(server, ManagedDeployableContainer.CONFIG_DIR, id);
+        return server.getAbsoluteFile();
+    }
+
+    private File createDirectoryWithFile(File server, String name, int id) {
+        File dir = new File(server, name);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        File file = new File(dir, String.valueOf(id));
+        try {
+            file.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertTrue(file.exists());
+
+        return dir.getAbsoluteFile();
+    }
+}


### PR DESCRIPTION
By default the container configuration option is set to `false`. The following directory are cleaned before running tests :
- standalone/data
- standalone/tmp
- standalone/log
