### PR TITLE
[AS7-6078] messaging: Allow expressions for attributes

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -112,6 +112,7 @@ public interface CommonAttributes {
 
     AttributeDefinition CLIENT_ID = create("client-id", ModelType.STRING)
             .setAllowNull(true)
+            .setAllowExpression(true)
             .build();
 
     SimpleAttributeDefinition CHECK_FOR_LIVE_SERVER = create("check-for-live-server", BOOLEAN)

--- a/messaging/src/main/java/org/jboss/as/messaging/InVMTransportDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/InVMTransportDefinition.java
@@ -42,6 +42,8 @@ import org.jboss.dmr.ModelNode;
 public class InVMTransportDefinition extends AbstractTransportDefinition {
 
     public static final SimpleAttributeDefinition SERVER_ID = create("server-id", INT)
+            .setDefaultValue(new ModelNode(0))
+            .setAllowExpression(true)
             .setAttributeMarshaller(new AttributeMarshaller() {
                 public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
                     if(isMarshallable(attribute, resourceModel)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -53,6 +53,7 @@ import static org.jboss.as.messaging.CommonAttributes.CALL_FAILOVER_TIMEOUT;
 import static org.jboss.as.messaging.CommonAttributes.CALL_TIMEOUT;
 import static org.jboss.as.messaging.CommonAttributes.CHECK_FOR_LIVE_SERVER;
 import static org.jboss.as.messaging.CommonAttributes.CHECK_PERIOD;
+import static org.jboss.as.messaging.CommonAttributes.CLIENT_ID;
 import static org.jboss.as.messaging.CommonAttributes.CLUSTERED;
 import static org.jboss.as.messaging.CommonAttributes.CLUSTER_CONNECTION;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTION_FACTORY;
@@ -465,10 +466,18 @@ public class MessagingExtension implements Extension {
 
         rejectExpressions(server, QueueDefinition.PATH, QueueDefinition.ADDRESS, FILTER, DURABLE);
 
-        final String[] transports = { CommonAttributes.ACCEPTOR, CommonAttributes.REMOTE_ACCEPTOR, CommonAttributes.IN_VM_ACCEPTOR,
-                CommonAttributes.CONNECTOR, CommonAttributes.REMOTE_CONNECTOR, CommonAttributes.IN_VM_CONNECTOR };
-        for (String path : transports) {
+        for (String path :  new String[]{ CommonAttributes.ACCEPTOR, CommonAttributes.CONNECTOR }) {
             TransformersSubRegistration transport = rejectExpressions(server, PathElement.pathElement(path), CommonAttributes.FACTORY_CLASS);
+            rejectExpressions(transport, TransportParamDefinition.PATH, VALUE);
+        }
+
+        for (String path :  new String[]{ CommonAttributes.IN_VM_ACCEPTOR, CommonAttributes.IN_VM_CONNECTOR }) {
+            TransformersSubRegistration transport = rejectExpressions(server, PathElement.pathElement(path), InVMTransportDefinition.SERVER_ID);
+            rejectExpressions(transport, TransportParamDefinition.PATH, VALUE);
+        }
+
+        for (String path :  new String[]{ CommonAttributes.REMOTE_ACCEPTOR, CommonAttributes.REMOTE_CONNECTOR }) {
+            TransformersSubRegistration transport = server.registerSubResource(PathElement.pathElement(path));
             rejectExpressions(transport, TransportParamDefinition.PATH, VALUE);
         }
 
@@ -491,7 +500,7 @@ public class MessagingExtension implements Extension {
 
         RejectExpressionValuesTransformer rejectConnectionFactoryExpressions = new RejectExpressionValuesTransformer(Regular.FACTORY_TYPE,
                 HA, MIN_LARGE_MESSAGE_SIZE, CALL_TIMEOUT,
-                AUTO_GROUP, BLOCK_ON_ACKNOWLEDGE, BLOCK_ON_DURABLE_SEND, BLOCK_ON_NON_DURABLE_SEND, CACHE_LARGE_MESSAGE_CLIENT, CLIENT_FAILURE_CHECK_PERIOD,
+                AUTO_GROUP, BLOCK_ON_ACKNOWLEDGE, BLOCK_ON_DURABLE_SEND, BLOCK_ON_NON_DURABLE_SEND, CACHE_LARGE_MESSAGE_CLIENT, CLIENT_FAILURE_CHECK_PERIOD, CLIENT_ID,
                 COMPRESS_LARGE_MESSAGES, CONFIRMATION_WINDOW_SIZE, CONNECTION_LOAD_BALANCING_CLASS_NAME, Common.CONNECTION_TTL, CONSUMER_MAX_RATE,
                 CONSUMER_WINDOW_SIZE, FAILOVER_ON_INITIAL_CONNECTION, GROUP_ID, Common.MAX_RETRY_INTERVAL, Common.MIN_LARGE_MESSAGE_SIZE, PRE_ACKNOWLEDGE,
                 PRODUCER_MAX_RATE, PRODUCER_WINDOW_SIZE, Common.RECONNECT_ATTEMPTS, Common.RETRY_INTERVAL, Common.RETRY_INTERVAL_MULTIPLIER, TRANSACTION_BATCH_SIZE,
@@ -503,7 +512,7 @@ public class MessagingExtension implements Extension {
                 new OperationTransformers.FailUnignoredAttributesOperationTransformer(CALL_FAILOVER_TIMEOUT)));
 
         RejectExpressionValuesTransformer rejectPooledConnectionFactoryExpressions = new RejectExpressionValuesTransformer(MIN_LARGE_MESSAGE_SIZE, CALL_TIMEOUT,
-                AUTO_GROUP, BLOCK_ON_ACKNOWLEDGE, BLOCK_ON_DURABLE_SEND, BLOCK_ON_NON_DURABLE_SEND, CACHE_LARGE_MESSAGE_CLIENT, CLIENT_FAILURE_CHECK_PERIOD,
+                AUTO_GROUP, BLOCK_ON_ACKNOWLEDGE, BLOCK_ON_DURABLE_SEND, BLOCK_ON_NON_DURABLE_SEND, CACHE_LARGE_MESSAGE_CLIENT, CLIENT_FAILURE_CHECK_PERIOD, CLIENT_ID,
                 COMPRESS_LARGE_MESSAGES, CONFIRMATION_WINDOW_SIZE, CONNECTION_LOAD_BALANCING_CLASS_NAME, Common.CONNECTION_TTL, CONSUMER_MAX_RATE,
                 CONSUMER_WINDOW_SIZE, FAILOVER_ON_INITIAL_CONNECTION, GROUP_ID, Common.MAX_RETRY_INTERVAL, Common.MIN_LARGE_MESSAGE_SIZE, PRE_ACKNOWLEDGE,
                 PRODUCER_MAX_RATE, PRODUCER_WINDOW_SIZE, Common.RETRY_INTERVAL, Common.RETRY_INTERVAL_MULTIPLIER, TRANSACTION_BATCH_SIZE,

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -834,7 +834,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             String name = null;
             String socketBinding = null;
-            int serverId = 0;
+            String serverId = null;
 
             int count = reader.getAttributeCount();
             for (int i = 0; i < count; i++) {
@@ -850,7 +850,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                         break;
                     }
                     case SERVER_ID: {
-                        serverId = Integer.valueOf(attrValue);
+                        serverId = attrValue;
                         break;
                     }
                     default: {
@@ -883,7 +883,9 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                     break;
                 } case IN_VM_ACCEPTOR: {
                     acceptorAddress.add(IN_VM_ACCEPTOR, name);
-                    operation.get(InVMTransportDefinition.SERVER_ID.getName()).set(serverId);
+                    if (serverId != null) {
+                        InVMTransportDefinition.SERVER_ID.parseAndSetParameter(serverId, operation, reader);
+                    }
                     parseTransportConfiguration(reader, operation, false);
                     break;
                 } default: {
@@ -1062,7 +1064,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             String name = null;
             String socketBinding = null;
-            int serverId = 0;
+            String serverId = null;
 
             int count = reader.getAttributeCount();
             for (int i = 0; i < count; i++) {
@@ -1078,7 +1080,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                         break;
                     }
                     case SERVER_ID: {
-                        serverId = Integer.valueOf(attrValue);
+                        serverId = attrValue;
                         break;
                     }
                     default: {
@@ -1111,7 +1113,9 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                     break;
                 } case IN_VM_CONNECTOR: {
                     connectorAddress.add(IN_VM_CONNECTOR, name);
-                    operation.get(InVMTransportDefinition.SERVER_ID.getName()).set(serverId);
+                    if (serverId != null) {
+                        InVMTransportDefinition.SERVER_ID.parseAndSetParameter(serverId, operation, reader);
+                    }
                     parseTransportConfiguration(reader, operation, false);
                     break;
                 } default: {

--- a/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
@@ -98,7 +98,7 @@ class TransportConfigOperationHandlers {
                 final String acceptorName = property.getName();
                 final ModelNode config = property.getValue();
                 final Map<String, Object> parameters = getParameters(context, config);
-                parameters.put(InVMTransportDefinition.SERVER_ID.getName(), config.get(InVMTransportDefinition.SERVER_ID.getName()).asInt());
+                parameters.put(InVMTransportDefinition.SERVER_ID.getName(), InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
                 acceptors.put(acceptorName, new TransportConfiguration(InVMAcceptorFactory.class.getName(), parameters, acceptorName));
             }
         }
@@ -161,7 +161,7 @@ class TransportConfigOperationHandlers {
                 final String connectorName = property.getName();
                 final ModelNode config = property.getValue();
                 final Map<String, Object> parameters = getParameters(context, config);
-                parameters.put(InVMTransportDefinition.SERVER_ID.getName(), config.get(InVMTransportDefinition.SERVER_ID.getName()).asInt());
+                parameters.put(InVMTransportDefinition.SERVER_ID.getName(), InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
                 connectors.put(connectorName, new TransportConfiguration(InVMConnectorFactory.class.getName(), parameters, connectorName));
             }
         }

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
@@ -68,7 +68,7 @@
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                   <param key="batch-delay" value="${batch.delay:50}"/>
                </netty-connector>
-               <in-vm-connector name="in-vm" server-id="0" />
+               <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
                <connector name="myconnector">
                   <factory-class>${factory.class:org.hornetq.core.remoting.impl.netty.NettyConnectorFactory}</factory-class>
                   <param key="host" value="192.168.1.2"/>
@@ -83,7 +83,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="0" />
+               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}" />
                <acceptor name="myacceptor">
                   <factory-class>${factory.class:org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory}</factory-class>
                   <param key="batch-delay" value="${batch.delay:50}"/>


### PR DESCRIPTION
- allow expressions for client-id attribute of connection-factory,
  pooled-connection-factory and jms-bridge resources
- allow expression for invm-acceptor & invm-connector's server-id
  attributes
- fix rejection of expressions for connector/acceptor resources
  (remote and in-vm resources defines different attributes to reject)
