### PR TITLE
[AS7-6180] allow expressions in remoting subsystem

### DIFF
--- a/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
+++ b/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
@@ -1,0 +1,131 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.remoting;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBaseTest {
+
+    public RemotingSubsystemTransformersTestCase() {
+        super(RemotingExtension.SUBSYSTEM_NAME, new RemotingExtension());
+    }
+
+    @Test
+    public void testExpressionsAreRejectedByVersion_1_1() throws Exception {
+        String subsystemXml = readResource("remoting-with-expressions.xml");
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXml(subsystemXml);
+
+        // Add legacy subsystems
+        ModelVersion version_1_1 = ModelVersion.create(1, 1);
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), version_1_1)
+                .addMavenResourceURL("org.jboss.as:jboss-as-remoting:7.1.2.Final");
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(version_1_1);
+        assertNotNull(legacyServices);
+        assertFalse(legacyServices.isSuccessfulBoot());
+    }
+
+    @Test
+    public void testTransformers() throws Exception {
+        String subsystemXml = readResource("remoting-without-expressions.xml");
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXml(subsystemXml);
+
+        // Add legacy subsystems
+        ModelVersion version_1_1 = ModelVersion.create(1, 1);
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), version_1_1)
+                .addMavenResourceURL("org.jboss.as:jboss-as-remoting:7.1.2.Final");
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(version_1_1);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkSubsystemModelTransformation(mainServices, version_1_1);
+
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        ModelNode address = new ModelNode();
+        address.add(SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
+        operation.get(OP_ADDR).set(address);
+        operation.get(NAME).set("worker-read-threads");
+        operation.get(VALUE).set("${worker.read.threads:5}");
+
+        ModelNode mainResult = mainServices.executeOperation(operation);
+        assertEquals(mainResult.toJSONString(true), SUCCESS, mainResult.get(OUTCOME).asString());
+
+        ModelNode successResult = new ModelNode();
+        successResult.get(OUTCOME).set(SUCCESS);
+        successResult.protect();
+        ModelNode failedResult = new ModelNode();
+        failedResult.get(OUTCOME).set(FAILED);
+        failedResult.protect();
+        ModelNode ignoreResult = new ModelNode();
+        ignoreResult.get(OUTCOME).set(IGNORED);
+        ignoreResult.protect();
+
+        final OperationTransformer.TransformedOperation op = mainServices.transformOperation(version_1_1, operation);
+        final ModelNode result = mainServices.executeOperation(version_1_1, op);
+        assertEquals("should reject the expression", FAILED, result.get(OUTCOME).asString());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("remoting-with-expressions.xml");
+    }
+
+    @Override
+    protected String getSubsystemXml(String resource) throws IOException {
+        return readResource(resource);
+    }
+}

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
@@ -1,0 +1,10 @@
+<subsystem xmlns="urn:jboss:domain:remoting:1.1">
+   <worker-thread-pool
+	    read-threads="${worker.read.threads:5}"
+	    task-core-threads="${worker.task.core.threads:6}"
+	    task-keepalive="${worker.task.keepalive:7}"
+	    task-limit="${worker.task.limit:8}"
+	    task-max-threads="${worker.task.max.threads:9}"
+	    write-threads="${worker.write.threads:10}"
+	 />
+</subsystem>

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
@@ -7,4 +7,41 @@
 	    task-max-threads="${worker.task.max.threads:9}"
 	    write-threads="${worker.write.threads:10}"
 	 />
+   <connector name="remoting-connector" socket-binding="remoting">
+      <properties>
+         <property name="c1" value="${connector.prop:connector one}"/>
+      </properties>
+       <sasl>
+           <server-auth value="${sasl.server.auth:true}"/>
+           <reuse-session value="${sasl.reuse.session:true}"/>
+           <policy>
+               <forward-secrecy value="${forward.secrecy:true}"/>
+               <no-active value="${no.active:true}"/>
+               <no-anonymous value="${no.anonymous:true}"/>
+               <no-dictionary value="${no.dictionary:true}"/>
+               <no-plain-text value="${no.plain.text:true}"/>
+               <pass-credentials value="${pass.credentials:true}"/>
+           </policy>
+           <properties>
+               <property name="sasl1" value="${sasl.prop:sasl one}"/>
+           </properties>
+       </sasl>
+   </connector>
+   <outbound-connections>
+      <outbound-connection name="generic-conn1" uri="myuri">
+         <properties>
+            <property name="org.xnio.Options.SSL_ENABLED" value="${generic.outbound.connection.prop:false}"/>
+         </properties>
+      </outbound-connection>
+      <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket" username="${remoting.user:myuser}">
+         <properties>
+            <property name="org.xnio.Options.SSL_ENABLED" value="${remote.outbound.connection.prop:false}"/>
+         </properties>
+      </remote-outbound-connection>
+      <local-outbound-connection name="local-conn1" outbound-socket-binding-ref="other-outbound-socket">
+         <properties>
+            <property name="org.xnio.Options.SSL_ENABLED" value="${local.outbound.connection.prop:false}"/>
+         </properties>
+      </local-outbound-connection>
+   </outbound-connections>
 </subsystem>

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-without-expressions.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-without-expressions.xml
@@ -7,4 +7,41 @@
 	    task-max-threads="9"
 	    write-threads="10"
 	 />
+   <connector name="remoting-connector" socket-binding="remoting">
+      <properties>
+         <property name="c1" value="connector one"/>
+      </properties>
+      <sasl>
+         <server-auth value="true"/>
+         <reuse-session value="true"/>
+         <policy>
+            <forward-secrecy value="true"/>
+            <no-active value="true"/>
+            <no-anonymous value="true"/>
+            <no-dictionary value="true"/>
+            <no-plain-text value="true"/>
+            <pass-credentials value="true"/>
+         </policy>
+         <properties>
+            <property name="sasl1" value="sasl one"/>
+         </properties>
+       </sasl>
+   </connector>
+   <outbound-connections>
+      <outbound-connection name="generic-conn1" uri="myuri">
+         <properties>
+            <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+         </properties>
+      </outbound-connection>
+      <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket" username="myuser">
+         <properties>
+            <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+         </properties>
+      </remote-outbound-connection>
+      <local-outbound-connection name="local-conn1" outbound-socket-binding-ref="other-outbound-socket">
+         <properties>
+            <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+         </properties>
+      </local-outbound-connection>
+   </outbound-connections>
 </subsystem>

--- a/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-without-expressions.xml
+++ b/remoting-test/src/test/resources/org/jboss/as/remoting/remoting-without-expressions.xml
@@ -1,0 +1,10 @@
+<subsystem xmlns="urn:jboss:domain:remoting:1.1">
+   <worker-thread-pool
+	    read-threads="5"
+	    task-core-threads="6"
+	    task-keepalive="7"
+	    task-limit="8"
+	    task-max-threads="9"
+	    write-threads="10"
+	 />
+</subsystem>

--- a/remoting/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/ConnectorAdd.java
@@ -71,7 +71,7 @@ public class ConnectorAdd extends AbstractAddStepHandler {
     }
 
     void launchServices(OperationContext context, String connectorName, ModelNode fullModel, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
-        OptionMap optionMap = ConnectorResource.getFullOptions(fullModel);
+        OptionMap optionMap = ConnectorResource.getFullOptions(context, fullModel);
 
         final ServiceTarget target = context.getServiceTarget();
 

--- a/remoting/src/main/java/org/jboss/as/remoting/ConnectorResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/ConnectorResource.java
@@ -22,13 +22,7 @@
 package org.jboss.as.remoting;
 
 import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
-import static org.jboss.as.remoting.CommonAttributes.FORWARD_SECRECY;
 import static org.jboss.as.remoting.CommonAttributes.INCLUDE_MECHANISMS;
-import static org.jboss.as.remoting.CommonAttributes.NO_ACTIVE;
-import static org.jboss.as.remoting.CommonAttributes.NO_ANONYMOUS;
-import static org.jboss.as.remoting.CommonAttributes.NO_DICTIONARY;
-import static org.jboss.as.remoting.CommonAttributes.NO_PLAIN_TEXT;
-import static org.jboss.as.remoting.CommonAttributes.PASS_CREDENTIALS;
 import static org.jboss.as.remoting.CommonAttributes.POLICY;
 import static org.jboss.as.remoting.CommonAttributes.PROPERTY;
 import static org.jboss.as.remoting.CommonAttributes.QOP;
@@ -38,6 +32,14 @@ import static org.jboss.as.remoting.CommonAttributes.SASL_POLICY;
 import static org.jboss.as.remoting.CommonAttributes.SECURITY;
 import static org.jboss.as.remoting.CommonAttributes.SERVER_AUTH;
 import static org.jboss.as.remoting.CommonAttributes.STRENGTH;
+import static org.jboss.as.remoting.SaslPolicyResource.FORWARD_SECRECY;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_ACTIVE;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_ANONYMOUS;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_DICTIONARY;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_PLAIN_TEXT;
+import static org.jboss.as.remoting.SaslPolicyResource.PASS_CREDENTIALS;
+import static org.jboss.as.remoting.SaslResource.REUSE_SESSION_ATTRIBUTE;
+import static org.jboss.as.remoting.SaslResource.SERVER_AUTH_ATTRIBUTE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,6 +47,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
@@ -70,47 +74,54 @@ import org.xnio.sasl.SaslStrength;
  */
 public class ConnectorResource extends SimpleResourceDefinition {
 
+    static final PathElement PATH = PathElement.pathElement(CommonAttributes.CONNECTOR);
+
     static final ConnectorResource INSTANCE = new ConnectorResource();
 
-    static final SimpleAttributeDefinition AUTHENTICATION_PROVIDER = new NamedValueAttributeDefinition(CommonAttributes.AUTHENTICATION_PROVIDER, Attribute.NAME, null, ModelType.STRING, true);
+    //FIXME is this attribute still used?
+    static final SimpleAttributeDefinition AUTHENTICATION_PROVIDER = new SimpleAttributeDefinitionBuilder(CommonAttributes.AUTHENTICATION_PROVIDER, ModelType.STRING)
+            .setDefaultValue(null)
+            .setAllowNull(true)
+            .setAttributeMarshaller(new WrappedAttributeMarshaller(Attribute.NAME))
+            .build();
+
     static final SimpleAttributeDefinition SOCKET_BINDING = new SimpleAttributeDefinition(CommonAttributes.SOCKET_BINDING, ModelType.STRING, false);
     static final SimpleAttributeDefinition SECURITY_REALM = new SimpleAttributeDefinitionBuilder(
             CommonAttributes.SECURITY_REALM, ModelType.STRING, true).setValidator(
             new StringLengthValidator(1, Integer.MAX_VALUE, true, false)).build();
 
     private ConnectorResource() {
-        super(PathElement.pathElement(CommonAttributes.CONNECTOR), RemotingExtension.getResourceDescriptionResolver(CONNECTOR),
+        super(PATH, RemotingExtension.getResourceDescriptionResolver(CONNECTOR),
                 ConnectorAdd.INSTANCE, ConnectorRemove.INSTANCE);
     }
 
-    protected static OptionMap getFullOptions(ModelNode fullModel) {
+    protected static OptionMap getFullOptions(OperationContext context, ModelNode fullModel) throws OperationFailedException {
         OptionMap.Builder builder = OptionMap.builder();
         ModelNode properties = fullModel.get(PROPERTY);
         if (properties.isDefined() && properties.asInt() > 0) {
-            addOptions(properties, builder);
+            addOptions(context, properties, builder);
         }
         if (fullModel.hasDefined(SECURITY)) {
             ModelNode security = fullModel.require(SECURITY);
             if (security.hasDefined(SASL)) {
                 ModelNode sasl = security.require(SASL);
-                addSasl(sasl, builder);
+                addSasl(context, sasl, builder);
             }
         }
-
         return builder.getMap();
     }
 
-    protected static OptionMap getOptions(ModelNode properties) {
+    protected static OptionMap getOptions(OperationContext context, ModelNode properties) throws OperationFailedException {
         if (properties.isDefined() && properties.asInt() > 0) {
             OptionMap.Builder builder = OptionMap.builder();
-            addOptions(properties, builder);
+            addOptions(context, properties, builder);
             return builder.getMap();
         } else {
             return OptionMap.EMPTY;
         }
     }
 
-    private static void addSasl(ModelNode sasl, OptionMap.Builder builder) {
+    private static void addSasl(OperationContext context, ModelNode sasl, OptionMap.Builder builder) throws OperationFailedException {
         if (sasl.hasDefined(INCLUDE_MECHANISMS)) {
             builder.set(Options.SASL_MECHANISMS, Sequence.of(asStringSet(sasl.get(INCLUDE_MECHANISMS))));
         }
@@ -124,31 +135,31 @@ public class ConnectorResource extends SimpleResourceDefinition {
             }
         }
         if (sasl.hasDefined(SERVER_AUTH)) {
-            builder.set(Options.SASL_SERVER_AUTH, sasl.get(SERVER_AUTH).asBoolean());
+            builder.set(Options.SASL_SERVER_AUTH, SERVER_AUTH_ATTRIBUTE.resolveModelAttribute(context, sasl).asBoolean());
         }
         if (sasl.hasDefined(REUSE_SESSION)) {
-            builder.set(Options.SASL_REUSE, sasl.get(REUSE_SESSION).asBoolean());
+            builder.set(Options.SASL_REUSE, REUSE_SESSION_ATTRIBUTE.resolveModelAttribute(context, sasl).asBoolean());
         }
         ModelNode saslPolicy;
         if (sasl.hasDefined(SASL_POLICY) && (saslPolicy = sasl.get(SASL_POLICY)).hasDefined(POLICY)) {
             ModelNode policy = saslPolicy.get(POLICY);
-            if (policy.hasDefined(FORWARD_SECRECY)) {
-                builder.set(Options.SASL_POLICY_FORWARD_SECRECY, policy.get(FORWARD_SECRECY).asBoolean());
+            if (policy.hasDefined(FORWARD_SECRECY.getName())) {
+                builder.set(Options.SASL_POLICY_FORWARD_SECRECY, FORWARD_SECRECY.resolveModelAttribute(context, policy).asBoolean());
             }
-            if (policy.hasDefined(NO_ACTIVE)) {
-                builder.set(Options.SASL_POLICY_NOACTIVE, policy.get(NO_ACTIVE).asBoolean());
+            if (policy.hasDefined(NO_ACTIVE.getName())) {
+                builder.set(Options.SASL_POLICY_NOACTIVE, NO_ACTIVE.resolveModelAttribute(context, policy).asBoolean());
             }
-            if (policy.hasDefined(NO_ANONYMOUS)) {
-                builder.set(Options.SASL_POLICY_NOANONYMOUS, policy.get(NO_ANONYMOUS).asBoolean());
+            if (policy.hasDefined(NO_ANONYMOUS.getName())) {
+                builder.set(Options.SASL_POLICY_NOANONYMOUS, NO_ANONYMOUS.resolveModelAttribute(context, policy).asBoolean());
             }
-            if (policy.hasDefined(NO_DICTIONARY)) {
-                builder.set(Options.SASL_POLICY_NODICTIONARY, policy.get(NO_DICTIONARY).asBoolean());
+            if (policy.hasDefined(NO_DICTIONARY.getName())) {
+                builder.set(Options.SASL_POLICY_NODICTIONARY, NO_DICTIONARY.resolveModelAttribute(context, policy).asBoolean());
             }
-            if (policy.hasDefined(NO_PLAIN_TEXT)) {
-                builder.set(Options.SASL_POLICY_NOPLAINTEXT, policy.get(NO_PLAIN_TEXT).asBoolean());
+            if (policy.hasDefined(NO_PLAIN_TEXT.getName())) {
+                builder.set(Options.SASL_POLICY_NOPLAINTEXT, NO_PLAIN_TEXT.resolveModelAttribute(context, policy).asBoolean());
             }
-            if (policy.hasDefined(PASS_CREDENTIALS)) {
-                builder.set(Options.SASL_POLICY_PASS_CREDENTIALS, policy.get(PASS_CREDENTIALS).asBoolean());
+            if (policy.hasDefined(PASS_CREDENTIALS.getName())) {
+                builder.set(Options.SASL_POLICY_PASS_CREDENTIALS, PASS_CREDENTIALS.resolveModelAttribute(context, policy).asBoolean());
             }
         }
 
@@ -157,13 +168,13 @@ public class ConnectorResource extends SimpleResourceDefinition {
             List<Property> props = property.asPropertyList();
             List<org.xnio.Property> converted = new ArrayList<org.xnio.Property>(props.size());
             for (Property current : props) {
-                converted.add(org.xnio.Property.of(current.getName(), current.getValue().asString()));
+                converted.add(org.xnio.Property.of(current.getName(), PropertyResource.VALUE.resolveModelAttribute(context, current.getValue()).asString()));
             }
             builder.set(Options.SASL_PROPERTIES, Sequence.of(converted));
         }
     }
 
-    private static void addOptions(ModelNode properties, OptionMap.Builder builder) {
+    private static void addOptions(OperationContext context, ModelNode properties, OptionMap.Builder builder) throws OperationFailedException {
         final ClassLoader loader = SecurityActions.getClassLoader(ConnectorResource.class);
         for (Property property : properties.asPropertyList()) {
             String name = property.getName();
@@ -171,7 +182,8 @@ public class ConnectorResource extends SimpleResourceDefinition {
                 name = "org.xnio.Options." + name;
             }
             final Option option = Option.fromString(name, loader);
-            builder.set(option, option.parseValue(property.getValue().get(CommonAttributes.VALUE).asString(), loader));
+            String value = PropertyResource.VALUE.resolveModelAttribute(context, property.getValue()).asString();
+            builder.set(option, option.parseValue(value, loader));
         }
     }
 

--- a/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/GenericOutboundConnectionAdd.java
@@ -91,7 +91,7 @@ class GenericOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler 
 
         final PathAddress pathAddress = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String connectionName = pathAddress.getLastElement().getValue();
-        final OptionMap connectionCreationOptions = ConnectorResource.getOptions(fullModel.get(CommonAttributes.PROPERTY));
+        final OptionMap connectionCreationOptions = ConnectorResource.getOptions(context, fullModel.get(CommonAttributes.PROPERTY));
 
 
         //final OptionMap connectionCreationOptions = getConnectionCreationOptions(outboundConnection);

--- a/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionAdd.java
@@ -70,7 +70,7 @@ class LocalOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler {
         final String outboundSocketBindingRef = LocalOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, operation).asString();
         final ServiceName outboundSocketBindingDependency = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketBindingRef);
         // fetch the connection creation options from the model
-        final OptionMap connectionCreationOptions = ConnectorResource.getOptions(fullModel.get(CommonAttributes.PROPERTY));
+        final OptionMap connectionCreationOptions = ConnectorResource.getOptions(context, fullModel.get(CommonAttributes.PROPERTY));
         // create the service
         final LocalOutboundConnectionService outboundConnectionService = new LocalOutboundConnectionService(connectionName, connectionCreationOptions);
         final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(connectionName);

--- a/remoting/src/main/java/org/jboss/as/remoting/PropertyResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/PropertyResource.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.RestartParentResourceRemoveHandler;
 import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
@@ -45,14 +46,20 @@ import org.jboss.msc.service.ServiceName;
  */
 public class PropertyResource extends SimpleResourceDefinition {
 
+    static final PathElement PATH = PathElement.pathElement(PROPERTY);
+
     static final PropertyResource INSTANCE_CONNECTOR = new PropertyResource(CONNECTOR);
 
-    static final SimpleAttributeDefinition VALUE = new NamedValueAttributeDefinition(CommonAttributes.VALUE, Attribute.VALUE, null, ModelType.STRING, true);
+    static final SimpleAttributeDefinition VALUE = SimpleAttributeDefinitionBuilder.create(CommonAttributes.VALUE, ModelType.STRING)
+            .setDefaultValue(null)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .build();
 
     private final String parent;
 
     protected PropertyResource(String parent) {
-        super(PathElement.pathElement(PROPERTY),
+        super(PATH,
                 RemotingExtension.getResourceDescriptionResolver(PROPERTY),
                 new PropertyAdd(parent),
                 new PropertyRemove(parent));

--- a/remoting/src/main/java/org/jboss/as/remoting/PropertyResourceTransformers.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/PropertyResourceTransformers.java
@@ -1,0 +1,44 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.remoting;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
+
+/**
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+public class PropertyResourceTransformers {
+
+    static TransformersSubRegistration registerTransformers(TransformersSubRegistration parent) {
+        TransformersSubRegistration property = parent.registerSubResource(PropertyResource.PATH);
+        RejectExpressionValuesTransformer rejectPropertyExpression = new RejectExpressionValuesTransformer(PropertyResource.VALUE);
+        property.registerOperationTransformer(ADD, rejectPropertyExpression);
+        property.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectPropertyExpression.getWriteAttributeTransformer());
+
+        return property;
+    }
+}

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
@@ -75,7 +75,7 @@ class RemoteOutboundConnectionAdd extends AbstractOutboundConnectionAddHandler {
         final String outboundSocketBindingRef = RemoteOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, operation).asString();
         final ServiceName outboundSocketBindingDependency = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketBindingRef);
         // fetch the connection creation options from the model
-        final OptionMap connectionCreationOptions = ConnectorResource.getOptions(fullModel.get(CommonAttributes.PROPERTY));
+        final OptionMap connectionCreationOptions = ConnectorResource.getOptions(context, fullModel.get(CommonAttributes.PROPERTY));
         final String username = fullModel.hasDefined(CommonAttributes.USERNAME) ? fullModel.require(CommonAttributes.USERNAME).asString() : null;
         final String securityRealm = fullModel.hasDefined(CommonAttributes.SECURITY_REALM) ? fullModel.require(CommonAttributes.SECURITY_REALM).asString() : null;
 

--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -43,8 +43,10 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
             .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
 
-    public static final SimpleAttributeDefinition USERNAME = new SimpleAttributeDefinitionBuilder(CommonAttributes.USERNAME,
-            ModelType.STRING, true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false)).build();
+    public static final SimpleAttributeDefinition USERNAME = new SimpleAttributeDefinitionBuilder(CommonAttributes.USERNAME, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
+            .build();
 
     public static final SimpleAttributeDefinition SECURITY_REALM = new SimpleAttributeDefinitionBuilder(
             CommonAttributes.SECURITY_REALM, ModelType.STRING, true).setValidator(

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -155,6 +155,23 @@ public class RemotingExtension implements Extension {
         final TransformersSubRegistration subsystem = registration.registerModelTransformers(VERSION_1_1, rejectExpression);
         subsystem.registerOperationTransformer(ADD, rejectExpression);
         subsystem.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectExpression.getWriteAttributeTransformer());
+
+        TransformersSubRegistration connector = subsystem.registerSubResource(ConnectorResource.PATH);
+        PropertyResourceTransformers.registerTransformers(connector);
+        SaslResourceTransformers.registerTransformers(connector);
+
+        TransformersSubRegistration remoteOutboundConnection = subsystem.registerSubResource(RemoteOutboundConnectionResourceDefinition.ADDRESS);
+        RejectExpressionValuesTransformer rejectUserNameExpression = new RejectExpressionValuesTransformer(RemoteOutboundConnectionResourceDefinition.USERNAME);
+        remoteOutboundConnection.registerOperationTransformer(ADD, rejectUserNameExpression);
+        remoteOutboundConnection.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectUserNameExpression.getWriteAttributeTransformer());
+
+        PropertyResourceTransformers.registerTransformers(remoteOutboundConnection);
+
+        TransformersSubRegistration localOutboundConnection = subsystem.registerSubResource(LocalOutboundConnectionResourceDefinition.ADDRESS);
+        PropertyResourceTransformers.registerTransformers(localOutboundConnection);
+
+        TransformersSubRegistration outboundConnection = subsystem.registerSubResource(GenericOutboundConnectionResourceDefinition.ADDRESS);
+        PropertyResourceTransformers.registerTransformers(outboundConnection);
     }
 
     /**

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -28,6 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.parsing.ParseUtils.duplicateAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
@@ -71,7 +72,10 @@ import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
@@ -81,6 +85,10 @@ import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.transform.AbstractSubsystemTransformer;
+import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLElementReader;
@@ -109,8 +117,10 @@ public class RemotingExtension implements Extension {
     }
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 1;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 2;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
+
+    private static final ModelVersion VERSION_1_1 = ModelVersion.create(1, 1);
 
     @Override
     public void initialize(ExtensionContext context) {
@@ -135,6 +145,16 @@ public class RemotingExtension implements Extension {
         subsystem.registerSubModel(LocalOutboundConnectionResourceDefinition.INSTANCE);
         // (generic) outbound connection
         subsystem.registerSubModel(GenericOutboundConnectionResourceDefinition.INSTANCE);
+
+        registerTransformers_1_1(registration);
+    }
+
+    private void registerTransformers_1_1(SubsystemRegistration registration) {
+
+        RejectExpressionValuesTransformer rejectExpression = new RejectExpressionValuesTransformer(RemotingSubsystemRootResource.ATTRIBUTES);
+        final TransformersSubRegistration subsystem = registration.registerModelTransformers(VERSION_1_1, rejectExpression);
+        subsystem.registerOperationTransformer(ADD, rejectExpression);
+        subsystem.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectExpression.getWriteAttributeTransformer());
     }
 
     /**

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
@@ -30,7 +30,6 @@ import static org.jboss.as.controller.parsing.ParseUtils.duplicateAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.readArrayAttributeElement;
-import static org.jboss.as.controller.parsing.ParseUtils.readBooleanAttributeElement;
 import static org.jboss.as.controller.parsing.ParseUtils.readProperty;
 import static org.jboss.as.controller.parsing.ParseUtils.readStringAttributeElement;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoAttributes;
@@ -40,26 +39,18 @@ import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
 import static org.jboss.as.remoting.CommonAttributes.AUTHENTICATION_PROVIDER;
 import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
-import static org.jboss.as.remoting.CommonAttributes.FORWARD_SECRECY;
 import static org.jboss.as.remoting.CommonAttributes.INCLUDE_MECHANISMS;
 import static org.jboss.as.remoting.CommonAttributes.LOCAL_OUTBOUND_CONNECTION;
-import static org.jboss.as.remoting.CommonAttributes.NO_ACTIVE;
-import static org.jboss.as.remoting.CommonAttributes.NO_ANONYMOUS;
-import static org.jboss.as.remoting.CommonAttributes.NO_DICTIONARY;
-import static org.jboss.as.remoting.CommonAttributes.NO_PLAIN_TEXT;
 import static org.jboss.as.remoting.CommonAttributes.OUTBOUND_CONNECTION;
 import static org.jboss.as.remoting.CommonAttributes.OUTBOUND_SOCKET_BINDING_REF;
-import static org.jboss.as.remoting.CommonAttributes.PASS_CREDENTIALS;
 import static org.jboss.as.remoting.CommonAttributes.POLICY;
 import static org.jboss.as.remoting.CommonAttributes.PROPERTY;
 import static org.jboss.as.remoting.CommonAttributes.QOP;
 import static org.jboss.as.remoting.CommonAttributes.REMOTE_OUTBOUND_CONNECTION;
-import static org.jboss.as.remoting.CommonAttributes.REUSE_SESSION;
 import static org.jboss.as.remoting.CommonAttributes.SASL;
 import static org.jboss.as.remoting.CommonAttributes.SASL_POLICY;
 import static org.jboss.as.remoting.CommonAttributes.SECURITY;
 import static org.jboss.as.remoting.CommonAttributes.SECURITY_REALM;
-import static org.jboss.as.remoting.CommonAttributes.SERVER_AUTH;
 import static org.jboss.as.remoting.CommonAttributes.SOCKET_BINDING;
 import static org.jboss.as.remoting.CommonAttributes.STRENGTH;
 import static org.jboss.as.remoting.CommonAttributes.URI;
@@ -311,11 +302,13 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
                     break;
                 }
                 case REUSE_SESSION: {
-                    saslElement.get(REUSE_SESSION).set(readBooleanAttributeElement(reader, "value"));
+                    String value = readStringAttributeElement(reader, "value");
+                    SaslResource.REUSE_SESSION_ATTRIBUTE.parseAndSetParameter(value, saslElement, reader);
                     break;
                 }
                 case SERVER_AUTH: {
-                    saslElement.get(SERVER_AUTH).set(readBooleanAttributeElement(reader, "value"));
+                    String value = readStringAttributeElement(reader, "value");
+                    SaslResource.SERVER_AUTH_ATTRIBUTE.parseAndSetParameter(value, saslElement, reader);
                     break;
                 }
                 case STRENGTH: {
@@ -356,27 +349,27 @@ class RemotingSubsystem11Parser implements XMLStreamConstants, XMLElementReader<
             visited.add(element);
             switch (element) {
                 case FORWARD_SECRECY: {
-                    policy.get(FORWARD_SECRECY).set(readBooleanAttributeElement(reader, "value"));
+                    SaslPolicyResource.FORWARD_SECRECY.parseAndSetParameter(readStringAttributeElement(reader, "value"), policy, reader);
                     break;
                 }
                 case NO_ACTIVE: {
-                    policy.get(NO_ACTIVE).set(readBooleanAttributeElement(reader, "value"));
+                    SaslPolicyResource.NO_ACTIVE.parseAndSetParameter(readStringAttributeElement(reader, "value"), policy, reader);
                     break;
                 }
                 case NO_ANONYMOUS: {
-                    policy.get(NO_ANONYMOUS).set(readBooleanAttributeElement(reader, "value"));
+                    SaslPolicyResource.NO_ANONYMOUS.parseAndSetParameter(readStringAttributeElement(reader, "value"), policy, reader);
                     break;
                 }
                 case NO_DICTIONARY: {
-                    policy.get(NO_DICTIONARY).set(readBooleanAttributeElement(reader, "value"));
+                    SaslPolicyResource.NO_DICTIONARY.parseAndSetParameter(readStringAttributeElement(reader, "value"), policy, reader);
                     break;
                 }
                 case NO_PLAIN_TEXT: {
-                    policy.get(NO_PLAIN_TEXT).set(readBooleanAttributeElement(reader, "value"));
+                    SaslPolicyResource.NO_PLAIN_TEXT.parseAndSetParameter(readStringAttributeElement(reader, "value"), policy, reader);
                     break;
                 }
                 case PASS_CREDENTIALS: {
-                    policy.get(PASS_CREDENTIALS).set(readBooleanAttributeElement(reader, "value"));
+                    SaslPolicyResource.PASS_CREDENTIALS.parseAndSetParameter(readStringAttributeElement(reader, "value"), policy, reader);
                     break;
                 }
                 default: {

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
@@ -53,6 +53,8 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition WORKER_TASK_MAX_THREADS = createIntAttribute(CommonAttributes.WORKER_TASK_MAX_THREADS, Attribute.WORKER_TASK_MAX_THREADS, 16);
     static final SimpleAttributeDefinition WORKER_WRITE_THREADS = createIntAttribute(CommonAttributes.WORKER_WRITE_THREADS, Attribute.WORKER_WRITE_THREADS, 1);
 
+    static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
+
     static AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {
             WORKER_READ_THREADS,
             WORKER_TASK_CORE_THREADS,
@@ -65,7 +67,7 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     private final ProcessType processType;
 
     public RemotingSubsystemRootResource(final ProcessType processType) {
-        super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME),
+        super(PATH,
                 RemotingExtension.getResourceDescriptionResolver(RemotingExtension.SUBSYSTEM_NAME),
                 processType.isServer() ? RemotingSubsystemAdd.SERVER : RemotingSubsystemAdd.DOMAIN,
                 RemotingSubsystemRemove.INSTANCE);
@@ -84,7 +86,12 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     }
 
     private static SimpleAttributeDefinition createIntAttribute(String name, Attribute attribute, int defaultValue) {
-        return SimpleAttributeDefinitionBuilder.create(name, ModelType.INT, true).setDefaultValue(new ModelNode().set(defaultValue)).setXmlName(attribute.getLocalName()).setValidator(new IntRangeValidator(1, true)).build();
+        return SimpleAttributeDefinitionBuilder.create(name, ModelType.INT, true)
+                .setDefaultValue(new ModelNode().set(defaultValue))
+                .setXmlName(attribute.getLocalName())
+                .setValidator(new IntRangeValidator(1, true))
+                .setAllowExpression(true)
+                .build();
     }
 
     private static class ThreadWriteAttributeHandler extends RestartParentWriteAttributeHandler {

--- a/remoting/src/main/java/org/jboss/as/remoting/SaslPolicyResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/SaslPolicyResource.java
@@ -28,6 +28,8 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
@@ -42,12 +44,12 @@ public class SaslPolicyResource extends SimpleResourceDefinition {
 
     static final SaslPolicyResource INSTANCE = new SaslPolicyResource();
 
-    static final AttributeDefinition FORWARD_SECRECY = new BooleanValueAttributeDefinition(CommonAttributes.FORWARD_SECRECY);
-    static final AttributeDefinition NO_ACTIVE = new BooleanValueAttributeDefinition(CommonAttributes.NO_ACTIVE);
-    static final AttributeDefinition NO_ANONYMOUS = new BooleanValueAttributeDefinition(CommonAttributes.NO_ANONYMOUS);
-    static final AttributeDefinition NO_DICTIONARY = new BooleanValueAttributeDefinition(CommonAttributes.NO_DICTIONARY);
-    static final AttributeDefinition NO_PLAIN_TEXT = new BooleanValueAttributeDefinition(CommonAttributes.NO_PLAIN_TEXT);
-    static final AttributeDefinition PASS_CREDENTIALS = new BooleanValueAttributeDefinition(CommonAttributes.PASS_CREDENTIALS);
+    static final SimpleAttributeDefinition FORWARD_SECRECY = createBooleanAttributeDefinition(CommonAttributes.FORWARD_SECRECY);
+    static final SimpleAttributeDefinition NO_ACTIVE = createBooleanAttributeDefinition(CommonAttributes.NO_ACTIVE);
+    static final SimpleAttributeDefinition NO_ANONYMOUS = createBooleanAttributeDefinition(CommonAttributes.NO_ANONYMOUS);
+    static final SimpleAttributeDefinition NO_DICTIONARY = createBooleanAttributeDefinition(CommonAttributes.NO_DICTIONARY);
+    static final SimpleAttributeDefinition NO_PLAIN_TEXT = createBooleanAttributeDefinition(CommonAttributes.NO_PLAIN_TEXT);
+    static final SimpleAttributeDefinition PASS_CREDENTIALS = createBooleanAttributeDefinition(CommonAttributes.PASS_CREDENTIALS);
 
     private SaslPolicyResource() {
         super(SASL_POLICY_CONFIG_PATH,
@@ -69,9 +71,12 @@ public class SaslPolicyResource extends SimpleResourceDefinition {
         resourceRegistration.registerReadWriteAttribute(PASS_CREDENTIALS, null, writeHandler);
     }
 
-    private static class BooleanValueAttributeDefinition extends NamedValueAttributeDefinition {
-        public BooleanValueAttributeDefinition(String name) {
-            super(name, Attribute.VALUE, new ModelNode().set(true), ModelType.BOOLEAN, true);
-        }
+    private static SimpleAttributeDefinition createBooleanAttributeDefinition(String name) {
+        return SimpleAttributeDefinitionBuilder.create(name, ModelType.BOOLEAN)
+                .setDefaultValue(new ModelNode(true))
+                .setAllowNull(true)
+                .setAllowExpression(true)
+                .setAttributeMarshaller(new WrappedAttributeMarshaller(Attribute.VALUE))
+                .build();
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/SaslPolicyResourceTransformers.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/SaslPolicyResourceTransformers.java
@@ -1,0 +1,55 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.remoting;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.remoting.SaslPolicyResource.FORWARD_SECRECY;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_ACTIVE;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_ANONYMOUS;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_DICTIONARY;
+import static org.jboss.as.remoting.SaslPolicyResource.NO_PLAIN_TEXT;
+import static org.jboss.as.remoting.SaslPolicyResource.PASS_CREDENTIALS;
+import static org.jboss.as.remoting.SaslPolicyResource.SASL_POLICY_CONFIG_PATH;
+import static org.jboss.as.remoting.SaslResource.REUSE_SESSION_ATTRIBUTE;
+import static org.jboss.as.remoting.SaslResource.SASL_CONFIG_PATH;
+import static org.jboss.as.remoting.SaslResource.SERVER_AUTH_ATTRIBUTE;
+
+import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
+
+/**
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+public class SaslPolicyResourceTransformers {
+
+    static TransformersSubRegistration registerTransformers(TransformersSubRegistration parent) {
+        TransformersSubRegistration policy = parent.registerSubResource(SASL_POLICY_CONFIG_PATH);
+        RejectExpressionValuesTransformer rejectExpression = new RejectExpressionValuesTransformer(FORWARD_SECRECY,
+                NO_ACTIVE, NO_ANONYMOUS, NO_DICTIONARY, NO_PLAIN_TEXT, PASS_CREDENTIALS);
+        policy.registerOperationTransformer(ADD, rejectExpression);
+        policy.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectExpression.getWriteAttributeTransformer());
+
+        return policy;
+    }
+}

--- a/remoting/src/main/java/org/jboss/as/remoting/SaslResource.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/SaslResource.java
@@ -40,6 +40,8 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -64,9 +66,18 @@ public class SaslResource extends SimpleResourceDefinition {
     static final AttributeDefinition INCLUDE_MECHANISMS_ATTRIBUTE = new SaslListAttributeDefinition(Element.INCLUDE_MECHANISMS, INCLUDE_MECHANISMS, true);
     static final AttributeDefinition QOP_ATTRIBUTE = new SaslListAttributeDefinition(Element.QOP, QOP, true, QopParameterValidation.INSTANCE);
     static final AttributeDefinition STRENGTH_ATTRIBUTE = new SaslListAttributeDefinition(Element.STRENGTH, STRENGTH, true, StrengthParameterValidation.INSTANCE);
-    static final AttributeDefinition REUSE_SESSION_ATTRIBUTE = new NamedValueAttributeDefinition(REUSE_SESSION, Attribute.VALUE, new ModelNode().set(false), ModelType.BOOLEAN, true);
-    static final AttributeDefinition SERVER_AUTH_ATTRIBUTE = new NamedValueAttributeDefinition(SERVER_AUTH, Attribute.VALUE, new ModelNode().set(false), ModelType.BOOLEAN, true);
-
+    static final SimpleAttributeDefinition SERVER_AUTH_ATTRIBUTE = SimpleAttributeDefinitionBuilder.create(SERVER_AUTH, ModelType.BOOLEAN)
+            .setDefaultValue(new ModelNode(false))
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setAttributeMarshaller(new WrappedAttributeMarshaller(Attribute.VALUE))
+            .build();
+    static final SimpleAttributeDefinition REUSE_SESSION_ATTRIBUTE = SimpleAttributeDefinitionBuilder.create(REUSE_SESSION, ModelType.BOOLEAN)
+            .setDefaultValue(new ModelNode(false))
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setAttributeMarshaller(new WrappedAttributeMarshaller(Attribute.VALUE))
+            .build();
 
     private SaslResource() {
         super(SASL_CONFIG_PATH,

--- a/remoting/src/main/java/org/jboss/as/remoting/SaslResourceTransformers.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/SaslResourceTransformers.java
@@ -1,0 +1,50 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.remoting;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.remoting.SaslResource.REUSE_SESSION_ATTRIBUTE;
+import static org.jboss.as.remoting.SaslResource.SASL_CONFIG_PATH;
+import static org.jboss.as.remoting.SaslResource.SERVER_AUTH_ATTRIBUTE;
+
+import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
+
+/**
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+public class SaslResourceTransformers {
+
+    static TransformersSubRegistration registerTransformers(TransformersSubRegistration parent) {
+        TransformersSubRegistration sasl = parent.registerSubResource(SASL_CONFIG_PATH);
+        RejectExpressionValuesTransformer rejectPropertyExpression = new RejectExpressionValuesTransformer(SERVER_AUTH_ATTRIBUTE, REUSE_SESSION_ATTRIBUTE);
+        sasl.registerOperationTransformer(ADD, rejectPropertyExpression);
+        sasl.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, rejectPropertyExpression.getWriteAttributeTransformer());
+
+        SaslPolicyResourceTransformers.registerTransformers(sasl);
+        PropertyResourceTransformers.registerTransformers(sasl);
+
+        return sasl;
+    }
+}

--- a/remoting/src/main/java/org/jboss/as/remoting/WrappedAttributeMarshaller.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/WrappedAttributeMarshaller.java
@@ -1,6 +1,6 @@
 /*
 * JBoss, Home of Professional Open Source.
-* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
 * as indicated by the @author tags. See the copyright.txt file in the
 * distribution for a full listing of individual contributors.
 *
@@ -19,28 +19,32 @@
 * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 */
+
 package org.jboss.as.remoting;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 
-class NamedValueAttributeDefinition extends SimpleAttributeDefinition {
-    final Attribute attribute;
-    public NamedValueAttributeDefinition(final String name, final Attribute attribute, final ModelNode defaultValue, final ModelType type, final boolean allowNull) {
-        super(name, defaultValue, type, allowNull);
-        this.attribute = attribute;
+/**
+ * <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+public class WrappedAttributeMarshaller extends AttributeMarshaller {
+
+    private final Attribute xmlAttribute;
+
+    WrappedAttributeMarshaller(Attribute xmlAttribute) {
+        this.xmlAttribute = xmlAttribute;
     }
 
     @Override
-    public void marshallAsElement(ModelNode resourceModel, final boolean marshalDefault, XMLStreamWriter writer)
-            throws XMLStreamException {
-        if (isMarshallable(resourceModel)) {
-            writer.writeEmptyElement(getXmlName());
-            writer.writeAttribute(attribute.getLocalName(), resourceModel.get(getName()).asString());
+    public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+        if (isMarshallable(attribute, resourceModel)) {
+            writer.writeEmptyElement(attribute.getXmlName());
+            writer.writeAttribute(xmlAttribute.getLocalName(), resourceModel.get(attribute.getName()).asString());
         }
     }
 }


### PR DESCRIPTION
- bump remoting management API from 1.1.0 up to 1.2.0
- allow expressions for most of its attributes (see below for a comparison of its 1.2.0 and 1.1.0 management models)
- there is one attribute that could allow expressions that I did not change is the connector's authentication-provider. I did not find any use for it and when it would be resolved (if it is still used anywhere...)

====== Resource root address: ["subsystem" => "remoting"] - Current version: 1.2.0; legacy version: 1.1.0 =======
--- Problems for relative address to root []:
Different 'expressions-allowed' for attribute 'worker-read-threads'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'worker-task-core-threads'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'worker-task-keepalive'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'worker-task-limit'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'worker-task-max-threads'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'worker-write-threads'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'worker-read-threads' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'worker-task-core-threads' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'worker-task-keepalive' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'worker-task-limit' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'worker-task-max-threads' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'worker-write-threads' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["connector" => "_","property" => "_"]:
Different 'expressions-allowed' for attribute 'value'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'value' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["connector" => "_","security" => "sasl"]:
Different 'expressions-allowed' for attribute 'reuse-session'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'server-auth'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'reuse-session' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'server-auth' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["connector" => "_","security" => "sasl","property" => "_"]:
Different 'expressions-allowed' for attribute 'value'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'value' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["connector" => "_","security" => "sasl","sasl-policy" => "policy"]:
Different 'expressions-allowed' for attribute 'forward-secrecy'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'no-active'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'no-anonymous'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'no-dictionary'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'no-plain-text'. Current: true; legacy: false
Different 'expressions-allowed' for attribute 'pass-credentials'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'forward-secrecy' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'no-active' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'no-anonymous' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'no-dictionary' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'no-plain-text' of operation 'add'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'pass-credentials' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["local-outbound-connection" => "_","property" => "_"]:
Different 'expressions-allowed' for attribute 'value'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'value' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["outbound-connection" => "_","property" => "_"]:
Different 'expressions-allowed' for attribute 'value'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'value' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["remote-outbound-connection" => "_"]:
Different 'expressions-allowed' for attribute 'username'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'username' of operation 'add'. Current: true; legacy: false
--- Problems for relative address to root ["remote-outbound-connection" => "_","property" => "*"]:
Different 'expressions-allowed' for attribute 'value'. Current: true; legacy: false
Different 'expressions-allowed' for parameter 'value' of operation 'add'. Current: true; legacy: false
