### PR TITLE
AS7-4694 JBAS014478: Could not find timeout method

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -804,6 +804,9 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 14260, value = "Cannot delete cache %s %s, will be deleted on exit")
     void cannotDeleteCacheFile(String fileType, String fileName);
 
+    @LogMessage(level = WARN)
+    @Message(id = 14261, value = "Failed to reinstate timer '%s' (id=%s) from it's persistent state")
+    void timerReinstatementFailed(String timedObjectId, String timerId, @Cause Throwable cause);
 
     // Don't add message ids greater that 14299!!! If you need more first check what EjbMessages is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -900,17 +900,21 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
             if (ineligibleTimerStates.contains(persistedTimer.getTimerState())) {
                 continue;
             }
-            TimerImpl activeTimer;
-            if (persistedTimer.isCalendarTimer()) {
-                final CalendarTimerEntity calendarTimerEntity = (CalendarTimerEntity) persistedTimer;
-                // create a timer instance from the persisted calendar timer
-                activeTimer = new CalendarTimer(calendarTimerEntity, this);
-            } else {
-                // create the timer instance from the persisted state
-                activeTimer = new TimerImpl(persistedTimer, this);
+            try {
+                TimerImpl activeTimer;
+                if (persistedTimer.isCalendarTimer()) {
+                    final CalendarTimerEntity calendarTimerEntity = (CalendarTimerEntity) persistedTimer;
+                    // create a timer instance from the persisted calendar timer
+                    activeTimer = new CalendarTimer(calendarTimerEntity, this);
+                } else {
+                    // create the timer instance from the persisted state
+                    activeTimer = new TimerImpl(persistedTimer, this);
+                }
+                // add it to the list of timers which will be restored
+                activeTimers.add(activeTimer);
+            } catch (RuntimeException e) {
+                EJB3_LOGGER.timerReinstatementFailed(persistedTimer.getTimedObjectId(), persistedTimer.getId(), e);
             }
-            // add it to the list of timers which will be restored
-            activeTimers.add(activeTimer);
         }
 
         return activeTimers;


### PR DESCRIPTION
- trap failure to recreate timer from persisted state and log a warning message instead

Note that I had made a start on cleaning a lot of this up, but Stuart Douglas informed me that a big refactor in this area was already under way. The work that I did can be inspected at https://github.com/sfcoy/jboss-as/compare/AS7-4694 if anyone is interested.
