### PR TITLE
AS7-6103, use findLoadedModuleLocal() to retrieve module to be unloaded.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/moduleservice/ServiceModuleLoader.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ServiceModuleLoader.java
@@ -97,13 +97,10 @@ public class ServiceModuleLoader extends ModuleLoader implements Service<Service
                 case STOP_REQUESTED_to_STOPPING: {
                     log.tracef("serviceStopping: %s", controller);
                     ModuleSpec moduleSpec = this.moduleSpec;
-                    try {
-                        Module module = loadModule(moduleSpec.getModuleIdentifier());
+                    ModuleIdentifier identifier = moduleSpec.getModuleIdentifier();
+                    Module module = findLoadedModuleLocal(identifier);
+                    if(module != null)
                         unloadModuleLocal(module);
-                    } catch (ModuleLoadException e) {
-                        // ignore, the module should always be already loaded by this point,
-                        // and if not we will only mask the true problem
-                    }
                     // TODO: what if the service is restarted?
                     controller.removeListener(this);
                     break;


### PR DESCRIPTION
AS7-6103 ServiceModuleLoader can't properly unload module if it failed to load module due to wrong dependency.

use findLoadedModuleLocal() to retrieve module to be unloaded, make module will be unload after loading failure.
