### PR TITLE
AS7-6132 Modernise the cascadeDelete method with generics

### DIFF
--- a/cmp/src/main/java/org/jboss/as/cmp/jdbc2/bridge/JDBCCMRFieldBridge2.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/jdbc2/bridge/JDBCCMRFieldBridge2.java
@@ -660,12 +660,9 @@ public class JDBCCMRFieldBridge2 extends JDBCAbstractCMRFieldBridge {
         }
 
         public void cascadeDelete(CmpEntityBeanContext ctx) throws RemoveException {
-            Collection value = (Collection) getValue(ctx);
-            if (!value.isEmpty()) {
-                EJBLocalObject[] locals = (EJBLocalObject[]) value.toArray();
-                for (int i = 0; i < locals.length; ++i) {
-                    locals[i].remove();
-                }
+            Collection<EJBLocalObject> cmrs = (Collection<EJBLocalObject>) getValue(ctx);
+            for (EJBLocalObject localEjb : cmrs) {
+                localEjb.remove();
             }
         }
 
@@ -1118,8 +1115,7 @@ public class JDBCCMRFieldBridge2 extends JDBCAbstractCMRFieldBridge {
         void addRelatedId(CmpEntityBeanContext ctx, Object relatedId);
     }
 
-    private class CMRSet
-            implements Set {
+    private class CMRSet implements Set {
         private final CmpEntityBeanContext ctx;
         private final CollectionValuedFieldState state;
 


### PR DESCRIPTION
which removes the downcast problem by eliminating the toArray call altogether.
