### PR TITLE
AS7-5639 Run OSGi TCK with AS7

### DIFF
--- a/embedded/src/main/java/org/jboss/as/embedded/StandaloneServer.java
+++ b/embedded/src/main/java/org/jboss/as/embedded/StandaloneServer.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
  * The standalone server interface.
  *
  * @author Thomas.Diesler@jboss.com
+ * @author David Bosschaert
  * @since 17-Nov-2010
  */
 public interface StandaloneServer {
@@ -48,10 +49,25 @@ public interface StandaloneServer {
      */
     Context getContext();
 
+    /**
+     * Retrieve an MSC service and waits for the service to be active.
+     * @param timeout The amount to time (in milliseconds) to wait for the service
+     * @param nameSegments The ServiceName segments
+     * @return the service or null if not found
+     */
+    Object getService(long timeout, String ... nameSegments);
+
     ModelControllerClient getModelControllerClient();
 
+    /**
+     * Start the server. This method blocks until all services have been started or failed.
+     * @throws ServerStartException
+     */
     void start() throws ServerStartException;
 
+    /**
+     * Shuts down the server and wait for its termination.
+     */
     void stop();
 
     // TODO: use a DeploymentPlan

--- a/osgi/launcher/pom.xml
+++ b/osgi/launcher/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.as</groupId>
+        <artifactId>jboss-as-osgi</artifactId>
+        <version>7.2.0.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jboss-as-osgi-launcher</artifactId>
+    <name>JBoss Application Server: OSGi Launcher</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-embedded</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${surefire.system.args}</argLine>
+                    <systemProperties>
+                        <property>
+                            <name>java.util.logging.manager</name>
+                            <value>org.jboss.logmanager.LogManager</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>
+                        -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
+                    </compilerArgument>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/EmbeddedOSGiFrameworkLauncher.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/EmbeddedOSGiFrameworkLauncher.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.LogManager;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.modules.log.JDKModuleLogger;
+import org.osgi.framework.Constants;
+
+/**
+ * Launch the Application Server using its EmbeddedServerFactory and activate the
+ * OSGi subsystem.
+ *
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ * @author <a href="mailto:mmatloka@gmail.com">Michal Matloka</a>
+ * @author Thomas.Diesler@jboss.com
+ * @author David Bosschaert
+ */
+public class EmbeddedOSGiFrameworkLauncher {
+    private static final String MODULE_ID_LOGMANAGER = "org.jboss.logmanager";
+    private static final String MODULE_ID_VFS = "org.jboss.vfs";
+    private static final String SYSPROP_KEY_CLASS_PATH = "java.class.path";
+    private static final String SYSPROP_KEY_MODULE_PATH = "module.path";
+    private static final String SYSPROP_KEY_BUNDLE_PATH = "jboss.bundles.dir";
+    private static final String SYSPROP_KEY_LOGMANAGER = "java.util.logging.manager";
+    private static final String SYSPROP_KEY_JBOSS_HOME = "jboss.home";
+    private static final String SYSPROP_KEY_JBOSS_HOME_DIR = "jboss.home.dir";
+    private static final String SYSPROP_KEY_JBOSS_MODULES_SYSTEM_PKGS = "jboss.modules.system.pkgs";
+    private static final String SYSPROP_VALUE_JBOSS_LOGMANAGER_PKG = "org.jboss.logmanager";
+    private static final String SYSPROP_VALUE_JBOSS_LOGMANAGER = SYSPROP_VALUE_JBOSS_LOGMANAGER_PKG + ".LogManager";
+
+    /**
+     * Hook to the server; used in start/stop, created by setup
+     */
+    private StandaloneServerIndirection server;
+
+    public void configure(Map<String, String> configuration) {
+        String jbossHomeProp = SecurityActions.getSystemProperty(SYSPROP_KEY_JBOSS_HOME_DIR);
+        if (jbossHomeProp == null) {
+            jbossHomeProp = SecurityActions.getSystemProperty(SYSPROP_KEY_JBOSS_HOME);
+
+            if (jbossHomeProp != null)
+                SecurityActions.setSystemProperty(SYSPROP_KEY_JBOSS_HOME_DIR, jbossHomeProp);
+        }
+
+        File jbossHomeDir = new File(jbossHomeProp).getAbsoluteFile();
+
+        ModuleLoader moduleLoader = setupModuleLoader(new File(jbossHomeDir, "modules"), configuration);
+        setupBundlePath(new File(jbossHomeDir, "bundles"));
+        setupVfsModule(moduleLoader);
+        setupLoggingSystem(moduleLoader);
+        setupServer(moduleLoader, jbossHomeDir, configuration);
+    }
+
+    private ModuleLoader setupModuleLoader(File modulesDir, Map<String, String> configuration) {
+        // Temporary code, can be removed as soon as Framework R5 is implemented
+        //
+        // The OSGi packages have to be shared between the caller and the framework. Note that also some OSGi 4.3/5.0 packages
+        // are included here because these are used by the resolver. When a package is picked up from the parent classloader
+        // JBoss Modules also expects all subpackages to be picked up from the parent classloader, therefore these need to be
+        // as well. This can probably be removed as soon as we support OSGi 4.3/5.0
+        // The following fixes up the OSGi packages, if they are specified on any of these properties.
+        String pkgs = fixOSGiPackages(configuration, Constants.FRAMEWORK_SYSTEMPACKAGES, false);
+        String pkgs1 = fixOSGiPackages(configuration, Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, false);
+        String pkgs2 = fixOSGiPackages(configuration, Constants.FRAMEWORK_BOOTDELEGATION, false);
+
+        String allPkgs;
+        if (pkgs.length() == 0 && pkgs1.length() == 0 && pkgs2.length() == 0) {
+            // Should add these packages to at least one of the above properties, add to FRAMEWORK_SYSTEMPACKAGES_EXTRA
+            allPkgs = fixOSGiPackages(configuration, Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, true);
+        } else {
+            allPkgs = pkgs + "," + pkgs1 + "," + pkgs2;
+        }
+        // End Temporary code.
+
+        // Strip any attributes of the package information as only bare packages need to passed into create() below.
+        List<String> sysPgsNoAttrs = new ArrayList<String>();
+        sysPgsNoAttrs.add(SYSPROP_VALUE_JBOSS_LOGMANAGER_PKG);
+        for (String sp : allPkgs.split(",")) {
+            int idx = sp.indexOf(';');
+            if (idx >= 0)
+                sysPgsNoAttrs.add(sp.substring(0, idx));
+            else
+                sysPgsNoAttrs.add(sp);
+        }
+        SecurityActions.setSystemProperty(SYSPROP_KEY_JBOSS_MODULES_SYSTEM_PKGS, sysPgsNoAttrs.toString());
+
+        String classPath = SecurityActions.getSystemProperty(SYSPROP_KEY_CLASS_PATH);
+        try {
+            // Set up sysprop env
+            SecurityActions.clearSystemProperty(SYSPROP_KEY_CLASS_PATH);
+            SecurityActions.setSystemProperty(SYSPROP_KEY_MODULE_PATH, modulesDir.getAbsolutePath());
+
+            return Module.getBootModuleLoader();
+        } finally {
+            // Return to previous state for classpath prop
+            SecurityActions.setSystemProperty(SYSPROP_KEY_CLASS_PATH, classPath);
+        }
+    }
+
+    private void setupBundlePath(File bundlesDir) {
+        SecurityActions.setSystemProperty(SYSPROP_KEY_BUNDLE_PATH, bundlesDir.getAbsolutePath());
+    }
+
+    private void setupVfsModule(ModuleLoader moduleLoader) {
+        ModuleIdentifier vfsModuleID = ModuleIdentifier.create(MODULE_ID_VFS);
+
+        try {
+            Module vfsModule = moduleLoader.loadModule(vfsModuleID);
+            Module.registerURLStreamHandlerFactoryModule(vfsModule);
+        } catch (ModuleLoadException mle) {
+            throw new RuntimeException(mle);
+        }
+    }
+
+    private void setupLoggingSystem(ModuleLoader moduleLoader) {
+        ModuleIdentifier logModuleId = ModuleIdentifier.create(MODULE_ID_LOGMANAGER);
+        Module logModule;
+        try {
+            logModule = moduleLoader.loadModule(logModuleId);
+        } catch (ModuleLoadException mle) {
+            throw new RuntimeException(mle);
+        }
+
+        ModuleClassLoader logModuleClassLoader = logModule.getClassLoader();
+        ClassLoader tccl = SecurityActions.getContextClassLoader();
+        try {
+            SecurityActions.setContextClassLoader(logModuleClassLoader);
+            SecurityActions.setSystemProperty(SYSPROP_KEY_LOGMANAGER, SYSPROP_VALUE_JBOSS_LOGMANAGER);
+
+            final Class<?> actualLogManagerClass = LogManager.getLogManager().getClass();
+            if (actualLogManagerClass == LogManager.class) {
+                System.err.println("Could not load JBoss LogManager; the LogManager or Logging subsystem has likely been accessed prior to this initialization.");
+            } else {
+                Module.setModuleLogger(new JDKModuleLogger());
+            }
+        } finally {
+            // Reset TCCL
+            SecurityActions.setContextClassLoader(tccl);
+        }
+    }
+
+    private void setupServer(ModuleLoader moduleLoader, File jbossHome, Map<String, String> configuration) {
+        // Set the launcher properties as system properties. Not the best approach, but we cannot
+        // use the DMR at this point yet, see AS7-5882.
+        for (Map.Entry<String, String> entry : configuration.entrySet()) {
+            System.setProperty(entry.getKey(), entry.getValue());
+        }
+
+        server = new StandaloneServerIndirection(moduleLoader, jbossHome);
+    }
+
+    public void getService(int timeout, String ... nameParts) {
+        server.getService(timeout, nameParts);
+    }
+
+    public final void start() {
+        server.start();
+    }
+
+    public void stop() {
+        server.stop();
+    }
+
+    public Object activateOSGiFramework() throws Exception {
+        server.activateOSGiSubsystem();
+
+        // ServiceName.toArray() does not produce the correct output for msc 1.0.2.GA.
+        // This issue is already fixed on 1.0.3
+        // return server.getService(10000, Services.FRAMEWORK_CREATE.toArray());
+        return server.getService(10000, "jbosgi", "framework", "CREATE");
+    }
+
+    private String fixOSGiPackages(Map<String, String> configuration, String property, boolean force) {
+        List<String> systemPackages = new ArrayList<String>();
+
+        String packages = configuration.get(property);
+        if ((packages != null && packages.contains("org.osgi.")) || force) {
+            systemPackages.add("org.osgi.framework");
+            systemPackages.add("org.osgi.framework.launch");
+            systemPackages.add("org.osgi.framework.namespace");
+            systemPackages.add("org.osgi.framework.wiring");
+            systemPackages.add("org.osgi.resource");
+            systemPackages.add("org.osgi.service.resolver");
+            systemPackages.add("org.osgi.util.tracker");
+            systemPackages.add("org.osgi.util.xml");
+
+            StringBuilder sb = new StringBuilder();
+            if (packages != null) {
+                sb.append(packages);
+                sb.append(',');
+            }
+
+            for (String sp : systemPackages) {
+                sb.append(sp);
+                sb.append(',');
+            }
+            configuration.put(property, sb.toString());
+            return sb.toString();
+        }
+        return "";
+    }
+}

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/FrameworkWrapper.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/FrameworkWrapper.java
@@ -1,0 +1,244 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleException;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
+import org.osgi.framework.launch.Framework;
+
+/**
+ * Implements the standard OSGi Framework launch API.
+ *
+ * @author David Bosschaert
+ */
+public class FrameworkWrapper implements Framework {
+    private final EmbeddedOSGiFrameworkLauncher launcher;
+    private final AtomicInteger frameworkState = new AtomicInteger(Bundle.INSTALLED);
+    private Bundle systemBundle;
+
+    public FrameworkWrapper(EmbeddedOSGiFrameworkLauncher launcher) {
+        this.launcher = launcher;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Enumeration findEntries(String path, String filePattern, boolean recurse) {
+        return systemBundle.findEntries(path, filePattern, recurse);
+    }
+
+    @Override
+    public BundleContext getBundleContext() {
+        return systemBundle.getBundleContext();
+    }
+
+    @Override
+    public URL getEntry(String path) {
+        return systemBundle.getEntry(path);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Enumeration getEntryPaths(String path) {
+        return systemBundle.getEntryPaths(path);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Dictionary getHeaders() {
+        return systemBundle.getHeaders();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Dictionary getHeaders(String locale) {
+        return systemBundle.getHeaders(locale);
+    }
+
+    @Override
+    public long getLastModified() {
+        return systemBundle.getLastModified();
+    }
+
+    @Override
+    public ServiceReference[] getRegisteredServices() {
+        return systemBundle.getRegisteredServices();
+    }
+
+    @Override
+    public URL getResource(String name) {
+        return systemBundle.getResource(name);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Enumeration getResources(String name) throws IOException {
+        return systemBundle.getResources(name);
+    }
+
+    @Override
+    public ServiceReference[] getServicesInUse() {
+        return systemBundle.getServicesInUse();
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Map getSignerCertificates(int signersType) {
+        return systemBundle.getSignerCertificates(signersType);
+    }
+
+    @Override
+    public int getState() {
+        return frameworkState.get();
+    }
+
+    @Override
+    public Version getVersion() {
+        return systemBundle.getVersion();
+    }
+
+    @Override
+    public boolean hasPermission(Object permission) {
+        return systemBundle.hasPermission(permission);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Class loadClass(String name) throws ClassNotFoundException {
+        return systemBundle.loadClass(name);
+    }
+
+    @Override
+    public long getBundleId() {
+        return 0;
+    }
+
+    @Override
+    public String getLocation() {
+        return systemBundle.getLocation();
+    }
+
+    @Override
+    public String getSymbolicName() {
+        return systemBundle.getSymbolicName();
+    }
+
+    @Override
+    public void init() throws BundleException {
+        int state = frameworkState.get();
+        if (state == Bundle.STARTING || state == Bundle.ACTIVE || state == Bundle.STOPPING)
+            return;
+
+        frameworkState.set(Bundle.STARTING);
+
+        try {
+            Object sbc = launcher.activateOSGiFramework();
+            systemBundle = ((BundleContext) sbc).getBundle();
+        } catch (Exception e) {
+            throw new BundleException(e.getLocalizedMessage(), e);
+        }
+        awaitFrameworkInit();
+    }
+
+    private void awaitFrameworkInit() {
+        launcher.getService(30000, "jbosgi", "framework", "INIT");
+    }
+
+    @Override
+    public void start() throws BundleException {
+        start(0);
+    }
+
+    @Override
+    public void start(int options) throws BundleException {
+        if (frameworkState.get() != Bundle.STARTING)
+            init();
+
+        awaitFrameworkActive();
+        frameworkState.set(Bundle.ACTIVE);
+    }
+
+    private void awaitFrameworkActive() {
+        launcher.getService(30000, "jbosgi", "framework", "ACTIVE");
+    }
+
+    @Override
+    public void stop() throws BundleException {
+        stop(0);
+    }
+
+    @Override
+    public void stop(int options) throws BundleException {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    waitForStop(0);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }).start();
+    }
+
+    @Override
+    public void uninstall() throws BundleException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void update() throws BundleException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void update(InputStream in) throws BundleException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FrameworkEvent waitForStop(long timeout) throws InterruptedException {
+        frameworkState.set(Bundle.STOPPING);
+
+        try {
+            launcher.stop();
+        } catch (Throwable e) {
+            InterruptedException ie = new InterruptedException(e.getLocalizedMessage());
+            ie.initCause(e);
+            throw ie;
+        }
+        frameworkState.set(Bundle.RESOLVED);
+
+        return new FrameworkEvent(FrameworkEvent.STOPPED, this, null);
+    }
+}

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/JBossOSGiFrameworkFactory.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/JBossOSGiFrameworkFactory.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.util.Map;
+
+import org.osgi.framework.launch.Framework;
+import org.osgi.framework.launch.FrameworkFactory;
+
+/**
+ * This class implements the FrameworkFactory that is defined in the OSGi launcher specification.
+ * It allows other programs to launch OSGi framework in a standard way and is also required in
+ * order to run the OSGi TCK with the JBoss AS.
+ *
+ * @author David Bosschaert
+ */
+public class JBossOSGiFrameworkFactory implements FrameworkFactory {
+    @Override
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Framework newFramework(Map configuration) {
+        EmbeddedOSGiFrameworkLauncher launcher = new EmbeddedOSGiFrameworkLauncher();
+        launcher.configure(configuration);
+        launcher.start();
+
+        return new FrameworkWrapper(launcher);
+    }
+}

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/SecurityActions.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/SecurityActions.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Secured actions not to leak out of this package
+ *
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ */
+final class SecurityActions {
+
+    private SecurityActions() {
+        throw new UnsupportedOperationException("No instances permitted");
+    }
+
+    static void setAccessible(final Method method) throws SecurityException {
+        if (method == null) {
+            throw new IllegalArgumentException("method must be specified");
+        }
+        if (System.getSecurityManager() == null) {
+            method.setAccessible(true);
+        } else {
+            try {
+                AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+
+                    @Override
+                    public Void run() throws Exception {
+                        method.setAccessible(true);
+                        return null;
+                    }
+                });
+            } catch (final PrivilegedActionException pae) {
+                final Throwable cause = pae.getCause();
+                if (cause instanceof SecurityException) {
+                    throw (SecurityException) cause;
+                } else {
+                    throw new RuntimeException("Unexpected exception encountered settingg accessibility of " + method
+                            + " to true", cause);
+                }
+            }
+        }
+    }
+
+    static Map<String, String> getSystemEnvironment() {
+        if (System.getSecurityManager() == null) {
+            return System.getenv();
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<Map<String, String>>() {
+                @Override
+                public Map<String, String> run() {
+                    return System.getenv();
+                }
+            });
+        }
+    }
+
+    static void clearSystemProperty(final String key) {
+        if (System.getSecurityManager() == null) {
+            System.clearProperty(key);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                @Override
+                public Void run() {
+                    System.clearProperty(key);
+                    return null;
+                }
+            });
+        }
+    }
+
+    static void setSystemProperty(final String key, final String value) {
+        if (System.getSecurityManager() == null) {
+            System.setProperty(key, value);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                @Override
+                public Void run() {
+                    System.setProperty(key, value);
+                    return null;
+                }
+            });
+        }
+    }
+
+    static String getSystemProperty(final String key) {
+        if (System.getSecurityManager() == null) {
+            return System.getProperty(key);
+        }
+
+        return AccessController.doPrivileged(new PrivilegedAction<String>() {
+
+            @Override
+            public String run() {
+                return System.getProperty(key);
+            }
+        });
+    }
+
+    private enum GetSystemPropertiesAction implements PrivilegedAction<Properties> {
+        INSTANCE;
+
+        @Override
+        public Properties run() {
+            return System.getProperties();
+        }
+    }
+
+    static Properties getSystemProperties() {
+        if (System.getSecurityManager() == null) {
+            return System.getProperties();
+        } else {
+            return AccessController.doPrivileged(GetSystemPropertiesAction.INSTANCE);
+        }
+    }
+
+    static ClassLoader getContextClassLoader() {
+
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+
+                @Override
+                public ClassLoader run() {
+                    return Thread.currentThread().getContextClassLoader();
+                }
+            });
+        }
+    }
+
+    static void setContextClassLoader(final ClassLoader tccl) {
+
+        if (System.getSecurityManager() == null) {
+            Thread.currentThread().setContextClassLoader(tccl);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                @Override
+                public Void run() {
+                    Thread.currentThread().setContextClassLoader(tccl);
+                    return null;
+                }
+            });
+        }
+    }
+}

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/StandaloneServerIndirection.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/StandaloneServerIndirection.java
@@ -1,0 +1,155 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.osgi.launcher;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.jboss.as.embedded.EmbeddedServerFactory;
+import org.jboss.as.embedded.StandaloneServer;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * Indirection to the {@link StandaloneServer}; used to encapsulate access to the underlying embedded AS Server instance in a
+ * manner that does not directly link this class. Necessary to avoid {@link ClassCastException} when this class is loaded by the
+ * application {@link ClassLoader} (or any other hierarchical CL) while the server is loaded by a modular environment.
+ *
+ * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ * @author David Bosschaert
+ */
+class StandaloneServerIndirection {
+    private static final ModuleIdentifier MODULE_ID_EMBEDDED = ModuleIdentifier.create("org.jboss.as.embedded");
+
+    /**
+     * Instance of {@link StandaloneServer}; represented as {@link Object} to avoid leaking a direct link from this class
+     */
+    private final Object standaloneServer;
+
+    /**
+     * Creates a new instance with the specified {@link ModuleLoader}.
+     *
+     * @param loader The Module Loader to use to create the embedded server.
+     * @param jbossHome Location of AS installation local filesystem
+     */
+    StandaloneServerIndirection(final ModuleLoader loader, final File jbossHome) {
+        // Load the Embedded Server Module
+        ModuleIdentifier embeddedModuleId = MODULE_ID_EMBEDDED;
+        Module embeddedModule;
+        try {
+            embeddedModule = loader.loadModule(embeddedModuleId);
+        } catch (ModuleLoadException mle) {
+            throw new RuntimeException(mle);
+        }
+
+        // Load the Embedded Server Factory via the modular environment
+        ModuleClassLoader embeddedModuleCL = embeddedModule.getClassLoader();
+        Class<?> embeddedServerFactoryClass;
+        try {
+            embeddedServerFactoryClass = embeddedModuleCL.loadClass(EmbeddedServerFactory.class.getName());
+        } catch (ClassNotFoundException cnfe) {
+            throw new RuntimeException(cnfe);
+        }
+
+        standaloneServer = invokeReflectively(embeddedServerFactoryClass, "create",
+                Arrays.<Class<?>>asList(ModuleLoader.class, File.class, Properties.class, Map.class),
+                Arrays.asList(loader, jbossHome, SecurityActions.getSystemProperties(), SecurityActions.getSystemEnvironment()));
+    }
+
+    /**
+     * Reflectively use the DMR to activate the OSGi subsystem.
+     */
+    public void activateOSGiSubsystem() throws Exception {
+        Object controller = invokeReflectively(standaloneServer, "getModelControllerClient");
+
+        // Create a model node with the activate operation for the OSGi subsystem
+        Class<?> modelNodeClass = controller.getClass().getClassLoader().loadClass("org.jboss.dmr.ModelNode");
+        Object modelNode = modelNodeClass.newInstance();
+        Object addressNode = invokeReflectively(modelNode, "get", String.class, "address");
+        Object opList = invokeReflectively(addressNode, "setEmptyList");
+        invokeReflectively(opList, "add", Arrays.<Class<?>>asList(String.class, String.class),
+                                          Arrays.asList("subsystem", "osgi"));
+        Object opNode = invokeReflectively(modelNode, "get", String.class, "operation");
+        invokeReflectively(opNode, "set", String.class, "activate");
+
+        // Execute it
+        invokeReflectively(controller, "execute", modelNodeClass, modelNode);
+    }
+
+    /**
+     * Retrieve an MSC service from the server and waits for the service to be active.
+     *
+     * @param timeout The amount to time (in milliseconds) to wait for the service
+     * @param nameSegments The ServiceName segments
+     * @return the service or null if not found
+     */
+    public Object getService(long timeout, String ... nameParts) {
+        return invokeReflectively(standaloneServer, "getService",
+                Arrays.<Class<?>>asList(long.class, String[].class),
+                Arrays.asList(timeout, nameParts));
+    }
+
+    /**
+     * Starts the server
+     */
+    void start() {
+        invokeReflectively(standaloneServer, "start");
+    }
+
+    /**
+     * Stops the server
+     */
+    void stop() {
+        invokeReflectively(standaloneServer, "stop");
+    }
+
+    private static Object invokeReflectively(Object object, String methodName) {
+        return invokeReflectively(object, methodName, Collections.<Class<?>>emptyList(), Collections.emptyList());
+    }
+
+    private static Object invokeReflectively(Object object, String methodName, Class<?> parameterType, Object param) {
+        return invokeReflectively(object, methodName, Collections.<Class<?>>singletonList(parameterType), Collections.singletonList(param));
+    }
+
+    private static Object invokeReflectively(Class<?> clazz, String methodName, List<Class<?>> parameterTypes, List<? extends Object> params) {
+        return invokeReflectively(null, clazz, methodName, parameterTypes, params);
+    }
+
+    private static Object invokeReflectively(Object object, String methodName, List<Class<?>> parameterTypes, List<? extends Object> params) {
+        return invokeReflectively(object, object.getClass(), methodName, parameterTypes, params);
+    }
+
+    private static Object invokeReflectively(Object object, Class<?> clazz, String methodName, List<Class<?>> parameterTypes, List<? extends Object> params) {
+        try {
+            Method m = clazz.getMethod(methodName, parameterTypes.toArray(new Class[] {}));
+            SecurityActions.setAccessible(m);
+            return m.invoke(object, params.toArray());
+        } catch (RuntimeException re) {
+            throw re;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/osgi/launcher/src/main/resources/META-INF/services/org.osgi.framework.launch.FrameworkFactory
+++ b/osgi/launcher/src/main/resources/META-INF/services/org.osgi.framework.launch.FrameworkFactory
@@ -1,0 +1,1 @@
+org.jboss.as.osgi.launcher.JBossOSGiFrameworkFactory

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -42,5 +42,6 @@
     <modules>
         <module>service</module>
         <module>integration</module>
+        <module>launcher</module>
     </modules>
 </project>

--- a/osgi/service/src/main/java/org/jboss/as/osgi/service/FrameworkBootstrapService.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/service/FrameworkBootstrapService.java
@@ -58,10 +58,10 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.osgi.framework.spi.FrameworkBuilderFactory;
 import org.jboss.osgi.framework.spi.FrameworkBuilder;
-import org.jboss.osgi.framework.spi.SystemPaths;
 import org.jboss.osgi.framework.spi.FrameworkBuilder.FrameworkPhase;
+import org.jboss.osgi.framework.spi.FrameworkBuilderFactory;
+import org.jboss.osgi.framework.spi.SystemPaths;
 import org.osgi.framework.Constants;
 
 /**
@@ -165,7 +165,7 @@ public class FrameworkBootstrapService implements Service<Void> {
     private void setupIntegrationProperties(StartContext context, Map<String, Object> props) {
 
         // Setup the Framework's storage area.
-        String storage = (String) props.get(Constants.FRAMEWORK_STORAGE);
+        String storage = getFrameworkProperty(Constants.FRAMEWORK_STORAGE, props);
         if (storage == null) {
             ServerEnvironment environment = injectedServerEnvironment.getValue();
             File dataDir = environment.getServerDataDir();
@@ -179,7 +179,7 @@ public class FrameworkBootstrapService implements Service<Void> {
             props.put(ModuleLogger.class.getName(), moduleLogger.getClass().getName());
 
         // Setup default system modules
-        String sysmodules = (String) props.get(PROP_JBOSS_OSGI_SYSTEM_MODULES);
+        String sysmodules = getFrameworkProperty(PROP_JBOSS_OSGI_SYSTEM_MODULES, props);
         if (sysmodules == null) {
             Set<String> sysModules = new LinkedHashSet<String>();
             sysModules.addAll(Arrays.asList(SystemPackagesIntegration.DEFAULT_SYSTEM_MODULES));
@@ -189,7 +189,7 @@ public class FrameworkBootstrapService implements Service<Void> {
         }
 
         // Setup default system packages
-        String syspackages = (String) props.get(Constants.FRAMEWORK_SYSTEMPACKAGES);
+        String syspackages = getFrameworkProperty(Constants.FRAMEWORK_SYSTEMPACKAGES, props);
         if (syspackages == null) {
             Set<String> sysPackages = new LinkedHashSet<String>();
             sysPackages.addAll(Arrays.asList(SystemPackagesIntegration.JAVAX_API_PACKAGES));
@@ -200,9 +200,18 @@ public class FrameworkBootstrapService implements Service<Void> {
             props.put(Constants.FRAMEWORK_SYSTEMPACKAGES, syspackages);
         }
 
-        String extrapackages = (String) props.get(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA);
+        String extrapackages = getFrameworkProperty(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, props);
         if (extrapackages != null) {
             props.put(Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA, extrapackages);
         }
+    }
+
+    private String getFrameworkProperty(String name, Map<String, Object> props) {
+        Object p = props.get(name);
+        if (p instanceof String)
+            return (String) p;
+
+        // not set, revert to system properties
+        return SecurityActions.getSystemProperty(name);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -46,10 +46,10 @@ import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.server.services.security.VaultReaderException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.invocation.proxy.MethodIdentifier;
+import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
-import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Param;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -672,4 +672,6 @@ public interface ServerMessages {
     @Message(id = 18784, value = "Null '%s'")
     OperationFailedException nullParameter(String name);
 
+    @Message(id = 18785, value = "Cannot obtain service value: %s")
+    RuntimeException cannotGetServiceValue(@Cause Throwable cause, ServiceName name);
 }

--- a/testsuite/integration/osgi/pom.xml
+++ b/testsuite/integration/osgi/pom.xml
@@ -32,6 +32,12 @@
     </properties>
 
 	<dependencies>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-osgi-launcher</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+  
 	    <dependency>
 	        <groupId>com.sun.xml.bind</groupId>
 	        <artifactId>jaxb-impl</artifactId>
@@ -93,7 +99,8 @@
                                 <goals><goal>test</goal></goals>
                                 <phase>none</phase>
                             </execution>
-                            <!-- Multi node clustering tests. -->
+                            
+                            <!-- OSGi integration tests. -->
                             <execution>
                                 <id>tests-osgi.surefire</id>
                                 <phase>test</phase>
@@ -103,15 +110,39 @@
                                     <includes>
                                         <include>org/jboss/as/test/integration/osgi/**/*TestCase.java</include>
                                     </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/osgi/launch/*TestCase.java</exclude>
+                                    </excludes>
 
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables>
                                         <arquillian.launch>osgi</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
 
+                            <!-- OSGi launcher tests. -->
+                            <execution>
+                                <id>tests-osgi-launcher.surefire</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Fork every test because it will launch a separate AS instance -->
+                                    <forkMode>always</forkMode>
+
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/osgi/launch/*TestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>osgi</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestBase.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestBase.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * @author David Bosschaert
+ */
+public abstract class EmbeddedOSGiFrameworkLauncherTestBase {
+    private Properties savedProps;
+
+    @Before
+    public void setUp() throws Exception {
+        URL classURL = getClass().getClassLoader().getResource(getClass().getName().replace('.', File.separatorChar) + ".class");
+        String classStr = new File(classURL.toURI()).getAbsolutePath();
+        String projectStr = classStr.substring(0, classStr.lastIndexOf("target"));
+        File projectDir = new File(projectStr);
+        File baseDir = projectDir.getParentFile().getParentFile().getParentFile();
+        File buildDir = new File(baseDir, "build/target");
+        File jbossDir = null;
+        for (File f : buildDir.listFiles()) {
+            if (f.getName().startsWith("jboss-as-")) {
+                jbossDir = f;
+                break;
+            }
+        }
+
+        // This can only be run once the build dir is there
+        if (jbossDir == null)
+            throw new IllegalStateException("Unable to find JBoss Build Dir, make sure that the ");
+
+        savedProps = new Properties();
+        savedProps.putAll(System.getProperties());
+        System.setProperty("jboss.home", jbossDir.getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() {
+        System.setProperties(savedProps);
+    }
+}

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestCase.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/EmbeddedOSGiFrameworkLauncherTestCase.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch;
+
+import java.util.HashMap;
+
+import junit.framework.Assert;
+
+import org.jboss.as.osgi.launcher.EmbeddedOSGiFrameworkLauncher;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+
+/**
+ * @author David Bosschaert
+ */
+public class EmbeddedOSGiFrameworkLauncherTestCase extends EmbeddedOSGiFrameworkLauncherTestBase {
+    @Test
+    public void testLaunchFramework() throws Exception {
+        EmbeddedOSGiFrameworkLauncher launcher = new EmbeddedOSGiFrameworkLauncher();
+        launcher.configure(new HashMap<String, String>());
+        try {
+            launcher.start();
+            BundleContext systemBundleContext = (BundleContext) launcher.activateOSGiFramework();
+            Assert.assertEquals(0L, systemBundleContext.getBundle().getBundleId());
+        } finally {
+            launcher.stop();
+        }
+    }
+}

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/JBossOSGiFrameworkFactoryTestCase.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/JBossOSGiFrameworkFactoryTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.jboss.as.osgi.launcher.JBossOSGiFrameworkFactory;
+import org.jboss.as.test.integration.osgi.launch.bundle.Activator;
+import org.jboss.osgi.metadata.OSGiManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.BundleListener;
+import org.osgi.framework.FrameworkEvent;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.launch.Framework;
+
+/**
+ * @author David Bosschaert
+ */
+public class JBossOSGiFrameworkFactoryTestCase extends EmbeddedOSGiFrameworkLauncherTestBase {
+    @Test
+    public void testFrameworkFactory() throws Exception {
+        HashMap<String, String> fwProps = new HashMap<String, String>();
+        fwProps.put("foo", "bar");
+        Framework framework = new JBossOSGiFrameworkFactory().newFramework(fwProps);
+        framework.init();
+        Assert.assertEquals(Bundle.STARTING, framework.getState());
+
+        framework.start();
+        Assert.assertEquals(Bundle.ACTIVE, framework.getState());
+
+        Assert.assertEquals(0, framework.getBundleId());
+
+        BundleContext sctx = framework.getBundleContext();
+        Assert.assertEquals("bar", sctx.getProperty("foo"));
+
+        Bundle b = sctx.installBundle("myBundle1.jar", getTestBundle());
+        b.start();
+
+        ServiceReference[] refs = sctx.getServiceReferences(String.class.getName(), "(org.jboss.launch.test=testproperty)");
+        Assert.assertEquals(1, refs.length);
+        Assert.assertEquals("a string service", sctx.getService(refs[0]));
+
+        final List<String> events = Collections.synchronizedList(new ArrayList<String>());
+        BundleListener listener = new BundleListener() {
+            @Override
+            public void bundleChanged(BundleEvent event) {
+                events.add(event.getBundle().getSymbolicName() + event.getType());
+            }
+        };
+
+        framework.getBundleContext().addBundleListener(listener);
+
+        Assert.assertEquals(0, events.size());
+        FrameworkEvent event = framework.waitForStop(0);
+        Assert.assertEquals(FrameworkEvent.STOPPED, event.getType());
+
+        Assert.assertTrue("Bundle should have been stopped", events.contains(b.getSymbolicName() + BundleEvent.STOPPED));
+        Assert.assertEquals(Framework.RESOLVED, framework.getState());
+    }
+
+    private InputStream getTestBundle() {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "bundle1.jar");
+        archive.addClasses(Activator.class);
+        archive.setManifest(new Asset() {
+            @Override
+            public InputStream openStream() {
+                OSGiManifestBuilder builder = OSGiManifestBuilder.newInstance();
+                builder.addBundleSymbolicName(archive.getName());
+                builder.addBundleManifestVersion(2);
+                builder.addImportPackages(BundleContext.class);
+                builder.addBundleActivator(Activator.class);
+                return builder.openStream();
+            }
+        });
+        ZipExporter ze = archive.as(ZipExporter.class);
+        return ze.exportAsInputStream();
+    }
+}

--- a/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/bundle/Activator.java
+++ b/testsuite/integration/osgi/src/test/java/org/jboss/as/test/integration/osgi/launch/bundle/Activator.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.osgi.launch.bundle;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author David Bosschaert
+ */
+public class Activator implements BundleActivator {
+    private ServiceRegistration reg;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        String stringService = "a string service";
+        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put("org.jboss.launch.test", "testproperty");
+        reg = context.registerService(String.class.getName(), stringService, props);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        reg.unregister();
+    }
+}


### PR DESCRIPTION
This commit provides the start of an implementation of the OSGi launcher API, which is part of the OSGi Core Specification.
The launcher API is a prerequisite for running AS7 through the OSGi TCK.

The pull request replaces an earlier pull request (https://github.com/jbossas/jboss-as/pull/3518). An additional indirection layer (StandaloneServerIndirection) was added as this is now required when using the EmbeddedServerFactory.
Some of the files in this commit were based on the Arquillian integration module, which works with the EmbeddedServerFactory in a similar way.
