### PR TITLE
Workaround MNG-4687

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -29,7 +29,8 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>9</version>
+      <version>10</version>
+      <relativePath></relativePath>
     </parent>
 
     <groupId>org.jboss.as</groupId>
@@ -64,6 +65,6 @@
                 <version>1.0-beta-7</version>
             </extension>
         </extensions>
-    </build>    
+    </build>
 
 </project>


### PR DESCRIPTION
Also, use same jboss-parent version as main pom.xml

The MNG-4687 workaround is to get rid of this noise that appears in the build:

[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jboss.as:jboss-as-build-config:jar:7.2.0.Alpha1-SNAPSHOT
[WARNING] 'parent.relativePath' points at org.jboss.as:jboss-as-parent instead of org.jboss:jboss-parent, please verify your project structure @ line 29, column 13
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
