### PR TITLE
AS7-6246 ENC read-only during legacy SAR deployment

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/jmx/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/jmx/main/module.xml
@@ -35,6 +35,7 @@
         <module name="javax.api"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.remoting" />
         <module name="org.jboss.as.server" />

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>jboss-as-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-naming</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.remotingjmx</groupId>
             <artifactId>remoting-jmx</artifactId>
         </dependency>

--- a/sar/src/main/java/org/jboss/as/service/AbstractService.java
+++ b/sar/src/main/java/org/jboss/as/service/AbstractService.java
@@ -26,7 +26,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import org.jboss.as.naming.WritableServiceBasedNamingStore;
-import org.jboss.msc.service.LifecycleContext;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
 
@@ -55,7 +54,7 @@ abstract class AbstractService implements Service<Object> {
         return mBeanInstance;
     }
 
-    protected void invokeLifecycleMethod(final Method method, final LifecycleContext context) throws InvocationTargetException, IllegalAccessException {
+    protected void invokeLifecycleMethod(final Method method) throws InvocationTargetException, IllegalAccessException {
         if (method != null) {
             WritableServiceBasedNamingStore.pushOwner(duServiceName);
             final ClassLoader old = SecurityActions.setThreadContextClassLoader(mBeanInstance.getClass().getClassLoader());

--- a/sar/src/main/java/org/jboss/as/service/CreateDestroyService.java
+++ b/sar/src/main/java/org/jboss/as/service/CreateDestroyService.java
@@ -59,7 +59,7 @@ final class CreateDestroyService extends AbstractService {
             SarLogger.ROOT_LOGGER.tracef("Creating Service: %s", context.getController().getName());
         }
         try {
-            invokeLifecycleMethod(createMethod, context);
+            invokeLifecycleMethod(createMethod);
         } catch (final Exception e) {
             throw SarMessages.MESSAGES.failedExecutingLegacyMethod(e, "create()");
         }
@@ -77,7 +77,7 @@ final class CreateDestroyService extends AbstractService {
             managedReference.release();
         }
         try {
-            invokeLifecycleMethod(destroyMethod, context);
+            invokeLifecycleMethod(destroyMethod);
         } catch (final Exception e) {
             SarLogger.ROOT_LOGGER.failedExecutingLegacyMethod(e, "create()");
         }

--- a/sar/src/main/java/org/jboss/as/service/StartStopService.java
+++ b/sar/src/main/java/org/jboss/as/service/StartStopService.java
@@ -52,7 +52,7 @@ final class StartStopService extends AbstractService {
             SarLogger.ROOT_LOGGER.tracef("Starting Service: %s", context.getController().getName());
         }
         try {
-            invokeLifecycleMethod(startMethod, context);
+            invokeLifecycleMethod(startMethod);
         } catch (final Exception e) {
             throw SarMessages.MESSAGES.failedExecutingLegacyMethod(e, "start()");
         }
@@ -64,7 +64,7 @@ final class StartStopService extends AbstractService {
             SarLogger.ROOT_LOGGER.tracef("Stopping Service: %s", context.getController().getName());
         }
         try {
-            invokeLifecycleMethod(stopMethod, context);
+            invokeLifecycleMethod(stopMethod);
         } catch (final Exception e) {
             SarLogger.ROOT_LOGGER.failedExecutingLegacyMethod(e, "stop()");
         }


### PR DESCRIPTION
When the `#startService()` and `#stopService()` methods of a sublass of
`ServiceMBeanSupport` are invoked the JNDI context is read only.
- pass the deployment unit service name to `MBeanRegistrationService`
- clean up `AbstractService`
- add a dependency to naming to jmx

Things aren't perfect after the path though. You still get an exception
when stopping JBoss AS. I can't make much sense out if this, it'd be
great if somebody could give me a pointer.

```
22:30:03,523 WARN  [com.github.marschall.sars.legacy.LegacySample] (MSC service thread 1-3) Stopping failed service.server.monitor:service=LegacySampleMBean: javax.naming.NamingException: JBAS011836: Could not resolve service service jboss.naming.context.java.global.env.foo.legacy
    at org.jboss.as.naming.WritableServiceBasedNamingStore.unbind(WritableServiceBasedNamingStore.java:108)
    at org.jboss.as.naming.NamingContext.unbind(NamingContext.java:286)
    at org.jboss.as.naming.InitialContext.unbind(InitialContext.java:167)
    at org.jboss.as.naming.NamingContext.unbind(NamingContext.java:294)
    at javax.naming.InitialContext.unbind(InitialContext.java:439) [rt.jar:1.8.0-ea]
    at com.github.marschall.sars.legacy.LegacySample.stopService(LegacySample.java:30) [sar-legacy-1.0.0-SNAPHSOT.sar:]
    at org.jboss.system.ServiceMBeanSupport.jbossInternalStop(ServiceMBeanSupport.java:283) [jboss-as-system-jmx-7.2.0.Alpha1-SNAPSHOT.jar:7.2.0.Alpha1-SNAPSHOT]
    at org.jboss.system.ServiceMBeanSupport.stop(ServiceMBeanSupport.java:163) [jboss-as-system-jmx-7.2.0.Alpha1-SNAPSHOT.jar:7.2.0.Alpha1-SNAPSHOT]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0-ea]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) [rt.jar:1.8.0-ea]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0-ea]
    at java.lang.reflect.Method.invoke(Method.java:474) [rt.jar:1.8.0-ea]
    at org.jboss.as.service.AbstractService.invokeLifecycleMethod(AbstractService.java:62)
    at org.jboss.as.service.StartStopService.stop(StartStopService.java:67)
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.stopService(ServiceControllerImpl.java:1911)
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.run(ServiceControllerImpl.java:1874)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110) [rt.jar:1.8.0-ea]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603) [rt.jar:1.8.0-ea]
    at java.lang.Thread.run(Thread.java:722) [rt.jar:1.8.0-ea]

22:30:03,532 SEVERE [sar-pojo] (MSC service thread 1-1) could not bind value: javax.naming.NamingException: JBAS011836: Could not resolve service service jboss.naming.context.java.global.env.foo
    at org.jboss.as.naming.WritableServiceBasedNamingStore.unbind(WritableServiceBasedNamingStore.java:108)
    at org.jboss.as.naming.NamingContext.unbind(NamingContext.java:286)
    at org.jboss.as.naming.InitialContext.unbind(InitialContext.java:167)
    at org.jboss.as.naming.NamingContext.unbind(NamingContext.java:294)
    at javax.naming.InitialContext.unbind(InitialContext.java:439) [rt.jar:1.8.0-ea]
    at com.github.marschall.sars.pojo.PojoSample.stop(PojoSample.java:33) [sar-pojo-1.0.0-SNAPHSOT.sar:]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) [rt.jar:1.8.0-ea]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57) [rt.jar:1.8.0-ea]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) [rt.jar:1.8.0-ea]
    at java.lang.reflect.Method.invoke(Method.java:474) [rt.jar:1.8.0-ea]
    at org.jboss.as.service.AbstractService.invokeLifecycleMethod(AbstractService.java:62)
    at org.jboss.as.service.StartStopService.stop(StartStopService.java:67)
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.stopService(ServiceControllerImpl.java:1911)
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.run(ServiceControllerImpl.java:1874)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110) [rt.jar:1.8.0-ea]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603) [rt.jar:1.8.0-ea]
    at java.lang.Thread.run(Thread.java:722) [rt.jar:1.8.0-ea]

22:30:03,551 ERROR [org.jboss.as.naming] (MSC service thread 1-2) JBAS011811: Failed to release binder service, used for a runtime made JNDI binding: java.lang.NullPointerException
    at org.jboss.as.naming.deployment.RuntimeBindReleaseService.stop(RuntimeBindReleaseService.java:69) [jboss-as-naming-7.2.0.Alpha1-SNAPSHOT.jar:7.2.0.Alpha1-SNAPSHOT]
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.stopService(ServiceControllerImpl.java:1911) [jboss-msc-1.0.3.GA.jar:1.0.3.GA]
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.run(ServiceControllerImpl.java:1874) [jboss-msc-1.0.3.GA.jar:1.0.3.GA]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110) [rt.jar:1.8.0-ea]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603) [rt.jar:1.8.0-ea]
    at java.lang.Thread.run(Thread.java:722) [rt.jar:1.8.0-ea]

22:30:03,558 ERROR [org.jboss.as.naming] (MSC service thread 1-3) JBAS011811: Failed to release binder service, used for a runtime made JNDI binding: java.lang.NullPointerException
    at org.jboss.as.naming.deployment.RuntimeBindReleaseService.stop(RuntimeBindReleaseService.java:69) [jboss-as-naming-7.2.0.Alpha1-SNAPSHOT.jar:7.2.0.Alpha1-SNAPSHOT]
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.stopService(ServiceControllerImpl.java:1911) [jboss-msc-1.0.3.GA.jar:1.0.3.GA]
    at org.jboss.msc.service.ServiceControllerImpl$StopTask.run(ServiceControllerImpl.java:1874) [jboss-msc-1.0.3.GA.jar:1.0.3.GA]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110) [rt.jar:1.8.0-ea]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603) [rt.jar:1.8.0-ea]
    at java.lang.Thread.run(Thread.java:722) [rt.jar:1.8.0-ea]
```

https://issues.jboss.org/browse/AS7-6246
