### PR TITLE
AS7-6189 Incorrect use of equals in SubDeploymentDependencyProcessor.deploy(DeploymentPhaseContext)

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/SubDeploymentDependencyProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/SubDeploymentDependencyProcessor.java
@@ -75,9 +75,9 @@ public class SubDeploymentDependencyProcessor implements DeploymentUnitProcessor
                     accessibleModules.add(dependency);
                 }
             }
-            for (ModuleDependency identifier : accessibleModules) {
-                if (!identifier.equals(moduleIdentifier)) {
-                    moduleSpec.addLocalDependency(identifier);
+            for (ModuleDependency dependency : accessibleModules) {
+                if (!dependency.getIdentifier().equals(moduleIdentifier)) {
+                    moduleSpec.addLocalDependency(dependency);
                 }
             }
         }


### PR DESCRIPTION
Modified loop to use ModuleDependency.getIdentifier() for performing
the equals comparison
