### PR TITLE
[AS7-6092] Allow users to deploy Maven projects directly from the CLI.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/MavenDeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/MavenDeployHandler.java
@@ -1,0 +1,176 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.handlers;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.operation.ParsedCommandLine;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.SAXException;
+
+/**
+ * Deploys a project to AS straight from a Maven pom.xml file.
+ *
+ * @author Nicholas DiPiazza
+ */
+public class MavenDeployHandler extends DeployHandler {
+
+    protected final ArgumentWithValue goals;
+
+    public MavenDeployHandler(CommandContext ctx) {
+        super(ctx);
+        goals = new ArgumentWithValue(this, "--goals");
+        goals.addRequiredPreceding(path);
+    }
+
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandFormatException {
+        final ModelControllerClient client = ctx.getModelControllerClient();
+
+        String mavenHome = System.getenv().get("MAVEN_HOME");
+
+        if (mavenHome == null) {
+            throw new CommandFormatException("In order to use the mavendeploy command, you must set the MAVEN_HOME so that jboss-cli has access to run maven.");
+        }
+
+        ParsedCommandLine args = ctx.getParsedCommandLine();
+        boolean l = this.l.isPresent(args);
+        if (!args.hasProperties() || l) {
+            listDeployments(ctx, l);
+            return;
+        }
+
+        final String path = this.path.getValue(args);
+        final File f;
+        if (path != null) {
+            f = new File(path);
+            if (!f.exists()) {
+                throw new CommandFormatException("Path " + f.getAbsolutePath() + " doesn't exist.");
+            } else if (!isMavenPomFile(f)) {
+                throw new CommandFormatException("Path " + f.getAbsolutePath() + " must point to a Maven pom.xml file.");
+            }
+        } else {
+            f = null;
+        }
+
+        String goalsStr = goals.getValue(args);
+        if (goalsStr == null) {
+            goalsStr = "install";
+        } else {
+            goalsStr = goalsStr.replace("\"", "");
+            goalsStr = goalsStr.replace(',', ' ');
+        }
+
+        String packaging = null;
+        String groupId = null;
+        String artifactId = null;
+        String name = null;
+
+        try {
+            Document mavenDom = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(f);
+            Element projectNode = mavenDom.getDocumentElement();
+            if (projectNode == null || !projectNode.getNodeName().equals("project")) {
+                throw new CommandFormatException("Invalid maven pom file specified " + f.getAbsolutePath() + " - cannot locate <project> root element.");
+            }
+            XPathFactory factory = XPathFactory.newInstance();
+            XPath xpath = factory.newXPath();
+
+            name = xpath.compile("/project/name").evaluate(mavenDom);
+            name = name == null || name.trim().length() == 0 ? null : name;
+
+            groupId = xpath.compile("/project/groupId").evaluate(mavenDom);
+            groupId = groupId == null || groupId.trim().length() == 0 ? null : groupId;
+
+            artifactId = xpath.compile("/project/artifactId").evaluate(mavenDom);
+            artifactId = artifactId == null || artifactId.trim().length() == 0 ? null : artifactId;
+
+            packaging = xpath.compile("/project/packaging").evaluate(mavenDom);
+            packaging = packaging == null || packaging.trim().length() == 0 ? null : packaging;
+
+        } catch (SAXException e) {
+            throw new CommandFormatException("Cannot parse " + f.getAbsolutePath(), e);
+        } catch (IOException e) {
+            throw new CommandFormatException("Cannot parse " + f.getAbsolutePath(), e);
+        } catch (ParserConfigurationException e) {
+            throw new CommandFormatException("Cannot parse " + f.getAbsolutePath(), e);
+        } catch (XPathExpressionException e) {
+            throw new CommandFormatException("Cannot parse " + f.getAbsolutePath(), e);
+        }
+
+        if (!"war".equals(packaging) && !"ejb".equals(packaging)) {
+            throw new CommandFormatException("The mavendeploy command can only deploy war or ejb's.");
+        }
+
+        int exitValue = -1;
+
+        try {
+            Process mavenProc = Util.isWindows() ? Runtime.getRuntime().exec(mavenHome + "\\bin\\mvn.bat -f " + f.getAbsolutePath() + " " + goalsStr) : Runtime.getRuntime().exec(mavenHome + "/bin/mvn -f " + f.getAbsolutePath() + " " + goalsStr);
+            String line = null;
+            BufferedReader in = new BufferedReader(new InputStreamReader(mavenProc.getInputStream()));
+            while ((line = in.readLine()) != null) {
+                ctx.printLine(line);
+            }
+            in.close();
+            exitValue = mavenProc.waitFor();
+        } catch (IOException e) {
+            throw new CommandFormatException("Failed to run maven on " + f.getAbsolutePath(), e);
+        } catch (InterruptedException e) {
+            throw new CommandFormatException("Failed to run maven on " + f.getAbsolutePath(), e);
+        }
+        if (exitValue != 0) {
+            throw new CommandFormatException("Maven Build Failed. Deployment will halt.");
+        }
+
+        File targetDirectory = new File(f.getParent(), "target");
+        if (!targetDirectory.isDirectory()) {
+            throw new CommandFormatException("Cannot find target directory. Expected at " + targetDirectory.getAbsolutePath() + ". This is likely because the maven build failed.");
+        }
+        File resourceToDeploy = new File(targetDirectory, artifactId + "." + packaging);
+        if (!resourceToDeploy.isFile()) {
+            throw new CommandFormatException("Cannot find newly created resource to deploy. Expected to find this at " + resourceToDeploy.getAbsolutePath() + ". This is likely because the maven build failed.");
+        }
+        final boolean unmanaged = this.unmanaged.isPresent(args);
+        doDepoyFile(ctx, client, args, unmanaged, resourceToDeploy);
+    }
+
+    private boolean isMavenPomFile(final File f) {
+        if (f.getName().toLowerCase().equals("pom.xml")) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -27,8 +27,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -87,12 +85,12 @@ import org.jboss.as.cli.handlers.CommandCommandHandler;
 import org.jboss.as.cli.handlers.ConnectHandler;
 import org.jboss.as.cli.handlers.DeployHandler;
 import org.jboss.as.cli.handlers.DeploymentInfoHandler;
-import org.jboss.as.cli.handlers.DeploymentOverlayHandler;
 import org.jboss.as.cli.handlers.EchoDMRHandler;
 import org.jboss.as.cli.handlers.GenericTypeOperationHandler;
 import org.jboss.as.cli.handlers.HelpHandler;
 import org.jboss.as.cli.handlers.HistoryHandler;
 import org.jboss.as.cli.handlers.LsHandler;
+import org.jboss.as.cli.handlers.MavenDeployHandler;
 import org.jboss.as.cli.handlers.OperationRequestHandler;
 import org.jboss.as.cli.handlers.PrefixHandler;
 import org.jboss.as.cli.handlers.PrintWorkingNodeHandler;
@@ -110,19 +108,12 @@ import org.jboss.as.cli.handlers.batch.BatchListHandler;
 import org.jboss.as.cli.handlers.batch.BatchMoveLineHandler;
 import org.jboss.as.cli.handlers.batch.BatchRemoveLineHandler;
 import org.jboss.as.cli.handlers.batch.BatchRunHandler;
-import org.jboss.as.cli.handlers.ifelse.ElseHandler;
-import org.jboss.as.cli.handlers.ifelse.EndIfHandler;
-import org.jboss.as.cli.handlers.ifelse.IfHandler;
 import org.jboss.as.cli.handlers.jca.JDBCDriverNameProvider;
 import org.jboss.as.cli.handlers.jca.JDBCDriverInfoHandler;
 import org.jboss.as.cli.handlers.jca.XADataSourceAddCompositeHandler;
 import org.jboss.as.cli.handlers.jms.CreateJmsResourceHandler;
 import org.jboss.as.cli.handlers.jms.DeleteJmsResourceHandler;
 import org.jboss.as.cli.handlers.module.ASModuleHandler;
-import org.jboss.as.cli.handlers.trycatch.CatchHandler;
-import org.jboss.as.cli.handlers.trycatch.EndTryHandler;
-import org.jboss.as.cli.handlers.trycatch.FinallyHandler;
-import org.jboss.as.cli.handlers.trycatch.TryHandler;
 import org.jboss.as.cli.operation.CommandLineParser;
 import org.jboss.as.cli.operation.NodePathFormatter;
 import org.jboss.as.cli.operation.OperationCandidatesProvider;
@@ -140,9 +131,6 @@ import org.jboss.as.cli.parsing.operation.OperationFormat;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
-import org.jboss.jreadline.console.settings.Settings;
-import org.jboss.logging.Logger;
-import org.jboss.logging.Logger.Level;
 import org.jboss.sasl.callback.DigestHashCallback;
 import org.jboss.sasl.util.HexConverter;
 
@@ -151,8 +139,6 @@ import org.jboss.sasl.util.HexConverter;
  * @author Alexey Loubyansky
  */
 class CommandContextImpl implements CommandContext {
-
-    private static final Logger log = Logger.getLogger(CommandContext.class);
 
     /** the cli configuration */
     private final CliConfig config;
@@ -214,9 +200,6 @@ class CommandContextImpl implements CommandContext {
 
     private File currentDir = new File("");
 
-    /** whether to resolve system properties passed in as values of operation parameters*/
-    private boolean resolveParameterValues;
-
     /**
      * Version mode - only used when --version is called from the command line.
      *
@@ -231,7 +214,6 @@ class CommandContextImpl implements CommandContext {
         config = CliConfigImpl.load(this);
         defaultControllerHost = config.getDefaultControllerHost();
         defaultControllerPort = config.getDefaultControllerPort();
-        resolveParameterValues = config.isResolveParameterValues();
         initSSLContext();
     }
 
@@ -262,14 +244,13 @@ class CommandContextImpl implements CommandContext {
         } else {
             this.defaultControllerPort = config.getDefaultControllerPort();
         }
-        resolveParameterValues = config.isResolveParameterValues();
         initCommands();
 
         initSSLContext();
 
         if (initConsole) {
             cmdCompleter = new CommandCompleter(cmdRegistry);
-            initBasicConsole(null, null);
+            initBasicConsole();
             console.addCompleter(cmdCompleter);
             this.operationCandidatesProvider = new DefaultOperationCandidatesProvider();
         } else {
@@ -278,52 +259,11 @@ class CommandContextImpl implements CommandContext {
         }
     }
 
-    CommandContextImpl(String defaultControllerHost, int defaultControllerPort,
-            String username, char[] password,
-            InputStream consoleInput, OutputStream consoleOutput)
-            throws CliInitializationException {
-
-        config = CliConfigImpl.load(this);
-
-        operationHandler = new OperationRequestHandler();
-
-        this.username = username;
-        this.password = password;
-        if (defaultControllerHost != null) {
-            this.defaultControllerHost = defaultControllerHost;
-        } else {
-            this.defaultControllerHost = config.getDefaultControllerHost();
-        }
-        if (defaultControllerPort != -1) {
-            this.defaultControllerPort = defaultControllerPort;
-        } else {
-            this.defaultControllerPort = config.getDefaultControllerPort();
-        }
-        resolveParameterValues = config.isResolveParameterValues();
-        initCommands();
-
-        initSSLContext();
-
-        cmdCompleter = new CommandCompleter(cmdRegistry);
-        initBasicConsole(consoleInput, consoleOutput);
-        console.addCompleter(cmdCompleter);
-        this.operationCandidatesProvider = new DefaultOperationCandidatesProvider();
-    }
-
-    protected void initBasicConsole(InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
-        copyConfigSettingsToConsole(consoleInput, consoleOutput);
+    protected void initBasicConsole() {
         this.console = Console.Factory.getConsole(this);
-    }
-
-    private void copyConfigSettingsToConsole(InputStream consoleInput, OutputStream consoleOutput) {
-        if(consoleInput != null)
-            Settings.getInstance().setInputStream(consoleInput);
-        if(consoleOutput != null)
-            Settings.getInstance().setStdOut(consoleOutput);
-
-        Settings.getInstance().setHistoryDisabled(!config.isHistoryEnabled());
-        Settings.getInstance().setHistoryFile(new File(config.getHistoryFileDir(), config.getHistoryFileName()));
-        Settings.getInstance().setHistorySize(config.getHistoryMaxSize());
+        console.setUseHistory(config.isHistoryEnabled());
+        console.setHistoryFile(new File(config.getHistoryFileDir(), config.getHistoryFileName()));
+        console.getHistory().setMaxSize(config.getHistoryMaxSize());
     }
 
     private void initCommands() {
@@ -332,7 +272,7 @@ class CommandContextImpl implements CommandContext {
         cmdRegistry.registerHandler(new CommandCommandHandler(cmdRegistry), "command");
         cmdRegistry.registerHandler(new ConnectHandler(), "connect");
         cmdRegistry.registerHandler(new EchoDMRHandler(), "echo-dmr");
-        cmdRegistry.registerHandler(new HelpHandler(cmdRegistry), "help", "h");
+        cmdRegistry.registerHandler(new HelpHandler(), "help", "h");
         cmdRegistry.registerHandler(new HistoryHandler(), "history");
         cmdRegistry.registerHandler(new LsHandler(), "ls");
         cmdRegistry.registerHandler(new ASModuleHandler(this), "module");
@@ -344,31 +284,20 @@ class CommandContextImpl implements CommandContext {
 
         // deployment
         cmdRegistry.registerHandler(new DeployHandler(this), "deploy");
+        cmdRegistry.registerHandler(new MavenDeployHandler(this), "mavendeploy");
         cmdRegistry.registerHandler(new UndeployHandler(this), "undeploy");
         cmdRegistry.registerHandler(new DeploymentInfoHandler(this), "deployment-info");
-        cmdRegistry.registerHandler(new DeploymentOverlayHandler(this), "deployment-overlay");
 
         // batch commands
-        cmdRegistry.registerHandler(new BatchHandler(this), "batch");
+        cmdRegistry.registerHandler(new BatchHandler(), "batch");
         cmdRegistry.registerHandler(new BatchDiscardHandler(), "discard-batch");
         cmdRegistry.registerHandler(new BatchListHandler(), "list-batch");
         cmdRegistry.registerHandler(new BatchHoldbackHandler(), "holdback-batch");
-        cmdRegistry.registerHandler(new BatchRunHandler(this), "run-batch");
+        cmdRegistry.registerHandler(new BatchRunHandler(), "run-batch");
         cmdRegistry.registerHandler(new BatchClearHandler(), "clear-batch");
         cmdRegistry.registerHandler(new BatchRemoveLineHandler(), "remove-batch-line");
         cmdRegistry.registerHandler(new BatchMoveLineHandler(), "move-batch-line");
         cmdRegistry.registerHandler(new BatchEditLineHandler(), "edit-batch-line");
-
-        // try-catch
-        cmdRegistry.registerHandler(new TryHandler(), "try");
-        cmdRegistry.registerHandler(new CatchHandler(), "catch");
-        cmdRegistry.registerHandler(new FinallyHandler(), "finally");
-        cmdRegistry.registerHandler(new EndTryHandler(), "end-try");
-
-        // if else
-        cmdRegistry.registerHandler(new IfHandler(), "if");
-        cmdRegistry.registerHandler(new ElseHandler(), "else");
-        cmdRegistry.registerHandler(new EndIfHandler(), "end-if");
 
         // data-source
         GenericTypeOperationHandler dsHandler = new GenericTypeOperationHandler(this, "/subsystem=datasources/data-source", null);
@@ -394,7 +323,7 @@ class CommandContextImpl implements CommandContext {
 
         // rollout plan
         final GenericTypeOperationHandler rolloutPlan = new GenericTypeOperationHandler(this, "/management-client-content=rollout-plans/rollout-plan", null);
-        rolloutPlan.addValueConverter("content", HeadersArgumentValueConverter.INSTANCE);
+        rolloutPlan.addValueConverter("content", new HeadersArgumentValueConverter(this));
         rolloutPlan.addValueCompleter("content", RolloutPlanCompleter.INSTANCE);
         cmdRegistry.registerHandler(rolloutPlan, "rollout-plan");
 
@@ -503,17 +432,11 @@ class CommandContextImpl implements CommandContext {
             return; // ignore comments
         }
 
-        int i = line.length() - 1;
-        while(i > 0 && line.charAt(i) <= ' ') {
-            if(line.charAt(--i) == '\\') {
-                break;
-            }
-        }
-        if(line.charAt(i) == '\\') {
+        if(line.charAt(line.length() - 1) == '\\') {
             if(lineBuffer == null) {
                 lineBuffer = new StringBuilder();
             }
-            lineBuffer.append(line, 0, i);
+            lineBuffer.append(line, 0, line.length() - 1);
             lineBuffer.append(' ');
             return;
         } else if(lineBuffer != null) {
@@ -580,14 +503,7 @@ class CommandContextImpl implements CommandContext {
         try {
             handle(line);
         } catch (CommandLineException e) {
-            final StringBuilder buf = new StringBuilder();
-            buf.append(e.getLocalizedMessage());
-            Throwable t = e.getCause();
-            while(t != null) {
-                buf.append(": ").append(t.getLocalizedMessage());
-                t = t.getCause();
-            }
-            error(buf.toString());
+            error(e.getLocalizedMessage());
         }
     }
 
@@ -616,16 +532,6 @@ class CommandContextImpl implements CommandContext {
 
     @Override
     public void printLine(String message) {
-        final Level logLevel;
-        if(exitCode != 0) {
-            logLevel = Level.ERROR;
-        } else {
-            logLevel = Level.INFO;
-        }
-        if(log.isEnabled(logLevel)) {
-            log.log(logLevel, message);
-        }
-
         if (outputTarget != null) {
             try {
                 outputTarget.append(message);
@@ -650,9 +556,9 @@ class CommandContextImpl implements CommandContext {
         printLine(message);
     }
 
-    private String readLine(String prompt, boolean password, boolean disableHistory) throws CommandLineException {
+    private String readLine(String prompt, boolean password, boolean disableHistory) throws IOException {
         if (console == null) {
-            initBasicConsole(null, null);
+            initBasicConsole();
         }
 
         boolean useHistory = console.isUseHistory();
@@ -675,9 +581,6 @@ class CommandContextImpl implements CommandContext {
 
     @Override
     public void printColumns(Collection<String> col) {
-        if(log.isInfoEnabled()) {
-            log.info(col);
-        }
         if (outputTarget != null) {
             try {
                 for (String item : col) {
@@ -707,11 +610,6 @@ class CommandContextImpl implements CommandContext {
     @Override
     public Object get(String key) {
         return map.get(key);
-    }
-
-    @Override
-    public Object remove(String key) {
-        return map.remove(key);
     }
 
     @Override
@@ -760,15 +658,28 @@ class CommandContextImpl implements CommandContext {
             retry = false;
             try {
                 ModelControllerClient newClient = null;
+
                 CallbackHandler cbh = new AuthenticationCallbackHandler(username, password);
-                if(log.isDebugEnabled()) {
-                    log.debug("connecting to " + host + ':' + port + " as " + username);
-                }
                 ModelControllerClient tempClient = ModelControllerClient.Factory.create(host, port, cbh, sslContext);
-                retry = tryConnection(tempClient, host, port);
-                if(!retry) {
-                    newClient = tempClient;
+                switch (initialConnection(tempClient)) {
+                    case SUCCESS:
+                        newClient = tempClient;
+                        break;
+                    case CONNECTION_FAILURE:
+                        throw new CommandLineException("The controller is not available at " + host + ":" + port);
+                    case AUTHENTICATION_FAILURE:
+                        throw new CommandLineException("Unable to authenticate against controller at " + host + ":" + port);
+                    case SSL_FAILURE:
+                        try {
+                            retry = handleSSLFailure();
+                        } catch (IOException ignored) {
+                        }
+                        if (retry == false) {
+                            throw new CommandLineException("Unable to negotiate SSL connection with controller at " + host + ":" + port);
+                        }
+                        break;
                 }
+
                 initNewClient(newClient, host, port);
             } catch (UnknownHostException e) {
                 throw new CommandLineException("Failed to resolve host '" + host + "': " + e.getLocalizedMessage());
@@ -814,7 +725,7 @@ class CommandContextImpl implements CommandContext {
      *
      * @return true if the connection should be retried.
      */
-    private boolean handleSSLFailure() throws CommandLineException {
+    private boolean handleSSLFailure() throws IOException {
         Certificate[] lastChain;
         if (trustManager == null || (lastChain = trustManager.getLastFailedCertificateChain()) == null) {
             return false;
@@ -863,13 +774,13 @@ class CommandContextImpl implements CommandContext {
 
     private static final String[] FINGERPRINT_ALGORITHMS = new String[] { "MD5", "SHA1" };
 
-    private Map<String, String> generateFingerprints(final X509Certificate cert) throws CommandLineException  {
+    private Map<String, String> generateFingerprints(final X509Certificate cert) throws IOException  {
         Map<String, String> fingerprints = new HashMap<String, String>(FINGERPRINT_ALGORITHMS.length);
         for (String current : FINGERPRINT_ALGORITHMS) {
             try {
                 fingerprints.put(current, generateFingerPrint(current, cert.getEncoded()));
             } catch (GeneralSecurityException e) {
-                throw new CommandLineException("Unable to generate fingerprint", e);
+                throw new IOException("Unable to generate fingerprint", e);
             }
         }
 
@@ -898,7 +809,7 @@ class CommandContextImpl implements CommandContext {
     /**
      * Used to make a call to the server to verify that it is possible to connect.
      */
-    private boolean tryConnection(final ModelControllerClient client, String host, int port) throws CommandLineException {
+    private ConnectStatus initialConnection(final ModelControllerClient client) {
         try {
             DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
             builder.setOperationName(Util.READ_ATTRIBUTE);
@@ -907,26 +818,22 @@ class CommandContextImpl implements CommandContext {
             client.execute(builder.buildRequest());
             // We don't actually care what the response is we just want to be sure the ModelControllerClient
             // does not throw an Exception.
-            return false;
+            return ConnectStatus.SUCCESS;
         } catch (Exception e) {
             try {
                 Throwable current = e;
                 while (current != null) {
                     if (current instanceof SaslException) {
-                        throw new CommandLineException("Unable to authenticate against controller at " + host + ":" + port, current);
+                        return ConnectStatus.AUTHENTICATION_FAILURE;
                     }
                     if (current instanceof SSLException) {
-                        if (!handleSSLFailure()) {
-                            throw new CommandLineException("Unable to negotiate SSL connection with controller at " + host + ":" + port);
-                        } else {
-                            return true;
-                        }
+                        return ConnectStatus.SSL_FAILURE;
                     }
                     current = current.getCause();
                 }
 
                 // We don't know what happened, most likely a timeout.
-                throw new CommandLineException("The controller is not available at " + host + ":" + port, e);
+                return ConnectStatus.CONNECTION_FAILURE;
             } finally {
                 StreamUtils.safeClose(client);
             }
@@ -962,9 +869,7 @@ class CommandContextImpl implements CommandContext {
 
     @Override
     public void clearScreen() {
-        if(console != null) {
-            console.clearScreen();
-        }
+        console.clearScreen();
     }
 
     String promptConnectPart;
@@ -1010,13 +915,6 @@ class CommandContextImpl implements CommandContext {
 
     @Override
     public CommandHistory getHistory() {
-        if(console == null) {
-            try {
-                initBasicConsole(null, null);
-            } catch (CliInitializationException e) {
-                throw new IllegalStateException("Failed to initialize console.", e);
-            }
-        }
         return console.getHistory();
     }
 
@@ -1048,6 +946,8 @@ class CommandContextImpl implements CommandContext {
         return batchManager;
     }
 
+    private final DefaultCallbackHandler tmpBatched = new DefaultCallbackHandler();
+
     @Override
     public BatchedCommand toBatchedCommand(String line) throws CommandFormatException {
         return new DefaultBatchedCommand(line, buildRequest(line, true));
@@ -1066,29 +966,38 @@ class CommandContextImpl implements CommandContext {
 
         final DefaultCallbackHandler originalParsedArguments = this.parsedCmd;
         try {
-            this.parsedCmd = new DefaultCallbackHandler();
+            this.parsedCmd = tmpBatched;
             resetArgs(line);
+        } catch (CommandFormatException e) {
+            this.parsedCmd = originalParsedArguments;
+            throw e;
+        }
 
-            if (parsedCmd.getFormat() == OperationFormat.INSTANCE) {
+        if (parsedCmd.getFormat() == OperationFormat.INSTANCE) {
+            try {
                 final ModelNode request = this.parsedCmd.toOperationRequest(this);
                 StringBuilder op = new StringBuilder();
                 op.append(prefixFormatter.format(parsedCmd.getAddress()));
                 op.append(line.substring(line.indexOf(':')));
                 return request;
+            } finally {
+                this.parsedCmd = originalParsedArguments;
             }
+        }
 
-            final CommandHandler handler = cmdRegistry.getCommandHandler(parsedCmd.getOperationName());
-            if (handler == null) {
-                throw new OperationFormatException("No command handler for '" + parsedCmd.getOperationName() + "'.");
+        final CommandHandler handler = cmdRegistry.getCommandHandler(parsedCmd.getOperationName());
+        if (handler == null) {
+            throw new OperationFormatException("No command handler for '" + parsedCmd.getOperationName() + "'.");
+        }
+        if(batchMode) {
+            if(!handler.isBatchMode(this)) {
+                throw new OperationFormatException("The command is not allowed in a batch.");
             }
-            if(batchMode) {
-                if(!handler.isBatchMode(this)) {
-                    throw new OperationFormatException("The command is not allowed in a batch.");
-                }
-            } else if (!(handler instanceof OperationCommand)) {
-                throw new OperationFormatException("The command does not translate to an operation request.");
-            }
+        } else if (!(handler instanceof OperationCommand)) {
+            throw new OperationFormatException("The command does not translate to an operation request.");
+        }
 
+        try {
             return ((OperationCommand) handler).buildRequest(this);
         } finally {
             this.parsedCmd = originalParsedArguments;
@@ -1170,14 +1079,8 @@ class CommandContextImpl implements CommandContext {
         }
     }
 
-    @Override
-    public boolean isResolveParameterValues() {
-        return resolveParameterValues;
-    }
-
-    @Override
-    public void setResolveParameterValues(boolean resolve) {
-        this.resolveParameterValues = resolve;
+    private enum ConnectStatus {
+        SUCCESS, AUTHENTICATION_FAILURE, SSL_FAILURE, CONNECTION_FAILURE
     }
 
     private class AuthenticationCallbackHandler implements CallbackHandler {
@@ -1224,11 +1127,7 @@ class CommandContextImpl implements CommandContext {
                     NameCallback ncb = (NameCallback) current;
                     if (username == null) {
                         showRealm();
-                        try {
-                            username = readLine("Username: ", false, true);
-                        } catch (CommandLineException e) {
-                            throw new IOException("Failed to read username.", e);
-                        }
+                        username = readLine("Username: ", false, true);
                         if (username == null || username.length() == 0) {
                             throw new SaslException("No username supplied.");
                         }
@@ -1239,12 +1138,7 @@ class CommandContextImpl implements CommandContext {
                     PasswordCallback pcb = (PasswordCallback) current;
                     if (password == null) {
                         showRealm();
-                        String temp;
-                        try {
-                            temp = readLine("Password: ", true, false);
-                        } catch (CommandLineException e) {
-                            throw new IOException("Failed to read password.", e);
-                        }
+                        String temp = readLine("Password: ", true, false);
                         if (temp != null) {
                             password = temp.toCharArray();
                         }


### PR DESCRIPTION
Allow users to deploy Maven projects directly from the CLI.

Create a new command "mavendeploy"

This will take a pom.xml for a war, ear or ejb project and will maven build, then deploy to the server using the DeployHandler.

First iteration of this would take same parameters as "deploy" except for one, --goals that specifies what goals to build the project with before deploying. (this makes it so you can clean before install, or just install, or call whatever goal that is needed to build the artifact).

Examples:

[standalone@localhost:9999 /] mavendeploy C:\workspace\test-webapp\pom.xml

[standalone@localhost:9999 /] mavendeploy C:\workspace\test-webapp\pom.xml --goals="clean install"
