### PR TITLE
Core model transformers test with 7.1.3

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
@@ -50,7 +50,8 @@ public interface LegacyKernelServicesInitializer {
 
     public enum TestControllerVersion {
         MASTER ("org.jboss.as:jboss-as-host-controller:" + VERSION, null),
-        V7_1_2_FINAL ("org.jboss.as:jboss-as-host-controller:7.1.2.Final", "7.1.2");
+        V7_1_2_FINAL ("org.jboss.as:jboss-as-host-controller:7.1.2.Final", "7.1.2"),
+        V7_1_3_FINAL ("org.jboss.as:jboss-as-host-controller:7.1.3.Final", "7.1.3");
 
         String mavenGav;
         String testControllerVersion;

--- a/core-model-test/tests/pom.xml
+++ b/core-model-test/tests/pom.xml
@@ -40,6 +40,15 @@
           <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+                 <execution>
+                    <id>default-test</id>
+                    <configuration>
+                       <argLine>${maven.test.jvmargs}</argLine>
+                       <forkMode>always</forkMode> 
+                    </configuration>
+                 </execution>
+              </executions>
               <configuration>
                   <redirectTestOutputToFile>true</redirectTestOutputToFile>
                   <enableAssertions>true</enableAssertions>

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
@@ -40,6 +40,7 @@ import org.jboss.as.core.model.test.util.TransformersTestParameters;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
@@ -53,14 +54,18 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
     private final boolean serverGroup;
     private final ModelNode expectedUndefined;
 
-    public AbstractSystemPropertyTransformersTest(SystemPropertyTransformersTestParameters params, String xmlResource, boolean serverGroup) {
+    public AbstractSystemPropertyTransformersTest(TransformersTestParameters params, String xmlResource, boolean serverGroup) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
         this.xmlResource = xmlResource;
         this.serverGroup = serverGroup;
-        this.expectedUndefined = params.getExpectedUndefined();
+        this.expectedUndefined = getExpectedUndefined(params.getModelVersion());
     }
 
+    @Parameters
+    public static List<Object[]> parameters(){
+        return TransformersTestParameters.setupVersions();
+    }
 
     @Test
     public void testSystemPropertyTransformer() throws Exception {
@@ -97,33 +102,13 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
         Assert.assertFalse(properties.get("sys.prop.test.four", VALUE).isDefined());
     }
 
-    static class SystemPropertyTransformersTestParameters extends TransformersTestParameters {
-        private ModelNode expectedUndefined;
-        public SystemPropertyTransformersTestParameters(TransformersTestParameters delegate, ModelNode expectedUndefined) {
-            super(delegate);
-            this.expectedUndefined = expectedUndefined;
+    private ModelNode getExpectedUndefined(ModelVersion modelVersion){
+        if (modelVersion.equals(ModelVersion.create(1, 4, 0))) {
+            return new ModelNode();
+        } else if (modelVersion.equals(ModelVersion.create(1, 2, 0))) {
+            return new ModelNode(true);
+        } else {
+            throw new IllegalStateException("Not known model version " + modelVersion);
         }
-
-        public ModelNode getExpectedUndefined() {
-            return expectedUndefined;
-        }
-
-    }
-
-    static List<Object[]> createSystemPropertyTestTransformerParameters(){
-        List<Object[]> params = TransformersTestParameters.setupVersions();
-        for (Object[] element : params) {
-            TransformersTestParameters param = (TransformersTestParameters)element[0];
-            ModelNode expectedUndefined;
-            if (param.getModelVersion().equals(ModelVersion.create(1, 4, 0))) {
-                expectedUndefined = new ModelNode();
-            } else if (param.getModelVersion().equals(ModelVersion.create(1, 2, 0))) {
-                expectedUndefined = new ModelNode(true);
-            } else {
-                throw new IllegalStateException("Not known model version " + param.getModelVersion());
-            }
-            element[0] = new SystemPropertyTransformersTestParameters(param, expectedUndefined);
-        }
-        return params;
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
@@ -105,10 +105,11 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
     private ModelNode getExpectedUndefined(ModelVersion modelVersion){
         if (modelVersion.equals(ModelVersion.create(1, 4, 0))) {
             return new ModelNode();
-        } else if (modelVersion.equals(ModelVersion.create(1, 2, 0))) {
+        } else if (modelVersion.equals(ModelVersion.create(1, 2, 0)) || modelVersion.equals(ModelVersion.create(1, 3, 0))) {
             return new ModelNode(true);
         } else {
             throw new IllegalStateException("Not known model version " + modelVersion);
         }
     }
+
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTransformersTestCase.java
@@ -21,11 +21,9 @@
 */
 package org.jboss.as.core.model.test.systemproperty;
 
-import java.util.List;
-
+import org.jboss.as.core.model.test.util.TransformersTestParameters;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 
 /**
@@ -35,12 +33,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class DomainServerGroupSystemPropertyTransformersTestCase extends AbstractSystemPropertyTransformersTest {
 
-    public DomainServerGroupSystemPropertyTransformersTestCase(AbstractSystemPropertyTransformersTest.SystemPropertyTransformersTestParameters params) {
+    public DomainServerGroupSystemPropertyTransformersTestCase(TransformersTestParameters params) {
         super(params, "domain-servergroup-systemproperties.xml", true);
-    }
-
-    @Parameters
-    public static List<Object[]> parameters(){
-        return AbstractSystemPropertyTransformersTest.createSystemPropertyTestTransformerParameters();
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainSystemPropertyTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainSystemPropertyTransformersTestCase.java
@@ -21,11 +21,9 @@
 */
 package org.jboss.as.core.model.test.systemproperty;
 
-import java.util.List;
-
+import org.jboss.as.core.model.test.util.TransformersTestParameters;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
@@ -34,14 +32,8 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class DomainSystemPropertyTransformersTestCase extends AbstractSystemPropertyTransformersTest {
 
-    public DomainSystemPropertyTransformersTestCase(AbstractSystemPropertyTransformersTest.SystemPropertyTransformersTestParameters params) {
+    public DomainSystemPropertyTransformersTestCase(TransformersTestParameters params) {
         super(params, "domain-systemproperties.xml", false);
-    }
-
-
-    @Parameters
-    public static List<Object[]> parameters(){
-        return AbstractSystemPropertyTransformersTest.createSystemPropertyTestTransformerParameters();
     }
 
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
@@ -56,6 +56,7 @@ public class TransformersTestParameters {
     public static List<Object[]> setupVersions(){
         List<Object[]> data = new ArrayList<Object[]>();
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), TestControllerVersion.V7_1_2_FINAL)});
+        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), TestControllerVersion.V7_1_2_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), TestControllerVersion.MASTER)});
         for (int i = 0 ; i < data.size() ; i++) {
             Object[] entry = data.get(i);


### PR DESCRIPTION
Also make the core model transformers tests test against 7.1.3.Final (as well as 7.1.2.Final which was already configured)

I raninto PermGen issues when running these tests with both 7.1.2 and 7.1.3 enabled, so I changed the forkMode from 'once' to 'always'. Perhaps it would have been better to increase the PermGen via command line parameters?
