### PR TITLE
AS7-6103, use findLoadedModuleLocal() to retrieve module to be unloaded

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -246,11 +246,6 @@ class FileSystemDeploymentService implements DeploymentScanner {
     }
 
     @Override
-    public void bootTimeScan(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers) {
-
-    }
-
-    @Override
     public synchronized void startScanner() {
         assert deploymentOperationsFactory != null : "deploymentOperationsFactory is null";
         startScanner(deploymentOperationsFactory.create());


### PR DESCRIPTION
AS7-6103 ServiceModuleLoader can't properly unload module if it failed to load module due to wrong dependency.

use findLoadedModuleLocal() to retrieve module to be unloaded, make module will be unload after loading failure.
