### PR TITLE
[AS7-6170] Remove ResultHandler completion from non-server process types

### DIFF
--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -177,7 +177,7 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
     }
 
     protected KernelServices boot() throws Exception {
-        final KernelServices kernelServices = createKernelServicesBuilder(LoggingTestEnvironment.get()).setSubsystemXml(getSubsystemXml()).build();
+        final KernelServices kernelServices = createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXml(getSubsystemXml()).build();
         final Throwable bootError = kernelServices.getBootError();
         Assert.assertTrue("Failed to boot: " + String.valueOf(bootError), kernelServices.isSuccessfulBoot());
         return kernelServices;


### PR DESCRIPTION
The host controller was attempting to write the logging.properties file as the `ResultHandler` was added even if the process was a non-server process.
