### PR TITLE
Fixing SOAP-over-JMS testsuite regression

### DIFF
--- a/webservices/tests-integration/pom.xml
+++ b/webservices/tests-integration/pom.xml
@@ -51,6 +51,12 @@
         <dependency>
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-security</artifactId>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hornetq</groupId>
+                <artifactId>hornetq-core</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>


### PR DESCRIPTION
Please pull this fix to the webservices test integration pom.xml which solves a soap-over-jms testsuite regression against AS master only: http://jbossws.jboss.org:8180/hudson/job/CXF-CORE-AS-7.2.0-SPRING-SUN-JDK-6/51/testReport/
