### PR TITLE
Fix failing logging tests on some platforms

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -70,8 +70,8 @@
                         -javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <jboss.server.log.dir>${project.build.directory}/logs</jboss.server.log.dir>
-                        <jboss.server.config.dir>${project.build.directory}/config</jboss.server.config.dir>
+                        <jboss.server.log.dir>${project.build.directory}${file.separator}logs</jboss.server.log.dir>
+                        <jboss.server.config.dir>${project.build.directory}${file.separator}config</jboss.server.config.dir>
                         <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
                         <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
                     </systemPropertyVariables>

--- a/logging/src/main/java/org/jboss/as/logging/LoggerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggerOperations.java
@@ -180,18 +180,6 @@ final class LoggerOperations {
             if (configuration == null) {
                 throw createOperationFailure(LoggingMessages.MESSAGES.loggerNotFound(loggerName));
             }
-            // This is a bit of a hack, but since loggers don't really get removed, set the logger to match the root logger.
-            final LoggerConfiguration rootConfiguration = logContextConfiguration.getLoggerConfiguration(ROOT_LOGGER_NAME);
-            if (rootConfiguration != null) {
-                configuration.setLevel(rootConfiguration.getLevel());
-                configuration.setFilter(rootConfiguration.getFilter());
-                configuration.setUseParentHandlers(true);
-                configuration.setHandlerNames(Collections.<String>emptyList());
-                // Commit the current changes as they need to be committed on a configured logger.
-                // TODO need to use the API when available
-                ConfigurationPersistence configurationPersistence = ConfigurationPersistence.getConfigurationPersistence(logContextConfiguration.getLogContext());
-                if (configurationPersistence != null) configurationPersistence.prepare();
-            }
             logContextConfiguration.removeLoggerConfiguration(loggerName);
         }
     };

--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -42,10 +42,12 @@ import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.config.FormatterConfiguration;
 import org.jboss.logmanager.config.HandlerConfiguration;
 import org.jboss.logmanager.config.LogContextConfiguration;
 import org.jboss.logmanager.config.LoggerConfiguration;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
@@ -79,6 +81,39 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
     public static void setUp() {
         // Just need to set-up the test environment
         LoggingTestEnvironment.get();
+    }
+
+    @After
+    public void clearLogContext() {
+        clearLogContext(LogContext.getLogContext());
+    }
+
+    protected void clearLogContext(final LogContext logContext) {
+        final ConfigurationPersistence configuration = ConfigurationPersistence.getConfigurationPersistence(logContext);
+        if (configuration != null) {
+            final LogContextConfiguration logContextConfiguration = configuration.getLogContextConfiguration();
+            // Remove all loggers
+            for (String loggerName : logContextConfiguration.getLoggerNames()) {
+                logContextConfiguration.removeLoggerConfiguration(loggerName);
+            }
+            // Remove all the handlers
+            for (String handlerName : logContextConfiguration.getHandlerNames()) {
+                logContextConfiguration.removeHandlerConfiguration(handlerName);
+            }
+            // Remove all the filters
+            for (String filterName : logContextConfiguration.getFilterNames()) {
+                logContextConfiguration.removeFilterConfiguration(filterName);
+            }
+            // Remove all the formatters
+            for (String formatterName : logContextConfiguration.getFormatterNames()) {
+                logContextConfiguration.removeFormatterConfiguration(formatterName);
+            }
+            // Remove all the error managers
+            for (String errorManager : logContextConfiguration.getErrorManagerNames()) {
+                logContextConfiguration.removeErrorManagerConfiguration(errorManager);
+            }
+            configuration.commit();
+        }
     }
 
     @Override

--- a/logging/src/test/java/org/jboss/as/logging/LoggingOperationsSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingOperationsSubsystemTestCase.java
@@ -38,6 +38,7 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.Logger;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -65,6 +66,17 @@ public class LoggingOperationsSubsystemTestCase extends AbstractLoggingSubsystem
         logDir = LoggingTestEnvironment.get().getLogDir();
         for (File file : logDir.listFiles()) {
             file.delete();
+        }
+    }
+
+    @After
+    @Override
+    public void clearLogContext() {
+        super.clearLogContext();
+        final LoggingProfileContextSelector contextSelector = LoggingProfileContextSelector.getInstance();
+        if (contextSelector.exists(PROFILE)) {
+            clearLogContext(contextSelector.get(PROFILE));
+            contextSelector.remove(PROFILE);
         }
     }
 

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
@@ -34,7 +34,6 @@ import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.LogContext;
-import org.jboss.logmanager.config.LogContextConfiguration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,40 +57,13 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
     }
 
     @After
-    public void cleanUp() throws Exception {
-        cleanUp(LogContext.getLogContext());
+    @Override
+    public void clearLogContext() {
+        super.clearLogContext();
         final LoggingProfileContextSelector contextSelector = LoggingProfileContextSelector.getInstance();
         if (contextSelector.exists(PROFILE_NAME)) {
-            cleanUp(contextSelector.get(PROFILE_NAME));
+            clearLogContext(contextSelector.get(PROFILE_NAME));
             contextSelector.remove(PROFILE_NAME);
-        }
-    }
-
-    private void cleanUp(final LogContext logContext) {
-        final ConfigurationPersistence configuration = ConfigurationPersistence.getConfigurationPersistence(logContext);
-        if (configuration != null) {
-            final LogContextConfiguration logContextConfiguration = configuration.getLogContextConfiguration();
-            // Remove all loggers
-            for (String loggerName : logContextConfiguration.getLoggerNames()) {
-                logContextConfiguration.removeLoggerConfiguration(loggerName);
-            }
-            // Remove all the handlers
-            for (String handlerName : logContextConfiguration.getHandlerNames()) {
-                logContextConfiguration.removeHandlerConfiguration(handlerName);
-            }
-            // Remove all the filters
-            for (String filterName : logContextConfiguration.getFilterNames()) {
-                logContextConfiguration.removeFilterConfiguration(filterName);
-            }
-            // Remove all the formatters
-            for (String formatterName : logContextConfiguration.getFormatterNames()) {
-                logContextConfiguration.removeFormatterConfiguration(formatterName);
-            }
-            // Remove all the error managers
-            for (String errorManager : logContextConfiguration.getErrorManagerNames()) {
-                logContextConfiguration.removeErrorManagerConfiguration(errorManager);
-            }
-            configuration.commit();
         }
     }
 


### PR DESCRIPTION
Logging tests were failing on Windows due comparing paths with different file separators.

Test order also seemed to be an issue as loggers were not properly being removed.
