### PR TITLE
Deployment overlays core model tests and fixes

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
@@ -48,7 +48,7 @@
                 <xs:element name="interfaces" type="named-interfacesType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="socket-binding-groups" type="socket-binding-groupsType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="deployments" type="domain-deploymentsType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="deployment-overlays" type="deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="domain-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="server-groups" type="server-groupsType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management-client-content" type="management-client-contentType" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
@@ -123,7 +123,7 @@
                 <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="deployments" type="server-deploymentsType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="deployment-overlays" type="deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="standalone-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="optional">
                 <xs:annotation>
@@ -232,10 +232,10 @@
         <xs:attribute name="security-realm" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a 
+                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a
                     connection to the LDAP server.
-                    
-                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.                
+
+                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -2307,7 +2307,7 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="deployment-overlaysType">
+    <xs:complexType name="standalone-deployment-overlaysType">
         <xs:annotation>
             <xs:documentation>
                 <![CDATA[
@@ -2316,11 +2316,11 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="deployment-overlay" type="deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="deployment-overlay" type="standalone-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="deployment-overlayType">
+    <xs:complexType name="standalone-deployment-overlayType">
         <xs:sequence>
             <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="deployment" type="deployment-overlay-deploymentType" minOccurs="0" maxOccurs="unbounded"/>
@@ -2328,18 +2328,26 @@
         <xs:attribute name="name" use="required" type="xs:token"/>
     </xs:complexType>
 
-    <xs:complexType name="deployment-overlay-contentType">
-        <xs:attribute name="path" type="xs:token" use="required"/>
-        <xs:attribute name="content" type="xs:token" use="required"/>
+    <xs:complexType name="domain-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="domain-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
     </xs:complexType>
 
-
-    <xs:complexType name="deployment-overlay-deploymentType">
-        <xs:attribute name="name" type="xs:string" use="required"/>
-        <xs:attribute name="regular-expression" type="xs:boolean" use="optional"/>
+    <xs:complexType name="domain-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
     </xs:complexType>
-
-
+        
     <xs:complexType name="server-group-deployment-overlaysType">
         <xs:annotation>
             <xs:documentation>
@@ -2359,5 +2367,15 @@
         </xs:sequence>
         <xs:attribute name="name" use="required" type="xs:token"/>
     </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-contentType">
+        <xs:attribute name="path" type="xs:token" use="required"/>
+        <xs:attribute name="content" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-deploymentType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
 
 </xs:schema>

--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -191,6 +191,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
                         processState.setRunning();
                     }
                 } catch (Throwable t) {
+                    t.printStackTrace();
                     container.shutdown();
                     if (t instanceof StackOverflowError) {
                         ROOT_LOGGER.errorBootingContainer(t, bootStackSize, BOOT_STACK_SIZE_PROPERTY);

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -209,7 +209,6 @@ public class ModelDescriptionConstants {
     public static final String RECURSIVE = "recursive";
     public static final String RECURSIVE_DEPTH = "recursive-depth";
     public static final String REDEPLOY = "redeploy";
-    public static final String REGULAR_EXPRESSION = "regular-expression";
     public static final String RELATIVE_TO = "relative-to";
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -94,7 +94,6 @@ public enum Attribute {
     PROTOCOL("protocol"),
     RECURSIVE("recursive"),
     REF("ref"),
-    REGULAR_EXPRESSION("regular-expression"),
     RELATIVE_TO("relative-to"),
     RUNTIME_NAME("runtime-name"),
     SEARCH_CREDENTIAL("search-credential"),

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
@@ -60,7 +60,7 @@ public class ChildFirstClassLoaderKernelServicesFactory {
 
         RunningModeControl runningModeControl = new HostRunningModeControl(RunningMode.ADMIN_ONLY, RestartMode.HC_ONLY);
         ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, runningModeControl);
-        return AbstractKernelServicesImpl.create(ProcessType.HOST_CONTROLLER, runningModeControl, validateOperations, bootOperations, testParser, legacyModelVersion, type, modelInitializer, extensionRegistry);
+        return AbstractKernelServicesImpl.create(ProcessType.HOST_CONTROLLER, runningModeControl, validateOperations, bootOperations, testParser, legacyModelVersion, type, modelInitializer, extensionRegistry, null);
     }
 
     private static class LegacyModelInitializer implements ModelInitializer {

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ClassLoaderObjectConverterImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ClassLoaderObjectConverterImpl.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.bridge.local.ClassLoaderObjectConverter;
 import org.jboss.as.core.model.bridge.shared.ObjectSerializer;
 import org.jboss.as.core.model.test.LegacyModelInitializerEntry;
+import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -86,6 +87,15 @@ public class ClassLoaderObjectConverterImpl implements ClassLoaderObjectConverte
         }
         try {
             return remote.deserializeLegacyModelInitializerEntry(local.serializeLegacyModelInitializerEntry(initializer));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Object convertIgnoreDomainTypeResourceToChildCl(IgnoreDomainResourceTypeResource resource) {
+        try {
+            return remote.deserializeIgnoreDomainTypeResource(local.serializeIgnoreDomainTypeResource(resource));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/local/ClassLoaderObjectConverter.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/local/ClassLoaderObjectConverter.java
@@ -23,6 +23,7 @@ package org.jboss.as.core.model.bridge.local;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.test.LegacyModelInitializerEntry;
+import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -35,4 +36,5 @@ public interface ClassLoaderObjectConverter {
     ModelNode convertModelNodeFromChildCl(Object object);
     Object convertModelVersionToChildCl(ModelVersion modelVersion);
     Object convertLegacyModelInitializerEntryToChildCl(LegacyModelInitializerEntry initializer);
+    Object convertIgnoreDomainTypeResourceToChildCl(IgnoreDomainResourceTypeResource resource);
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/local/ScopedKernelServicesBootstrap.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/local/ScopedKernelServicesBootstrap.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.bridge.impl.ChildFirstClassLoaderKernelServicesFactory;
 import org.jboss.as.core.model.bridge.impl.ClassLoaderObjectConverterImpl;
-import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.LegacyModelInitializerEntry;
 import org.jboss.dmr.ModelNode;
 
@@ -46,7 +45,7 @@ public class ScopedKernelServicesBootstrap {
     }
 
 
-    public KernelServices createKernelServices(List<ModelNode> bootOperations, boolean validateOperations, ModelVersion legacyModelVersion, List<LegacyModelInitializerEntry> modelInitializerEntries) throws Exception {
+    public LegacyControllerKernelServicesProxy createKernelServices(List<ModelNode> bootOperations, boolean validateOperations, ModelVersion legacyModelVersion, List<LegacyModelInitializerEntry> modelInitializerEntries) throws Exception {
 
         Object childClassLoaderKernelServices = createChildClassLoaderKernelServices(bootOperations, validateOperations, legacyModelVersion, modelInitializerEntries);
         return new LegacyControllerKernelServicesProxy(legacyChildFirstClassLoader, childClassLoaderKernelServices, objectConverter);

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/shared/ObjectSerializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/shared/ObjectSerializer.java
@@ -46,6 +46,10 @@ public interface ObjectSerializer {
 
     Object deserializeLegacyModelInitializerEntry(byte[] object) throws IOException;
 
+    byte[] serializeIgnoreDomainTypeResource(Object object) throws IOException;
+
+    Object deserializeIgnoreDomainTypeResource(byte[] object) throws IOException;
+
     public static class FACTORY {
         public static ObjectSerializer createSerializer(ClassLoader classLoader) {
             try {

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractKernelServicesImpl.java
@@ -71,11 +71,10 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         ServiceTarget target = container.subTarget();
 
         //Initialize the content repository
+        File repositoryFile = new File("target/deployment-repository");
         if (contentRepositoryHashes != null) {
-            File repositoryFile = new File("target/deployment-repository");
             deleteFile(repositoryFile);
-            ContentRepository.Factory.addService(target, repositoryFile);
-            ContentRepository repo = ContentRepository.Factory.create(repositoryFile);
+            repositoryFile.mkdir();
             for (String hash : contentRepositoryHashes) {
                 File file = new File(repositoryFile, hash.substring(0, 2));
                 file.mkdir();
@@ -85,6 +84,7 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
                 file.createNewFile();
             }
         }
+        ContentRepository.Factory.addService(target, repositoryFile);
 
         //Initialize the controller
         StringConfigurationPersister persister = new StringConfigurationPersister(bootOperations, testParser);
@@ -112,7 +112,7 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
                 new MainKernelServicesImpl(container, svc, persister, svc.getRootRegistration(),
                         new OperationValidator(svc.getRootRegistration()), legacyModelVersion, svc.isSuccessfulBoot(), svc.getBootError(), extensionRegistry) :
                             new LegacyKernelServicesImpl(container, svc, persister, svc.getRootRegistration(),
-                                    new OperationValidator(svc.getRootRegistration()), legacyModelVersion, svc.isSuccessfulBoot(), svc.getBootError(), extensionRegistry);
+                                    new OperationValidator(svc.getRootRegistration()), legacyModelVersion, svc.isSuccessfulBoot(), svc.getBootError(), extensionRegistry, ContentRepository.Factory.create(repositoryFile));
 
         return kernelServices;
     }
@@ -130,6 +130,8 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
     public abstract TransformedOperation transformOperation(ModelVersion modelVersion, ModelNode operation) throws OperationFailedException;
 
     public abstract ModelNode readTransformedModel(ModelVersion modelVersion);
+
+    public abstract ModelNode callReadMasterDomainModelHandler(ModelVersion modelVersion);
 
     public abstract ModelNode executeOperation(final ModelVersion modelVersion, final TransformedOperation op);
 

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractKernelServicesImpl.java
@@ -62,7 +62,7 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
     }
 
     public static AbstractKernelServicesImpl create(ProcessType processType, RunningModeControl runningModeControl, boolean validateOperations,
-            List<ModelNode> bootOperations, ModelTestParser testParser, ModelVersion legacyModelVersion, TestModelType type, ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry) throws Exception {
+            List<ModelNode> bootOperations, ModelTestParser testParser, ModelVersion legacyModelVersion, TestModelType type, ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry, List<String> contentRepositoryHashes) throws Exception {
 
         //TODO initialize the path manager service like we do for subsystems?
 
@@ -71,9 +71,20 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         ServiceTarget target = container.subTarget();
 
         //Initialize the content repository
-        File repositoryFile = new File("target/deployment-repository");
-        deleteFile(repositoryFile);
-        ContentRepository.Factory.addService(target, repositoryFile);
+        if (contentRepositoryHashes != null) {
+            File repositoryFile = new File("target/deployment-repository");
+            deleteFile(repositoryFile);
+            ContentRepository.Factory.addService(target, repositoryFile);
+            ContentRepository repo = ContentRepository.Factory.create(repositoryFile);
+            for (String hash : contentRepositoryHashes) {
+                File file = new File(repositoryFile, hash.substring(0, 2));
+                file.mkdir();
+                file = new File(file, hash.substring(2, hash.length()));
+                file.mkdir();
+                file = new File(file, "content");
+                file.createNewFile();
+            }
+        }
 
         //Initialize the controller
         StringConfigurationPersister persister = new StringConfigurationPersister(bootOperations, testParser);

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -57,10 +57,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +81,9 @@ import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.parsing.Namespace;
+import org.jboss.as.core.model.bridge.local.LegacyControllerKernelServicesProxy;
 import org.jboss.as.core.model.bridge.local.ScopedKernelServicesBootstrap;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
 import org.jboss.as.host.controller.HostRunningModeControl;
 import org.jboss.as.host.controller.RestartMode;
 import org.jboss.as.model.test.ChildFirstClassLoaderBuilder;
@@ -93,8 +96,6 @@ import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLMapper;
-import org.sonatype.aether.collection.DependencyCollectionException;
-import org.sonatype.aether.resolution.DependencyResolutionException;
 
 
 
@@ -427,18 +428,22 @@ public class CoreModelTestDelegate {
             for (Map.Entry<ModelVersion, LegacyKernelServicesInitializerImpl> entry : legacyControllerInitializers.entrySet()) {
                 LegacyKernelServicesInitializerImpl legacyInitializer = entry.getValue();
 
-                List<ModelNode> transformedBootOperations = new ArrayList<ModelNode>();
-                for (ModelNode op : bootOperations) {
+                List<ModelNode> transformedBootOperations;
+                if (legacyInitializer.isDontUseBootOperations()) {
+                    transformedBootOperations = Collections.emptyList();
+                } else {
+                    transformedBootOperations = new ArrayList<ModelNode>();
+                    for (ModelNode op : bootOperations) {
 
-                    ModelNode transformed = kernelServices.transformOperation(entry.getKey(), op).getTransformedOperation();
-                    if (transformed != null) {
-                        transformedBootOperations.add(transformed);
+                        ModelNode transformed = kernelServices.transformOperation(entry.getKey(), op).getTransformedOperation();
+                        if (transformed != null) {
+                            transformedBootOperations.add(transformed);
+                        }
                     }
                 }
 
-                KernelServices legacyServices = legacyInitializer.install(transformedBootOperations);
+                LegacyControllerKernelServicesProxy legacyServices = legacyInitializer.install(kernelServices, transformedBootOperations);
                 kernelServices.addLegacyKernelService(entry.getKey(), legacyServices);
-
             }
 
 
@@ -453,11 +458,11 @@ public class CoreModelTestDelegate {
         }
 
         @Override
-        public LegacyKernelServicesInitializer createLegacyKernelServicesBuilder(ModelVersion modelVersion) {
+        public LegacyKernelServicesInitializer createLegacyKernelServicesBuilder(ModelVersion modelVersion, TestControllerVersion testControllerVersion) {
             if (type != TestModelType.DOMAIN) {
                 throw new IllegalStateException("Can only create legacy kernel services for DOMAIN.");
             }
-            LegacyKernelServicesInitializerImpl legacyKernelServicesInitializerImpl = new LegacyKernelServicesInitializerImpl(modelVersion);
+            LegacyKernelServicesInitializerImpl legacyKernelServicesInitializerImpl = new LegacyKernelServicesInitializerImpl(modelVersion, testControllerVersion);
             legacyControllerInitializers.put(modelVersion, legacyKernelServicesInitializerImpl);
             return legacyKernelServicesInitializerImpl;
         }
@@ -474,22 +479,44 @@ public class CoreModelTestDelegate {
         private final ChildFirstClassLoaderBuilder classLoaderBuilder = new ChildFirstClassLoaderBuilder();
         private final ModelVersion modelVersion;
         private final List<LegacyModelInitializerEntry> modelInitializerEntries = new ArrayList<LegacyModelInitializerEntry>();
+        private final TestControllerVersion testControllerVersion;
         private boolean validateOperations = true;
+        private boolean dontUseBootOperations = false;
 
-        public LegacyKernelServicesInitializerImpl(ModelVersion modelVersion) {
+        public LegacyKernelServicesInitializerImpl(ModelVersion modelVersion, TestControllerVersion version) {
             this.modelVersion = modelVersion;
+            this.testControllerVersion = version;
         }
 
-        private KernelServices install(List<ModelNode> bootOperations) throws Exception {
-            classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-framework:7.2.0.Alpha1-SNAPSHOT");
-            classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-model-test:7.2.0.Alpha1-SNAPSHOT");
-            classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.core.model.bridge.shared.*");
-            ClassLoader legacyCl = classLoaderBuilder.build();
+        private LegacyControllerKernelServicesProxy install(AbstractKernelServicesImpl mainServices, List<ModelNode> bootOperations) throws Exception {
+            if (testControllerVersion == null) {
+                throw new IllegalStateException();
+            }
 
+            classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.core.model.bridge.shared.*");
+
+            File file = new File("target", "cached-classloader" + modelVersion + "_" + testControllerVersion);
+            boolean cached = file.exists();
+            ClassLoader legacyCl;
+            if (cached) {
+                classLoaderBuilder.createFromFile(file);
+                legacyCl = classLoaderBuilder.build();
+            } else {
+                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-framework:7.2.0.Alpha1-SNAPSHOT");
+                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-model-test:7.2.0.Alpha1-SNAPSHOT");
+
+                if (testControllerVersion != TestControllerVersion.MASTER) {
+                    classLoaderBuilder.addRecursiveMavenResourceURL(testControllerVersion.getLegacyControllerMavenGav());
+                    classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-controller-" + testControllerVersion.getTestControllerVersion() + ":" + VERSION);
+                }
+                legacyCl = classLoaderBuilder.build(file);
+            }
 
 
             ScopedKernelServicesBootstrap scopedBootstrap = new ScopedKernelServicesBootstrap(legacyCl);
-            return scopedBootstrap.createKernelServices(bootOperations, validateOperations, modelVersion, modelInitializerEntries);
+            LegacyControllerKernelServicesProxy legacyServices = scopedBootstrap.createKernelServices(bootOperations, validateOperations, modelVersion, modelInitializerEntries);
+
+            return legacyServices;
         }
 
         @Override
@@ -499,20 +526,20 @@ public class CoreModelTestDelegate {
         }
 
         @Override
-        public LegacyKernelServicesInitializer setTestControllerVersion(TestControllerVersion version) throws MalformedURLException, DependencyCollectionException, DependencyResolutionException {
-            classLoaderBuilder.addRecursiveMavenResourceURL(version.getLegacyControllerMavenGav());
-            if (version.getTestControllerVersion() != null) {
-                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-controller-" + version.getTestControllerVersion() + ":" + VERSION);
-            }
-            return this;
-        }
-
-        @Override
         public LegacyKernelServicesInitializer setDontValidateOperations() {
             validateOperations = false;
             return this;
         }
+
+        @Override
+        public LegacyKernelServicesInitializer setDontUseBootOperations() {
+            dontUseBootOperations = true;
+            return this;
+        }
+
+        boolean isDontUseBootOperations() {
+            return dontUseBootOperations;
+        }
+
     }
-
-
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -358,6 +358,7 @@ public class CoreModelTestDelegate {
         private boolean validateOperations = true;
         private XMLMapper xmlMapper = XMLMapper.Factory.create();
         private Map<ModelVersion, LegacyKernelServicesInitializerImpl> legacyControllerInitializers = new HashMap<ModelVersion, LegacyKernelServicesInitializerImpl>();
+        private List<String> contentRepositoryContents = new ArrayList<String>();
         RunningModeControl runningModeControl;
         ExtensionRegistry extensionRegistry;
 
@@ -403,10 +404,16 @@ public class CoreModelTestDelegate {
         }
 
 
+        @Override
+        public KernelServicesBuilder createContentRepositoryContent(String hash) {
+            contentRepositoryContents.add(hash);
+            return this;
+        }
+
         public KernelServices build() throws Exception {
             bootOperationBuilder.validateNotAlreadyBuilt();
             List<ModelNode> bootOperations = bootOperationBuilder.build();
-            AbstractKernelServicesImpl kernelServices = AbstractKernelServicesImpl.create(processType, runningModeControl, validateOperations, bootOperations, testParser, null, type, modelInitializer, extensionRegistry);
+            AbstractKernelServicesImpl kernelServices = AbstractKernelServicesImpl.create(processType, runningModeControl, validateOperations, bootOperations, testParser, null, type, modelInitializer, extensionRegistry, contentRepositoryContents);
             CoreModelTestDelegate.this.kernelServices.add(kernelServices);
 
             if (validateDescription) {

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServices.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServices.java
@@ -21,6 +21,11 @@
 */
 package org.jboss.as.core.model.test;
 
+import java.util.List;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
 import org.jboss.as.model.test.ModelTestKernelServices;
 
 /**
@@ -29,4 +34,13 @@ import org.jboss.as.model.test.ModelTestKernelServices;
  */
 public interface KernelServices extends ModelTestKernelServices<KernelServices> {
 
+    /**
+     * Applies the master domain model to the slave controller with the given model version
+     *
+     * @param modelVersion the model version of the legacy controller
+     * @param ignoredResources resources ignored on the legacy controller
+     * @throws IllegalStateException if we are not the main controller
+     * @throws OperationFailedException if something went wrong applying the master domain model
+     */
+    void applyMasterDomainModel(ModelVersion modelVersion, List<IgnoreDomainResourceTypeResource> ignoredResources);
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServicesBuilder.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServicesBuilder.java
@@ -29,7 +29,7 @@ import javax.xml.stream.XMLStreamException;
 import junit.framework.AssertionFailedError;
 
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.RunningMode;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -110,12 +110,12 @@ public interface KernelServicesBuilder {
      *
      * @param additionalInit Additional initialization that should be done to the parsers, controller and service container before initializing our extension
      * @param modelVersion The model version of the legacy subsystem
+     * @param testControllerVersion the version of the legacy controller to load up
      * @return the legacy kernel services initializer
-     * @throws IllegalArgumentException if {@code additionalInit} does not have a running mode of {@link RunningMode#ADMIN_ONLY}
      * @throws IllegalStateException if {@link #build()} has already been called
      * @throws AssertionFailedError if the extension class name was not found in the {@code resources}
      */
-     LegacyKernelServicesInitializer createLegacyKernelServicesBuilder(ModelVersion modelVersion);
+     LegacyKernelServicesInitializer createLegacyKernelServicesBuilder(ModelVersion modelVersion, TestControllerVersion testControllerVersion);
 
     /**
      * Creates the controller and initializes it with the passed in configuration options.

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServicesBuilder.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServicesBuilder.java
@@ -103,6 +103,7 @@ public interface KernelServicesBuilder {
      */
     KernelServicesBuilder setModelInitializer(ModelInitializer modelInitializer, ModelWriteSanitizer modelWriteSanitizer);
 
+    KernelServicesBuilder createContentRepositoryContent(String hash);
     /**
      * Creates a new legacy kernel services initializer used to configure a new controller containing an older version of the subsystem being tested.
      * When {@link #build()} is called any legacy controllers will be created as well.

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesImpl.java
@@ -21,14 +21,41 @@
 */
 package org.jboss.as.core.model.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_MODEL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_CLIENT_CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLAN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLANS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import java.util.List;
+
+import org.jboss.as.controller.ControlledProcessState.State;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.validation.OperationValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
+import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.domain.controller.operations.ApplyRemoteMasterDomainModelHandler;
+import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
+import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
+import org.jboss.as.management.client.content.ManagedDMRContentTypeResource;
 import org.jboss.as.model.test.ModelTestModelControllerService;
 import org.jboss.as.model.test.StringConfigurationPersister;
+import org.jboss.as.repository.ContentRepository;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceContainer;
 
@@ -37,14 +64,16 @@ import org.jboss.msc.service.ServiceContainer;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class LegacyKernelServicesImpl extends AbstractKernelServicesImpl {
+    private final ContentRepository contentRepository;
 
     public LegacyKernelServicesImpl(ServiceContainer container, ModelTestModelControllerService controllerService,
             StringConfigurationPersister persister, ManagementResourceRegistration rootRegistration,
             OperationValidator operationValidator, ModelVersion legacyModelVersion, boolean successfulBoot, Throwable bootError,
-            ExtensionRegistry extensionRegistry) {
+            ExtensionRegistry extensionRegistry, ContentRepository contentRepository) {
         // FIXME MainKernelServicesImpl constructor
         super(container, controllerService, persister, rootRegistration, operationValidator, legacyModelVersion, successfulBoot,
                 bootError, extensionRegistry);
+        this.contentRepository = contentRepository;
     }
 
     @Override
@@ -69,4 +98,168 @@ public class LegacyKernelServicesImpl extends AbstractKernelServicesImpl {
         return null;
     }
 
+    @Override
+    public ModelNode callReadMasterDomainModelHandler(ModelVersion modelVersion) {
+        //Will throw an error since we are not the main controller
+        checkIsMainController();
+        return null;
+    }
+
+    @Override
+    public void applyMasterDomainModel(ModelVersion modelVersion, List<IgnoreDomainResourceTypeResource> ignoredResources) {
+        //Will throw an error since we are not the main controller
+        checkIsMainController();
+    }
+
+    public void applyMasterDomainModel(ModelNode resources, List<IgnoreDomainResourceTypeResource> ignoredResources) {
+        ModelNode applyDomainModel = new ModelNode();
+        applyDomainModel.get(OP).set(ApplyRemoteMasterDomainModelHandler.OPERATION_NAME);
+        //FIXME this makes the op work after boot (i.e. slave connects to restarted master), but does not make the slave resync the servers
+        applyDomainModel.get(OPERATION_HEADERS, "execute-for-coordinator").set(true);
+        applyDomainModel.get(OP_ADDR).setEmptyList();
+        applyDomainModel.get(DOMAIN_MODEL).set(resources);
+
+        //Simulate ApplyRemoteMasterDomainModelHandler
+        final IgnoredDomainResourceRegistry ignoredResourceRegistry = createIgnoredDomainResourceRegistry(ignoredResources);
+        ModelNode result = internalExecute(applyDomainModel, new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                try {
+                    // We get the model as a list of resources descriptions
+                    final ModelNode domainModel = operation.get(DOMAIN_MODEL);
+                    final ModelNode startRoot = Resource.Tools.readModel(context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS));
+                    final Resource rootResource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
+
+                    for (final ModelNode resourceDescription : domainModel.asList()) {
+
+                        final PathAddress resourceAddress = PathAddress.pathAddress(resourceDescription.require("domain-resource-address"));
+                        if (ignoredResourceRegistry.isResourceExcluded(resourceAddress)) {
+                            continue;
+                        }
+
+                        final Resource resource = getResource(resourceAddress, rootResource, context);
+                        if (resourceAddress.size() == 1 && resourceAddress.getElement(0).getKey().equals(EXTENSION)) {
+                            // Extensions are handled in ApplyExtensionsHandler
+                            continue;
+                        }
+                        resource.writeModel(resourceDescription.get("domain-resource-model"));
+                    }
+
+                    context.completeStep();
+                }catch (Exception e) {
+                    throw new OperationFailedException(e.getMessage());
+                }
+            }
+
+            private Resource getResource(PathAddress resourceAddress, Resource rootResource, OperationContext context) {
+                if(resourceAddress.size() == 0) {
+                    return rootResource;
+                }
+                Resource temp = rootResource;
+                int idx = 0;
+                for(PathElement element : resourceAddress) {
+                    temp = temp.getChild(element);
+                    if(temp == null) {
+                        if (idx == 0) {
+                            String type = element.getKey();
+                            if (type.equals(EXTENSION)) {
+                                // Extensions are handled in ApplyExtensionsHandler
+                                continue;
+                            } else if (type.equals(MANAGEMENT_CLIENT_CONTENT) && element.getValue().equals(ROLLOUT_PLANS)) {
+                                // Needs a specialized resource type
+                                temp = new ManagedDMRContentTypeResource(element, ROLLOUT_PLAN, null, contentRepository);
+                                context.addResource(resourceAddress, temp);
+                            }
+                        }
+                        if (temp == null) {
+                            temp = context.createResource(resourceAddress);
+                        }
+                        break;
+                    }
+                    idx++;
+                }
+                return temp;
+            }
+        });
+
+        if (!SUCCESS.equals(result.get(OUTCOME).asString())) {
+            throw new RuntimeException(result.get(FAILURE_DESCRIPTION).asString());
+        }
+    }
+
+    private IgnoredDomainResourceRegistry createIgnoredDomainResourceRegistry(List<IgnoreDomainResourceTypeResource> ignoredResources) {
+        IgnoredDomainResourceRegistry reg = new IgnoredDomainResourceRegistry(new LocalHostControllerInfo() {
+
+            @Override
+            public boolean isMasterDomainController() {
+                return false;
+            }
+
+            @Override
+            public String getRemoteDomainControllerUsername() {
+                return null;
+            }
+
+            @Override
+            public int getRemoteDomainControllerPort() {
+                return 0;
+            }
+
+            @Override
+            public String getRemoteDomainControllerHost() {
+                return null;
+            }
+
+            @Override
+            public State getProcessState() {
+                return null;
+            }
+
+            @Override
+            public String getNativeManagementSecurityRealm() {
+                return null;
+            }
+
+            @Override
+            public int getNativeManagementPort() {
+                return 0;
+            }
+
+            @Override
+            public String getNativeManagementInterface() {
+                return null;
+            }
+
+            @Override
+            public String getLocalHostName() {
+                return null;
+            }
+
+            @Override
+            public String getHttpManagementSecurityRealm() {
+                return null;
+            }
+
+            @Override
+            public int getHttpManagementSecurePort() {
+                return 0;
+            }
+
+            @Override
+            public int getHttpManagementPort() {
+                return 0;
+            }
+
+            @Override
+            public String getHttpManagementInterface() {
+                return null;
+            }
+        });
+
+        for (IgnoreDomainResourceTypeResource resource : ignoredResources) {
+            reg.getRootResource().registerChild(PathElement.pathElement(ModelDescriptionConstants.IGNORED_RESOURCE_TYPE, resource.getName()), resource);
+        }
+
+        return reg;
+    }
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
@@ -21,13 +21,9 @@
 */
 package org.jboss.as.core.model.test;
 
-import java.net.MalformedURLException;
-
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.dmr.ModelNode;
-import org.sonatype.aether.collection.DependencyCollectionException;
-import org.sonatype.aether.resolution.DependencyResolutionException;
 
 /**
  *
@@ -39,7 +35,10 @@ public interface LegacyKernelServicesInitializer {
 
     LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model);
 
-    LegacyKernelServicesInitializer setTestControllerVersion(TestControllerVersion version) throws MalformedURLException, DependencyCollectionException, DependencyResolutionException;
+    /**
+     * If called, will not use boot operations rather ship across the model via ApplyRemoteMasterDomainHandler
+     */
+    LegacyKernelServicesInitializer setDontUseBootOperations();
 
     /**
      * The default is to validate the operations sent in to the model controller. Turn it off call this method
@@ -47,6 +46,7 @@ public interface LegacyKernelServicesInitializer {
      * @return this builder
      */
     LegacyKernelServicesInitializer setDontValidateOperations();
+
 
     public enum TestControllerVersion {
         MASTER ("org.jboss.as:jboss-as-host-controller:" + VERSION, null),

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTestCase.java
@@ -1,0 +1,74 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deploymentoverlay;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import junit.framework.Assert;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.core.model.test.ModelWriteSanitizer;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class DomainDeploymentOverlayTestCase extends AbstractCoreModelTest {
+
+    @Test
+    public void testDomainOverlays() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
+            .setXmlResource("domain.xml")
+            .setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER)
+            .createContentRepositoryContent("12345678901234567890")
+            .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), "domain.xml"), marshalled);
+    }
+
+    private static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
+        public void populateModel(Resource rootResource) {
+            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
+            rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
+        }
+    };
+
+    private final ModelWriteSanitizer XML_MODEL_WRITE_SANITIZER = new ModelWriteSanitizer() {
+        @Override
+        public ModelNode sanitize(ModelNode model) {
+            //Remove the profile and socket-binding-group removed by the initializer so the xml does not include a profile
+            model.remove(PROFILE);
+            model.remove(SOCKET_BINDING_GROUP);
+            return model;
+        }
+    };
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTestCase.java
@@ -21,19 +21,13 @@
 */
 package org.jboss.as.core.model.test.deploymentoverlay;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import junit.framework.Assert;
 
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
-import org.jboss.as.core.model.test.ModelInitializer;
-import org.jboss.as.core.model.test.ModelWriteSanitizer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
-import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 
 /**
@@ -46,7 +40,7 @@ public class DomainDeploymentOverlayTestCase extends AbstractCoreModelTest {
     public void testDomainOverlays() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
             .setXmlResource("domain.xml")
-            .setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER)
+            .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
             .createContentRepositoryContent("12345678901234567890")
             .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
@@ -54,21 +48,4 @@ public class DomainDeploymentOverlayTestCase extends AbstractCoreModelTest {
         String marshalled = kernelServices.getPersistedSubsystemXml();
         ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), "domain.xml"), marshalled);
     }
-
-    private static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
-        public void populateModel(Resource rootResource) {
-            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
-            rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
-        }
-    };
-
-    private final ModelWriteSanitizer XML_MODEL_WRITE_SANITIZER = new ModelWriteSanitizer() {
-        @Override
-        public ModelNode sanitize(ModelNode model) {
-            //Remove the profile and socket-binding-group removed by the initializer so the xml does not include a profile
-            model.remove(PROFILE);
-            model.remove(SOCKET_BINDING_GROUP);
-            return model;
-        }
-    };
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
@@ -1,0 +1,249 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deploymentoverlay;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import junit.framework.Assert;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.KernelServicesBuilder;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
+import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
+import org.jboss.as.model.test.ModelFixer;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@RunWith(Parameterized.class)
+public class DomainDeploymentOverlayTransformersTestCase extends AbstractCoreModelTest {
+
+    private final ModelVersion modelVersion;
+    private final TestControllerVersion testControllerVersion;
+
+    @Parameters
+    public static List<Object[]> parameters(){
+        return TransformersTestParameters.setupVersions();
+    }
+
+    public DomainDeploymentOverlayTransformersTestCase(TransformersTestParameters params) {
+        this.modelVersion = params.getModelVersion();
+        this.testControllerVersion = params.getTestControllerVersion();
+    }
+
+    @Test
+    public void testDeploymentOverlaysTransformer() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain.xml");
+
+        LegacyKernelServicesInitializer legacyInitializer = StandardServerGroupInitializers.addServerGroupInitializers(builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion));
+
+        if (modelVersion.getMajor() == 1 && modelVersion.getMinor() < 4) {
+            testDeploymentOverlaysTransformer_7_1_x(modelVersion, builder, legacyInitializer);
+        } else {
+            testDeploymentOverlaysTransformerMaster(modelVersion, builder, legacyInitializer);
+        }
+    }
+
+    @Test
+    public void testDeploymentOverlaysNotIgnoredOnOlderVersionFails() throws Exception {
+        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() >= 4) {
+            return;
+        }
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain.xml");
+
+        //Start up an empty legacy controller
+        StandardServerGroupInitializers.addServerGroupInitializers(
+                    builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
+                )
+                .setDontUseBootOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        //Since we had not set up the ignores the legacy controller cannot have the master model applied
+        try {
+            mainServices.applyMasterDomainModel(modelVersion, null);
+            Assert.fail("Should have failed to apply model without deployment-overlay ignored on host");
+        } catch(Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("14738")); //14738 comes from ControllerMessages.noChildType(String)
+        }
+    }
+
+    @Test
+    public void testDeploymentOverlaysIgnoredOnOlderVersionGetIgnoredButFailDueToServerGroupEntry() throws Exception {
+        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() >= 4) {
+            return;
+        }
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain.xml");
+
+        //Start up an empty legacy controller
+        StandardServerGroupInitializers.addServerGroupInitializers(
+                    builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
+                )
+                .setDontUseBootOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        //Since the server group deployment deployment-overlay is there we should fail
+        try {
+            mainServices.applyMasterDomainModel(modelVersion, null);
+            Assert.fail("Should have failed to apply model since server group still has a deployment overlay");
+        } catch(Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("14738")); //14738 comes from ControllerMessages.noChildType(String)
+        }
+    }
+
+    @Test
+    public void testDeploymentOverlaysIgnoredOnOlderVersionGetIgnored() throws Exception {
+        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() >= 4) {
+            return;
+        }
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain-no-servergroup-overlay.xml");
+
+        //Start up an empty legacy controller
+        StandardServerGroupInitializers.addServerGroupInitializers(
+                    builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
+                )
+                .setDontUseBootOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        //This should pass since the deployment-overlay resource is ignored, and there is no use of deployment-overlay in server-group
+        mainServices.applyMasterDomainModel(modelVersion, Collections.singletonList(new IgnoreDomainResourceTypeResource(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, new ModelNode(), true)));
+
+        //Check deployment overlays exist in the master model but not in the legacy model
+        ModelNode masterModel = mainServices.readWholeModel();
+        ModelNode legacyModel = legacyServices.readWholeModel();
+        Assert.assertTrue(masterModel.hasDefined(ModelDescriptionConstants.DEPLOYMENT_OVERLAY) && masterModel.get(ModelDescriptionConstants.DEPLOYMENT_OVERLAY).hasDefined("test-overlay"));
+        Assert.assertFalse(legacyModel.hasDefined(ModelDescriptionConstants.DEPLOYMENT_OVERLAY));
+
+        //Compare the transformed and legacy models
+        checkCoreModelTransformation(
+                mainServices,
+                modelVersion,
+                new ModelFixer() {
+                    @Override
+                    public ModelNode fixModel(ModelNode modelNode) {
+                        //This one is just noise due to a different format
+                        //Perhaps this should go into the model comparison itself?
+                        ModelNode socketBindingGroup = modelNode.get(SOCKET_BINDING_GROUP, "test-sockets");
+                        if (socketBindingGroup.isDefined()) {
+                            Set<String> names = new HashSet<String>();
+                            for (String key : socketBindingGroup.keys()) {
+                                if (!socketBindingGroup.get(key).isDefined()) {
+                                    names.add(key);
+                                }
+                            }
+                            for(String name : names) {
+                                socketBindingGroup.remove(name);
+                            }
+                            if (socketBindingGroup.keys().size() == 0) {
+                                socketBindingGroup.clear();
+                            }
+                        }
+                        return modelNode;
+                    }
+                },
+                new ModelFixer() {
+                    @Override
+                    public ModelNode fixModel(ModelNode modelNode) {
+                        modelNode.remove(ModelDescriptionConstants.DEPLOYMENT_OVERLAY);
+                        return modelNode;
+                    }
+                });
+    }
+    private void testDeploymentOverlaysTransformer_7_1_x(ModelVersion modelVersion, KernelServicesBuilder builder, LegacyKernelServicesInitializer legacyInitializer) throws Exception {
+        //Don't validate ops since they definitely won't exist in target controller
+        legacyInitializer.setDontValidateOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertFalse(legacyServices.isSuccessfulBoot());
+
+    }
+
+    private void testDeploymentOverlaysTransformerMaster(ModelVersion modelVersion, KernelServicesBuilder builder, LegacyKernelServicesInitializer legacyInitializer) throws Exception {
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkCoreModelTransformation(mainServices, modelVersion, MODEL_FIXER, MODEL_FIXER);
+
+    }
+
+    private final ModelFixer MODEL_FIXER = new ModelFixer() {
+
+        @Override
+        public ModelNode fixModel(ModelNode modelNode) {
+            modelNode.remove(SOCKET_BINDING_GROUP);
+            modelNode.remove(PROFILE);
+            return modelNode;
+        }
+    };
+
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/StandaloneDeploymentOverlayTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/StandaloneDeploymentOverlayTestCase.java
@@ -1,0 +1,49 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deploymentoverlay;
+
+import junit.framework.Assert;
+
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class StandaloneDeploymentOverlayTestCase extends AbstractCoreModelTest {
+
+    @Test
+    public void testDomainOverlays() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.STANDALONE)
+            .setXmlResource("standalone.xml")
+            .createContentRepositoryContent("12345678901234567890")
+            .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), "standalone.xml"), marshalled);
+    }
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/InterfacesTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/InterfacesTransformersTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
-import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.core.model.test.util.TransformersTestParameters;
@@ -61,8 +60,7 @@ public class InterfacesTransformersTestCase extends AbstractCoreModelTest {
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXmlResource("domain.xml");
 
-        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion)
-            .setTestControllerVersion(testControllerVersion);
+        builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion);
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/DomainModelJvmModelTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/DomainModelJvmModelTestCase.java
@@ -22,9 +22,7 @@
 package org.jboss.as.core.model.test.jvm;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import junit.framework.Assert;
 
 import org.jboss.as.controller.PathAddress;
@@ -32,8 +30,8 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.ModelInitializer;
-import org.jboss.as.core.model.test.ModelWriteSanitizer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
@@ -54,7 +52,7 @@ public class DomainModelJvmModelTestCase extends GlobalJvmModelTestCase {
     public void testFullJvmXml() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder()
                 .setXmlResource("domain-full.xml")
-                .setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
                 .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
         String xml = kernelServices.getPersistedSubsystemXml();
@@ -70,7 +68,7 @@ public class DomainModelJvmModelTestCase extends GlobalJvmModelTestCase {
     public void testEmptyJvmXml() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder()
                 .setXmlResource("domain-empty.xml")
-                .setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
                 .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
         String xml = kernelServices.getPersistedSubsystemXml();
@@ -97,21 +95,4 @@ public class DomainModelJvmModelTestCase extends GlobalJvmModelTestCase {
     protected ModelNode getPathAddress(String jvmName, String... subaddress) {
         return PathAddress.pathAddress(PARENT, PathElement.pathElement(JVM, "test")).toModelNode();
     }
-
-    private static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
-        public void populateModel(Resource rootResource) {
-            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
-            rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
-        }
-    };
-
-    private final ModelWriteSanitizer XML_MODEL_WRITE_SANITIZER = new ModelWriteSanitizer() {
-        @Override
-        public ModelNode sanitize(ModelNode model) {
-            //Remove the profile and socket-binding-group removed by the initializer so the xml does not include a profile
-            model.remove(PROFILE);
-            model.remove(SOCKET_BINDING_GROUP);
-            return model;
-        }
-    };
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/PathsTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/PathsTransformersTestCase.java
@@ -61,8 +61,7 @@ public class PathsTransformersTestCase extends AbstractCoreModelTest {
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXmlResource("domain.xml");
 
-        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion)
-            .setTestControllerVersion(testControllerVersion);
+        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion);
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/profile/ProfileTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/profile/ProfileTransformersTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
-import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.core.model.test.util.TransformersTestParameters;
@@ -62,8 +61,7 @@ public class ProfileTransformersTestCase extends AbstractCoreModelTest {
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXmlResource("domain.xml");
 
-        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion)
-            .setTestControllerVersion(testControllerVersion);
+        builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion);
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/SocketBindingGroupTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/SocketBindingGroupTransformersTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
-import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.core.model.test.util.TransformersTestParameters;
@@ -62,8 +61,7 @@ public class SocketBindingGroupTransformersTestCase extends AbstractCoreModelTes
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXmlResource("domain.xml");
 
-        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion)
-            .setTestControllerVersion(testControllerVersion);
+        builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion);
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
@@ -31,14 +31,13 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
 import org.jboss.as.core.model.test.util.TransformersTestParameters;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.dmr.ModelNode;
@@ -71,14 +70,12 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXmlResource(xmlResource);
         if (serverGroup) {
-            builder.setModelInitializer(DomainServerGroupSystemPropertyTestCase.XML_MODEL_INITIALIZER, DomainServerGroupSystemPropertyTestCase.XML_MODEL_WRITE_SANITIZER);
+            builder.setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER);
         }
 
-        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion)
-            .setTestControllerVersion(testControllerVersion);
+        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion);
         if (serverGroup) {
-            legacyInitializer.initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(PROFILE, "test"), null);
-            legacyInitializer.initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), new ModelNode().setEmptyObject());
+            StandardServerGroupInitializers.addServerGroupInitializers(legacyInitializer);
         }
 
         KernelServices mainServices = builder.build();

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTestCase.java
@@ -21,9 +21,7 @@
 */
 package org.jboss.as.core.model.test.systemproperty;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import junit.framework.Assert;
 
@@ -33,8 +31,8 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.ModelInitializer;
-import org.jboss.as.core.model.test.ModelWriteSanitizer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 
@@ -57,7 +55,7 @@ public class DomainServerGroupSystemPropertyTestCase extends AbstractSystemPrope
     protected KernelServicesBuilder createKernelServicesBuilder(boolean xml) {
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN);
         if (xml) {
-            builder.setModelInitializer(XML_MODEL_INITIALIZER, XML_MODEL_WRITE_SANITIZER);
+            builder.setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER);
         }
         return builder;
     }
@@ -82,23 +80,6 @@ public class DomainServerGroupSystemPropertyTestCase extends AbstractSystemPrope
         public void populateModel(Resource rootResource) {
             Resource host = Resource.Factory.create();
             rootResource.registerChild(PARENT.getElement(0), host);
-        }
-    };
-
-    static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
-        public void populateModel(Resource rootResource) {
-            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
-            rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
-        }
-    };
-
-    static final ModelWriteSanitizer XML_MODEL_WRITE_SANITIZER = new ModelWriteSanitizer() {
-        @Override
-        public ModelNode sanitize(ModelNode model) {
-            //Remove the profile and socket-binding-group removed by the initializer so the xml does not include a profile
-            model.remove(PROFILE);
-            model.remove(SOCKET_BINDING_GROUP);
-            return model;
         }
     };
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
@@ -1,0 +1,63 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.util;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.core.model.test.ModelWriteSanitizer;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class StandardServerGroupInitializers {
+    public static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
+        public void populateModel(Resource rootResource) {
+            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
+            rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
+        }
+    };
+
+    public static final ModelWriteSanitizer XML_MODEL_WRITE_SANITIZER = new ModelWriteSanitizer() {
+        @Override
+        public ModelNode sanitize(ModelNode model) {
+            //Remove the profile and socket-binding-group removed by the initializer so the xml does not include a profile
+            model.remove(PROFILE);
+            model.remove(SOCKET_BINDING_GROUP);
+            return model;
+        }
+    };
+
+    public static LegacyKernelServicesInitializer addServerGroupInitializers(LegacyKernelServicesInitializer legacyKernelServicesInitializer) {
+        legacyKernelServicesInitializer.initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(PROFILE, "test"), null)
+            .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), null);
+        return legacyKernelServicesInitializer;
+    }
+
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
@@ -36,7 +36,7 @@ public class TransformersTestParameters {
     private final ModelVersion modelVersion;
     private final TestControllerVersion testControllerVersion;
 
-    protected TransformersTestParameters(ModelVersion modelVersion, TestControllerVersion testControllerVersion) {
+    public TransformersTestParameters(ModelVersion modelVersion, TestControllerVersion testControllerVersion) {
         this.modelVersion = modelVersion;
         this.testControllerVersion = testControllerVersion;
     }
@@ -57,6 +57,17 @@ public class TransformersTestParameters {
         List<Object[]> data = new ArrayList<Object[]>();
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), TestControllerVersion.V7_1_2_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), TestControllerVersion.MASTER)});
+        for (int i = 0 ; i < data.size() ; i++) {
+            Object[] entry = data.get(i);
+            System.out.println("Parameter " + i + ": " + entry[0]);
+        }
         return data;
     }
+
+    @Override
+    public String toString() {
+        return "TransformersTestParameters={modelVersion=" + modelVersion + "; testControllerVersion=" + testControllerVersion + "}";
+    }
+
+
 }

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
@@ -14,10 +14,6 @@ This is the shipped configuration with the extensions and profiles removed
         <server-group name="test" profile="test">
            <!-- Needed for the add operation -->
            <socket-binding-group ref="test-sockets"/>
-	        <deployment-overlays>
-		         <deployment-overlay name="test-overlay">
-	            </deployment-overlay>
-	        </deployment-overlays>
         </server-group> 
     </server-groups>
 </domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+This is the shipped configuration with the extensions and profiles removed  
+ -->
+
+<domain xmlns="urn:jboss:domain:1.4">
+    <deployment-overlays>
+        <deployment-overlay name="test-overlay">
+            <content path="/test/123" content="12345678901234567890"/>
+            <!--
+               The xsd mentions this element but there is no resource for it 
+            deployment name="test.war"/>  -->
+        </deployment-overlay>
+    </deployment-overlays>
+    <server-groups>
+        <server-group name="test" profile="test">
+           <!-- Needed for the add operation -->
+           <socket-binding-group ref="test-sockets"/>
+	        <deployment-overlays>
+		         <deployment-overlay name="test-overlay">
+	            </deployment-overlay>
+	        </deployment-overlays>
+        </server-group> 
+    </server-groups>
+</domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<server xmlns="urn:jboss:domain:1.4">
+    <deployment-overlays>
+        <deployment-overlay name="test-overlay">
+            <content path="/test/123" content="12345678901234567890"/>
+            <deployment name="test.war"/>
+        </deployment-overlay>
+    </deployment-overlays>
+</server>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
@@ -47,7 +47,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PAT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE_NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REGULAR_EXPRESSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE_DESTINATION_OUTBOUND_SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
@@ -577,11 +576,8 @@ public final class ManagedServerOperationsFactory {
                         for (Property content : deploymentsNode.get(DEPLOYMENT).asPropertyList()) {
                             final String deploymentName = content.getName();
                             final ModelNode deploymentDetails = content.getValue();
-                            boolean regEx = deploymentDetails.hasDefined(REGULAR_EXPRESSION) ? deploymentDetails.require(REGULAR_EXPRESSION).asBoolean() : false;
-
                             addr = PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT_OVERLAY, name), PathElement.pathElement(DEPLOYMENT, deploymentName));
                             addOp = Util.getEmptyOperation(ADD, addr.toModelNode());
-                            addOp.get(REGULAR_EXPRESSION).set(regEx);
                             updates.add(addOp);
                         }
                         }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoreDomainResourceTypeResource.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoreDomainResourceTypeResource.java
@@ -22,9 +22,10 @@
 
 package org.jboss.as.host.controller.ignored;
 
-import java.util.LinkedHashSet;
+import static org.jboss.as.host.controller.ignored.IgnoredDomainTypeResourceDefinition.NAMES;
+import static org.jboss.as.host.controller.ignored.IgnoredDomainTypeResourceDefinition.WILDCARD;
 
-import static org.jboss.as.host.controller.ignored.IgnoredDomainTypeResourceDefinition.*;
+import java.util.LinkedHashSet;
 
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.PlaceholderResource;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoredDomainResourceRoot.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoredDomainResourceRoot.java
@@ -23,8 +23,7 @@
 package org.jboss.as.host.controller.ignored;
 
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED_RESOURCE_TYPE;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -425,7 +425,7 @@ public class DomainXml extends CommonXml {
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.DEPLOYMENT_OVERLAYS) {
-            parseDeploymentOverlays(reader, expectedNs, new ModelNode(), list);
+            parseDeploymentOverlays(reader, expectedNs, new ModelNode(), list, true, false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.SERVER_GROUPS) {
@@ -763,7 +763,7 @@ public class DomainXml extends CommonXml {
                         break;
                     }
                     case DEPLOYMENT_OVERLAYS: {
-                        parseDeploymentOverlays(reader, expectedNs, groupAddress, list);
+                        parseDeploymentOverlays(reader, expectedNs, groupAddress, list, false, true);
                         break;
                     }
                     case SYSTEM_PROPERTIES: {

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentAdd.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentAdd.java
@@ -64,12 +64,11 @@ public class DeploymentOverlayDeploymentAdd extends AbstractAddStepHandler {
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String name = address.getLastElement().getValue();
         final String deploymentOverlay =address.getElement(address.size() - 2).getValue();
-        final Boolean regularExpression = DeploymentOverlayDeploymentDefinition.REGULAR_EXPRESSION.resolveModelAttribute(context, model).asBoolean();
-        installServices(context, verificationHandler, newControllers, name, deploymentOverlay, regularExpression, priority);
+        installServices(context, verificationHandler, newControllers, name, deploymentOverlay, priority);
     }
 
-    static void installServices(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final String name, final String deploymentOverlay, final boolean regularExpression, final DeploymentOverlayPriority priority) {
-        final DeploymentOverlayLinkService service = new DeploymentOverlayLinkService(name, regularExpression, priority);
+    static void installServices(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final String name, final String deploymentOverlay, final DeploymentOverlayPriority priority) {
+        final DeploymentOverlayLinkService service = new DeploymentOverlayLinkService(name, priority);
 
         final ServiceName serviceName = DeploymentOverlayLinkService.SERVICE_NAME.append(deploymentOverlay).append(name);
         ServiceBuilder<DeploymentOverlayLinkService> builder = context.getServiceTarget().addService(serviceName, service)

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentDefinition.java
@@ -23,16 +23,11 @@
 package org.jboss.as.server.deploymentoverlay;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.server.deploymentoverlay.service.DeploymentOverlayPriority;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 
 /**
  * Links a deployment overlay to a deployment
@@ -40,15 +35,7 @@ import org.jboss.dmr.ModelType;
  */
 public class DeploymentOverlayDeploymentDefinition extends SimpleResourceDefinition {
 
-    static final SimpleAttributeDefinition REGULAR_EXPRESSION =
-            new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.REGULAR_EXPRESSION, ModelType.BOOLEAN, false)
-                    .setAllowExpression(true)
-                    .setDefaultValue(new ModelNode().set(false))
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
-                    .build();
-
-
-    private static final AttributeDefinition[] ATTRIBUTES = { REGULAR_EXPRESSION };
+    private static final AttributeDefinition[] ATTRIBUTES = {  };
 
     public static AttributeDefinition[] attributes() {
         return ATTRIBUTES.clone();

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemove.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemove.java
@@ -51,8 +51,7 @@ public class DeploymentOverlayDeploymentRemove extends AbstractRemoveStepHandler
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String name = address.getLastElement().getValue();
         final String deploymentOverlay = address.getElement(address.size() - 2).getValue();
-        final Boolean regularExpression = DeploymentOverlayDeploymentDefinition.REGULAR_EXPRESSION.resolveModelAttribute(context, model).asBoolean();
-        DeploymentOverlayDeploymentAdd.installServices(context, null, null, name, deploymentOverlay, regularExpression, priority);
+        DeploymentOverlayDeploymentAdd.installServices(context, null, null, name, deploymentOverlay, priority);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayIndexService.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayIndexService.java
@@ -72,7 +72,7 @@ public class DeploymentOverlayIndexService implements Service<DeploymentOverlayI
 
         final List<DeploymentOverlayLinkService> matched = new ArrayList<DeploymentOverlayLinkService>();
         for (final DeploymentOverlayLinkService service : services) {
-            if (service.isRegex()) {
+            if (service.isWildcard()) {
                 if (service.getPattern().matcher(deploymentName).matches()) {
                     matched.add(service);
                 }
@@ -87,9 +87,9 @@ public class DeploymentOverlayIndexService implements Service<DeploymentOverlayI
                 if (res != 0) {
                     return res;
                 }
-                if (o2.isRegex() && !o1.isRegex()) {
+                if (o2.isWildcard() && !o1.isWildcard()) {
                     return -1;
-                } else if (o1.isRegex() && !o2.isRegex()) {
+                } else if (o1.isWildcard() && !o2.isWildcard()) {
                     return 1;
                 }
                 return 0;

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
@@ -53,17 +53,13 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
     private final String deployment;
     private final DeploymentOverlayPriority priority;
     private final Pattern pattern;
-    private final boolean regex;
+    private final boolean wildcard;
 
-    public DeploymentOverlayLinkService(final String deployment, final boolean regex, final DeploymentOverlayPriority priority) {
+    public DeploymentOverlayLinkService(final String deployment, final DeploymentOverlayPriority priority) {
         this.deployment = deployment;
         this.priority = priority;
-        this.regex = regex;
-        if (regex) {
-            this.pattern = Pattern.compile(wildcardToJavaRegexp(deployment));
-        } else {
-            this.pattern = null;
-        }
+        this.pattern = Pattern.compile(wildcardToJavaRegexp(deployment));
+        wildcard = deployment.contains("*") || deployment.contains("?");
     }
 
     @Override
@@ -101,7 +97,7 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
         return pattern;
     }
 
-    public boolean isRegex() {
-        return regex;
+    public boolean isWildcard() {
+        return wildcard;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -468,7 +468,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
         }
 
         if (element == Element.DEPLOYMENT_OVERLAYS) {
-            parseDeploymentOverlays(reader, namespace, new ModelNode(), list);
+            parseDeploymentOverlays(reader, namespace, new ModelNode(), list, true, true);
             element = nextElement(reader, namespace);
         }
         if (element != null) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -270,7 +270,6 @@ public class DeploymentOverlayTestCase {
         addr.add(ModelDescriptionConstants.DEPLOYMENT, "*.war");
         op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
         op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-        op.get(ModelDescriptionConstants.REGULAR_EXPRESSION).set(true);
         steps.add(op);
 
         executeOnMaster(opBuilder.build());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
@@ -106,7 +106,6 @@ public class DeploymentOverlayTestCase {
             addr.add(ModelDescriptionConstants.DEPLOYMENT, "*.war");
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            op.get(ModelDescriptionConstants.REGULAR_EXPRESSION).set(true);
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
         }
 


### PR DESCRIPTION
No transformation is added for deployment overlays for older slaves not having it. Using an older slave against a DC with deployment overlays will fail unless deployment overlays are ignored resources on the slave.

I have not tested deployment overlay operations on the DC being ignored on the slaves having them as ignored resources, as I believe that is already tested elsewhere as part of the core framework
