### PR TITLE
AS7-6024 - Fix naming subsystem schema to refer to 'class' not 'factoryC...

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-naming_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_1_1.xsd
@@ -89,7 +89,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="factoryClass" type="xs:token" use="required">
+        <xs:attribute name="class" type="xs:token" use="required">
             <xs:annotation>
                 <xs:documentation>
                     The javax.naming.spi.ObjectFactory that provides the value.

--- a/build/src/main/resources/docs/schema/jboss-as-naming_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_1_2.xsd
@@ -98,7 +98,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="factoryClass" type="xs:token" use="required">
+        <xs:attribute name="class" type="xs:token" use="required">
             <xs:annotation>
                 <xs:documentation>
                     The javax.naming.spi.ObjectFactory that provides the value.


### PR DESCRIPTION
...lass'
