### PR TITLE
Add a test for WELD-848 to the PassivationSucceedsUnitTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ManagedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ManagedBean.java
@@ -1,0 +1,22 @@
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * 
+ * @author Marek Schmidt
+ *
+ */
+@ApplicationScoped
+public class ManagedBean
+{
+    private String message = "foo";
+   
+    public void setMessage(String message) {
+        this.message = message;
+    }
+   
+    public String getMessage() {
+        return message;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationSucceedsUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationSucceedsUnitTestCase.java
@@ -31,6 +31,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
@@ -54,6 +55,7 @@ public class PassivationSucceedsUnitTestCase {
     public static Archive<?> deploy() throws Exception {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "passivation-test.jar");
         jar.addPackage(PassivationSucceedsUnitTestCase.class.getPackage());
+        jar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"),
                 "MANIFEST.MF");
         jar.addAsManifestResource(PassivationSucceedsUnitTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
@@ -69,6 +71,7 @@ public class PassivationSucceedsUnitTestCase {
         Assert.assertEquals("Returned remote1 result was not expected", TestPassivationRemote.EXPECTED_RESULT,
                 remote1.returnTrueString());
         remote1.addEntity(1, "Bob");
+        remote1.setManagedBeanMessage("bar");
         Assert.assertTrue(remote1.isPersistenceContextSame());
 
         TestPassivationRemote remote2 = (TestPassivationRemote) ctx.lookup("java:module/"
@@ -88,6 +91,8 @@ public class PassivationSucceedsUnitTestCase {
         Assert.assertTrue(remote2.isPersistenceContextSame());
         Assert.assertEquals("Super", remote1.getSuperEmployee().getName());
         Assert.assertEquals("Super", remote2.getSuperEmployee().getName());
+        Assert.assertEquals("bar", remote1.getManagedBeanMessage());
+        Assert.assertEquals("bar", remote2.getManagedBeanMessage());
 
         remote1.remove();
         remote2.remove();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationBean.java
@@ -32,6 +32,7 @@ import javax.ejb.PrePassivate;
 import javax.ejb.Remote;
 import javax.ejb.Remove;
 import javax.ejb.Stateful;
+import javax.inject.Inject;
 import javax.interceptor.Interceptors;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -54,6 +55,9 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
 
     @EJB
     private NestledBean nestledBean;
+    
+    @Inject
+    private ManagedBean managedBean;
 
     private String identificator;
     private boolean beenPassivated = false;
@@ -96,6 +100,14 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
         e.setId(id);
         entityManager.persist(e);
         entityManager.flush();
+    }
+
+    public void setManagedBeanMessage(String message) {
+        this.managedBean.setMessage(message);
+    }
+
+    public String getManagedBeanMessage() {
+        return managedBean.getMessage();
     }
 
     @PostConstruct

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationRemote.java
@@ -56,4 +56,11 @@ public interface TestPassivationRemote {
     void remove();
 
     Employee getSuperEmployee();
+    
+    /**
+     * returns a value of a property of a CDI bean 
+     */
+    String getManagedBeanMessage();
+    
+    void setManagedBeanMessage(String message);
 }


### PR DESCRIPTION
test proving to Ales that WELD-848 is not an issue on AS7.

see https://issues.jboss.org/browse/WELD-848

I believe this test does belong more to the ejb passivation tests family than weld, hence this pull request. It adds beans.xml and an @ApplicationScoped CDI bean to the ejb/stateful/passivation/PassivationSucceedsUnitTestCase. 
