### PR TITLE
[AS7-6143] HiloKeygenerator not registered in JNDI

### DIFF
--- a/cmp/src/main/java/org/jboss/as/cmp/subsystem/Attribute.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/subsystem/Attribute.java
@@ -30,7 +30,9 @@ import java.util.Map;
  */
 public enum Attribute {
     UNKNOWN(null),
-    NAME("name");
+    NAME("name"),
+    JNDI_NAME("jndi-name");
+
 
     private final String name;
 

--- a/cmp/src/main/java/org/jboss/as/cmp/subsystem/CmpSubsystemModel.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/subsystem/CmpSubsystemModel.java
@@ -31,6 +31,7 @@ public class CmpSubsystemModel {
     public static String HILO_KEY_GENERATOR = "hilo-keygenerator";
     public static String UUID_KEY_GENERATOR = "uuid-keygenerator";
 
+    public static String JNDI_NAME = "jndi-name";
     public static String BLOCK_SIZE = "block-size";
     public static String CREATE_TABLE = "create-table";
     public static String CREATE_TABLE_DDL = "create-table-ddl";

--- a/cmp/src/main/java/org/jboss/as/cmp/subsystem/HiLoKeyGeneratorResourceDescription.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/subsystem/HiLoKeyGeneratorResourceDescription.java
@@ -42,6 +42,11 @@ public class HiLoKeyGeneratorResourceDescription extends SimpleResourceDefinitio
 
     public static final HiLoKeyGeneratorResourceDescription INSTANCE = new HiLoKeyGeneratorResourceDescription();
 
+    public static final SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder(CmpSubsystemModel.JNDI_NAME, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .build();
+
     public static final SimpleAttributeDefinition BLOCK_SIZE = new SimpleAttributeDefinitionBuilder(CmpSubsystemModel.BLOCK_SIZE, ModelType.LONG, true)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
@@ -93,10 +98,11 @@ public class HiLoKeyGeneratorResourceDescription extends SimpleResourceDefinitio
             .build();
 
     public static final Map<String, SimpleAttributeDefinition> ATTRIBUTE_MAP;
-    public static final SimpleAttributeDefinition[] ATTRIBUTES = {BLOCK_SIZE, CREATE_TABLE, CREATE_TABLE_DDL, DATA_SOURCE, DROP_TABLE, ID_COLUMN, SELECT_HI_DDL, SEQUENCE_COLUMN, SEQUENCE_NAME, TABLE_NAME};
+    public static final SimpleAttributeDefinition[] ATTRIBUTES = {JNDI_NAME, BLOCK_SIZE, CREATE_TABLE, CREATE_TABLE_DDL, DATA_SOURCE, DROP_TABLE, ID_COLUMN, SELECT_HI_DDL, SEQUENCE_COLUMN, SEQUENCE_NAME, TABLE_NAME};
 
     static {
         Map<String, SimpleAttributeDefinition> map = new LinkedHashMap<String, SimpleAttributeDefinition>();
+        map.put(JNDI_NAME.getName(), JNDI_NAME);
         map.put(BLOCK_SIZE.getName(), BLOCK_SIZE);
         map.put(CREATE_TABLE.getName(), CREATE_TABLE);
         map.put(CREATE_TABLE_DDL.getName(), CREATE_TABLE_DDL);

--- a/cmp/src/main/java/org/jboss/as/cmp/subsystem/UUIDKeyGeneratorAdd.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/subsystem/UUIDKeyGeneratorAdd.java
@@ -24,6 +24,7 @@ package org.jboss.as.cmp.subsystem;
 
 import org.jboss.as.cmp.keygenerator.KeyGeneratorFactory;
 import org.jboss.as.cmp.keygenerator.uuid.UUIDKeyGeneratorFactory;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
@@ -47,6 +48,9 @@ public class UUIDKeyGeneratorAdd extends AbstractKeyGeneratorAdd {
     }
 
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        for(AttributeDefinition attribute : UUIDKeyGeneratorResourceDescription.ATTRIBUTES) {
+            attribute.validateAndSet(operation, model);
+        }
     }
 
 }

--- a/cmp/src/main/java/org/jboss/as/cmp/subsystem/UUIDKeyGeneratorResourceDescription.java
+++ b/cmp/src/main/java/org/jboss/as/cmp/subsystem/UUIDKeyGeneratorResourceDescription.java
@@ -22,8 +22,18 @@
 
 package org.jboss.as.cmp.subsystem;
 
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * @author Stuart Douglas
@@ -31,6 +41,20 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 public class UUIDKeyGeneratorResourceDescription extends SimpleResourceDefinition {
 
     public static final UUIDKeyGeneratorResourceDescription INSTANCE = new UUIDKeyGeneratorResourceDescription();
+
+    protected static final SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder(CmpSubsystemModel.JNDI_NAME, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .build();
+
+    public static final Map<String, SimpleAttributeDefinition> ATTRIBUTE_MAP;
+    public static final SimpleAttributeDefinition[] ATTRIBUTES = {JNDI_NAME};
+
+    static {
+        Map<String, SimpleAttributeDefinition> map = new LinkedHashMap<String, SimpleAttributeDefinition>();
+        map.put(JNDI_NAME.getName(), JNDI_NAME);
+        ATTRIBUTE_MAP = Collections.unmodifiableMap(map);
+    }
 
     private UUIDKeyGeneratorResourceDescription() {
         super(CmpSubsystemModel.UUID_KEY_GENERATOR_PATH,
@@ -40,6 +64,8 @@ public class UUIDKeyGeneratorResourceDescription extends SimpleResourceDefinitio
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-
+        for (AttributeDefinition attr : ATTRIBUTE_MAP.values()) {
+            resourceRegistration.registerReadWriteAttribute(attr, null, new ReloadRequiredWriteAttributeHandler(attr));
+        }
     }
 }

--- a/cmp/src/main/resources/org/jboss/as/cmp/subsystem/LocalDescriptions.properties
+++ b/cmp/src/main/resources/org/jboss/as/cmp/subsystem/LocalDescriptions.properties
@@ -28,11 +28,13 @@ uuid-keygenerator=UUID based key generators
 uuid-keygenerator.add=Add a UUID key generator
 uuid-keygenerator.remove=Remove a UUID key generator
 
+uuid-keygenerator.jndi-name=JNDI name to where uuid-keygenerator should be bound
+
 hilo-keygenerator=HiLo based key generators
 hilo-keygenerator.add=Add a HiLo key generator
 hilo-keygenerator.remove=Remove a HiLo key generator
 
-
+hilo-keygenerator.jndi-name=JNDI name to where hilo-keygenerator should be bound
 hilo-keygenerator.data-source=The datasource used for sequence generation
 hilo-keygenerator.table-name=The table name
 hilo-keygenerator.sequence-column=The sequence column name


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-6143

Extended key-generators (<hilo> and <uuid>) with an optional attribute <code>jndi-name</code> which leads to an JNDI registration of the key generator factory when existant.
