### PR TITLE
AS7-6188 Incorrect use of equals in JMSBridgeHandler.executeRuntimeStep(OperationContext, ModelNode)

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
@@ -88,7 +88,7 @@ public class JMSBridgeHandler extends AbstractRuntimeOnlyHandler {
             final String name = operation.require(NAME).asString();
             if (STARTED.equals(name)) {
                 context.getResult().set(bridge.isStarted());
-            } else if (PAUSED.equals(name)) {
+            } else if (PAUSED.getName().equals(name)) {
                 context.getResult().set(bridge.isPaused());
             } else {
                 throw MESSAGES.unsupportedAttribute(name);


### PR DESCRIPTION
Fixed code to perform comparison with AttributeDefinition.getName()
