### PR TITLE
Enable several domain tests

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionAddHandler.java
@@ -86,13 +86,17 @@ public class ExtensionAddHandler implements OperationStepHandler {
 
     void initializeExtension(String module) throws OperationFailedException {
         try {
+            boolean unknownModule = false;
             for (Extension extension : Module.loadServiceFromCallerModuleLoader(ModuleIdentifier.fromString(module), Extension.class)) {
                 ClassLoader oldTccl = SecurityActions.setThreadContextClassLoader(extension.getClass());
                 try {
-                    if (!extensionRegistry.getExtensionModuleNames().contains(module)) {
+                    if (unknownModule || !extensionRegistry.getExtensionModuleNames().contains(module)) {
                         // This extension wasn't handled by the standalone.xml or domain.xml parsing logic, so we
                         // need to initialize its parsers so we can display what XML namespaces it supports
                         extension.initializeParsers(extensionRegistry.getExtensionParsingContext(module, null));
+                        // AS7-6190 - ensure we initialize parsers for other extensions from this module
+                        // now that we know the registry was unaware of the module
+                        unknownModule = true;
                     }
                     extension.initialize(extensionRegistry.getExtensionContext(module));
                 } finally {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
@@ -1,0 +1,204 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.checkState;
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.startServer;
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.waitUntilState;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.suites.DomainTestSuite;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests of running domain hosts in admin-only move.
+ */
+public class AdminOnlyModeTestCase {
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+
+    private static final ModelNode slave = new ModelNode();
+    private static final ModelNode mainOne = new ModelNode();
+    private static final ModelNode newServerConfigAddress = new ModelNode();
+    private static final ModelNode newRunningServerAddress = new ModelNode();
+
+    static {
+        // (host=slave)
+        slave.add("host", "slave");
+        // (host=slave),(server-config=new-server)
+        newServerConfigAddress.add("host", "slave");
+        newServerConfigAddress.add("server-config", "new-server");
+        // (host=slave),(server=new-server)
+        newRunningServerAddress.add("host", "slave");
+        newRunningServerAddress.add("server", "new-server");
+        // (host=master),(server-config=main-one)
+        mainOne.add("host", "master");
+        mainOne.add("server-config", "main-one");
+    }
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(AdminOnlyModeTestCase.class.getSimpleName());
+
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        DomainTestSuite.stopSupport();
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+    }
+
+    @Test
+    public void testAdminOnlyMode() throws Exception {
+
+        // restart master HC in admin only mode
+        final DomainClient masterClient = domainMasterLifecycleUtil.getDomainClient();
+        ModelNode op = new ModelNode();
+        op.get(OP_ADDR).add(HOST, "master");
+        op.get(OP).set("reload");
+        op.get("admin-only").set(true);
+        domainMasterLifecycleUtil.executeAwaitConnectionClosed(op);
+
+        // Try to reconnect to the hc
+        domainMasterLifecycleUtil.connect();
+
+        op = new ModelNode();
+        op.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        op.get(OP_ADDR).add(HOST, "master");
+        op.get(NAME).set("running-mode");
+
+        // Validate that we are started in the --admin-only mode
+        final ModelNode result = executeForResult(masterClient, op);
+        Assert.assertEquals("ADMIN_ONLY", result.asString());
+
+        // restart back to normal mode
+        op = new ModelNode();
+        op.get(OP_ADDR).add(HOST, "master");
+        op.get(OP).set("reload");
+        op.get("admin-only").set(false);
+        domainMasterLifecycleUtil.executeAwaitConnectionClosed(op);
+
+        // Try to reconnect to the hc
+        domainMasterLifecycleUtil.connect();
+
+        // check that the servers are up
+        domainMasterLifecycleUtil.awaitServers(System.currentTimeMillis());
+
+        // Wait for the slave to reconnect
+        waitForHost(masterClient, "slave");
+        domainSlaveLifecycleUtil.awaitServers(System.currentTimeMillis());
+    }
+
+    private ModelNode executeForResult(final ModelControllerClient client, final ModelNode operation) throws IOException {
+        final ModelNode result = client.execute(operation);
+        return validateResponse(result);
+    }
+
+    private ModelNode validateResponse(ModelNode response) {
+        return validateResponse(response, true);
+    }
+
+    private ModelNode validateResponse(ModelNode response, boolean validateResult) {
+
+        if(! SUCCESS.equals(response.get(OUTCOME).asString())) {
+            System.out.println("Failed response:");
+            System.out.println(response);
+            Assert.fail(response.get(FAILURE_DESCRIPTION).toString());
+        }
+
+        if (validateResult) {
+            Assert.assertTrue("result exists", response.has(RESULT));
+        }
+        return response.get(RESULT);
+    }
+
+    private static void waitForHost(final ModelControllerClient client, final String hostName) throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_CHILDREN_NAMES_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(CHILD_TYPE).set(HOST);
+        final ModelNode host = new ModelNode().set(hostName);
+        final long timeout = 30L;
+        final TimeUnit timeUnit = TimeUnit.SECONDS;
+        final long deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
+        for(;;) {
+            final long remaining = deadline - System.currentTimeMillis();
+            final ModelNode result = client.execute(operation);
+            if(result.get(RESULT).asList().contains(host)) {
+                return;
+            }
+            if(remaining <= 0) {
+                Assert.fail(hostName + " did not register within 30 seconds");
+            }
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Assert.fail("Interrupted while waiting for registration of host " + hostName);
+            }
+        }
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SubsystemInitialization.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SubsystemInitialization.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
@@ -87,6 +88,7 @@ class SubsystemInitialization {
         final AttributeDefinition string = SimpleAttributeDefinitionBuilder.create("string", ModelType.STRING).setAllowExpression(allowExpressions).build();
         registration.registerReadWriteAttribute(integer, null, new BasicAttributeWriteHandler(integer));
         registration.registerReadWriteAttribute(string, null, new BasicAttributeWriteHandler(string));
+        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         return new RegistrationResult() {
             @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestExtension.java
@@ -33,9 +33,11 @@ import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.staxmapper.XMLElementReader;
@@ -60,11 +62,13 @@ public class TestExtension implements Extension {
     public void initialize(ExtensionContext context) {
         SubsystemRegistration one = context.registerSubsystem("1", 1, 1, 1);
         one.registerXMLElementWriter(parserOne);
-        one.registerSubsystemModel(new Subsystem("1"));
+        ManagementResourceRegistration mrrOne = one.registerSubsystemModel(new Subsystem("1"));
+        mrrOne.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         SubsystemRegistration two = context.registerSubsystem("2", 2, 2, 2);
         two.registerXMLElementWriter(parserTwo);
-        two.registerSubsystemModel(new Subsystem("2"));
+        ManagementResourceRegistration mrrTwo = two.registerSubsystemModel(new Subsystem("2"));
+        mrrTwo.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
     }
 
     @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DatasourceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DatasourceTestCase.java
@@ -68,7 +68,7 @@ public class DatasourceTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = DomainTestSuite.createSupport(ManagementAccessTestCase.class.getSimpleName());
+        testSupport = DomainTestSuite.createSupport(DatasourceTestCase.class.getSimpleName());
         domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
         domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DirectoryGroupingByTypeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DirectoryGroupingByTypeTestCase.java
@@ -41,7 +41,7 @@ public class DirectoryGroupingByTypeTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = DomainTestSuite.createSupport(CoreResourceManagementTestCase.class.getSimpleName());
+        testSupport = DomainTestSuite.createSupport(DirectoryGroupingByTypeTestCase.class.getSimpleName());
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.domain.suites;
 
+import org.jboss.as.test.integration.domain.AdminOnlyModeTestCase;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.JBossAsManagedConfigurationParameters;
 import org.junit.AfterClass;
@@ -38,17 +39,23 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses ({
         CoreResourceManagementTestCase.class,
-        ManagementReadsTestCase.class,
+        DatasourceTestCase.class,
         DeploymentManagementTestCase.class,
         DeploymentOverlayTestCase.class,
-        ServerManagementTestCase.class,
-        ServerRestartRequiredTestCase.class,
+        DirectoryGroupingByTypeTestCase.class,
+        ExtensionManagementTestCase.class,
+        IgnoredResourcesTestCase.class,
         ManagementAccessTestCase.class,
         ManagementClientContentTestCase.class,
-        ValidateOperationOperationTestCase.class,
+        ManagementReadsTestCase.class,
+        ManagementVersionTestCase.class,
+        ModelPersistenceTestCase.class,
+        OperationTransformationTestCase.class,
         ReadEnvironmentVariablesTestCase.class,
-        ExtensionManagementTestCase.class,
-        OperationTransformationTestCase.class
+        ServerManagementTestCase.class,
+        ServerRestartRequiredTestCase.class,
+        ValidateAddressOperationTestCase.class,
+        ValidateOperationOperationTestCase.class
 })
 public class DomainTestSuite {
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/IgnoredResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/IgnoredResourcesTestCase.java
@@ -22,10 +22,6 @@
 
 package org.jboss.as.test.integration.domain.suites;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
-
 import java.io.IOException;
 
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -33,10 +29,7 @@ import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.version.Version;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -78,7 +71,7 @@ public class IgnoredResourcesTestCase {
         ModelNode result = executeOperation(op, domainMasterLifecycleUtil.getDomainClient());
         boolean found = false;
         for (ModelNode profile : result.asList()) {
-            if ("ignored".equals(profile)) {
+            if ("ignored".equals(profile.asString())) {
                 found = true;
                 break;
             }
@@ -88,19 +81,19 @@ public class IgnoredResourcesTestCase {
         // Resource should not exist on slave
         result = executeOperation(op, domainSlaveLifecycleUtil.getDomainClient());
         for (ModelNode profile : result.asList()) {
-            if ("ignored".equals(profile)) {
+            if ("ignored".equals(profile.asString())) {
                 Assert.fail("found profile 'ignored'");
             }
         }
 
         // Modify the ignored profile
-        ModelNode mod = createOpNode("/profile=ignored/subsystem=naming", "add");
+        ModelNode mod = createOpNode("profile=ignored/subsystem=naming", "add");
         executeOperation(mod, domainMasterLifecycleUtil.getDomainClient());
 
         // Resource still should not exist on slave
         result = executeOperation(op, domainSlaveLifecycleUtil.getDomainClient());
         for (ModelNode profile : result.asList()) {
-            if ("ignored".equals(profile)) {
+            if ("ignored".equals(profile.asString())) {
                 Assert.fail("found profile 'ignored'");
             }
         }
@@ -116,7 +109,7 @@ public class IgnoredResourcesTestCase {
         ModelNode result = executeOperation(op, domainMasterLifecycleUtil.getDomainClient());
         boolean found = false;
         for (ModelNode profile : result.asList()) {
-            if ("ignored".equals(profile)) {
+            if ("ignored".equals(profile.asString())) {
                 found = true;
                 break;
             }
@@ -126,20 +119,20 @@ public class IgnoredResourcesTestCase {
         // Resource should not exist on slave
         result = executeOperation(op, domainSlaveLifecycleUtil.getDomainClient());
         for (ModelNode profile : result.asList()) {
-            if ("ignored".equals(profile)) {
+            if ("ignored".equals(profile.asString())) {
                 Assert.fail("found socket-binding-group 'ignored'");
             }
         }
 
         // Modify the ignored group
-        ModelNode mod = createOpNode("/socket-binding-group=ignored/socket-binding=test", "add");
+        ModelNode mod = createOpNode("socket-binding-group=ignored/socket-binding=test", "add");
         mod.get("port").set(12345);
         executeOperation(mod, domainMasterLifecycleUtil.getDomainClient());
 
         // Resource still should not exist on slave
         result = executeOperation(op, domainSlaveLifecycleUtil.getDomainClient());
         for (ModelNode profile : result.asList()) {
-            if ("ignored".equals(profile)) {
+            if ("ignored".equals(profile.asString())) {
                 Assert.fail("found socket-binding-group 'ignored'");
             }
         }
@@ -154,31 +147,29 @@ public class IgnoredResourcesTestCase {
 
         // Sanity check againt domain
         ModelNode result = executeOperation(op, domainMasterLifecycleUtil.getDomainClient());
-        boolean found = false;
         for (ModelNode profile : result.asList()) {
-            if ("org.jboss.as.jsr77".equals(profile)) {
+            if ("org.jboss.as.jsr77".equals(profile.asString())) {
                 Assert.fail("found extension 'org.jboss.as.jsr77'");
             }
         }
-        Assert.assertTrue(found);
 
         // Resource should not exist on slave
         result = executeOperation(op, domainSlaveLifecycleUtil.getDomainClient());
         for (ModelNode profile : result.asList()) {
-            if ("org.jboss.as.jsr77".equals(profile)) {
+            if ("org.jboss.as.jsr77".equals(profile.asString())) {
                 Assert.fail("found extension 'org.jboss.as.jsr77'");
             }
         }
 
         // Add the ignored extension
-        ModelNode mod = createOpNode("/extension=org.jboss.as.jsr77", "add");
+        ModelNode mod = createOpNode("extension=org.jboss.as.jsr77", "add");
         mod.get("port").set(12345);
         executeOperation(mod, domainMasterLifecycleUtil.getDomainClient());
 
         // Resource still should not exist on slave
         result = executeOperation(op, domainSlaveLifecycleUtil.getDomainClient());
         for (ModelNode profile : result.asList()) {
-            if ("org.jboss.as.jsr77".equals(profile)) {
+            if ("org.jboss.as.jsr77".equals(profile.asString())) {
                 Assert.fail("found extension 'org.jboss.as.jsr77'");
             }
         }
@@ -188,7 +179,7 @@ public class IgnoredResourcesTestCase {
     @Test
     public void testIgnoreTypeHost() throws IOException {
 
-        ModelNode op = createOpNode("/core-service=ignored-resources/ignored-resource-type=host", "add");
+        ModelNode op = createOpNode("core-service=ignored-resources/ignored-resource-type=host", "add");
         op.get("wildcard").set(true);
 
         try {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementAccessTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ManagementAccessTestCase.java
@@ -74,7 +74,7 @@ public class ManagementAccessTestCase {
     private static DomainLifecycleUtil domainMasterLifecycleUtil;
     private static DomainLifecycleUtil domainSlaveLifecycleUtil;
 
-    private static final String TEST = "test";
+    private static final String TEST = "mgmt-access-test";
     private static final ModelNode ROOT_ADDRESS = new ModelNode().setEmptyList();
     private static final ModelNode MASTER_ROOT_ADDRESS = new ModelNode().add(HOST, "master");
     private static final ModelNode SLAVE_ROOT_ADDRESS = new ModelNode().add(HOST, "slave");

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ServerRestartRequiredTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ServerRestartRequiredTestCase.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.AdminOnlyModeTestCase;
 import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
@@ -90,7 +91,7 @@ public class ServerRestartRequiredTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = DomainTestSuite.createSupport(ServerManagementTestCase.class.getSimpleName());
+        testSupport = DomainTestSuite.createSupport(ServerRestartRequiredTestCase.class.getSimpleName());
 
         domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
         domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateAddressOperationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateAddressOperationTestCase.java
@@ -21,34 +21,44 @@
 */
 package org.jboss.as.test.integration.domain.suites;
 
-import java.io.IOException;
-
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
-import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.management.util.ModelUtil;
-import org.jboss.dmr.ModelNode;
-import static org.junit.Assert.assertThat;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROBLEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALID;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests that the validate-address operation works as it should
  *
  * @author <a href="alex@jboss.org">Alexey Loubyansky</a>
  */
-@RunWith(Arquillian.class)
-@RunAsClient
-public class ValidateAddressOperationTestCase extends ContainerResourceMgmtTestBase {
+public class ValidateAddressOperationTestCase  {
+
+    private static DomainTestSupport testSupport;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(ValidateAddressOperationTestCase.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport = null;
+        DomainTestSuite.stopSupport();
+    }
 
     @Test
     public void testValidRootAddress() throws IOException, MgmtOperationException {
@@ -94,17 +104,21 @@ public class ValidateAddressOperationTestCase extends ContainerResourceMgmtTestB
         ModelNode op = ModelUtil.createOpNode(null, ValidateAddressOperationHandler.OPERATION_NAME);
         final ModelNode addr = op.get(VALUE);
         addr.add("host", "slave");
-        assertTrue(executeOperation(op).get(RESULT, VALID).asBoolean());
+        assertTrue(executeOperation(op).get(VALID).asBoolean());
 
         addr.add("server", "main-three");
-        assertTrue(executeOperation(op).get(RESULT, VALID).asBoolean());
+        assertTrue(executeOperation(op).get(VALID).asBoolean());
 
         addr.add("core-service", "platform-mbean");
         addr.add("type", "garbage-collector");
-        assertTrue(executeOperation(op).get(RESULT, VALID).asBoolean());
+        assertTrue(executeOperation(op).get(VALID).asBoolean());
 
         addr.add("non-existent", "resource");
-        assertFalse(executeOperation(op).get(RESULT, VALID).asBoolean());
+        assertFalse(executeOperation(op).get(VALID).asBoolean());
+    }
+
+    private ModelNode executeOperation(final ModelNode op) throws IOException, MgmtOperationException {
+        return DomainTestUtils.executeForResult(op, testSupport.getDomainMasterLifecycleUtil().getDomainClient());
     }
 
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateOperationOperationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateOperationOperationTestCase.java
@@ -60,7 +60,8 @@ public class ValidateOperationOperationTestCase extends AbstractMgmtTestBase {
 
     @BeforeClass
     public static void setup() throws UnknownHostException {
-        client = ModelControllerClient.Factory.create(DomainTestSupport.masterAddress, TestSuiteEnvironment.getServerPort());
+        DomainTestSupport testSupport = DomainTestSuite.createSupport(ValidateOperationOperationTestCase.class.getSimpleName());
+        client = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
     }
 
     @AfterClass

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -61,7 +61,7 @@
         <!-- Remote domain controller configuration with a host and port -->
         <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
             <ignored-resources type="extension">
-                <instance name="ignored"/>
+                <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>
             <ignored-resources type="profile">
                 <instance name="ignored"/>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestUtils.java
@@ -295,19 +295,19 @@ public class DomainTestUtils {
      *
      * @param client the controller client
      * @param serverAddress the server address
-     * @param state the required state
+     * @param required the required state
      * @param timeout the timeout
      * @param unit the time unit
      * @throws IOException
      */
-    public static void waitUntilState(final ModelControllerClient client, final ModelNode serverAddress, final String state, final long timeout, final TimeUnit unit) throws IOException {
+    public static void waitUntilState(final ModelControllerClient client, final ModelNode serverAddress, final String required, final long timeout, final TimeUnit unit) throws IOException {
         final long deadline = System.currentTimeMillis() + unit.toMillis(timeout);
         for(;;) {
             final long remaining = deadline - System.currentTimeMillis();
             if(remaining <= 0) {
                 break;
             }
-            if (checkState(client, serverAddress, state)) {
+            if (checkState(client, serverAddress, required)) {
                 return;
             }
             try {
@@ -317,7 +317,7 @@ public class DomainTestUtils {
                 return;
             }
         }
-        final String required = getServerState(client, serverAddress);
+        final String state = getServerState(client, serverAddress);
         Assert.assertEquals(serverAddress.toString(), required, state);
     }
 


### PR DESCRIPTION
Many of the domain tests were not executing during test runs because they were not added to CLITestSuite or DomainTestSuite. This pull request fixes this and resolves a number of problems that showed up when running the tests in the suite.

Also includes a commit fixing AS7-6190.
