### PR TITLE
[AS7-4828] Add expression support to JGroups transport and protocol properties

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTransformer_1_3.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTransformer_1_3.java
@@ -47,6 +47,14 @@ public class InfinispanSubsystemTransformer_1_3 extends AbstractSubsystemTransfo
         return model;
     }
 
+    /**
+     * Transform the cache into the earlier management api version, in which indexing properties,
+     * segments and virtual nodes were not defined.
+     *
+     * @param model
+     * @param containerName
+     * @param cacheType
+     */
     private void transformCache(final ModelNode model, final String containerName, final String cacheType) {
         if (!(model.get(ModelKeys.CACHE_CONTAINER).has(containerName) && model.get(ModelKeys.CACHE_CONTAINER, containerName).has(cacheType))) {
             return;

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java
@@ -59,8 +59,8 @@ public class JGroupsExtension implements Extension {
     public static final String RESOURCE_NAME = JGroupsExtension.class.getPackage().getName() + "." +"LocalDescriptions";
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MICRO_VERSION = 1;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 2;
+    private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
     // Temporary workaround for JGRP-1475
     // Configure JGroups to use jboss-logging.

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolLayerAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolLayerAdd.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -98,7 +97,7 @@ public class ProtocolLayerAdd implements OperationStepHandler {
                     throw JGroupsMessages.MESSAGES.propertyNotDefined(property.getName(), protocolRelativePath.toString());
                 }
                 // set the value of the property
-                param.getModel().get(ModelDescriptionConstants.VALUE).set(value);
+                PropertyResource.VALUE.validateAndSet(value, param.getModel());
             }
         }
         // This needs a reload

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
@@ -200,7 +200,7 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
         Transport transportConfig = new Transport(type);
         transportConfig.setShared(shared);
         transportConfig.setTopology(site, rack, machine);
-        initProtocolProperties(transport, transportConfig);
+        initProtocolProperties(context, transport, transportConfig);
 
         // set up the protocol stack Protocol objects
         ProtocolStack stackConfig = new ProtocolStack(name, transportConfig);
@@ -209,7 +209,7 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
             ModelNode protocol = protocolProperty.getValue();
             final String protocolType = (resolvedValue = ProtocolResource.TYPE.resolveModelAttribute(context, protocol)).isDefined() ? resolvedValue.asString() : null;
             Protocol protocolConfig = new Protocol(protocolType);
-            initProtocolProperties(protocol, protocolConfig);
+            initProtocolProperties(context, protocol, protocolConfig);
             stackConfig.getProtocols().add(protocolConfig);
             final String protocolSocketBinding = (resolvedValue = ProtocolResource.SOCKET_BINDING.resolveModelAttribute(context, protocol)).isDefined() ? resolvedValue.asString() : null;
             protocolSocketBindings.add(new AbstractMap.SimpleImmutableEntry<Protocol, String>(protocolConfig, protocolSocketBinding));
@@ -278,7 +278,7 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
         return builder.install();
     }
 
-    private void initProtocolProperties(ModelNode protocol, Protocol protocolConfig) {
+    private void initProtocolProperties(OperationContext context, ModelNode protocol, Protocol protocolConfig) throws OperationFailedException {
 
         Map<String, String> properties = protocolConfig.getProperties();
         // properties are a child resource of protocol
@@ -289,9 +289,11 @@ public class ProtocolStackAdd extends AbstractAddStepHandler implements Descript
                 //       "relative-to" => {"value" => "fred"},
                 //   }
                 String propertyName = property.getName();
-                Property complexValue = property.getValue().asProperty();
-                String propertyValue = complexValue.getValue().asString();
-                properties.put(propertyName, propertyValue);
+                // get the value from the ModelNode {"value" => "fred"}
+                ModelNode propertyValue = null ;
+                propertyValue = PropertyResource.VALUE.resolveModelAttribute(context, property.getValue());
+
+                properties.put(propertyName, propertyValue.asString());
             }
        }
     }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportLayerAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportLayerAdd.java
@@ -28,7 +28,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -71,7 +70,7 @@ public class TransportLayerAdd implements OperationStepHandler {
                     throw JGroupsMessages.MESSAGES.propertyNotDefined(property.getName(), transportRelativePath.toString());
                 }
                 // set the value of the property
-                param.getModel().get(ModelDescriptionConstants.VALUE).set(value);
+                PropertyResource.VALUE.validateAndSet(value, param.getModel());
             }
         }
         // This needs a reload

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTransformerTestCase.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTransformerTestCase.java
@@ -1,0 +1,101 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author <a href="tomaz.cerar@redhat.com">Tomaz Cerar</a>
+ */
+
+public class JGroupsSubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
+
+
+    public JGroupsSubsystemTransformerTestCase() {
+        super(JGroupsExtension.SUBSYSTEM_NAME, new JGroupsExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("jgroups-transformer_1_1.xml");
+    }
+
+    @Override
+    protected Set<PathAddress> getIgnoredChildResourcesForRemovalTest() {
+        // create a collection of resources in the test which are not removed by a "remove" command
+        // i.e. all resources of form /subsystem=jgroups/stack=maximal/protocol=*
+
+        String[] protocolList = {"MPING", "MERGE2", "FD_SOCK", "FD", "VERIFY_SUSPECT", "BARRIER",
+                "pbcast.NAKACK", "UNICAST2", "pbcast.STABLE", "pbcast.GMS", "UFC", "MFC", "FRAG2",
+                "pbcast.STATE_TRANSFER", "pbcast.FLUSH"};
+        PathAddress subsystem = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME));
+        PathAddress stack = subsystem.append(PathElement.pathElement(ModelKeys.STACK, "maximal"));
+        List<PathAddress> addresses = new ArrayList<PathAddress>();
+        for (String protocol : protocolList) {
+            PathAddress ignoredChild = stack.append(PathElement.pathElement(ModelKeys.PROTOCOL, protocol));
+            ;
+            addresses.add(ignoredChild);
+        }
+        return new HashSet<PathAddress>(addresses);
+    }
+
+    /**
+     * Tests transformation of model from 1.1.1 version into 1.1.0 version.
+     *
+     * This test does not pass because of an error in the 1.1.0 model:
+     * The model entry 'protocols' in /subsystem=jgroups/stack=* is used
+     * to store an ordered list of protocol names, but it is not registered
+     * as an attribute, where as it is registered in the 1.1.1 model.
+     * This breaks the test.
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testTransformer_1_1_0() throws Exception {
+        ModelVersion version = ModelVersion.create(1, 1);
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXml(getSubsystemXml());
+        builder.createLegacyKernelServicesBuilder(null, version)
+            .addMavenResourceURL("org.jboss.as:jboss-as-clustering-jgroups:7.1.2.Final");
+
+        KernelServices mainServices = builder.build();
+
+        checkSubsystemModelTransformation(mainServices, version);
+    }
+}

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationSequencesTestCase.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationSequencesTestCase.java
@@ -119,7 +119,7 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
             targetClass="org.jboss.as.clustering.jgroups.subsystem.ProtocolStackRemove",
             targetMethod="performRuntime",
             targetLocation="AT EXIT",
-            action="$1.setRollbackOnly()")
+            action="traceln(\"Injecting rollback fault via Byteman\");$1.setRollbackOnly()")
     public void testProtocolStackRemoveRollback() throws Exception {
 
         // Parse and install the XML into the controller

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
@@ -183,6 +183,18 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return writeOp ;
     }
 
+    protected static ModelNode getTransportPropertyAddOperation(String stackName, String propertyName, String propertyValue) {
+        // create the address of the subsystem
+        PathAddress transportPropertyAddress = getTransportPropertyAddress(stackName, propertyName);
+        ModelNode addOp = new ModelNode() ;
+        addOp.get(OP).set(ADD);
+        addOp.get(OP_ADDR).set(transportPropertyAddress.toModelNode());
+        // required attributes
+        addOp.get(NAME).set(ModelKeys.VALUE);
+        addOp.get(VALUE).set(propertyValue);
+        return addOp ;
+    }
+
     protected static ModelNode getTransportPropertyReadOperation(String stackName, String propertyName) {
         // create the address of the subsystem
         PathAddress transportPropertyAddress = getTransportPropertyAddress(stackName, propertyName);
@@ -254,12 +266,24 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return writeOp ;
     }
 
+    protected static ModelNode getProtocolPropertyAddOperation(String stackName, String protocolName, String propertyName, String propertyValue) {
+        // create the address of the subsystem
+        PathAddress protocolPropertyAddress = getProtocolPropertyAddress(stackName, protocolName, propertyName);
+        ModelNode addOp = new ModelNode() ;
+        addOp.get(OP).set(ADD);
+        addOp.get(OP_ADDR).set(protocolPropertyAddress.toModelNode());
+        // required attributes
+        addOp.get(NAME).set(ModelKeys.VALUE);
+        addOp.get(VALUE).set(propertyValue);
+        return addOp ;
+    }
+
     protected static ModelNode getProtocolPropertyReadOperation(String stackName, String protocolName, String propertyName) {
         // create the address of the subsystem
-        PathAddress transportPropertyAddress = getProtocolPropertyAddress(stackName, protocolName, propertyName);
+        PathAddress protocolPropertyAddress = getProtocolPropertyAddress(stackName, protocolName, propertyName);
         ModelNode readOp = new ModelNode() ;
         readOp.get(OP).set(READ_ATTRIBUTE_OPERATION);
-        readOp.get(OP_ADDR).set(transportPropertyAddress.toModelNode());
+        readOp.get(OP_ADDR).set(protocolPropertyAddress.toModelNode());
         // required attributes
         readOp.get(NAME).set(ModelKeys.VALUE);
         return readOp ;
@@ -267,10 +291,10 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     protected static ModelNode getProtocolPropertyWriteOperation(String stackName, String protocolName, String propertyName, String propertyValue) {
         // create the address of the subsystem
-        PathAddress transportPropertyAddress = getProtocolPropertyAddress(stackName, protocolName, propertyName);
+        PathAddress protocolPropertyAddress = getProtocolPropertyAddress(stackName, protocolName, propertyName);
         ModelNode writeOp = new ModelNode() ;
         writeOp.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-        writeOp.get(OP_ADDR).set(transportPropertyAddress.toModelNode());
+        writeOp.get(OP_ADDR).set(protocolPropertyAddress.toModelNode());
         // required attributes
         writeOp.get(NAME).set(ModelKeys.VALUE);
         writeOp.get(VALUE).set(propertyValue);

--- a/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/jgroups-transformer_1_1.xml
+++ b/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/jgroups-transformer_1_1.xml
@@ -1,0 +1,28 @@
+<subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="minimal">
+    <stack name="minimal">
+        <transport type="UDP"/>
+    </stack>
+    <stack name="maximal">
+        <transport type="TCP" socket-binding="jgroups-tcp" diagnostics-socket-binding="jgroups-diagnostics" default-executor="jgroups" oob-executor="jgroups-oob" timer-executor="jgroups-timer" shared="false" thread-factory="jgroups-thread-factory"
+        machine="machine1" rack="rack1" site="site1" >
+            <property name="enable_bundling">true</property>
+        </transport>
+        <protocol type="MPING" socket-binding="jgroups-mping">
+            <property name="name">value</property>
+        </protocol>
+        <protocol type="MERGE2"/>
+        <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+        <protocol type="FD"/>
+        <protocol type="VERIFY_SUSPECT"/>
+        <protocol type="BARRIER"/>
+        <protocol type="pbcast.NAKACK"/>
+        <protocol type="UNICAST2"/>
+        <protocol type="pbcast.STABLE"/>
+        <protocol type="pbcast.GMS"/>
+        <protocol type="UFC"/>
+        <protocol type="MFC"/>
+        <protocol type="FRAG2"/>
+        <protocol type="pbcast.STATE_TRANSFER" socket-binding="jgroups-state-xfr"/>
+        <protocol type="pbcast.FLUSH"/>
+    </stack>
+</subsystem>


### PR DESCRIPTION
This request:
- adds in expression support for JGroups protocol and transport properties
- adds in test cases for transformers and expression resolution
- bumps management api version from 1.1.0 to 1.2.0
  This is the main stage of the task to satisfy AS7-6120.  
