### PR TITLE
AS7-5842 Upgrading joda time to version 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
         <version.aesh>0.27</version.aesh>
         <version.jansi>1.8</version.jansi>
-        <version.joda-time>1.6.2</version.joda-time>
+        <version.joda-time>2.1</version.joda-time>
         <version.junit>4.10</version.junit>
         <version.log4j>1.2.16</version.log4j>
         <version.net.jcip>1.0</version.net.jcip>


### PR DESCRIPTION
Version 2.x is source compatible with 1.6 (with the exception of deprecated methods removal) so it should be a simple version change. 

See http://joda-time.sourceforge.net/upgradeto200.html
