### PR TITLE
[AS7-4978] allow expression for jvm resource attributes

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/AbstractJvmModelTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/AbstractJvmModelTest.java
@@ -47,6 +47,7 @@ import org.jboss.as.host.controller.model.jvm.JVMEnvironmentVariableAddHandler;
 import org.jboss.as.host.controller.model.jvm.JVMEnvironmentVariableRemoveHandler;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 import org.junit.Test;
 
 /**
@@ -171,6 +172,13 @@ public abstract class AbstractJvmModelTest extends AbstractCoreModelTest {
     }
 
     @Test
+    public void testWriteJvmOptionsWithExpression() throws Exception {
+        KernelServices kernelServices = doEmptyJvmAdd();
+        ModelNode value = new ModelNode().add("-Xmx${my.xmx:100}m");
+        Assert.assertEquals(value, writeTest(kernelServices, "jvm-options", value));
+    }
+
+    @Test
     public void testWriteEnvironmentVariables() throws Exception {
         KernelServices kernelServices = doEmptyJvmAdd();
         ModelNode value = new ModelNode().add("ENV1", "one").add("ENV2", "two");
@@ -247,6 +255,16 @@ public abstract class AbstractJvmModelTest extends AbstractCoreModelTest {
         Assert.assertEquals(new ModelNode().add("-Xoption"), getJvmResource(kernelServices).get("jvm-options"));
         kernelServices.executeForFailure(createAddJvmOptionOperation("-Xoption"));
         Assert.assertEquals(new ModelNode().add("-Xoption"), getJvmResource(kernelServices).get("jvm-options"));
+    }
+
+    @Test
+    public void testAddJvmOptionWithExpression() throws Exception {
+        KernelServices kernelServices = doEmptyJvmAdd();
+        kernelServices.executeForResult(createAddJvmOptionOperation("-X${myoption:option}"));
+
+        ModelNode result = getJvmResource(kernelServices).get("jvm-options");
+        Assert.assertEquals(ModelType.EXPRESSION, result.get(0).getType());
+        Assert.assertEquals("-X${myoption:option}", result.get(0).asString());
     }
 
     @Test

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
@@ -1,0 +1,134 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.jvm;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.KernelServicesBuilder;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.core.model.test.ModelWriteSanitizer;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.model.test.ModelFixer;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+@RunWith(Parameterized.class)
+public class JvmTransformersTestCase extends AbstractCoreModelTest {
+    private final ModelVersion modelVersion;
+    private final TestControllerVersion testControllerVersion;
+
+    public JvmTransformersTestCase(TransformersTestParameters params) {
+        this.modelVersion = params.getModelVersion();
+        this.testControllerVersion = params.getTestControllerVersion();
+    }
+
+    @Parameters
+    public static List<Object[]> parameters(){
+        return TransformersTestParameters.setupVersions();
+    }
+
+    @Test
+    public void jvmResourceWithExpressions() throws Exception {
+        doJvmTransformer("domain-with-expressions.xml", testControllerVersion != TestControllerVersion.V7_1_2_FINAL);
+    }
+
+    @Test
+    public void jvmResourceWithoutExpressions() throws Exception {
+        doJvmTransformer("domain-without-expressions.xml", true);
+    }
+
+    private void doJvmTransformer(String xmlResource, boolean legacyMustBoot) throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setXmlResource(xmlResource)
+                .setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER);
+
+        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion);
+        legacyInitializer.setTestControllerVersion(testControllerVersion)
+                .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(PROFILE, "test"), null)
+                .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), new ModelNode().setEmptyObject());
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        if (legacyMustBoot) {
+            assertTrue(legacyServices.isSuccessfulBoot());
+            checkCoreModelTransformation(mainServices, modelVersion, MODEL_FIXER, MODEL_FIXER);
+        } else {
+            assertFalse(legacyServices.isSuccessfulBoot());
+        }
+    }
+
+    /**
+     * add "fake" profile and socket-binding-group so that the server-group specified in the XML is valid.
+     */
+    private static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
+        public void populateModel(Resource rootResource) {
+            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
+            rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
+        }
+    };
+
+    /**
+     * Remove the resources that were added to the XML model.
+     */
+    private final ModelNode removeResources(ModelNode modelNode) {
+        modelNode.remove(SOCKET_BINDING_GROUP);
+        modelNode.remove(PROFILE);
+        return modelNode;
+    }
+
+    private final ModelFixer MODEL_FIXER = new ModelFixer() {
+        @Override
+        public ModelNode fixModel(ModelNode modelNode) {
+            return removeResources(modelNode);
+        }
+    };
+
+    private final ModelWriteSanitizer XML_MODEL_WRITE_SANITIZER = new ModelWriteSanitizer() {
+        @Override
+        public ModelNode sanitize(ModelNode modelNode) {
+            return removeResources(modelNode);
+        }
+    };
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
@@ -82,8 +82,7 @@ public class JvmTransformersTestCase extends AbstractCoreModelTest {
                 .setXmlResource(xmlResource)
                 .setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER);
 
-        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion);
-        legacyInitializer.setTestControllerVersion(testControllerVersion)
+        builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
                 .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(PROFILE, "test"), null)
                 .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), new ModelNode().setEmptyObject());
 

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<domain xmlns="urn:jboss:domain:1.4">
+    <server-groups>
+        <server-group name="test" profile="test">
+            <jvm name="default">
+                <heap size="${heap.size:heapSize}" max-size="${max.heap.size:maxHeapSize}"/>
+                <permgen size="${permgen.size:permgenSize}" max-size="${max.permgen.size:maxPermGenSize}"/>
+                <jvm-options>
+                    <option value="${option:option1}"/>
+                </jvm-options>
+             </jvm>
+             <socket-binding-group ref="test-sockets"/>
+         </server-group>
+    </server-groups>
+</domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
@@ -4,11 +4,14 @@
     <server-groups>
         <server-group name="test" profile="test">
             <jvm name="default">
-                <heap size="${heap.size:heapSize}" max-size="${max.heap.size:maxHeapSize}"/>
-                <permgen size="${permgen.size:permgenSize}" max-size="${max.permgen.size:maxPermGenSize}"/>
+                <heap size="${mytest.heap.size:heapSize}" max-size="${mytest.max.heap.size:maxHeapSize}"/>
+                <permgen size="${mytest.permgen.size:permgenSize}" max-size="${mytest.max.permgen.size:maxPermGenSize}"/>
                 <jvm-options>
-                    <option value="${option:option1}"/>
+                    <option value="${mytest.option:option1}"/>
                 </jvm-options>
+                <environment-variables>
+                    <variable name="name1" value="${mytest.value:value1}"/>
+                </environment-variables>
              </jvm>
              <socket-binding-group ref="test-sockets"/>
          </server-group>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-without-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-without-expressions.xml
@@ -9,6 +9,9 @@
                 <jvm-options>
                     <option value="option1"/>
                 </jvm-options>
+                <environment-variables>
+                    <variable name="name1" value="value1"/>
+                </environment-variables>
              </jvm>
              <socket-binding-group ref="test-sockets"/>
          </server-group>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-without-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-without-expressions.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<domain xmlns="urn:jboss:domain:1.4">
+    <server-groups>
+        <server-group name="test" profile="test">
+            <jvm name="default">
+                <heap size="heapSize" max-size="maxHeapSize"/>
+                <permgen size="permgenSize" max-size="maxPermGenSize"/>
+                <jvm-options>
+                    <option value="option1"/>
+                </jvm-options>
+             </jvm>
+             <socket-binding-group ref="test-sockets"/>
+         </server-group>
+    </server-groups>
+</domain>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -41,6 +41,7 @@ import org.jboss.as.controller.transform.TransformationTarget;
 import org.jboss.as.controller.transform.TransformerRegistry;
 import org.jboss.as.controller.transform.TransformersSubRegistration;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
+import org.jboss.as.host.controller.model.jvm.JvmResourceDefinition;
 
 /**
  * Global transformation rules for the domain, host and server-config model.
@@ -85,6 +86,7 @@ public class DomainTransformers {
             SystemPropertyTransformers.registerTransformers(domain);
             TransformersSubRegistration serverGroup = domain.registerSubResource(ServerGroupResourceDefinition.PATH);
             SystemPropertyTransformers.registerTransformers(serverGroup);
+            JvmTransformers.registerTransformers(serverGroup);
 
             //Add the domain interface and path name. This is from a read attribute handler but in < 1.4.0 it existed in the model
             domain.registerSubResource(PathElement.pathElement(INTERFACE), AddNameFromAddressResourceTransformer.INSTANCE);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JvmTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JvmTransformers.java
@@ -23,6 +23,7 @@ package org.jboss.as.domain.controller.transformers;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.ENVIRONMENT_VARIABLES;
 import static org.jboss.as.host.controller.model.jvm.JvmAttributes.HEAP_SIZE;
 import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MAX_HEAP_SIZE;
 import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MAX_PERMGEN_SIZE;
@@ -46,7 +47,7 @@ class JvmTransformers {
         TransformersSubRegistration reg = parent.registerSubResource(JvmResourceDefinition.GLOBAL.getPathElement(), ResourceTransformer.DEFAULT);
 
         RejectExpressionValuesTransformer rejectExpression = new RejectExpressionValuesTransformer(HEAP_SIZE, MAX_HEAP_SIZE, PERMGEN_SIZE, MAX_PERMGEN_SIZE,
-                STACK_SIZE, OPTIONS);
+                STACK_SIZE, OPTIONS, ENVIRONMENT_VARIABLES);
 
         reg.registerOperationTransformer(ADD, rejectExpression);
         reg.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectExpression.getWriteAttributeTransformer());

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JvmTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JvmTransformers.java
@@ -1,0 +1,59 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.domain.controller.transformers;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.HEAP_SIZE;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MAX_HEAP_SIZE;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.MAX_PERMGEN_SIZE;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.OPTIONS;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.PERMGEN_SIZE;
+import static org.jboss.as.host.controller.model.jvm.JvmAttributes.STACK_SIZE;
+
+import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
+import org.jboss.as.controller.transform.ResourceTransformer;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
+import org.jboss.as.host.controller.model.jvm.JvmResourceDefinition;
+
+/**
+ * The older versions of the model do not allow expressions for the jmv resource's attributes.
+ * Reject the attributes if they contain an expression.
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+class JvmTransformers {
+    static TransformersSubRegistration registerTransformers(TransformersSubRegistration parent) {
+        TransformersSubRegistration reg = parent.registerSubResource(JvmResourceDefinition.GLOBAL.getPathElement(), ResourceTransformer.DEFAULT);
+
+        RejectExpressionValuesTransformer rejectExpression = new RejectExpressionValuesTransformer(HEAP_SIZE, MAX_HEAP_SIZE, PERMGEN_SIZE, MAX_PERMGEN_SIZE,
+                STACK_SIZE, OPTIONS);
+
+        reg.registerOperationTransformer(ADD, rejectExpression);
+        reg.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectExpression.getWriteAttributeTransformer());
+
+        return reg;
+    }
+
+
+
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
@@ -118,7 +118,27 @@ class ManagedServerBootCmdFactory implements ManagedServerBootConfiguration {
 
         final String jvmName = serverVMName != null ? serverVMName : groupVMName;
         final ModelNode hostVM = jvmName != null ? hostModel.get(JVM, jvmName) : null;
-        this.jvmElement = new JvmElement(jvmName, hostVM, groupVM, serverVM);
+
+        this.jvmElement = new JvmElement(jvmName,
+                resolveJVMOptions(hostVM),
+                resolveJVMOptions(groupVM),
+                resolveJVMOptions(serverVM));
+    }
+
+    /**
+     * resolve expressions of the jvm model (if there is any)
+     */
+    private ModelNode resolveJVMOptions(final ModelNode vmModel) {
+        if (vmModel == null) {
+            return null;
+        }
+        try {
+            return expressionResolver.resolveExpressions(vmModel.clone());
+        } catch (OperationFailedException e) {
+            // should we fail or allow to proceed without having resolved the expression?
+            HostControllerLogger.CONTROLLER_MANAGEMENT_LOGGER.warn(e.getLocalizedMessage());
+            return vmModel;
+        }
     }
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionAddHandler.java
@@ -42,8 +42,10 @@ final class JVMOptionAddHandler implements OperationStepHandler {
     static final String OPERATION_NAME = "add-jvm-option";
     static final JVMOptionAddHandler INSTANCE = new JVMOptionAddHandler();
 
+    // the attribute allows expressions that are resolved in JVMAddHandler upon server restart
     static final SimpleAttributeDefinition JVM_OPTION = SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_OPTION, ModelType.STRING, false)
-            .setValidator(new StringLengthValidator(1))
+            .setValidator(new StringLengthValidator(1, false, true))
+            .setAllowExpression(true)
             .build();
 
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, HostResolver.getResolver("jvm"))

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionRemoveHandler.java
@@ -41,7 +41,8 @@ final class JVMOptionRemoveHandler implements OperationStepHandler {
     static final JVMOptionRemoveHandler INSTANCE = new JVMOptionRemoveHandler();
 
     static final SimpleAttributeDefinition JVM_OPTION = SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_OPTION, ModelType.STRING, false)
-            .setValidator(new StringLengthValidator(1))
+            .setValidator(new StringLengthValidator(1, false, true))
+            .setAllowExpression(true)
             .build();
 
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, HostResolver.getResolver("jvm"))
@@ -54,6 +55,8 @@ final class JVMOptionRemoveHandler implements OperationStepHandler {
         final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
         final ModelNode model = resource.getModel();
 
+        // the attribute allow expressions but it is *not* resolved. This enables to remove a jvm option
+        // which was added with an expression. If the expression was resolved it would not be found in the JVM_OPTIONS list
         final ModelNode option = JVM_OPTION.validateOperation(operation);
         if (model.hasDefined(JvmAttributes.JVM_OPTIONS)) {
             final ModelNode values = model.get(JvmAttributes.JVM_OPTIONS).clone();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmAttributes.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmAttributes.java
@@ -83,7 +83,8 @@ public class JvmAttributes {
     public static final PropertiesAttributeDefinition ENVIRONMENT_VARIABLES = new PropertiesAttributeDefinition.Builder(JvmAttributes.JVM_ENV_VARIABLES, true)
             .setXmlName(Element.VARIABLE.getLocalName())
             .setAllowNull(true)
-            .setValidator(new StringLengthValidator(1, true))
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, true, true))
             .setWrapperElement(JvmAttributes.JVM_ENV_VARIABLES)
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmAttributes.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmAttributes.java
@@ -98,9 +98,13 @@ public class JvmAttributes {
             .setAllowExpression(false)
             .build();
 
+    /**
+     * JVM options are resolved in ManagedServerBootCmdFactory before the JVM is launched.
+     */
     public static final AttributeDefinition OPTIONS = new StringListAttributeDefinition.Builder(JvmAttributes.JVM_OPTIONS)
-            .setValidator(new StringLengthValidator(1, true))
+            .setValidator(new StringLengthValidator(1, true, true))
             .setAllowNull(true)
+            .setAllowExpression(true)
             .setAttributeMarshaller(new AttributeMarshaller() {
                 @Override
                 public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
@@ -121,7 +125,7 @@ public class JvmAttributes {
 
     public static final SimpleAttributeDefinition STACK_SIZE =
             SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_STACK, ModelType.STRING, true)
-            .setAllowExpression(false)
+            .setAllowExpression(true)
             .setXmlName(JvmAttributes.SIZE)
             .build();
 
@@ -133,25 +137,25 @@ public class JvmAttributes {
 
     public static final SimpleAttributeDefinition HEAP_SIZE =
             SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_HEAP, ModelType.STRING, true)
-            .setAllowExpression(false)
+            .setAllowExpression(true)
             .setXmlName(JvmAttributes.SIZE)
             .build();
 
     public static final SimpleAttributeDefinition MAX_HEAP_SIZE =
             SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_MAX_HEAP, ModelType.STRING, true)
-            .setAllowExpression(false)
+            .setAllowExpression(true)
             .setXmlName(JvmAttributes.MAX_SIZE)
             .build();
 
     public static final SimpleAttributeDefinition PERMGEN_SIZE =
             SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_PERMGEN, ModelType.STRING, true)
-            .setAllowExpression(false)
+            .setAllowExpression(true)
             .setXmlName(JvmAttributes.SIZE)
             .build();
 
     public static final SimpleAttributeDefinition MAX_PERMGEN_SIZE =
             SimpleAttributeDefinitionBuilder.create(JvmAttributes.JVM_MAX_PERMGEN, ModelType.STRING, true)
-            .setAllowExpression(false)
+            .setAllowExpression(true)
             .setXmlName(JvmAttributes.MAX_SIZE)
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
@@ -210,7 +210,7 @@ public class JvmXml {
             }
             final String[] array = requireAttributes(reader, Attribute.NAME.getLocalName(), Attribute.VALUE.getLocalName());
             requireNoContent(reader);
-            properties.add(array[0], array[1]);
+            properties.add(array[0], ParseUtils.parsePossibleExpression(array[1]));
         }
 
         if (!properties.isDefined()) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
@@ -431,7 +431,7 @@ public class JvmXml {
             final Element element = Element.forName(reader.getLocalName());
             if (element == Element.OPTION) {
                 // Handle attributes
-                String option = null;
+                ModelNode option = null;
                 final int count = reader.getAttributeCount();
                 for (int i = 0; i < count; i++) {
                     final String attrValue = reader.getAttributeValue(i);
@@ -441,7 +441,7 @@ public class JvmXml {
                         final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
                         switch (attribute) {
                             case VALUE: {
-                                option = attrValue;
+                                option = ParseUtils.parsePossibleExpression(attrValue);
                                 break;
                             }
                             default:
@@ -454,7 +454,6 @@ public class JvmXml {
                 }
 
                 options.add(option);
-
                 // Handle elements
                 requireNoContent(reader);
             } else {


### PR DESCRIPTION
this is a subtask to expand expression support [AS7-6120]
- allow expressions for JVM attributes:
  - stack-size
  - heap-size
  - max-heap-size
  - permgen-size
  - max-permgen-size
  - options

I did _not_ allow expressions for other jvm attributes:
- environment-variables => I don't see the whole implication to add expression to env variables
  that could be used to resolve the expressions itself... is it a can of worms?
- java-home => I have a reasonable doubt about this one. This could be useful for heterogeneous env... 
- agent-related attributes
- type

I've also added a resource transformer to reject any expression in these attributes for legacy versions
