### PR TITLE
Deployment overlays core model tests and fixes

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
@@ -48,7 +48,7 @@
                 <xs:element name="interfaces" type="named-interfacesType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="socket-binding-groups" type="socket-binding-groupsType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="deployments" type="domain-deploymentsType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="deployment-overlays" type="deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="domain-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="server-groups" type="server-groupsType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="management-client-content" type="management-client-contentType" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
@@ -123,7 +123,7 @@
                 <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="deployments" type="server-deploymentsType" minOccurs="0" maxOccurs="1"/>
-                <xs:element name="deployment-overlays" type="deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="standalone-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="optional">
                 <xs:annotation>
@@ -232,10 +232,10 @@
         <xs:attribute name="security-realm" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a 
+                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a
                     connection to the LDAP server.
-                    
-                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.                
+
+                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -2307,7 +2307,7 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="deployment-overlaysType">
+    <xs:complexType name="standalone-deployment-overlaysType">
         <xs:annotation>
             <xs:documentation>
                 <![CDATA[
@@ -2316,11 +2316,11 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="deployment-overlay" type="deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="deployment-overlay" type="standalone-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="deployment-overlayType">
+    <xs:complexType name="standalone-deployment-overlayType">
         <xs:sequence>
             <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="deployment" type="deployment-overlay-deploymentType" minOccurs="0" maxOccurs="unbounded"/>
@@ -2328,18 +2328,26 @@
         <xs:attribute name="name" use="required" type="xs:token"/>
     </xs:complexType>
 
-    <xs:complexType name="deployment-overlay-contentType">
-        <xs:attribute name="path" type="xs:token" use="required"/>
-        <xs:attribute name="content" type="xs:token" use="required"/>
+    <xs:complexType name="domain-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="domain-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
     </xs:complexType>
 
-
-    <xs:complexType name="deployment-overlay-deploymentType">
-        <xs:attribute name="name" type="xs:string" use="required"/>
-        <xs:attribute name="regular-expression" type="xs:boolean" use="optional"/>
+    <xs:complexType name="domain-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
     </xs:complexType>
-
-
+        
     <xs:complexType name="server-group-deployment-overlaysType">
         <xs:annotation>
             <xs:documentation>
@@ -2359,5 +2367,15 @@
         </xs:sequence>
         <xs:attribute name="name" use="required" type="xs:token"/>
     </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-contentType">
+        <xs:attribute name="path" type="xs:token" use="required"/>
+        <xs:attribute name="content" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-deploymentType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
 
 </xs:schema>

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -114,7 +114,6 @@ public class Util {
     public static final String READ_RESOURCE = "read-resource";
     public static final String READ_RESOURCE_DESCRIPTION = "read-resource-description";
     public static final String REDEPLOY = "redeploy";
-    public static final String REGULAR_EXPRESSION = "regular-expression";
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";
     public static final String REMOVE = "remove";

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -209,7 +209,6 @@ public class ModelDescriptionConstants {
     public static final String RECURSIVE = "recursive";
     public static final String RECURSIVE_DEPTH = "recursive-depth";
     public static final String REDEPLOY = "redeploy";
-    public static final String REGULAR_EXPRESSION = "regular-expression";
     public static final String RELATIVE_TO = "relative-to";
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -94,7 +94,6 @@ public enum Attribute {
     PROTOCOL("protocol"),
     RECURSIVE("recursive"),
     REF("ref"),
-    REGULAR_EXPRESSION("regular-expression"),
     RELATIVE_TO("relative-to"),
     RUNTIME_NAME("runtime-name"),
     SEARCH_CREDENTIAL("search-credential"),

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTestCase.java
@@ -1,0 +1,51 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deploymentoverlay;
+
+import junit.framework.Assert;
+
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class DomainDeploymentOverlayTestCase extends AbstractCoreModelTest {
+
+    @Test
+    public void testDomainOverlays() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
+            .setXmlResource("domain.xml")
+            .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+            .createContentRepositoryContent("12345678901234567890")
+            .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), "domain.xml"), marshalled);
+    }
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
@@ -1,0 +1,249 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deploymentoverlay;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import junit.framework.Assert;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.KernelServicesBuilder;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
+import org.jboss.as.core.model.test.LegacyKernelServicesInitializer.TestControllerVersion;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
+import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
+import org.jboss.as.model.test.ModelFixer;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@RunWith(Parameterized.class)
+public class DomainDeploymentOverlayTransformersTestCase extends AbstractCoreModelTest {
+
+    private final ModelVersion modelVersion;
+    private final TestControllerVersion testControllerVersion;
+
+    @Parameters
+    public static List<Object[]> parameters(){
+        return TransformersTestParameters.setupVersions();
+    }
+
+    public DomainDeploymentOverlayTransformersTestCase(TransformersTestParameters params) {
+        this.modelVersion = params.getModelVersion();
+        this.testControllerVersion = params.getTestControllerVersion();
+    }
+
+    @Test
+    public void testDeploymentOverlaysTransformer() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain.xml");
+
+        LegacyKernelServicesInitializer legacyInitializer = StandardServerGroupInitializers.addServerGroupInitializers(builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion));
+
+        if (modelVersion.getMajor() == 1 && modelVersion.getMinor() < 4) {
+            testDeploymentOverlaysTransformer_7_1_x(modelVersion, builder, legacyInitializer);
+        } else {
+            testDeploymentOverlaysTransformerMaster(modelVersion, builder, legacyInitializer);
+        }
+    }
+
+    @Test
+    public void testDeploymentOverlaysNotIgnoredOnOlderVersionFails() throws Exception {
+        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() >= 4) {
+            return;
+        }
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain.xml");
+
+        //Start up an empty legacy controller
+        StandardServerGroupInitializers.addServerGroupInitializers(
+                    builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
+                )
+                .setDontUseBootOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        //Since we had not set up the ignores the legacy controller cannot have the master model applied
+        try {
+            mainServices.applyMasterDomainModel(modelVersion, null);
+            Assert.fail("Should have failed to apply model without deployment-overlay ignored on host");
+        } catch(Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("14738")); //14738 comes from ControllerMessages.noChildType(String)
+        }
+    }
+
+    @Test
+    public void testDeploymentOverlaysIgnoredOnOlderVersionGetIgnoredButFailDueToServerGroupEntry() throws Exception {
+        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() >= 4) {
+            return;
+        }
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain.xml");
+
+        //Start up an empty legacy controller
+        StandardServerGroupInitializers.addServerGroupInitializers(
+                    builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
+                )
+                .setDontUseBootOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        //Since the server group deployment deployment-overlay is there we should fail
+        try {
+            mainServices.applyMasterDomainModel(modelVersion, null);
+            Assert.fail("Should have failed to apply model since server group still has a deployment overlay");
+        } catch(Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("14738")); //14738 comes from ControllerMessages.noChildType(String)
+        }
+    }
+
+    @Test
+    public void testDeploymentOverlaysIgnoredOnOlderVersionGetIgnored() throws Exception {
+        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() >= 4) {
+            return;
+        }
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .setXmlResource("domain-no-servergroup-overlay.xml");
+
+        //Start up an empty legacy controller
+        StandardServerGroupInitializers.addServerGroupInitializers(
+                    builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
+                )
+                .setDontUseBootOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        //This should pass since the deployment-overlay resource is ignored, and there is no use of deployment-overlay in server-group
+        mainServices.applyMasterDomainModel(modelVersion, Collections.singletonList(new IgnoreDomainResourceTypeResource(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, new ModelNode(), true)));
+
+        //Check deployment overlays exist in the master model but not in the legacy model
+        ModelNode masterModel = mainServices.readWholeModel();
+        ModelNode legacyModel = legacyServices.readWholeModel();
+        Assert.assertTrue(masterModel.hasDefined(ModelDescriptionConstants.DEPLOYMENT_OVERLAY) && masterModel.get(ModelDescriptionConstants.DEPLOYMENT_OVERLAY).hasDefined("test-overlay"));
+        Assert.assertFalse(legacyModel.hasDefined(ModelDescriptionConstants.DEPLOYMENT_OVERLAY));
+
+        //Compare the transformed and legacy models
+        checkCoreModelTransformation(
+                mainServices,
+                modelVersion,
+                new ModelFixer() {
+                    @Override
+                    public ModelNode fixModel(ModelNode modelNode) {
+                        //This one is just noise due to a different format
+                        //Perhaps this should go into the model comparison itself?
+                        ModelNode socketBindingGroup = modelNode.get(SOCKET_BINDING_GROUP, "test-sockets");
+                        if (socketBindingGroup.isDefined()) {
+                            Set<String> names = new HashSet<String>();
+                            for (String key : socketBindingGroup.keys()) {
+                                if (!socketBindingGroup.get(key).isDefined()) {
+                                    names.add(key);
+                                }
+                            }
+                            for(String name : names) {
+                                socketBindingGroup.remove(name);
+                            }
+                            if (socketBindingGroup.keys().size() == 0) {
+                                socketBindingGroup.clear();
+                            }
+                        }
+                        return modelNode;
+                    }
+                },
+                new ModelFixer() {
+                    @Override
+                    public ModelNode fixModel(ModelNode modelNode) {
+                        modelNode.remove(ModelDescriptionConstants.DEPLOYMENT_OVERLAY);
+                        return modelNode;
+                    }
+                });
+    }
+    private void testDeploymentOverlaysTransformer_7_1_x(ModelVersion modelVersion, KernelServicesBuilder builder, LegacyKernelServicesInitializer legacyInitializer) throws Exception {
+        //Don't validate ops since they definitely won't exist in target controller
+        legacyInitializer.setDontValidateOperations();
+
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertFalse(legacyServices.isSuccessfulBoot());
+
+    }
+
+    private void testDeploymentOverlaysTransformerMaster(ModelVersion modelVersion, KernelServicesBuilder builder, LegacyKernelServicesInitializer legacyInitializer) throws Exception {
+        KernelServices mainServices = builder.build();
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkCoreModelTransformation(mainServices, modelVersion, MODEL_FIXER, MODEL_FIXER);
+
+    }
+
+    private final ModelFixer MODEL_FIXER = new ModelFixer() {
+
+        @Override
+        public ModelNode fixModel(ModelNode modelNode) {
+            modelNode.remove(SOCKET_BINDING_GROUP);
+            modelNode.remove(PROFILE);
+            return modelNode;
+        }
+    };
+
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/StandaloneDeploymentOverlayTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/StandaloneDeploymentOverlayTestCase.java
@@ -1,0 +1,49 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deploymentoverlay;
+
+import junit.framework.Assert;
+
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class StandaloneDeploymentOverlayTestCase extends AbstractCoreModelTest {
+
+    @Test
+    public void testDomainOverlays() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.STANDALONE)
+            .setXmlResource("standalone.xml")
+            .createContentRepositoryContent("12345678901234567890")
+            .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), "standalone.xml"), marshalled);
+    }
+}

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+This is the shipped configuration with the extensions and profiles removed  
+ -->
+
+<domain xmlns="urn:jboss:domain:1.4">
+    <deployment-overlays>
+        <deployment-overlay name="test-overlay">
+            <content path="/test/123" content="12345678901234567890"/>
+        </deployment-overlay>
+    </deployment-overlays>
+    <server-groups>
+        <server-group name="test" profile="test">
+           <!-- Needed for the add operation -->
+           <socket-binding-group ref="test-sockets"/>
+        </server-group> 
+    </server-groups>
+</domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+This is the shipped configuration with the extensions and profiles removed  
+ -->
+
+<domain xmlns="urn:jboss:domain:1.4">
+    <deployment-overlays>
+        <deployment-overlay name="test-overlay">
+            <content path="/test/123" content="12345678901234567890"/>
+        </deployment-overlay>
+    </deployment-overlays>
+    <server-groups>
+        <server-group name="test" profile="test">
+           <!-- Needed for the add operation -->
+           <socket-binding-group ref="test-sockets"/>
+	        <deployment-overlays>
+		         <deployment-overlay name="test-overlay">
+	            </deployment-overlay>
+	        </deployment-overlays>
+        </server-group> 
+    </server-groups>
+</domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<server xmlns="urn:jboss:domain:1.4">
+    <deployment-overlays>
+        <deployment-overlay name="test-overlay">
+            <content path="/test/123" content="12345678901234567890"/>
+            <deployment name="test.war"/>
+        </deployment-overlay>
+    </deployment-overlays>
+</server>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
@@ -47,7 +47,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PAT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE_NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REGULAR_EXPRESSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE_DESTINATION_OUTBOUND_SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
@@ -577,11 +576,8 @@ public final class ManagedServerOperationsFactory {
                         for (Property content : deploymentsNode.get(DEPLOYMENT).asPropertyList()) {
                             final String deploymentName = content.getName();
                             final ModelNode deploymentDetails = content.getValue();
-                            boolean regEx = deploymentDetails.hasDefined(REGULAR_EXPRESSION) ? deploymentDetails.require(REGULAR_EXPRESSION).asBoolean() : false;
-
                             addr = PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT_OVERLAY, name), PathElement.pathElement(DEPLOYMENT, deploymentName));
                             addOp = Util.getEmptyOperation(ADD, addr.toModelNode());
-                            addOp.get(REGULAR_EXPRESSION).set(regEx);
                             updates.add(addOp);
                         }
                         }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -425,7 +425,7 @@ public class DomainXml extends CommonXml {
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.DEPLOYMENT_OVERLAYS) {
-            parseDeploymentOverlays(reader, expectedNs, new ModelNode(), list);
+            parseDeploymentOverlays(reader, expectedNs, new ModelNode(), list, true, false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.SERVER_GROUPS) {
@@ -763,7 +763,7 @@ public class DomainXml extends CommonXml {
                         break;
                     }
                     case DEPLOYMENT_OVERLAYS: {
-                        parseDeploymentOverlays(reader, expectedNs, groupAddress, list);
+                        parseDeploymentOverlays(reader, expectedNs, groupAddress, list, false, true);
                         break;
                     }
                     case SYSTEM_PROPERTIES: {

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentAdd.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentAdd.java
@@ -64,12 +64,11 @@ public class DeploymentOverlayDeploymentAdd extends AbstractAddStepHandler {
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String name = address.getLastElement().getValue();
         final String deploymentOverlay =address.getElement(address.size() - 2).getValue();
-        final Boolean regularExpression = DeploymentOverlayDeploymentDefinition.REGULAR_EXPRESSION.resolveModelAttribute(context, model).asBoolean();
-        installServices(context, verificationHandler, newControllers, name, deploymentOverlay, regularExpression, priority);
+        installServices(context, verificationHandler, newControllers, name, deploymentOverlay, priority);
     }
 
-    static void installServices(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final String name, final String deploymentOverlay, final boolean regularExpression, final DeploymentOverlayPriority priority) {
-        final DeploymentOverlayLinkService service = new DeploymentOverlayLinkService(name, regularExpression, priority);
+    static void installServices(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final String name, final String deploymentOverlay, final DeploymentOverlayPriority priority) {
+        final DeploymentOverlayLinkService service = new DeploymentOverlayLinkService(name, priority);
 
         final ServiceName serviceName = DeploymentOverlayLinkService.SERVICE_NAME.append(deploymentOverlay).append(name);
         ServiceBuilder<DeploymentOverlayLinkService> builder = context.getServiceTarget().addService(serviceName, service)

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentDefinition.java
@@ -23,16 +23,11 @@
 package org.jboss.as.server.deploymentoverlay;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.server.deploymentoverlay.service.DeploymentOverlayPriority;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 
 /**
  * Links a deployment overlay to a deployment
@@ -40,15 +35,7 @@ import org.jboss.dmr.ModelType;
  */
 public class DeploymentOverlayDeploymentDefinition extends SimpleResourceDefinition {
 
-    static final SimpleAttributeDefinition REGULAR_EXPRESSION =
-            new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.REGULAR_EXPRESSION, ModelType.BOOLEAN, false)
-                    .setAllowExpression(true)
-                    .setDefaultValue(new ModelNode().set(false))
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
-                    .build();
-
-
-    private static final AttributeDefinition[] ATTRIBUTES = { REGULAR_EXPRESSION };
+    private static final AttributeDefinition[] ATTRIBUTES = {  };
 
     public static AttributeDefinition[] attributes() {
         return ATTRIBUTES.clone();

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemove.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemove.java
@@ -51,8 +51,7 @@ public class DeploymentOverlayDeploymentRemove extends AbstractRemoveStepHandler
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String name = address.getLastElement().getValue();
         final String deploymentOverlay = address.getElement(address.size() - 2).getValue();
-        final Boolean regularExpression = DeploymentOverlayDeploymentDefinition.REGULAR_EXPRESSION.resolveModelAttribute(context, model).asBoolean();
-        DeploymentOverlayDeploymentAdd.installServices(context, null, null, name, deploymentOverlay, regularExpression, priority);
+        DeploymentOverlayDeploymentAdd.installServices(context, null, null, name, deploymentOverlay, priority);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayIndexService.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayIndexService.java
@@ -72,7 +72,7 @@ public class DeploymentOverlayIndexService implements Service<DeploymentOverlayI
 
         final List<DeploymentOverlayLinkService> matched = new ArrayList<DeploymentOverlayLinkService>();
         for (final DeploymentOverlayLinkService service : services) {
-            if (service.isRegex()) {
+            if (service.isWildcard()) {
                 if (service.getPattern().matcher(deploymentName).matches()) {
                     matched.add(service);
                 }
@@ -87,9 +87,9 @@ public class DeploymentOverlayIndexService implements Service<DeploymentOverlayI
                 if (res != 0) {
                     return res;
                 }
-                if (o2.isRegex() && !o1.isRegex()) {
+                if (o2.isWildcard() && !o1.isWildcard()) {
                     return -1;
-                } else if (o1.isRegex() && !o2.isRegex()) {
+                } else if (o1.isWildcard() && !o2.isWildcard()) {
                     return 1;
                 }
                 return 0;

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/service/DeploymentOverlayLinkService.java
@@ -53,17 +53,13 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
     private final String deployment;
     private final DeploymentOverlayPriority priority;
     private final Pattern pattern;
-    private final boolean regex;
+    private final boolean wildcard;
 
-    public DeploymentOverlayLinkService(final String deployment, final boolean regex, final DeploymentOverlayPriority priority) {
+    public DeploymentOverlayLinkService(final String deployment, final DeploymentOverlayPriority priority) {
         this.deployment = deployment;
         this.priority = priority;
-        this.regex = regex;
-        if (regex) {
-            this.pattern = Pattern.compile(wildcardToJavaRegexp(deployment));
-        } else {
-            this.pattern = null;
-        }
+        this.pattern = Pattern.compile(wildcardToJavaRegexp(deployment));
+        wildcard = deployment.contains("*") || deployment.contains("?");
     }
 
     @Override
@@ -101,7 +97,7 @@ public class DeploymentOverlayLinkService implements Service<DeploymentOverlayLi
         return pattern;
     }
 
-    public boolean isRegex() {
-        return regex;
+    public boolean isWildcard() {
+        return wildcard;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -468,7 +468,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
         }
 
         if (element == Element.DEPLOYMENT_OVERLAYS) {
-            parseDeploymentOverlays(reader, namespace, new ModelNode(), list);
+            parseDeploymentOverlays(reader, namespace, new ModelNode(), list, true, true);
             element = nextElement(reader, namespace);
         }
         if (element != null) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
@@ -207,7 +207,7 @@ public class DomainDeploymentOverlayTestCase {
     public void testWildcardOverride() throws Exception {
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment*.war --server-groups=main-server-group --redeploy-affected");
+                + " --deployments=deployment*.war --server-groups=main-server-group --redeploy-affected");
 
         ctx.handle("deploy --server-groups=main-server-group " + war1.getAbsolutePath());
         ctx.handle("deploy --server-groups=main-server-group " + war2.getAbsolutePath());
@@ -229,7 +229,7 @@ public class DomainDeploymentOverlayTestCase {
         ctx.handle("deploy --server-groups=main-server-group " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment*.war --server-groups=main-server-group --redeploy-affected");
+                + " --deployments=deployment*.war --server-groups=main-server-group --redeploy-affected");
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -256,7 +256,7 @@ public class DomainDeploymentOverlayTestCase {
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "deployment1"));
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
 
-        ctx.handle("deployment-overlay link --name=overlay-test --wildcards=a*.war --server-groups=main-server-group");
+        ctx.handle("deployment-overlay link --name=overlay-test --deployments=a*.war --server-groups=main-server-group");
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -294,7 +294,7 @@ public class DomainDeploymentOverlayTestCase {
         assertEquals("NON OVERRIDDEN", performHttpCall("slave", "main-three", "deployment1"));
         assertEquals("OVERRIDDEN", performHttpCall("slave", "main-three", "another"));
 
-        ctx.handle("deployment-overlay remove --name=overlay-test --wildcards=a*.war --server-groups=main-server-group");
+        ctx.handle("deployment-overlay remove --name=overlay-test --deployments=a*.war --server-groups=main-server-group");
 
         assertEquals("OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));
@@ -333,7 +333,7 @@ public class DomainDeploymentOverlayTestCase {
         ctx.handle("deploy --server-groups=main-server-group " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath());
-        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war --wildcards=a*.war --server-groups=main-server-group");
+        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war,a*.war --server-groups=main-server-group");
 
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment0"));
         assertEquals("NON OVERRIDDEN", performHttpCall("master", "main-one", "deployment1"));

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -270,7 +270,6 @@ public class DeploymentOverlayTestCase {
         addr.add(ModelDescriptionConstants.DEPLOYMENT, "*.war");
         op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
         op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-        op.get(ModelDescriptionConstants.REGULAR_EXPRESSION).set(true);
         steps.add(op);
 
         executeOnMaster(opBuilder.build());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
@@ -106,7 +106,6 @@ public class DeploymentOverlayTestCase {
             addr.add(ModelDescriptionConstants.DEPLOYMENT, "*.war");
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            op.get(ModelDescriptionConstants.REGULAR_EXPRESSION).set(true);
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
@@ -195,7 +195,7 @@ public class DeploymentOverlayTestCase {
     public void testWildcardOverride() throws Exception {
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment*.war");
+                + " --deployments=deployment*.war");
 
         ctx.handle("deploy " + war1.getAbsolutePath());
         ctx.handle("deploy " + war2.getAbsolutePath());
@@ -217,7 +217,7 @@ public class DeploymentOverlayTestCase {
         ctx.handle("deploy " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath()
-                + " --wildcards=deployment*.war --redeploy-affected");
+                + " --deployments=deployment*.war --redeploy-affected");
 
         //Thread.sleep(2000);
         String response = readResponse("deployment0");
@@ -245,7 +245,7 @@ public class DeploymentOverlayTestCase {
         response = readResponse("another");
         assertEquals("NON OVERRIDDEN", response);
 
-        ctx.handle("deployment-overlay link --name=overlay-test --wildcards=a*.war");
+        ctx.handle("deployment-overlay link --name=overlay-test --deployments=a*.war");
 
         response = readResponse("deployment0");
         assertEquals("OVERRIDDEN", response);
@@ -283,7 +283,7 @@ public class DeploymentOverlayTestCase {
         response = readResponse("another");
         assertEquals("OVERRIDDEN", response);
 
-        ctx.handle("deployment-overlay remove --name=overlay-test --wildcards=a*.war");
+        ctx.handle("deployment-overlay remove --name=overlay-test --deployments=a*.war");
 
         response = readResponse("deployment0");
         assertEquals("OVERRIDDEN", response);
@@ -330,7 +330,7 @@ public class DeploymentOverlayTestCase {
         ctx.handle("deploy " + war3.getAbsolutePath());
 
         ctx.handle("deployment-overlay add --name=overlay-test --content=WEB-INF/web.xml=" + overrideXml.getAbsolutePath());
-        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war --wildcards=a*.war");
+        ctx.handle("deployment-overlay link --name=overlay-test --deployments=deployment0.war,a*.war");
 
         String response = readResponse("deployment0");
         assertEquals("NON OVERRIDDEN", response);


### PR DESCRIPTION
This replaces #3653

This removes the REGULAR_EXPRESSION attribute from the model. As we are now just using simple wildcards and not full regular expressions, it is no longer necessary nor accurate. 

The original blurb of the old PR:
No transformation is added for deployment overlays for older slaves not having it. Using an older slave against a DC with deployment overlays will fail unless deployment overlays are ignored resources on the slave.

I have not tested deployment overlay operations on the DC being ignored on the slaves having them as ignored resources, as I believe that is already tested elsewhere as part of the core framework
