### PR TITLE
[AS7-4974] Add persisted enable flag for handlers

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_2.xsd
@@ -170,6 +170,7 @@
         </xs:all>
         <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="fileHandlerType">
@@ -188,6 +189,7 @@
         </xs:all>
         <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="periodicFileHandlerType">
@@ -208,6 +210,7 @@
         </xs:all>
         <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
         <xs:complexType name="sizeFileHandlerType">
@@ -229,6 +232,7 @@
         </xs:all>
         <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="asyncHandlerType">
@@ -246,6 +250,7 @@
             <xs:element name="subhandlers" type="handlersType"/>
         </xs:all>
         <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="customHandlerType">
@@ -264,6 +269,7 @@
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="module" type="xs:string" use="required"/>
         <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
     <xs:complexType name="queueLengthType">

--- a/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.logging;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISABLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLE;
+import static org.jboss.as.logging.CommonAttributes.ENABLED;
 import static org.jboss.as.logging.CommonAttributes.ENCODING;
 import static org.jboss.as.logging.CommonAttributes.FILTER;
 import static org.jboss.as.logging.CommonAttributes.FILTER_SPEC;
@@ -59,6 +60,7 @@ abstract class AbstractHandlerDefinition extends SimpleResourceDefinition {
 
     static final AttributeDefinition[] DEFAULT_ATTRIBUTES = {
             LEVEL,
+            ENABLED,
             ENCODING,
             FORMATTER,
             FILTER_SPEC,
@@ -68,9 +70,13 @@ abstract class AbstractHandlerDefinition extends SimpleResourceDefinition {
             FILTER,
     };
 
-    static final SimpleOperationDefinition ENABLE_HANDLER = new SimpleOperationDefinitionBuilder(ENABLE, HANDLER_RESOLVER).build();
+    static final SimpleOperationDefinition ENABLE_HANDLER = new SimpleOperationDefinitionBuilder(ENABLE, HANDLER_RESOLVER)
+            .setDeprecated(ModelVersion.create(1, 2, 0))
+            .build();
 
-    static final SimpleOperationDefinition DISABLE_HANDLER = new SimpleOperationDefinitionBuilder(DISABLE, HANDLER_RESOLVER).build();
+    static final SimpleOperationDefinition DISABLE_HANDLER = new SimpleOperationDefinitionBuilder(DISABLE, HANDLER_RESOLVER)
+            .setDeprecated(ModelVersion.create(1, 2, 0))
+            .build();
 
     static final SimpleOperationDefinition CHANGE_LEVEL = new SimpleOperationDefinitionBuilder(CHANGE_LEVEL_OPERATION_NAME, HANDLER_RESOLVER)
             .setDeprecated(ModelVersion.create(1, 2, 0))

--- a/logging/src/main/java/org/jboss/as/logging/Attribute.java
+++ b/logging/src/main/java/org/jboss/as/logging/Attribute.java
@@ -39,6 +39,7 @@ enum Attribute {
     AUTOFLUSH(CommonAttributes.AUTOFLUSH),
     CATEGORY(CommonAttributes.CATEGORY),
     CLASS(CommonAttributes.CLASS),
+    ENABLED(CommonAttributes.ENABLED),
     MIN_INCLUSIVE(CommonAttributes.MIN_INCLUSIVE),
     MIN_LEVEL(CommonAttributes.MIN_LEVEL),
     MAX_BACKUP_INDEX(CommonAttributes.MAX_BACKUP_INDEX),

--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -85,6 +85,10 @@ public interface CommonAttributes {
 
     String CUSTOM_HANDLER = "custom-handler";
 
+    PropertyAttributeDefinition ENABLED = PropertyAttributeDefinition.Builder.of("enabled", ModelType.STRING, true)
+            .setDefaultValue(new ModelNode(true))
+            .build();
+
     PropertyAttributeDefinition ENCODING = PropertyAttributeDefinition.Builder.of("encoding", ModelType.STRING, true)
             .setAllowExpression(true)
             .setAttributeMarshaller(ElementAttributeMarshaller.VALUE_ATTRIBUTE_MARSHALLER)

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -142,22 +142,36 @@ public class LoggingExtension implements Extension {
         registerTransformersSubModels(registration, loggingProfileReg, RootLoggerResourceDefinition.ROOT_LOGGER_PATH, new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC),
                 ModelDescriptionConstants.ADD, RootLoggerResourceDefinition.ROOT_LOGGER_ADD_OPERATION_NAME, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION,
                 CommonAttributes.ADD_HANDLER_OPERATION_NAME, CommonAttributes.REMOVE_HANDLER_OPERATION_NAME);
+
         registerTransformersSubModels(registration, loggingProfileReg, LoggerResourceDefinition.LOGGER_PATH, new LoggingResourceTransformer(CommonAttributes.CATEGORY, CommonAttributes.FILTER_SPEC),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION,
                 CommonAttributes.ADD_HANDLER_OPERATION_NAME, CommonAttributes.REMOVE_HANDLER_OPERATION_NAME);
-        registerTransformersSubModels(registration, loggingProfileReg, AsyncHandlerResourceDefinition.ASYNC_HANDLER_PATH, new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC),
+
+        registerTransformersSubModels(registration, loggingProfileReg, AsyncHandlerResourceDefinition.ASYNC_HANDLER_PATH,
+                new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC, CommonAttributes.ENABLED),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, AbstractHandlerDefinition.UPDATE_OPERATION_NAME,
                 CommonAttributes.ADD_HANDLER_OPERATION_NAME, CommonAttributes.REMOVE_HANDLER_OPERATION_NAME);
-        registerTransformersSubModels(registration, loggingProfileReg, ConsoleHandlerResourceDefinition.CONSOLE_HANDLER_PATH, new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC),
+
+        registerTransformersSubModels(registration, loggingProfileReg, ConsoleHandlerResourceDefinition.CONSOLE_HANDLER_PATH,
+                new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC, CommonAttributes.ENABLED),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, AbstractHandlerDefinition.UPDATE_OPERATION_NAME);
-        registerTransformersSubModels(registration, loggingProfileReg, FileHandlerResourceDefinition.FILE_HANDLER_PATH, new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC),
+
+        registerTransformersSubModels(registration, loggingProfileReg, FileHandlerResourceDefinition.FILE_HANDLER_PATH,
+                new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC, CommonAttributes.ENABLED),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, AbstractHandlerDefinition.UPDATE_OPERATION_NAME);
-        registerTransformersSubModels(registration, loggingProfileReg, PeriodicHandlerResourceDefinition.PERIODIC_HANDLER_PATH, new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC),
+
+        registerTransformersSubModels(registration, loggingProfileReg, PeriodicHandlerResourceDefinition.PERIODIC_HANDLER_PATH,
+                new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC, CommonAttributes.ENABLED),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, AbstractHandlerDefinition.UPDATE_OPERATION_NAME);
-        registerTransformersSubModels(registration, loggingProfileReg, SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_HANDLER_PATH, new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC),
+
+        registerTransformersSubModels(registration, loggingProfileReg, SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_HANDLER_PATH,
+                new LoggingResourceTransformer(CommonAttributes.NAME, CommonAttributes.FILTER_SPEC, CommonAttributes.ENABLED),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, AbstractHandlerDefinition.UPDATE_OPERATION_NAME);
-        registerTransformersSubModels(registration, loggingProfileReg, CustomHandlerResourceDefinition.CUSTOM_HANDLE_PATH, ResourceTransformer.DEFAULT,
+
+        registerTransformersSubModels(registration, loggingProfileReg, CustomHandlerResourceDefinition.CUSTOM_HANDLE_PATH,
+                new LoggingResourceTransformer(CommonAttributes.ENABLED),
                 ModelDescriptionConstants.ADD, ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, AbstractHandlerDefinition.UPDATE_OPERATION_NAME);
+
     }
 
     private void registerTransformersSubModels(final TransformersSubRegistration registration, final TransformersSubRegistration loggingProfileReg, final PathElement pathElement, final ResourceTransformer transformer, final String... operationNames) {
@@ -214,6 +228,15 @@ public class LoggingExtension implements Extension {
                     operation.get(ModelDescriptionConstants.NAME).set(CommonAttributes.FILTER.getName());
                     final String filterExpression = operation.get(ModelDescriptionConstants.VALUE).asString();
                     operation.get(ModelDescriptionConstants.VALUE).set(Filters.filterSpecToFilter(filterExpression));
+                } else if (attributeName.equals(CommonAttributes.ENABLED.getName())) {
+                    final boolean enabled = operation.get(ModelDescriptionConstants.VALUE).asBoolean();
+                    if (enabled) {
+                        operation.get(ModelDescriptionConstants.OP).set(AbstractHandlerDefinition.ENABLE_HANDLER.getName());
+                    } else {
+                        operation.get(ModelDescriptionConstants.OP).set(AbstractHandlerDefinition.DISABLE_HANDLER.getName());
+                    }
+                    operation.remove(ModelDescriptionConstants.NAME);
+                    operation.remove(ModelDescriptionConstants.VALUE);
                 }
             } else if (operationName.equals(ModelDescriptionConstants.ADD)) {
                 // Category or name is required for add operations
@@ -239,6 +262,8 @@ public class LoggingExtension implements Extension {
             }
             // Always remove the filter-spec
             operation.remove(CommonAttributes.FILTER_SPEC.getName());
+            // Always remove the enable attribute
+            operation.remove(CommonAttributes.ENABLED.getName());
             return operation;
         }
     }
@@ -251,6 +276,7 @@ public class LoggingExtension implements Extension {
             COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.APPEND.getName(), "logging.common");
             COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.AUTOFLUSH.getName(), "logging.common");
             COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.CLASS.getName(), "logging.custom-handler");
+            COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.ENABLED.getName(), "logging.common");
             COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.ENCODING.getName(), "logging.common");
             COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.FILE.getName(), "logging.handler");
             COMMON_ATTRIBUTE_NAMES.put(CommonAttributes.FILTER.getName(), "logging.common");

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -42,6 +42,7 @@ import static org.jboss.as.logging.CommonAttributes.CATEGORY;
 import static org.jboss.as.logging.CommonAttributes.CLASS;
 import static org.jboss.as.logging.CommonAttributes.CONSOLE_HANDLER;
 import static org.jboss.as.logging.CommonAttributes.CUSTOM_HANDLER;
+import static org.jboss.as.logging.CommonAttributes.ENABLED;
 import static org.jboss.as.logging.CommonAttributes.ENCODING;
 import static org.jboss.as.logging.CommonAttributes.FILE;
 import static org.jboss.as.logging.CommonAttributes.FILE_HANDLER;
@@ -278,6 +279,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static void parseAsyncHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
@@ -292,6 +294,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     name = value;
                     break;
                 }
+                case ENABLED:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ENABLED.parseAndSetParameter(value, node, reader);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -309,7 +317,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Elements
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
-        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         while (reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (!encountered.add(element)) {
@@ -399,6 +406,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static void parseConsoleHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
@@ -417,6 +425,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     AUTOFLUSH.parseAndSetParameter(value, node, reader);
                     break;
                 }
+                case ENABLED:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ENABLED.parseAndSetParameter(value, node, reader);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -434,7 +448,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         // Elements
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
-        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         while (reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (!encountered.add(element)) {
@@ -476,6 +489,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static void parseFileHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
@@ -494,6 +508,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     AUTOFLUSH.parseAndSetParameter(value, node, reader);
                     break;
                 }
+                case ENABLED:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ENABLED.parseAndSetParameter(value, node, reader);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -512,7 +532,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         // Elements
         final EnumSet<Element> requiredElem = EnumSet.of(Element.FILE);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
-        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         while (reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (!encountered.add(element)) {
@@ -558,6 +577,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static void parseCustomHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.CLASS, Attribute.MODULE);
@@ -580,6 +600,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     MODULE.parseAndSetParameter(value, node, reader);
                     break;
                 }
+                case ENABLED:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ENABLED.parseAndSetParameter(value, node, reader);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -596,7 +622,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
 
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
-        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         while (reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (!encountered.add(element)) {
@@ -634,6 +659,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static void parsePeriodicRotatingFileHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
@@ -652,6 +678,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     AUTOFLUSH.parseAndSetParameter(value, node, reader);
                     break;
                 }
+                case ENABLED:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ENABLED.parseAndSetParameter(value, node, reader);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -669,7 +701,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         final EnumSet<Element> requiredElem = EnumSet.of(Element.FILE, Element.SUFFIX);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
-        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         while (reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (!encountered.add(element)) {
@@ -719,6 +750,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
     static void parseSizeRotatingHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> list, final Set<String> names) throws XMLStreamException {
         final ModelNode node = new ModelNode();
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         // Attributes
         String name = null;
         final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
@@ -737,6 +769,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     AUTOFLUSH.parseAndSetParameter(value, node, reader);
                     break;
                 }
+                case ENABLED:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ENABLED.parseAndSetParameter(value, node, reader);
+                    break;
                 default:
                     throw unexpectedAttribute(reader, i);
             }
@@ -754,7 +792,6 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
 
         final EnumSet<Element> requiredElem = EnumSet.of(Element.FILE);
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
-        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
         while (reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (!encountered.add(element)) {
@@ -1307,6 +1344,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         writer.writeStartElement(Element.CONSOLE_HANDLER.getLocalName());
         writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
         AUTOFLUSH.marshallAsAttribute(node, writer);
+        ENABLED.marshallAsAttribute(node, false, writer);
         writeCommonHandler(writer, node);
         TARGET.marshallAsElement(node, writer);
         writer.writeEndElement();
@@ -1316,6 +1354,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         writer.writeStartElement(Element.FILE_HANDLER.getLocalName());
         writer.writeAttribute(Attribute.NAME.getLocalName(), name);
         AUTOFLUSH.marshallAsAttribute(node, writer);
+        ENABLED.marshallAsAttribute(node, false, writer);
         writeCommonHandler(writer, node);
         FILE.marshallAsElement(node, writer);
         APPEND.marshallAsElement(node, writer);
@@ -1329,6 +1368,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
         CLASS.marshallAsAttribute(node, writer);
         MODULE.marshallAsAttribute(node, writer);
+        ENABLED.marshallAsAttribute(node, false, writer);
         writeCommonHandler(writer, node);
         PROPERTIES.marshallAsElement(node, writer);
 
@@ -1339,6 +1379,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         writer.writeStartElement(Element.PERIODIC_ROTATING_FILE_HANDLER.getLocalName());
         writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
         AUTOFLUSH.marshallAsAttribute(node, writer);
+        ENABLED.marshallAsAttribute(node, false, writer);
         writeCommonHandler(writer, node);
         FILE.marshallAsElement(node, writer);
         SUFFIX.marshallAsElement(node, writer);
@@ -1351,6 +1392,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         writer.writeStartElement(Element.SIZE_ROTATING_FILE_HANDLER.getLocalName());
         writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
         AUTOFLUSH.marshallAsAttribute(node, writer);
+        ENABLED.marshallAsAttribute(node, false, writer);
         writeCommonHandler(writer, node);
         FILE.marshallAsElement(node, writer);
         ROTATE_SIZE.marshallAsElement(node, writer);
@@ -1363,6 +1405,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
     private void writeAsynchHandler(final XMLExtendedStreamWriter writer, final ModelNode node, final String name) throws XMLStreamException {
         writer.writeStartElement(Element.ASYNC_HANDLER.getLocalName());
         writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
+        ENABLED.marshallAsAttribute(node, false, writer);
         LEVEL.marshallAsElement(node, writer);
         FILTER_SPEC.marshallAsElement(node, writer);
         FORMATTER.marshallAsElement(node, writer);

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/LoggerConfigurationImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/LoggerConfigurationImpl.java
@@ -67,6 +67,7 @@ final class LoggerConfigurationImpl extends AbstractBasicConfiguration<Logger, L
             }
 
             public void applyPostCreate(final ObjectProducer param) {
+                if (configuration.getHandlerRefs().containsKey(getName()))
                configuration.getHandlerRefs().get(getName()).setFilter((Filter) param.getObject());
             }
 

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -56,7 +56,9 @@ logging.handler.remove=Remove an existing logging handler.
 logging.handler.name=The handler's name.
 logging.handler.name.deprecated=The name attribute should not be used as the handler's address contains the name.
 logging.handler.enable=Enable a logging handler.
+logging.handler.enable.deprecated=Use the write-attribute for the enabled attribute.
 logging.handler.disable=Disable a logging handler.
+logging.handler.disable.deprecated=Use the write-attribute for the enabled attribute.
 logging.handler.change-log-level=Change the logging level for a handler.
 logging.handler.change-log-level.deprecated=Use the write-attribute operation.
 logging.handler.change-file=Change the file for a handler.
@@ -114,6 +116,7 @@ logging.custom-handler.properties.value=Defines value of the property.
 # Common attribute descriptions
 logging.common.append=Specify whether to append to the target file.
 logging.common.autoflush=Automatically flush after each write.
+logging.common.enabled=If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.
 logging.common.encoding=The character encoding used by this Handler.
 logging.common.formatter=Defines a pattern for the formatter.
 logging.common.handlers=The Handlers associated with this Logger.

--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -305,7 +305,14 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
                 String modelStringValue = modelValue.asString();
                 final String configValue;
                 // Special properties
-                if (modelPropertyName.equals(CommonAttributes.ENCODING.getName())) {
+                if (modelPropertyName.equals(CommonAttributes.ENABLED.getName())) {
+                    final String propertyName = CommonAttributes.ENABLED.getPropertyName();
+                    if (configPropertyNames.contains(propertyName)) {
+                        configValue = handlerConfig.getPropertyValueString(propertyName);
+                    } else {
+                        continue;
+                    }
+                } else if (modelPropertyName.equals(CommonAttributes.ENCODING.getName())) {
                     configValue = handlerConfig.getEncoding();
                 } else if (modelPropertyName.equals(CommonAttributes.FORMATTER.getName())) {
                     final String formatterName = handlerConfig.getFormatterName();

--- a/logging/src/test/java/org/jboss/as/logging/Operations.java
+++ b/logging/src/test/java/org/jboss/as/logging/Operations.java
@@ -48,7 +48,7 @@ public class Operations extends ClientConstants {
     public static final String VALUE = ModelDescriptionConstants.VALUE;
     public static final String WRITE_ATTRIBUTE = ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
-    static final ModelNode UNDEFINED = new ModelNode(ModelType.UNDEFINED);
+    static final ModelNode UNDEFINED = new ModelNode();
 
     static {
         UNDEFINED.protect();
@@ -88,6 +88,28 @@ public class Operations extends ClientConstants {
             msg = String.format("An unexpected response was found. Result: %s", result);
         }
         return msg;
+    }
+
+    /**
+     * Returns the address for the operation.
+     *
+     * @param op the operation
+     *
+     * @return the operation address or an undefined model node
+     */
+    public static ModelNode getOperationAddress(final ModelNode op) {
+        return op.hasDefined(OP_ADDR) ? op.get(OP_ADDR) : UNDEFINED;
+    }
+
+    /**
+     * Returns the name of the operation.
+     *
+     * @param op the operation
+     *
+     * @return the name of the operation or {@code null} if not defined
+     */
+    public static String getOperationName(final ModelNode op) {
+        return op.hasDefined(OP) ? op.get(OP).asString() : null;
     }
 
     /**
@@ -218,6 +240,35 @@ public class Operations extends ClientConstants {
      */
     public static ModelNode createWriteAttributeOperation(final ModelNode address, final AttributeDefinition attribute, final String value) {
         return createWriteAttributeOperation(address, attribute.getName(), value);
+    }
+
+    /**
+     * Creates an operation to write an attribute value represented by the {@code attributeName} parameter.
+     *
+     * @param address   the address to create the write attribute for
+     * @param attribute the attribute to write
+     * @param value     the value to set the attribute to
+     *
+     * @return the operation
+     */
+    public static ModelNode createWriteAttributeOperation(final ModelNode address, final AttributeDefinition attribute, final boolean value) {
+        return createWriteAttributeOperation(address, attribute.getName(), value);
+    }
+
+    /**
+     * Creates an operation to write an attribute value represented by the {@code attributeName} parameter.
+     *
+     * @param address       the address to create the write attribute for
+     * @param attributeName the name of the attribute to write
+     * @param value         the value to set the attribute to
+     *
+     * @return the operation
+     */
+    public static ModelNode createWriteAttributeOperation(final ModelNode address, final String attributeName, final boolean value) {
+        ModelNode op = createOperation(WRITE_ATTRIBUTE, address);
+        op.get(NAME).set(attributeName);
+        op.get(VALUE).set(value);
+        return op;
     }
 
     /**

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -38,7 +38,7 @@
         </formatter>
     </console-handler>
 
-    <file-handler name="anotherFile">
+    <file-handler name="anotherFile" enabled="false">
         <filter-spec value="levelRange(TRACE,WARN]" />
         <file relative-to="jboss.server.log.dir" path="another.log"/>
         <append value="true"/>


### PR DESCRIPTION
In previous releases there was an `enable` and `disable` operation for log handlers. The state of the handler being disabled was not persisted therefore on a reload or reboot the handler was enabled. 

This change adds an attribute to the model of the log handlers and deprecates the previous operations in favor of the `write-attribute` operation.
