### PR TITLE
AS7-5432: chain RuntimeExceptions thrown from the EJB-code with the TransactionRolledbackLocalException

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/EjbExceptionTransformingInterceptorFactories.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/EjbExceptionTransformingInterceptorFactories.java
@@ -90,7 +90,11 @@ public class EjbExceptionTransformingInterceptorFactories {
             } catch (EJBTransactionRequiredException e) {
                 throw new TransactionRequiredLocalException(e.getMessage());
             } catch (EJBTransactionRolledbackException e) {
-                throw new TransactionRolledbackLocalException(e.getMessage());
+                throw new TransactionRolledbackLocalException(e.getMessage(),
+                                                              // AS7-5432: propagate the causing exception to the caller
+                                                              // (RuntimeExceptions thrown from the EJB-code arrive here as cause of
+                                                              // EJBTransactionRolledbackException - see org.jboss.as.ejb3.tx.CMTTxInterceptor.handleInCallerTx(...))
+                                                              e.getCausedByException());
             } catch (NoSuchEJBException e) {
                 throw new NoSuchObjectLocalException(e.getMessage());
             } catch (NoSuchEntityException e) {


### PR DESCRIPTION
A fix for https://issues.jboss.org/browse/AS7-5432 (a TransactionRolledbackLocalException triggered by a RuntimeException isn't chained with the triggering RuntimeException).
