### PR TITLE
AS7-6103, use findLoadedModuleLocal() to retrieve module to be unloaded

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -246,11 +246,6 @@ class FileSystemDeploymentService implements DeploymentScanner {
     }
 
     @Override
-    public void bootTimeScan(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers) {
-
-    }
-
-    @Override
     public synchronized void startScanner() {
         assert deploymentOperationsFactory != null : "deploymentOperationsFactory is null";
         startScanner(deploymentOperationsFactory.create());

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/api/DeploymentScanner.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/api/DeploymentScanner.java
@@ -137,13 +137,4 @@ public interface DeploymentScanner {
      * @param timeout The deployment timeout
      */
     void setDeploymentTimeout(long timeout);
-
-    /**
-     * Perform a scan as part of the server boot operation.
-     *
-     * @param context
-     * @param verificationHandler
-     * @param newControllers
-     */
-    void bootTimeScan(OperationContext context, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers);
 }

--- a/server/src/main/java/org/jboss/as/server/moduleservice/ServiceModuleLoader.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ServiceModuleLoader.java
@@ -100,13 +100,9 @@ public class ServiceModuleLoader extends ModuleLoader implements Service<Service
                 case STOP_REQUESTED_to_STOPPING: {
                     log.tracef("serviceStopping: %s", controller);
                     ModuleSpec moduleSpec = this.moduleSpec;
-                    try {
-                        Module module = loadModule(moduleSpec.getModuleIdentifier());
-                        unloadModuleLocal(module);
-                    } catch (ModuleLoadException e) {
-                        // ignore, the module should always be already loaded by this point,
-                        // and if not we will only mask the true problem
-                    }
+                    ModuleIdentifier identifier = moduleSpec.getModuleIdentifier();
+                    Module module = findLoadedModuleLocal(identifier);
+                    unloadModuleLocal(module);
                     // TODO: what if the service is restarted?
                     controller.removeListener(this);
                     break;


### PR DESCRIPTION
AS7-6103 ServiceModuleLoader can't properly unload module if it failed to load module due to wrong dependency.

use findLoadedModuleLocal() to retrieve module to be unloaded, make module will be unload after loading failure.
