### PR TITLE
AS7-6086: catches all throwables when handling a msg, not just specific ...

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -2013,7 +2013,7 @@ public interface EjbMessages {
     EJBException componentIsShuttingDown();
 
     @Message(id = 14560, value = "Could not open message outputstream for writing to Channel")
-    RuntimeException failedToOpenMessageOutputStream(@Cause Exception e);
+    IOException failedToOpenMessageOutputStream(@Cause Throwable e);
 
     @Message(id = 14561, value = "Could not create session for stateful bean %s")
     RuntimeException failedToCreateSessionForStatefulBean(@Cause Exception e, String beanName);
@@ -2104,4 +2104,11 @@ public interface EjbMessages {
 
     @Message(id = 14230, value = "EJB %s of type %s must not be declared final")
     DeploymentUnitProcessingException ejbMustNotBeFinalClass(String componentName, String componentClassName);
+
+    @Message(id = 14233, value = "Failed to read EJB info")
+    IOException failedToReadEjbInfo(@Cause Throwable e);
+
+    @Message(id = 14234, value = "Failed to read EJB Locator")
+    IOException failedToReadEJBLocator(@Cause Throwable e);
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -118,8 +118,8 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             moduleName = (String) unmarshaller.readObject();
             distinctName = (String) unmarshaller.readObject();
             beanName = (String) unmarshaller.readObject();
-        } catch (ClassNotFoundException e) {
-            throw EjbMessages.MESSAGES.classNotFoundException(e);
+        } catch (Throwable e) {
+            throw EjbMessages.MESSAGES.failedToReadEjbInfo(e);
         }
         final EjbDeploymentInformation ejbDeploymentInformation = this.findEJB(appName, moduleName, distinctName, beanName);
         if (ejbDeploymentInformation == null) {
@@ -138,8 +138,8 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             final EJBLocator<?> locator;
             try {
                 locator = (EJBLocator<?>) unmarshaller.readObject();
-            } catch (ClassNotFoundException e) {
-                throw EjbMessages.MESSAGES.classNotFoundException(e);
+            } catch (Throwable e) {
+                throw EjbMessages.MESSAGES.failedToReadEJBLocator(e);
             }
             final String viewClassName = locator.getViewType().getName();
             // Make sure it's a remote view
@@ -160,9 +160,9 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                 for (int i = 0; i < methodParamTypes.length; i++) {
                     try {
                         methodParams[i] = unmarshaller.readObject();
-                    } catch (ClassNotFoundException cnfe) {
+                    } catch (Throwable e) {
                         // write out the failure
-                        MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, cnfe, null);
+                        MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, e, null);
                         return;
                     }
                 }
@@ -171,9 +171,9 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             final Map<String, Object> attachments;
             try {
                 attachments = this.readAttachments(unmarshaller);
-            } catch (ClassNotFoundException cnfe) {
+            } catch (Throwable e) {
                 // write out the failure
-                MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, cnfe, null);
+                MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, e, null);
                 return;
             }
             // done with unmarshalling
@@ -204,7 +204,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                         try {
                             // write out the failure
                             MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, throwable, attachments);
-                        } catch (IOException ioe) {
+                        } catch (Throwable ioe) {
                             // we couldn't write out a method invocation failure message. So let's at least log the
                             // actual method invocation exception, for debugging/reference
                             EjbLogger.ROOT_LOGGER.errorInvokingMethod(throwable, invokedMethod, beanName, appName, moduleName, distinctName);
@@ -236,7 +236,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                             attachments.put(Affinity.WEAK_AFFINITY_CONTEXT_KEY, weakAffinity);
                         }
                         writeMethodInvocationResponse(channelAssociation, invocationId, result, attachments);
-                    } catch (IOException ioe) {
+                    } catch (Throwable ioe) {
                         EjbLogger.ROOT_LOGGER.couldNotWriteMethodInvocation(ioe, invokedMethod, beanName, appName, moduleName, distinctName);
                         // close the channel unless this is a NotSerializableException
                         //as this does not represent a problem with the channel there is no
@@ -350,7 +350,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
         final MessageOutputStream messageOutputStream;
         try {
             messageOutputStream = channelAssociation.acquireChannelMessageOutputStream();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw EjbMessages.MESSAGES.failedToOpenMessageOutputStream(e);
         }
         outputStream = new DataOutputStream(messageOutputStream);
@@ -378,7 +378,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
         final MessageOutputStream messageOutputStream;
         try {
             messageOutputStream = channelAssociation.acquireChannelMessageOutputStream();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw EjbMessages.MESSAGES.failedToOpenMessageOutputStream(e);
         }
         outputStream = new DataOutputStream(messageOutputStream);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -181,7 +181,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             // enroll for next message (whenever it's available)
             channel.receiveMessage(this);
 
-        } catch (IOException e) {
+        } catch (Throwable e) {
             // log it
             EjbLogger.ROOT_LOGGER.exceptionOnChannel(e, channel, messageInputStream);
             // no more messages can be sent or received on this channel


### PR DESCRIPTION
...ones such as CNFE, also changes catch on invoker to act properly on every Throwable, not just IOException. Additionally changed the RuntimeException thrown by EJB Messages, to IOException, since the failures are IO and match the method throws spec.

Master PR: #3750
