### PR TITLE
AS7-6125 Upgrade PicketBox to 4.0.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
         <version.org.opensaml.opensaml>2.5.1-1</version.org.opensaml.opensaml>
         <version.org.opensaml.openws>1.4.2-1</version.org.opensaml.openws>
         <version.org.opensaml.xmltooling>1.3.2-1</version.org.opensaml.xmltooling>
-        <version.org.picketbox>4.0.14.Final</version.org.picketbox>
+        <version.org.picketbox>4.0.15.Final</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.1.4.Final</version.org.picketlink>
         <version.org.powermock>1.4.11</version.org.powermock>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/JACCAuthzPropagationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/JACCAuthzPropagationTestCase.java
@@ -112,7 +112,6 @@ public class JACCAuthzPropagationTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore("JBPAPP6-1686")
     public void testBridge(@ArquillianResource URL webAppURL) throws Exception {
         assertAccessAllowed(webAppURL, Manage.BEAN_NAME_BRIDGE, PropagationTestServlet.METHOD_NAME_MANAGE, Manage.ROLE_ADMIN);
         assertAccessAllowed(webAppURL, Manage.BEAN_NAME_BRIDGE, PropagationTestServlet.METHOD_NAME_MANAGE, Manage.ROLE_MANAGER);

--- a/web/src/main/java/org/jboss/as/web/security/jaspi/WebJASPIAuthenticator.java
+++ b/web/src/main/java/org/jboss/as/web/security/jaspi/WebJASPIAuthenticator.java
@@ -329,10 +329,10 @@ public class WebJASPIAuthenticator extends AuthenticatorBase {
                 roles.add(group);
         }
 
-        // if no roles were retrieved yet, look for the roles declared in the deployment descriptor.
+        // look for the roles declared in the deployment descriptor.
         JBossWebRealm realm = (JBossWebRealm) this.getContainer().getRealm();
         Set<String> descriptorRoles = realm.getPrincipalVersusRolesMap().get(principal.getName());
-        if (roles.isEmpty() && descriptorRoles != null)
+        if (descriptorRoles != null)
             roles.addAll(descriptorRoles);
 
         // build and return the JBossGenericPrincipal.


### PR DESCRIPTION
AS7-6125 Upgrade PicketBox to 4.0.15.Final 
- includes a fix for the failing JACC TCK tests that use run-as identity

AS7-6220 Add descriptor roles when building the JBossGenericPrincipal
- fixes the JASPIC TCK tests that were failing due to incorrect roles being assigned to the authenticated principal
