### PR TITLE
CLI AS7-1833 connection management for shutdown and reload operations

### DIFF
--- a/build/src/main/resources/modules/org/jboss/as/cli/main/module.xml
+++ b/build/src/main/resources/modules/org/jboss/as/cli/main/module.xml
@@ -35,13 +35,15 @@
 
     <dependencies>
         <module name="org.jboss.aesh"/>
-        <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.as.controller-client"/>
-        <module name="org.jboss.logging"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.dmr"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager" services="import"/>
+        <module name="org.jboss.remoting3"/>
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.threads"/>
         <module name="org.jboss.vfs"/>
         <module name="javax.api"/>
     </dependencies>

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
@@ -1,0 +1,219 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.handlers;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.impl.CLIModelControllerClient;
+import org.jboss.as.cli.impl.CommaSeparatedCompleter;
+import org.jboss.as.cli.operation.ParsedCommandLine;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class ReloadHandler extends BaseOperationCommand {
+
+    private final ArgumentWithValue adminOnly;
+    // standalone only arguments
+    private final ArgumentWithValue useCurrentServerConfig;
+    // domain only arguments
+    private final ArgumentWithValue host;
+    private final ArgumentWithValue restartServers;
+    private final ArgumentWithValue useCurrentDomainConfig;
+    private final ArgumentWithValue useCurrentHostConfig;
+
+    public ReloadHandler(CommandContext ctx) {
+        super(ctx, "reload", true);
+
+        adminOnly = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--admin-only");
+
+        useCurrentServerConfig = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--use-current-server-config"){
+            @Override
+            public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
+            if(ctx.isDomainMode()) {
+                return false;
+            }
+            return super.canAppearNext(ctx);
+        }};
+
+        restartServers = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--restart-servers"){
+            @Override
+            public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
+            if(!ctx.isDomainMode()) {
+                return false;
+            }
+            return super.canAppearNext(ctx);
+        }};
+
+        useCurrentDomainConfig = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--use-current-domain-config"){
+            @Override
+            public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
+            if(!ctx.isDomainMode()) {
+                return false;
+            }
+            return super.canAppearNext(ctx);
+        }};
+
+        useCurrentHostConfig = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--use-current-host-config"){
+            @Override
+            public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
+            if(!ctx.isDomainMode()) {
+                return false;
+            }
+            return super.canAppearNext(ctx);
+        }};
+
+        host = new ArgumentWithValue(this, new CommaSeparatedCompleter() {
+            @Override
+            protected Collection<String> getAllCandidates(CommandContext ctx) {
+                if(!ctx.isDomainMode()) {
+                    return Collections.emptyList();
+                }
+                final ModelControllerClient client = ctx.getModelControllerClient();
+                if(client == null) {
+                    return Collections.emptyList();
+                }
+                final ModelNode op = new ModelNode();
+                op.get(Util.ADDRESS).setEmptyList();
+                op.get(Util.OPERATION).set(Util.READ_CHILDREN_NAMES);
+                op.get(Util.CHILD_TYPE).set(Util.HOST);
+                try {
+                    ModelNode outcome = client.execute(op);
+                    if (Util.isSuccess(outcome)) {
+                        return Util.getList(outcome);
+                    }
+                } catch (Exception e) {
+                }
+                return Collections.emptyList();
+            }} , "--host") {
+            @Override
+            public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
+                if(!ctx.isDomainMode()) {
+                    return false;
+                }
+                return super.canAppearNext(ctx);
+            }
+        };
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.as.cli.handlers.CommandHandlerWithHelp#doHandle(org.jboss.as.cli.CommandContext)
+     */
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        if(client == null) {
+            throw new CommandLineException("Connection is now available.");
+        }
+        if(!(client instanceof CLIModelControllerClient)) {
+            throw new CommandLineException("Unsupported ModelControllerClient implementation " + client.getClass().getName());
+        }
+        final CLIModelControllerClient cliClient = (CLIModelControllerClient) client;
+
+
+        final ModelNode op = this.buildRequestWithoutHeaders(ctx);
+        final ModelNode response;
+        try {
+            response = cliClient.execute(op, true);
+        } catch(IOException e) {
+            ctx.disconnectController();
+            throw new CommandLineException("Failed to execute :reload", e);
+        }
+
+        if(Util.isSuccess(response)) {
+            //ctx.disconnectController(); it'll automatically try to re-connect for the next command/operation
+        } else {
+            throw new CommandLineException(Util.getFailureDescription(response));
+        }
+    }
+
+    @Override
+    protected ModelNode buildRequestWithoutHeaders(CommandContext ctx) throws CommandFormatException {
+        final ParsedCommandLine args = ctx.getParsedCommandLine();
+
+        final ModelNode op = new ModelNode();
+        if(ctx.isDomainMode()) {
+            if(useCurrentServerConfig.isPresent(args)) {
+                throw new CommandFormatException(useCurrentServerConfig.getFullName() + " is not allowed in the domain mode.");
+            }
+
+            final String hostName = host.getValue(args);
+            if(hostName == null) {
+                throw new CommandFormatException("Missing required argument " + host.getFullName());
+            }
+            op.get(Util.ADDRESS).add(Util.HOST, hostName);
+
+            setBooleanArgument(args, op, restartServers, "restart-servers");
+            setBooleanArgument(args, op, this.useCurrentDomainConfig, "use-current-domain-config");
+            setBooleanArgument(args, op, this.useCurrentHostConfig, "use-current-host-config");
+        } else {
+            if(host.isPresent(args)) {
+                throw new CommandFormatException(host.getFullName() + " is not allowed in the standalone mode.");
+            }
+            if(useCurrentDomainConfig.isPresent(args)) {
+                throw new CommandFormatException(useCurrentDomainConfig.getFullName() + " is not allowed in the standalone mode.");
+            }
+            if(useCurrentHostConfig.isPresent(args)) {
+                throw new CommandFormatException(useCurrentHostConfig.getFullName() + " is not allowed in the standalone mode.");
+            }
+            if(restartServers.isPresent(args)) {
+                throw new CommandFormatException(restartServers.getFullName() + " is not allowed in the standalone mode.");
+            }
+
+            op.get(Util.ADDRESS).setEmptyList();
+            setBooleanArgument(args, op, this.useCurrentServerConfig, "use-current-server-config");
+        }
+        op.get(Util.OPERATION).set("reload");
+
+        setBooleanArgument(args, op, adminOnly, "admin-only");
+        return op;
+    }
+
+    protected void setBooleanArgument(final ParsedCommandLine args, final ModelNode op, ArgumentWithValue arg, String paramName)
+            throws CommandFormatException {
+        if(!arg.isPresent(args)) {
+            return;
+        }
+        final String value = arg.getValue(args);
+        if(value == null) {
+            throw new CommandFormatException(arg.getFullName() + " is missing value.");
+        }
+        if(value.equalsIgnoreCase(Util.TRUE)) {
+            op.get(paramName).set(true);
+        } else if(value.equalsIgnoreCase(Util.FALSE)) {
+            op.get(paramName).set(false);
+        } else {
+            throw new CommandFormatException("Invalid value for " + arg.getFullName() + ": '" + value + "'");
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.handlers;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.impl.CLIModelControllerClient;
+import org.jboss.as.cli.impl.CommaSeparatedCompleter;
+import org.jboss.as.cli.operation.ParsedCommandLine;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class ShutdownHandler extends BaseOperationCommand {
+
+    private final ArgumentWithValue restart;
+    private final ArgumentWithValue host;
+
+    public ShutdownHandler(CommandContext ctx) {
+        super(ctx, "shutdown", true);
+
+        restart = new ArgumentWithValue(this, SimpleTabCompleter.BOOLEAN, "--restart");
+
+        host = new ArgumentWithValue(this, new CommaSeparatedCompleter() {
+            @Override
+            protected Collection<String> getAllCandidates(CommandContext ctx) {
+                if(!ctx.isDomainMode()) {
+                    return Collections.emptyList();
+                }
+                final ModelControllerClient client = ctx.getModelControllerClient();
+                if(client == null) {
+                    return Collections.emptyList();
+                }
+                final ModelNode op = new ModelNode();
+                op.get(Util.ADDRESS).setEmptyList();
+                op.get(Util.OPERATION).set(Util.READ_CHILDREN_NAMES);
+                op.get(Util.CHILD_TYPE).set(Util.HOST);
+                try {
+                    ModelNode outcome = client.execute(op);
+                    if (Util.isSuccess(outcome)) {
+                        return Util.getList(outcome);
+                    }
+                } catch (Exception e) {
+                }
+                return Collections.emptyList();
+            }} , "--host") {
+            @Override
+            public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {
+                if(!ctx.isDomainMode()) {
+                    return false;
+                }
+                return super.canAppearNext(ctx);
+            }
+        };
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.as.cli.handlers.CommandHandlerWithHelp#doHandle(org.jboss.as.cli.CommandContext)
+     */
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        if(client == null) {
+            throw new CommandLineException("Connection is now available.");
+        }
+        if(!(client instanceof CLIModelControllerClient)) {
+            throw new CommandLineException("Unsupported ModelControllerClient implementation " + client.getClass().getName());
+        }
+        final CLIModelControllerClient cliClient = (CLIModelControllerClient) client;
+
+        final ModelNode op = this.buildRequestWithoutHeaders(ctx);
+        final ModelNode response;
+        try {
+            response = cliClient.execute(op, true);
+        } catch(IOException e) {
+            ctx.disconnectController();
+            throw new CommandLineException("Failed to execute :shutdown", e);
+        }
+
+        if(Util.isSuccess(response)) {
+            final String restartValue = restart.getValue(ctx.getParsedCommandLine());
+            if(restartValue == null || !Util.TRUE.equals(restartValue)) {
+                ctx.disconnectController();
+            }
+        } else {
+            throw new CommandLineException(Util.getFailureDescription(response));
+        }
+    }
+
+    @Override
+    protected ModelNode buildRequestWithoutHeaders(CommandContext ctx) throws CommandFormatException {
+        final ModelNode op = new ModelNode();
+        final ParsedCommandLine args = ctx.getParsedCommandLine();
+        if(ctx.isDomainMode()) {
+            final String hostName = host.getValue(args);
+            if(hostName == null) {
+                throw new CommandFormatException("Missing required argument " + host.getFullName());
+            }
+            op.get(Util.ADDRESS).add(Util.HOST, hostName);
+        } else {
+            if(host.isPresent(args)) {
+                throw new CommandFormatException(host.getFullName() + " is not allowed in the standalone mode.");
+            }
+            op.get(Util.ADDRESS).setEmptyList();
+        }
+        op.get(Util.OPERATION).set("shutdown");
+        setBooleanArgument(args, op, restart, "restart");
+        return op;
+    }
+
+    protected void setBooleanArgument(final ParsedCommandLine args, final ModelNode op, ArgumentWithValue arg, String paramName)
+            throws CommandFormatException {
+        if(!arg.isPresent(args)) {
+            return;
+        }
+        final String value = arg.getValue(args);
+        if(value == null) {
+            throw new CommandFormatException(arg.getFullName() + " is missing value.");
+        }
+        if(value.equalsIgnoreCase(Util.TRUE)) {
+            op.get(paramName).set(true);
+        } else if(value.equalsIgnoreCase(Util.FALSE)) {
+            op.get(paramName).set(false);
+        } else {
+            throw new CommandFormatException("Invalid value for " + arg.getFullName() + ": '" + value + "'");
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -140,6 +140,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
                 @Override
                 public void close() throws IOException {
                     channel.close(); // Probably should not be done here
+                    // TODO I never received a call here
                 }
             };
 
@@ -153,7 +154,9 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
 
     @Override
     public void close() throws IOException {
-        // TODO connection.close(); // Probably should not be done here
+        if(association != null) {
+            association.getChannel().getConnection().close();
+        }
     }
 
     public ModelNode execute(ModelNode operation, boolean awaitClose) throws IOException {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -1,0 +1,173 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.impl;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.AccessController;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.ModelControllerClientFactory.ConnectionCloseHandler;
+import org.jboss.as.controller.client.impl.AbstractModelControllerClient;
+import org.jboss.as.protocol.ProtocolConnectionConfiguration;
+import org.jboss.as.protocol.ProtocolConnectionUtils;
+import org.jboss.as.protocol.mgmt.ManagementChannelAssociation;
+import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
+import org.jboss.as.protocol.mgmt.ManagementClientChannelStrategy;
+import org.jboss.dmr.ModelNode;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.CloseHandler;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.Remoting;
+import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
+import org.jboss.threads.JBossThreadFactory;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class CLIModelControllerClient extends AbstractModelControllerClient {
+
+    private static final ThreadPoolExecutor executorService;
+    static {
+        final BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<Runnable>(4);
+        final ThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("cli remoting"), Boolean.FALSE, null,
+                "%G - %t", null, null, AccessController.getContext());
+        executorService = new ThreadPoolExecutor(2, 4, 60L, TimeUnit.SECONDS, workQueue, threadFactory);
+        // Allow the core threads to time out as well
+        executorService.allowCoreThreadTimeOut(true);
+    }
+
+    private final CallbackHandler handler;
+    private final String hostName;
+    private final int connectionTimeout;
+    private final ConnectionCloseHandler closeHandler;
+    private final int port;
+    private final SSLContext sslContext;
+    private ManagementChannelHandler association;
+
+    CLIModelControllerClient(CallbackHandler handler, String hostName, int connectionTimeout,
+            ConnectionCloseHandler closeHandler, int port, SSLContext sslContext) {
+        this.handler = handler;
+        this.hostName = hostName;
+        this.connectionTimeout = connectionTimeout;
+        this.closeHandler = closeHandler;
+        this.port = port;
+        this.sslContext = sslContext;
+    }
+
+    @Override
+    protected ManagementChannelAssociation getChannelAssociation() throws IOException {
+        if (association == null) {
+            // System.out.println("ASSOCIATION IS NULL");
+            // Setup the remoting endpoint
+            final Endpoint endpoint = Remoting.createEndpoint("management-client", OptionMap.EMPTY);
+            endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
+
+            final URI connect;
+            try {
+                connect = new URI("remote://" + hostName + ':' + port);
+            } catch (URISyntaxException e) {
+                throw new IllegalStateException(e);
+            }
+
+            // Setup the remoting configuration
+            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connect);
+            configuration.setCallbackHandler(handler);
+            configuration.setSslContext(sslContext);
+            configuration.setConnectionTimeout(connectionTimeout);
+
+            // Open the connection
+            final Connection connection = ProtocolConnectionUtils.connectSync(configuration);
+            // Open the 'management' channel
+            final IoFuture<Channel> future = connection.openChannel("management", OptionMap.EMPTY);
+            // final Status futureStatus = future.await(configuration.getConnectionTimeout(), TimeUnit.MILLISECONDS);
+            // if(!futureStatus.equals(Status.DONE)) {
+            // throw new IOException("Failed to connect to the controller in " + configuration.getConnectionTimeout() + "ms");
+            // }
+            final Channel channel = future.get();
+
+            // Get a notification on the connection close (or use ProtocolConnection manager)
+            connection.addCloseHandler(new CloseHandler<Connection>() {
+                @Override
+                public void handleClose(final Connection closed, final IOException exception) {
+                    // System.err.println("CONNECTION CLOSED " + exception);
+                    association = null;
+                    if (closeHandler != null) {
+                        closeHandler.handleClose();
+                    }
+                }
+            });
+
+            // Implememnt custom ManagementClientChannelStrategy (or use FutureManagementChannel)
+            final ManagementClientChannelStrategy strategy = new ManagementClientChannelStrategy() {
+                @Override
+                public Channel getChannel() throws IOException {
+                    return channel;
+                }
+
+                @Override
+                public void close() throws IOException {
+                    channel.close(); // Probably should not be done here
+                }
+            };
+
+            // Setup the management channel handlers
+            association = new ManagementChannelHandler(strategy, executorService);
+            // Setup the receiver
+            channel.receiveMessage(association.getReceiver());
+        }
+        return association;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // TODO connection.close(); // Probably should not be done here
+    }
+
+    public ModelNode execute(ModelNode operation, boolean awaitClose) throws IOException {
+        final ModelNode response = super.execute(operation);
+        if(!Util.isSuccess(response)) {
+            return response;
+        }
+
+        if (awaitClose) {
+            try {
+                association.getChannel().getConnection().awaitClosed();
+            } catch (InterruptedException e) {
+            }
+        }
+        return response;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.impl;
+
+import java.io.IOException;
+
+import javax.net.ssl.SSLContext;
+import javax.security.auth.callback.CallbackHandler;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public interface ModelControllerClientFactory {
+
+    interface ConnectionCloseHandler {
+        void handleClose();
+    }
+
+    ModelControllerClient getClient(String hostName, int port, CallbackHandler handler,
+            SSLContext sslContext, int connectionTimeout, ConnectionCloseHandler closeHandler) throws IOException;
+
+    ModelControllerClientFactory DEFAULT = new ModelControllerClientFactory() {
+        @Override
+        public ModelControllerClient getClient(String hostName, int port, CallbackHandler handler,
+                SSLContext sslContext, int connectionTimeout, ConnectionCloseHandler closeHandler) throws IOException {
+            return ModelControllerClient.Factory.create(hostName, port, handler, sslContext, connectionTimeout);
+        }
+    };
+
+    ModelControllerClientFactory CUSTOM = new ModelControllerClientFactory() {
+
+        @Override
+        public ModelControllerClient getClient(final String hostName, final int port,
+                final CallbackHandler handler, final SSLContext sslContext,
+                final int connectionTimeout, final ConnectionCloseHandler closeHandler) throws IOException {
+
+            return new CLIModelControllerClient(handler, hostName, connectionTimeout, closeHandler, port, sslContext);
+        }};
+}

--- a/cli/src/main/resources/help/reload.txt
+++ b/cli/src/main/resources/help/reload.txt
@@ -47,7 +47,7 @@ ARGUMENTS
                  the host name to reload.
 
  --restart-servers  - optional, allowed only in the domain mode. If true the
-                      servers will be reloaded, and if false the servers will
+                      servers will be restarted, and if false the servers will
                  be left running and reconnect to the Host Controller when
                  started again. If not present, true value is assumed.
                       

--- a/cli/src/main/resources/help/reload.txt
+++ b/cli/src/main/resources/help/reload.txt
@@ -1,0 +1,76 @@
+SYNOPSIS
+
+   Standalone mode:
+
+      reload [--admin-only=true|false] [--use-current-server-config=true|false]
+
+   Domain mode:
+
+      reload --host=host_name [--admin-only=true|false] [--restart-servers=true|false]
+             [--user-current-domain-config=true|false] [--user-current-host-config=true|false]
+      
+DESCRIPTION
+
+    Sends the :reload operation request to the server/domain controller
+    and waits for the controller to close the connection and then
+    it returns the control back to the client. It does not put
+    the CLI client into the disconnected state. Instead, for the
+    next entered command or operation it will try to automatically
+    re-connect to the controller.
+    
+    If there was an i/o error while sending the request or receiving
+    the response, the reload handler will disconnect from the controller.
+    
+    If the reload operation failed, i.e. the response received successfully
+    indicated a failure, the handler will log the failure message and
+    will not disconnect from the controller.
+    
+    NOTE: this command cannot be used in a batch because the handler
+    is waiting for the controller to shutdown before returning the
+    control back to the client which would not possible if the
+    command was executed as a step in a composite operation.
+    So, if there is a need to reload the controller from a batch,
+    :reload operation must be used instead (and should be the last
+    operation in the batch).
+
+ARGUMENTS
+
+ --admin-only  - whether the controller should start in running mode ADMIN_ONLY
+                 when it restarts. An ADMIN_ONLY controller will start any
+                 configured management interfaces and accept management requests,
+                 but will not start servers or, if this host controller is
+                 the master for the domain, accept incoming connections from
+                 slave host controllers.
+                 If not present, false value is assumed.
+
+ --host        - is allowed and required only in the domain mode, specifies
+                 the host name to reload.
+
+ --restart-servers  - optional, allowed only in the domain mode. If true the
+                      servers will be reloaded, and if false the servers will
+                 be left running and reconnect to the Host Controller when
+                 started again. If not present, true value is assumed.
+                      
+ --use-current-domain-config  - optional, allowed only in the domain mode. Only
+                                has an effect if --read-only-domain-config was
+                 specified when starting the controller. In that case, if this
+                 parameter is set to false the reloaded controller loads the
+                 original configuration version; if null or true the current
+                 runtime version of the model is used.
+                 If not present, true value is assumed.
+
+ --use-current-host-config  - optional, allowed only in the domain mode. Only
+                              has an effect if --read-only-host-config was
+                 specified when starting the controller. In that case, if this
+                 parameter is set to false the reloaded controller loads the
+                 original configuration version; if null or true the current
+                 runtime version of the model is used.
+                 If not present, true value is assumed.
+                 
+ --use-current-server-config  - optional, allowed only in the standalone mode.
+                                Only has an effect if --read-only-server-config
+                 was specified when starting the server. In that case, if this
+                 parameter is set to false the reloaded server loads the
+                 original configuration version; if null or true the current
+                 runtime version of the model is used.
+                 If not present, true value is assumed.

--- a/cli/src/main/resources/help/shutdown.txt
+++ b/cli/src/main/resources/help/shutdown.txt
@@ -1,0 +1,41 @@
+SYNOPSIS
+
+   Standalone mode:
+
+      shutdown [--restart=true|false]
+
+   Domain mode:
+   
+      shutdown --host=host_name [--restart=true|false]
+      
+DESCRIPTION
+
+    Sends the :shutdown operation request to the server/domain controller
+    and waits for the controller to close the connection.
+    
+    If there was an i/o error while sending the request or receiving
+    the response, the shutdown handler will disconnect from the controller.
+    
+    If the shutdown operation was executed successfully and the restart
+    argument wasn't specified or was set to false, the handler will put the
+    CLI client into the disconnected state.
+    
+    If the shutdown operation failed, i.e. the response received successfully
+    indicated a failure, the handler will log the failure message and
+    will not disconnect from the controller.
+    
+    NOTE: this command cannot be used in a batch because it the handler
+    is waiting for the controller to shutdown before returning the
+    control back to the client which would not possible if the
+    command was executed as a step in a composite operation.
+    So, if there is a need to shutdown the controller from a batch,
+    :shutdown operation must be used instead (and should be the last
+    operation in the batch).
+
+ARGUMENTS
+
+ --host      - is allowed and required only in the domain mode, specifies
+               the host name to shutdown;
+               
+ --restart   - optional, if true, once shutdown the controller will be
+               restarted again; if not present, false is assumed.


### PR DESCRIPTION
This is an attempt to handle connection issues after reload and shutdown operations.

Unfortunately, it's based directly only the remoting3 api.

The CLI now receives and handles connection close notifications.
- Operations

shutdown and reload operations are executed as any other operation. But when the connection close notification is received and the operation executed was 'shutdown' then the cli switches to the disconnected mode. In case of reload, it will try to re-connect when the next command/operation is entered.
- Commands

The commit adds shutdown and reload commands. These will use execute requests and wait until the connection is actually closed and then will return the control back to the client.
