### PR TITLE
[master only] Add support for AS7-5897

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -135,6 +135,9 @@ public class InterceptorOrder {
         public static final int EJB_EXCEPTION_LOGGING_INTERCEPTOR = 0x210;
         public static final int SHUTDOWN_INTERCEPTOR = 0x220;
         public static final int INVALID_METHOD_EXCEPTION = 0x230;
+        // Allows users to specify user application specific "container interceptors" which run before the
+        // other JBoss specific container interceptors like the security interceptor
+        public static final int USER_APP_SPECIFIC_CONTAINER_INTERCEPTORS = 0x249;
         public static final int SECURITY_CONTEXT = 0x250;
         public static final int EJB_SECURITY_AUTHORIZATION_INTERCEPTOR = 0x300;
         // after security we take note of the invocation

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/ContainerInterceptorMethodInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/ContainerInterceptorMethodInterceptorFactory.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component;
+
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorContext;
+import org.jboss.invocation.InterceptorFactory;
+import org.jboss.invocation.InterceptorFactoryContext;
+import org.jboss.invocation.Interceptors;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * An {@link InterceptorFactory} responsible for creating {@link Interceptor} instance corresponding to a <code>container-interceptor</code>
+ * applicable for a EJB
+ *
+ * @author Jaikiran Pai
+ */
+final class ContainerInterceptorMethodInterceptorFactory implements InterceptorFactory {
+    private final ManagedReference interceptorInstanceRef;
+    private final Method method;
+
+    /**
+     * @param interceptorInstanceRef The managed reference to the container-interceptor instance
+     * @param method                 The method for which the interceptor has to be created
+     */
+    ContainerInterceptorMethodInterceptorFactory(final ManagedReference interceptorInstanceRef, final Method method) {
+        this.interceptorInstanceRef = interceptorInstanceRef;
+        this.method = method;
+    }
+
+    /**
+     * Creates and returns a {@link Interceptor} which invokes the underlying container-interceptor during a method invocation
+     *
+     * @param context The interceptor factory context
+     * @return
+     */
+    public Interceptor create(final InterceptorFactoryContext context) {
+        return new ContainerInterceptorMethodInterceptor(this.interceptorInstanceRef, method);
+    }
+
+
+    /**
+     * {@link Interceptor} responsible for invoking the underlying container-interceptor in its {@link #processInvocation(org.jboss.invocation.InterceptorContext)}
+     * method
+     */
+    private static final class ContainerInterceptorMethodInterceptor implements Interceptor {
+
+        private final ManagedReference interceptorInstanceRef;
+        private final Method method;
+
+        /**
+         * @param interceptorInstanceRef The managed reference to the container-interceptor instance
+         * @param method                 The method on which the interceptor applies
+         */
+        ContainerInterceptorMethodInterceptor(final ManagedReference interceptorInstanceRef, final Method method) {
+            this.method = method;
+            this.interceptorInstanceRef = interceptorInstanceRef;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public Object processInvocation(final InterceptorContext context) throws Exception {
+            // get the container-interceptor instance
+            final Object interceptorInstance = interceptorInstanceRef.getInstance();
+            try {
+                final Method method = this.method;
+                return method.invoke(interceptorInstance, context.getInvocationContext());
+            } catch (IllegalAccessException e) {
+                final IllegalAccessError n = new IllegalAccessError(e.getMessage());
+                n.setStackTrace(e.getStackTrace());
+                throw n;
+            } catch (InvocationTargetException e) {
+                throw Interceptors.rethrow(e.getCause());
+            }
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBContainerInterceptorsViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBContainerInterceptorsViewConfigurator.java
@@ -1,0 +1,321 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component;
+
+import org.jboss.as.ee.component.Attachments;
+import org.jboss.as.ee.component.ClassDescriptionTraversal;
+import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEApplicationClasses;
+import org.jboss.as.ee.component.EEModuleClassDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ee.component.InterceptorDescription;
+import org.jboss.as.ee.component.ViewConfiguration;
+import org.jboss.as.ee.component.ViewConfigurator;
+import org.jboss.as.ee.component.ViewDescription;
+import org.jboss.as.ee.component.interceptors.InterceptorClassDescription;
+import org.jboss.as.ee.component.interceptors.InterceptorOrder;
+import org.jboss.as.ee.component.interceptors.UserInterceptorFactory;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.ValueManagedReference;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.reflect.ClassIndex;
+import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
+import org.jboss.as.server.deployment.reflect.ClassReflectionIndexUtil;
+import org.jboss.as.server.deployment.reflect.DeploymentClassIndex;
+import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorFactory;
+import org.jboss.invocation.InterceptorFactoryContext;
+import org.jboss.invocation.Interceptors;
+import org.jboss.invocation.proxy.MethodIdentifier;
+import org.jboss.logging.Logger;
+import org.jboss.msc.value.CachedValue;
+import org.jboss.msc.value.ConstructedValue;
+import org.jboss.msc.value.Value;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.jboss.as.ee.EeMessages.MESSAGES;
+import static org.jboss.as.server.deployment.Attachments.REFLECTION_INDEX;
+
+/**
+ * A {@link ViewConfigurator} which sets up the EJB view with the relevant {@link Interceptor}s
+ * which will carry out invocation on the container-interceptor(s) applicable for a EJB, during a EJB method invocation
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBContainerInterceptorsViewConfigurator implements ViewConfigurator {
+
+    private static final Logger logger = Logger.getLogger(EJBContainerInterceptorsViewConfigurator.class);
+    private static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
+
+    public static final EJBContainerInterceptorsViewConfigurator INSTANCE = new EJBContainerInterceptorsViewConfigurator();
+
+    private EJBContainerInterceptorsViewConfigurator() {
+    }
+
+    @Override
+    public void configure(DeploymentPhaseContext deploymentPhaseContext, ComponentConfiguration componentConfiguration, ViewDescription viewDescription, ViewConfiguration viewConfiguration) throws DeploymentUnitProcessingException {
+        final ComponentDescription componentDescription = componentConfiguration.getComponentDescription();
+        // ideally it should always be a EJBComponentDescription when this view configurator is invoked, but let's just make sure
+        if (!(componentDescription instanceof EJBComponentDescription)) {
+            return;
+        }
+        final EJBComponentDescription ejbComponentDescription = (EJBComponentDescription) componentDescription;
+        // we don't want to waste time processing if there are no container interceptors applicable for the EJB
+        final Set<InterceptorDescription> allContainerInterceptors = ejbComponentDescription.getAllContainerInterceptors();
+        if (allContainerInterceptors == null || allContainerInterceptors.isEmpty()) {
+            return;
+        }
+        // do the processing
+        this.doConfigure(deploymentPhaseContext, ejbComponentDescription, viewConfiguration);
+    }
+
+    private void doConfigure(final DeploymentPhaseContext context, final EJBComponentDescription ejbComponentDescription,
+                             final ViewConfiguration viewConfiguration) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = context.getDeploymentUnit();
+        final EEApplicationClasses applicationClasses = deploymentUnit.getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
+        final DeploymentClassIndex deploymentClassIndex = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.CLASS_INDEX);
+
+        final Map<String, List<InterceptorFactory>> userAroundInvokesByInterceptorClass = new HashMap<String, List<InterceptorFactory>>();
+        final Map<String, List<InterceptorFactory>> userAroundTimeoutsByInterceptorClass;
+        if (ejbComponentDescription.isTimerServiceApplicable()) {
+            userAroundTimeoutsByInterceptorClass = new HashMap<String, List<InterceptorFactory>>();
+        } else {
+            userAroundTimeoutsByInterceptorClass = null;
+        }
+        // First step - find the applicable @AroundInvoke/@AroundTimeout methods on all the container-interceptors and keep track of that
+        // info
+        for (final InterceptorDescription interceptorDescription : ejbComponentDescription.getAllContainerInterceptors()) {
+            final String interceptorClassName = interceptorDescription.getInterceptorClassName();
+            final ClassIndex interceptorClassIndex;
+            try {
+                interceptorClassIndex = deploymentClassIndex.classIndex(interceptorClassName);
+            } catch (ClassNotFoundException e) {
+                throw MESSAGES.cannotLoadInterceptor(e, interceptorClassName);
+            }
+            // run the interceptor class (and its super class hierarchy) through the InterceptorClassDescriptionTraversal so that it can
+            // find the relevant @AroundInvoke/@AroundTimeout methods
+            final InterceptorClassDescriptionTraversal interceptorClassDescriptionTraversal = new InterceptorClassDescriptionTraversal(interceptorClassIndex.getModuleClass(), applicationClasses, deploymentUnit, ejbComponentDescription);
+            interceptorClassDescriptionTraversal.run();
+            // now that the InterceptorClassDescriptionTraversal has done the relevant processing, keep track of the @AroundInvoke and
+            // @AroundTimeout methods applicable for this interceptor class, within a map
+            final List<InterceptorFactory> aroundInvokeInterceptorFactories = interceptorClassDescriptionTraversal.getAroundInvokeInterceptorFactories();
+            if (aroundInvokeInterceptorFactories != null) {
+                userAroundInvokesByInterceptorClass.put(interceptorClassName, aroundInvokeInterceptorFactories);
+            }
+
+            final List<InterceptorFactory> aroundTimeoutInterceptorFactories = interceptorClassDescriptionTraversal.getAroundTimeoutInterceptorFactories();
+            if (aroundTimeoutInterceptorFactories != null) {
+                userAroundTimeoutsByInterceptorClass.put(interceptorClassName, aroundTimeoutInterceptorFactories);
+            }
+        }
+
+        // At this point we have each interceptor class mapped against their corresponding @AroundInvoke/@AroundTimeout InterceptorFactory(s)
+        // Let's now iterate over all the methods of the EJB view and apply the relevant InterceptorFactory(s) to that method
+        final List<InterceptorDescription> classLevelContainerInterceptors = ejbComponentDescription.getClassLevelContainerInterceptors();
+        final Map<MethodIdentifier, List<InterceptorDescription>> methodLevelContainerInterceptors = ejbComponentDescription.getMethodLevelContainerInterceptors();
+        final List<Method> viewMethods = viewConfiguration.getProxyFactory().getCachedMethods();
+        for (final Method method : viewMethods) {
+            final MethodIdentifier methodIdentifier = MethodIdentifier.getIdentifier(method.getReturnType(), method.getName(), method.getParameterTypes());
+            final List<InterceptorFactory> aroundInvokesApplicableForMethod = new ArrayList<InterceptorFactory>();
+            final List<InterceptorFactory> aroundTimeoutsApplicableForMethod = new ArrayList<InterceptorFactory>();
+            // first add the default interceptors (if not excluded) to the deque
+            if (!ejbComponentDescription.isExcludeDefaultContainerInterceptors() && !ejbComponentDescription.isExcludeDefaultContainerInterceptors(methodIdentifier)) {
+                for (final InterceptorDescription interceptorDescription : ejbComponentDescription.getDefaultContainerInterceptors()) {
+                    String interceptorClassName = interceptorDescription.getInterceptorClassName();
+                    final List<InterceptorFactory> aroundInvokesOnInterceptor = userAroundInvokesByInterceptorClass.get(interceptorClassName);
+                    if (aroundInvokesOnInterceptor != null) {
+                        aroundInvokesApplicableForMethod.addAll(aroundInvokesOnInterceptor);
+                    }
+                    if (ejbComponentDescription.isTimerServiceApplicable()) {
+                        final List<InterceptorFactory> aroundTimeoutsOnInterceptor = userAroundTimeoutsByInterceptorClass.get(interceptorClassName);
+                        if (aroundTimeoutsOnInterceptor != null) {
+                            aroundTimeoutsApplicableForMethod.addAll(aroundTimeoutsOnInterceptor);
+                        }
+                    }
+                }
+            }
+
+            // now add class level interceptors (if not excluded) to the deque
+            if (!ejbComponentDescription.isExcludeClassLevelContainerInterceptors(methodIdentifier)) {
+                for (final InterceptorDescription interceptorDescription : classLevelContainerInterceptors) {
+                    String interceptorClassName = interceptorDescription.getInterceptorClassName();
+                    final List<InterceptorFactory> aroundInvokesOnInterceptor = userAroundInvokesByInterceptorClass.get(interceptorClassName);
+                    if (aroundInvokesOnInterceptor != null) {
+                        aroundInvokesApplicableForMethod.addAll(aroundInvokesOnInterceptor);
+                    }
+                    if (ejbComponentDescription.isTimerServiceApplicable()) {
+                        final List<InterceptorFactory> aroundTimeoutsOnInterceptor = userAroundTimeoutsByInterceptorClass.get(interceptorClassName);
+                        if (aroundTimeoutsOnInterceptor != null) {
+                            aroundTimeoutsApplicableForMethod.addAll(aroundTimeoutsOnInterceptor);
+                        }
+                    }
+                }
+            }
+
+            // now add method level interceptors for to the deque so that they are triggered after the class interceptors
+            final List<InterceptorDescription> interceptorsForMethod = methodLevelContainerInterceptors.get(methodIdentifier);
+            if (interceptorsForMethod != null) {
+                for (final InterceptorDescription methodLevelInterceptor : interceptorsForMethod) {
+                    String interceptorClassName = methodLevelInterceptor.getInterceptorClassName();
+                    final List<InterceptorFactory> aroundInvokesOnInterceptor = userAroundInvokesByInterceptorClass.get(interceptorClassName);
+                    if (aroundInvokesOnInterceptor != null) {
+                        aroundInvokesApplicableForMethod.addAll(aroundInvokesOnInterceptor);
+                    }
+                    if (ejbComponentDescription.isTimerServiceApplicable()) {
+                        final List<InterceptorFactory> aroundTimeoutsOnInterceptor = userAroundTimeoutsByInterceptorClass.get(interceptorClassName);
+                        if (aroundTimeoutsOnInterceptor != null) {
+                            aroundTimeoutsApplicableForMethod.addAll(aroundTimeoutsOnInterceptor);
+                        }
+                    }
+                }
+            }
+            // apply the interceptors to the view's method.
+            viewConfiguration.addViewInterceptor(method, new UserInterceptorFactory(weaved(aroundInvokesApplicableForMethod), weaved(aroundTimeoutsApplicableForMethod)), InterceptorOrder.View.USER_APP_SPECIFIC_CONTAINER_INTERCEPTORS);
+        }
+    }
+
+    private static InterceptorFactory weaved(final Collection<InterceptorFactory> interceptorFactories) {
+        return new InterceptorFactory() {
+            @Override
+            public Interceptor create(InterceptorFactoryContext context) {
+                final Interceptor[] interceptors = new Interceptor[interceptorFactories.size()];
+                final Iterator<InterceptorFactory> factories = interceptorFactories.iterator();
+                for (int i = 0; i < interceptors.length; i++) {
+                    interceptors[i] = factories.next().create(context);
+                }
+                return Interceptors.getWeavedInterceptor(interceptors);
+            }
+        };
+    }
+
+    /**
+     * Traveses the interceptor class and its class hierarchy to find the aroundinvoke and aroundtimeout methods
+     */
+    private class InterceptorClassDescriptionTraversal extends ClassDescriptionTraversal {
+
+        private final EEModuleDescription moduleDescription;
+        private final EJBComponentDescription ejbComponentDescription;
+        private final DeploymentReflectionIndex deploymentReflectionIndex;
+        private final Class<?> interceptorClass;
+        private final String interceptorClassName;
+
+        private final List<InterceptorFactory> aroundInvokeInterceptorFactories = new ArrayList<InterceptorFactory>();
+        private final List<InterceptorFactory> aroundTimeoutInterceptorFactories = new ArrayList<InterceptorFactory>();
+
+        InterceptorClassDescriptionTraversal(final Class<?> interceptorClass, final EEApplicationClasses applicationClasses,
+                                             final DeploymentUnit deploymentUnit, final EJBComponentDescription ejbComponentDescription) {
+
+            super(interceptorClass, applicationClasses);
+
+            this.ejbComponentDescription = ejbComponentDescription;
+            this.deploymentReflectionIndex = deploymentUnit.getAttachment(REFLECTION_INDEX);
+            this.moduleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+            this.interceptorClass = interceptorClass;
+            this.interceptorClassName = interceptorClass.getName();
+
+        }
+
+        @Override
+        public void handle(final Class<?> clazz, EEModuleClassDescription classDescription) throws DeploymentUnitProcessingException {
+            final InterceptorClassDescription interceptorConfig;
+            if (classDescription != null) {
+                interceptorConfig = InterceptorClassDescription.merge(classDescription.getInterceptorClassDescription(), moduleDescription.getInterceptorClassOverride(clazz.getName()));
+            } else {
+                interceptorConfig = InterceptorClassDescription.merge(null, moduleDescription.getInterceptorClassOverride(clazz.getName()));
+            }
+            // get the container-interceptor class' constructor
+            final ClassReflectionIndex<?> interceptorClassReflectionIndex = deploymentReflectionIndex.getClassIndex(interceptorClass);
+            final Constructor<?> interceptorClassConstructor = interceptorClassReflectionIndex.getConstructor(EMPTY_CLASS_ARRAY);
+            if (interceptorClassConstructor == null) {
+                throw MESSAGES.defaultConstructorNotFound(interceptorClass);
+            }
+
+            final MethodIdentifier aroundInvokeMethodIdentifier = interceptorConfig.getAroundInvoke();
+            final InterceptorFactory aroundInvokeInterceptorFactory = createInterceptorFactory(clazz, aroundInvokeMethodIdentifier, interceptorClassConstructor);
+            if (aroundInvokeInterceptorFactory != null) {
+                this.aroundInvokeInterceptorFactories.add(aroundInvokeInterceptorFactory);
+            }
+
+            if (ejbComponentDescription.isTimerServiceApplicable()) {
+                final MethodIdentifier aroundTimeoutMethodIdentifier = interceptorConfig.getAroundTimeout();
+                final InterceptorFactory aroundTimeoutInterceptorFactory = createInterceptorFactory(clazz, aroundTimeoutMethodIdentifier, interceptorClassConstructor);
+                if (aroundTimeoutInterceptorFactory != null) {
+                    this.aroundTimeoutInterceptorFactories.add(aroundTimeoutInterceptorFactory);
+                }
+            }
+
+        }
+
+        private InterceptorFactory createInterceptorFactory(final Class<?> clazz, final MethodIdentifier methodIdentifier, final Constructor<?> interceptorClassConstructor) throws DeploymentUnitProcessingException {
+            if (methodIdentifier == null) {
+                return null;
+            }
+            final Method method = ClassReflectionIndexUtil.findRequiredMethod(deploymentReflectionIndex, clazz, methodIdentifier);
+            if (isNotOverriden(clazz, method, this.interceptorClass, deploymentReflectionIndex)) {
+                return this.createInterceptorFactoryForContainerInterceptor(method, interceptorClassConstructor);
+            }
+            return null;
+        }
+
+        private boolean isNotOverriden(final Class<?> clazz, final Method method, final Class<?> actualClass, final DeploymentReflectionIndex deploymentReflectionIndex) throws DeploymentUnitProcessingException {
+            return Modifier.isPrivate(method.getModifiers()) || ClassReflectionIndexUtil.findRequiredMethod(deploymentReflectionIndex, actualClass, method).getDeclaringClass() == clazz;
+        }
+
+        private List<InterceptorFactory> getAroundInvokeInterceptorFactories() {
+            return this.aroundInvokeInterceptorFactories;
+        }
+
+        private List<InterceptorFactory> getAroundTimeoutInterceptorFactories() {
+            return this.aroundTimeoutInterceptorFactories;
+        }
+
+        private InterceptorFactory createInterceptorFactoryForContainerInterceptor(final Method method, final Constructor interceptorConstructor) {
+            // The managed reference is going to be ConstructedValue, using the container-interceptor's constructor
+            final ConstructedValue interceptorInstanceValue = new ConstructedValue(interceptorConstructor, Collections.<Value<?>>emptyList());
+            // we *don't* create multiple instances of the container-interceptor class, but we just reuse a single instance and it's *not*
+            // tied to the EJB component instance lifecycle.
+            final CachedValue cachedInterceptorInstanceValue = new CachedValue(interceptorInstanceValue);
+            // ultimately create the managed reference which is backed by the CachedValue
+            final ManagedReference interceptorInstanceRef = new ValueManagedReference(cachedInterceptorInstanceValue);
+            // return the ContainerInterceptorMethodInterceptorFactory which is responsible for creating a Interceptor
+            // which can invoke the container-interceptor's around-invoke/around-timeout methods
+            return new ContainerInterceptorMethodInterceptorFactory(interceptorInstanceRef, method);
+        }
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBViewDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBViewDescription.java
@@ -66,6 +66,8 @@ public class EJBViewDescription extends ViewDescription {
                 configuration.putPrivateData(MethodIntf.class, getMethodIntf());
             }
         });
+        // add a view configurator for setting up application specific container interceptors for the EJB view
+        getConfigurators().add(EJBContainerInterceptorsViewConfigurator.INSTANCE);
     }
 
     public MethodIntf getMethodIntf() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
@@ -44,6 +44,7 @@ import org.jboss.as.ejb3.cache.EJBBoundCacheParser;
 import org.jboss.as.ejb3.clustering.EJBBoundClusteringMetaDataParser;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.deployment.EjbJarDescription;
+import org.jboss.as.ejb3.interceptor.ContainerInterceptorsParser;
 import org.jboss.as.ejb3.pool.EJBBoundPoolParser;
 import org.jboss.as.ejb3.resourceadapterbinding.parser.EJBBoundResourceAdapterBindingMetaDataParser;
 import org.jboss.as.ejb3.security.parser.EJBBoundSecurityMetaDataParser;
@@ -300,6 +301,7 @@ public class EjbJarParsingDeploymentUnitProcessor implements DeploymentUnitProce
         parsers.put("urn:trans-timeout:1.0", new TransactionTimeoutMetaDataParser());
         parsers.put(EJBBoundPoolParser.NAMESPACE_URI, new EJBBoundPoolParser());
         parsers.put(EJBBoundCacheParser.NAMESPACE_URI, new EJBBoundCacheParser());
+        parsers.put(ContainerInterceptorsParser.NAMESPACE_URI_1_0, ContainerInterceptorsParser.INSTANCE);
         return parsers;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/ContainerInterceptorBindingsDDProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/ContainerInterceptorBindingsDDProcessor.java
@@ -1,0 +1,319 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.deployment.processors.dd;
+
+import org.jboss.as.ee.component.Attachments;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ee.component.InterceptorDescription;
+import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
+import org.jboss.as.ejb3.interceptor.ContainerInterceptorsMetaData;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
+import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.invocation.proxy.MethodIdentifier;
+import org.jboss.logging.Logger;
+import org.jboss.metadata.ejb.spec.EjbJarMetaData;
+import org.jboss.metadata.ejb.spec.InterceptorBindingMetaData;
+import org.jboss.metadata.ejb.spec.InterceptorBindingsMetaData;
+import org.jboss.metadata.ejb.spec.NamedMethodMetaData;
+import org.jboss.modules.Module;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+
+/**
+ * A {@link DeploymentUnitProcessor} which processes the container interceptor bindings that are configured the jboss-ejb3.xml
+ * deployment descriptor of a deployment
+ *
+ * @author Jaikiran Pai
+ */
+public class ContainerInterceptorBindingsDDProcessor implements DeploymentUnitProcessor {
+
+    private static final Logger logger = Logger.getLogger(ContainerInterceptorBindingsDDProcessor.class);
+
+    @Override
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final EjbJarMetaData metaData = deploymentUnit.getAttachment(EjbDeploymentAttachmentKeys.EJB_JAR_METADATA);
+        if (metaData == null || metaData.getAssemblyDescriptor() == null) {
+            return;
+        }
+        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+        final Module module = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE);
+        final DeploymentReflectionIndex index = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.REFLECTION_INDEX);
+
+        // fetch the container-interceptors
+        final List<ContainerInterceptorsMetaData> containerInterceptorConfigurations = metaData.getAssemblyDescriptor().getAny(ContainerInterceptorsMetaData.class);
+        if (containerInterceptorConfigurations == null || containerInterceptorConfigurations.isEmpty()) {
+            return;
+        }
+        final ContainerInterceptorsMetaData containerInterceptorsMetaData = containerInterceptorConfigurations.get(0);
+        if (containerInterceptorsMetaData == null) {
+            return;
+        }
+        final InterceptorBindingsMetaData containerInterceptorBindings = containerInterceptorsMetaData.getInterceptorBindings();
+        // no interceptor-binding == nothing to do
+        if (containerInterceptorBindings == null || containerInterceptorBindings.isEmpty()) {
+            return;
+        }
+        // we have now found some container interceptors which are bound to certain EJBs, start the real work!
+
+        final Map<String, List<InterceptorBindingMetaData>> bindingsPerEJB = new HashMap<String, List<InterceptorBindingMetaData>>();
+        final List<InterceptorBindingMetaData> bindingsForAllEJBs = new ArrayList<InterceptorBindingMetaData>();
+        for (final InterceptorBindingMetaData containerInterceptorBinding : containerInterceptorBindings) {
+            if (containerInterceptorBinding.getEjbName().equals("*")) {
+                // container interceptor bindings that are applicable for all EJBs are *not* expected to specify a method
+                // since all EJBs having the same method is not really practical
+                if (containerInterceptorBinding.getMethod() != null) {
+                    throw MESSAGES.defaultInterceptorsNotBindToMethod();
+                }
+                if (containerInterceptorBinding.getInterceptorOrder() != null) {
+                    throw MESSAGES.defaultInterceptorsNotSpecifyOrder();
+                }
+                // Make a note that this container interceptor binding is applicable for all EJBs
+                bindingsForAllEJBs.add(containerInterceptorBinding);
+            } else {
+                // fetch existing container interceptor bindings for the EJB, if any.
+                List<InterceptorBindingMetaData> bindings = bindingsPerEJB.get(containerInterceptorBinding.getEjbName());
+                if (bindings == null) {
+                    bindings = new ArrayList<InterceptorBindingMetaData>();
+                    bindingsPerEJB.put(containerInterceptorBinding.getEjbName(), bindings);
+                }
+                // Make a note that the container interceptor binding is applicable for this specific EJB
+                bindings.add(containerInterceptorBinding);
+            }
+        }
+        // At this point we now know which container interceptor bindings have been configured for which EJBs.
+        // Next, we create InterceptorDescription(s) out of those.
+        final List<InterceptorDescription> interceptorDescriptionsForAllEJBs = new ArrayList<InterceptorDescription>();
+        // first process container interceptors applicable for all EJBs
+        for (InterceptorBindingMetaData binding : bindingsForAllEJBs) {
+            if (binding.getInterceptorClasses() != null) {
+                for (final String clazz : binding.getInterceptorClasses()) {
+                    interceptorDescriptionsForAllEJBs.add(new InterceptorDescription(clazz));
+                }
+            }
+        }
+        // Now process container interceptors for each EJB
+        for (final ComponentDescription componentDescription : eeModuleDescription.getComponentDescriptions()) {
+            if (!(componentDescription instanceof EJBComponentDescription)) {
+                continue;
+            }
+            final EJBComponentDescription ejbComponentDescription = (EJBComponentDescription) componentDescription;
+            final Class<?> componentClass;
+            try {
+                componentClass = module.getClassLoader().loadClass(ejbComponentDescription.getComponentClassName());
+            } catch (ClassNotFoundException e) {
+                throw MESSAGES.failToLoadComponentClass(ejbComponentDescription.getComponentClassName());
+            }
+            final List<InterceptorBindingMetaData> bindingsApplicableForCurrentEJB = bindingsPerEJB.get(ejbComponentDescription.getComponentName());
+            final Map<Method, List<InterceptorBindingMetaData>> methodInterceptors = new HashMap<Method, List<InterceptorBindingMetaData>>();
+            final List<InterceptorBindingMetaData> classLevelBindings = new ArrayList<InterceptorBindingMetaData>();
+            // we only want to exclude default and class level interceptors if every binding
+            // has the exclude element.
+            boolean classLevelExcludeDefaultInterceptors = false;
+            Map<Method, Boolean> methodLevelExcludeDefaultInterceptors = new HashMap<Method, Boolean>();
+            Map<Method, Boolean> methodLevelExcludeClassInterceptors = new HashMap<Method, Boolean>();
+
+            // if an absolute order has been defined at any level then absolute ordering takes precedence
+            boolean classLevelAbsoluteOrder = false;
+            final Map<Method, Boolean> methodLevelAbsoluteOrder = new HashMap<Method, Boolean>();
+            if (bindingsApplicableForCurrentEJB != null) {
+                for (final InterceptorBindingMetaData binding : bindingsApplicableForCurrentEJB) {
+                    if (binding.getMethod() == null) {
+                        // The container interceptor is expected to be fired for all methods of that EJB
+                        classLevelBindings.add(binding);
+                        // if even one binding does not say exclude default then we do not exclude
+                        if (binding.isExcludeDefaultInterceptors()) {
+                            classLevelExcludeDefaultInterceptors = true;
+                        }
+                        if (binding.isTotalOrdering()) {
+                            if (classLevelAbsoluteOrder) {
+                                throw MESSAGES.twoEjbBindingsSpecifyAbsoluteOrder(componentClass.toString());
+                            } else {
+                                classLevelAbsoluteOrder = true;
+                            }
+                        }
+                    } else {
+                        // Method level bindings
+                        // First find the right method
+                        final NamedMethodMetaData methodData = binding.getMethod();
+                        final ClassReflectionIndex<?> classIndex = index.getClassIndex(componentClass);
+                        Method resolvedMethod = null;
+                        if (methodData.getMethodParams() == null) {
+                            final Collection<Method> methods = classIndex.getAllMethods(methodData.getMethodName());
+                            if (methods.isEmpty()) {
+                                throw MESSAGES.failToFindMethodInEjbJarXml(componentClass.getName(), methodData.getMethodName());
+                            } else if (methods.size() > 1) {
+                                throw MESSAGES.multipleMethodReferencedInEjbJarXml(methodData.getMethodName(), componentClass.getName());
+                            }
+                            resolvedMethod = methods.iterator().next();
+                        } else {
+                            final Collection<Method> methods = classIndex.getAllMethods(methodData.getMethodName(), methodData.getMethodParams().size());
+                            for (final Method method : methods) {
+                                boolean match = true;
+                                for (int i = 0; i < method.getParameterTypes().length; ++i) {
+                                    if (!method.getParameterTypes()[i].getName().equals(methodData.getMethodParams().get(i))) {
+                                        match = false;
+                                        break;
+                                    }
+                                }
+                                if (match) {
+                                    resolvedMethod = method;
+                                    break;
+                                }
+                            }
+                            if (resolvedMethod == null) {
+                                throw MESSAGES.failToFindMethodWithParameterTypes(componentClass.getName(), methodData.getMethodName(), methodData.getMethodParams());
+                            }
+                        }
+                        List<InterceptorBindingMetaData> methodSpecificInterceptorBindings = methodInterceptors.get(resolvedMethod);
+                        if (methodSpecificInterceptorBindings == null) {
+                            methodSpecificInterceptorBindings = new ArrayList<InterceptorBindingMetaData>();
+                            methodInterceptors.put(resolvedMethod, methodSpecificInterceptorBindings);
+                        }
+                        methodSpecificInterceptorBindings.add(binding);
+                        if (binding.isExcludeDefaultInterceptors()) {
+                            methodLevelExcludeDefaultInterceptors.put(resolvedMethod, true);
+                        }
+                        if (binding.isExcludeClassInterceptors()) {
+                            methodLevelExcludeClassInterceptors.put(resolvedMethod, true);
+                        }
+                        if (binding.isTotalOrdering()) {
+                            if (methodLevelAbsoluteOrder.containsKey(resolvedMethod)) {
+                                throw MESSAGES.twoEjbBindingsSpecifyAbsoluteOrder(resolvedMethod.toString());
+                            } else {
+                                methodLevelAbsoluteOrder.put(resolvedMethod, true);
+                            }
+                        }
+                    }
+                }
+            }
+            // Now we have all the bindings in a format we can use
+            // Build the list of default interceptors
+            ejbComponentDescription.setDefaultContainerInterceptors(interceptorDescriptionsForAllEJBs);
+
+            if (classLevelExcludeDefaultInterceptors) {
+                ejbComponentDescription.setExcludeDefaultContainerInterceptors(true);
+            }
+            final List<InterceptorDescription> classLevelInterceptors = new ArrayList<InterceptorDescription>();
+            if (classLevelAbsoluteOrder) {
+                // We have an absolute ordering for the class level interceptors
+                for (final InterceptorBindingMetaData binding : classLevelBindings) {
+                    // Find the class level container interceptor binding which specifies the total ordering (there will
+                    // only be one since we have already validated in an earlier step, then more than one binding cannot
+                    // specify a ordering
+                    if (binding.isTotalOrdering()) {
+                        for (final String interceptor : binding.getInterceptorOrder()) {
+                            classLevelInterceptors.add(new InterceptorDescription(interceptor));
+                        }
+                        break;
+                    }
+                }
+                // We have merged the default interceptors into the class interceptors
+                ejbComponentDescription.setExcludeDefaultContainerInterceptors(true);
+            } else {
+                for (InterceptorBindingMetaData binding : classLevelBindings) {
+                    if (binding.getInterceptorClasses() != null) {
+                        for (final String interceptor : binding.getInterceptorClasses()) {
+                            classLevelInterceptors.add(new InterceptorDescription(interceptor));
+                        }
+                    }
+                }
+            }
+            // We now know about the class level container interceptors for this EJB
+            ejbComponentDescription.setClassLevelContainerInterceptors(classLevelInterceptors);
+
+            // Now process method level container interceptors for the EJB
+            for (Map.Entry<Method, List<InterceptorBindingMetaData>> entry : methodInterceptors.entrySet()) {
+                final Method method = entry.getKey();
+                final List<InterceptorBindingMetaData> methodBindings = entry.getValue();
+                boolean totalOrder = methodLevelAbsoluteOrder.containsKey(method);
+                final MethodIdentifier methodIdentifier = MethodIdentifier.getIdentifierForMethod(method);
+
+                Boolean excludeDefaultInterceptors = methodLevelExcludeDefaultInterceptors.get(method);
+                excludeDefaultInterceptors = excludeDefaultInterceptors == null ? false : excludeDefaultInterceptors;
+                if (!excludeDefaultInterceptors) {
+                    excludeDefaultInterceptors = ejbComponentDescription.isExcludeDefaultContainerInterceptors() || ejbComponentDescription.isExcludeDefaultContainerInterceptors(methodIdentifier);
+                }
+
+                Boolean excludeClassInterceptors = methodLevelExcludeClassInterceptors.get(method);
+                excludeClassInterceptors = excludeClassInterceptors == null ? false : excludeClassInterceptors;
+                if (!excludeClassInterceptors) {
+                    excludeClassInterceptors = ejbComponentDescription.isExcludeClassLevelContainerInterceptors(methodIdentifier);
+                }
+
+                final List<InterceptorDescription> methodLevelInterceptors = new ArrayList<InterceptorDescription>();
+                if (totalOrder) {
+                    // If there is a total order we just use it
+                    for (final InterceptorBindingMetaData binding : methodBindings) {
+                        if (binding.isTotalOrdering()) {
+                            for (final String interceptor : binding.getInterceptorOrder()) {
+                                methodLevelInterceptors.add(new InterceptorDescription(interceptor));
+                            }
+                        }
+                    }
+                } else {
+                    // First add default interceptors and then class level interceptors for the method and finally
+                    // the method specific interceptors
+                    if (!excludeDefaultInterceptors) {
+                        methodLevelInterceptors.addAll(interceptorDescriptionsForAllEJBs);
+                    }
+                    if (!excludeClassInterceptors) {
+                        for (InterceptorDescription interceptor : classLevelInterceptors) {
+                            methodLevelInterceptors.add(interceptor);
+                        }
+                    }
+                    for (final InterceptorBindingMetaData binding : methodBindings) {
+                        if (binding.getInterceptorClasses() != null) {
+                            for (final String interceptor : binding.getInterceptorClasses()) {
+                                methodLevelInterceptors.add(new InterceptorDescription(interceptor));
+                            }
+                        }
+                    }
+
+                }
+                // We have already taken component and default interceptors into account
+                ejbComponentDescription.excludeClassLevelContainerInterceptors(methodIdentifier);
+                ejbComponentDescription.excludeDefaultContainerInterceptors(methodIdentifier);
+                ejbComponentDescription.setMethodContainerInterceptors(methodIdentifier, methodLevelInterceptors);
+            }
+        }
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/interceptor/ContainerInterceptorsMetaData.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/interceptor/ContainerInterceptorsMetaData.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.interceptor;
+
+import org.jboss.metadata.ejb.spec.InterceptorBindingMetaData;
+import org.jboss.metadata.ejb.spec.InterceptorBindingsMetaData;
+
+/**
+ * Holds the interceptor bindings information configured within a <code>container-interceptors</code>
+ * element of jboss-ejb3.xml
+ *
+ * @author Jaikiran Pai
+ */
+public class ContainerInterceptorsMetaData {
+
+    private final InterceptorBindingsMetaData interceptorBindings = new InterceptorBindingsMetaData();
+
+    public InterceptorBindingsMetaData getInterceptorBindings() {
+        return this.interceptorBindings;
+    }
+
+    void addInterceptorBinding(final InterceptorBindingMetaData interceptorBinding) {
+        this.interceptorBindings.add(interceptorBinding);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/interceptor/ContainerInterceptorsParser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/interceptor/ContainerInterceptorsParser.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.interceptor;
+
+import org.jboss.metadata.ejb.parser.spec.AbstractMetaDataParser;
+import org.jboss.metadata.ejb.parser.spec.InterceptorBindingMetaDataParser;
+import org.jboss.metadata.ejb.spec.InterceptorBindingMetaData;
+import org.jboss.metadata.property.PropertyReplacer;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+/**
+ * Responsible for parsing the <code>container-interceptors</code> in jboss-ejb3.xml
+ *
+ * @author Jaikiran Pai
+ */
+public class ContainerInterceptorsParser extends AbstractMetaDataParser<ContainerInterceptorsMetaData> {
+
+    public static final ContainerInterceptorsParser INSTANCE = new ContainerInterceptorsParser();
+    public static final String NAMESPACE_URI_1_0 = "urn:container-interceptors:1.0";
+
+    private static final String ELEMENT_CONTAINER_INTERCEPTORS = "container-interceptors";
+    private static final String ELEMENT_INTERCEPTOR_BINDING = "interceptor-binding";
+
+    @Override
+    public ContainerInterceptorsMetaData parse(XMLStreamReader reader, PropertyReplacer propertyReplacer) throws XMLStreamException {
+        // make sure it's the right namespace
+        if (!reader.getNamespaceURI().equals(NAMESPACE_URI_1_0)) {
+            throw unexpectedElement(reader);
+        }
+        // only process relevant elements
+        if (!reader.getLocalName().equals(ELEMENT_CONTAINER_INTERCEPTORS)) {
+            throw unexpectedElement(reader);
+        }
+
+        final ContainerInterceptorsMetaData metaData = new ContainerInterceptorsMetaData();
+        processElements(metaData, reader, propertyReplacer);
+        return metaData;
+    }
+
+    @Override
+    protected void processElement(final ContainerInterceptorsMetaData containerInterceptorsMetadata, final XMLStreamReader reader, final PropertyReplacer propertyReplacer) throws XMLStreamException {
+        final String localName = reader.getLocalName();
+        if (!localName.equals(ELEMENT_INTERCEPTOR_BINDING)) {
+            throw unexpectedElement(reader);
+        }
+        // parse the interceptor-binding
+        final InterceptorBindingMetaData interceptorBinding = this.readInterceptorBinding(reader, propertyReplacer);
+        // add the interceptor binding to the container interceptor metadata
+        containerInterceptorsMetadata.addInterceptorBinding(interceptorBinding);
+    }
+
+    /**
+     * Parses the <code>interceptor-binding</code> element and returns the corresponding {@link InterceptorBindingMetaData}
+     *
+     * @param reader
+     * @param propertyReplacer
+     * @return
+     * @throws XMLStreamException
+     */
+    private InterceptorBindingMetaData readInterceptorBinding(final XMLStreamReader reader, final PropertyReplacer propertyReplacer) throws XMLStreamException {
+        return InterceptorBindingMetaDataParser.INSTANCE.parse(reader, propertyReplacer);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -73,6 +73,7 @@ import org.jboss.as.ejb3.deployment.processors.SessionBeanHomeProcessor;
 import org.jboss.as.ejb3.deployment.processors.TimerServiceJndiBindingProcessor;
 import org.jboss.as.ejb3.deployment.processors.annotation.EjbAnnotationProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.AssemblyDescriptorProcessor;
+import org.jboss.as.ejb3.deployment.processors.dd.ContainerInterceptorBindingsDDProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.DeploymentDescriptorInterceptorBindingsProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.DeploymentDescriptorMethodProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.InterceptorClassDeploymentDescriptorProcessor;
@@ -255,6 +256,8 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_SLSB_POOL_NAME_MERGE, new StatelessSessionBeanPoolMergingProcessor());
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_MDB_POOL_NAME_MERGE, new MessageDrivenBeanPoolMergingProcessor());
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_ENTITY_POOL_NAME_MERGE, new EntityBeanPoolMergingProcessor());
+                    // Add the deployment unit processor responsible for processing the user application specific container interceptors configured in jboss-ejb3.xml
+                    processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_USER_APP_SPECIFIC_CONTAINER_INTERCEPTORS, new ContainerInterceptorBindingsDDProcessor());
 
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_DEPENDS_ON_ANNOTATION, new EjbDependsOnMergingProcessor());
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_DEPLOYMENT_REPOSITORY, new DeploymentRepositoryProcessor());

--- a/ejb3/src/main/resources/jboss-ejb-container-interceptors_1_0.xsd
+++ b/ejb3/src/main/resources/jboss-ejb-container-interceptors_1_0.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema xmlns="urn:container-interceptors:1.0" xmlns:javaee="http://java.sun.com/xml/ns/javaee" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:container-interceptors:1.0" version="1.0" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd">
+    <xs:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd"/>
+
+    <xs:element name="container-interceptors" substitutionGroup="javaee:assembly-descriptor-entry" type="container-interceptorsType"/>
+
+    <xs:complexType name="container-interceptorsType">
+        <xs:complexContent>
+            <xs:extension base="javaee:jboss-assembly-descriptor-bean-entryType">
+                <xs:annotation>
+                    <xs:documentation>The container interceptor bindings applicable for various EJBs in the deployment</xs:documentation>
+                </xs:annotation>
+                <xs:sequence>
+                    <xs:element name="interceptor-binding" type="javaee:interceptor-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -363,6 +363,7 @@ public enum Phase {
     public static final int POST_MODULE_EJB_SLSB_POOL_NAME_MERGE        = 0x0507;
     public static final int POST_MODULE_EJB_MDB_POOL_NAME_MERGE         = 0x0508;
     public static final int POST_MODULE_EJB_ENTITY_POOL_NAME_MERGE      = 0x0509;
+    public static final int POST_MODULE_EJB_USER_APP_SPECIFIC_CONTAINER_INTERCEPTORS = 0x050A;
     public static final int POST_MODULE_EJB_DD_INTERCEPTORS             = 0x0600;
     public static final int POST_MODULE_EJB_TIMER_SERVICE               = 0x0601;
     public static final int POST_MODULE_EJB_TRANSACTION_MANAGEMENT      = 0x0602;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/AnotherFlowTrackingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/AnotherFlowTrackingBean.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateless;
+import javax.interceptor.Interceptors;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@LocalBean
+public class AnotherFlowTrackingBean extends FlowTrackingBean {
+
+    public String echoWithMethodSpecificContainerInterceptor(final String msg) {
+        return msg;
+    }
+
+    public String echoInSpecificOrderOfContainerInterceptors(final String msg) {
+        return msg;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ClassLevelContainerInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ClassLevelContainerInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class ClassLevelContainerInterceptor {
+    @AroundInvoke
+    private Object iAmAround(final InvocationContext invocationContext) throws Exception {
+        return this.getClass().getName() + " " + invocationContext.proceed();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorOne.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorOne.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import org.jboss.logging.Logger;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class ContainerInterceptorOne {
+
+    private static final Logger logger = Logger.getLogger(ContainerInterceptorOne.class);
+
+    @AroundInvoke
+    public Object aroundInvoke(final InvocationContext invocationContext) throws Exception {
+        logger.info("Container interceptor invoked!!!");
+        final String skipInterceptor = (String) invocationContext.getContextData().get(FlowTrackingBean.CONTEXT_DATA_KEY);
+        if (skipInterceptor != null && this.getClass().getName().equals(skipInterceptor)) {
+            return invocationContext.proceed();
+        }
+        return this.getClass().getName() + " " + invocationContext.proceed();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/ContainerInterceptorsTestCase.java
@@ -1,0 +1,205 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+/**
+ * Tests that the <code>container-interceptors</code> configured in jboss-ejb3.xml and processed and applied correctly to the relevant
+ * EJBs.
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class ContainerInterceptorsTestCase {
+
+    private static final int CLIENT_INTERCEPTOR_ORDER = 0x99999;
+
+    private static final String EJB_JAR_NAME = "ejb-container-interceptors";
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EJB_JAR_NAME + ".jar");
+        jar.addPackage(ContainerInterceptorsTestCase.class.getPackage());
+        jar.addAsManifestResource(ContainerInterceptorsTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
+        return jar;
+    }
+
+    /**
+     * Tests that the container-interceptor(s) are invoked when a EJB method on a local view is invoked
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInvocationOnLocalView() throws Exception {
+        final FlowTrackingBean bean = InitialContext.doLookup("java:module/" + FlowTrackingBean.class.getSimpleName() + "!" + FlowTrackingBean.class.getName());
+        final String message = "foo";
+        // all interceptors (container-interceptor and Java EE interceptor) are expected to be invoked.
+        final String expectedResultForFirstInvocation = ContainerInterceptorOne.class.getName() + " " + NonContainerInterceptor.class.getName() + " " + FlowTrackingBean.class.getName()
+                + " " + message;
+        final String firstResult = bean.echo(message);
+        Assert.assertEquals("Unexpected result after first invocation on bean", expectedResultForFirstInvocation, firstResult);
+
+        final String secondMessage = "bar";
+        // all interceptors (container-interceptor and Java EE interceptor) are expected to be invoked.
+        final String expectedResultForSecondInvocation = ContainerInterceptorOne.class.getName() + " " + NonContainerInterceptor.class.getName() + " " + FlowTrackingBean.class.getName()
+                + " " + secondMessage;
+        final String secondResult = bean.echo(secondMessage);
+        Assert.assertEquals("Unexpected result after second invocation on bean", expectedResultForSecondInvocation, secondResult);
+    }
+
+    /**
+     * Tests that the container-interceptor(s) are invoked when a EJB method on a remote view is invoked
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInvocationOnRemoteView() throws Exception {
+        final FlowTracker bean = InitialContext.doLookup("java:module/" + FlowTrackingBean.class.getSimpleName() + "!" + FlowTracker.class.getName());
+        final String message = "foo";
+        // all interceptors (container-interceptor and Java EE interceptor) are expected to be invoked.
+        final String expectedResultForFirstInvocation = ContainerInterceptorOne.class.getName() + " " + NonContainerInterceptor.class.getName() + " " + FlowTrackingBean.class.getName()
+                + " " + message;
+        final String firstResult = bean.echo(message);
+        Assert.assertEquals("Unexpected result after first invocation on remote view of bean", expectedResultForFirstInvocation, firstResult);
+
+        final String secondMessage = "bar";
+        // all interceptors (container-interceptor and Java EE interceptor) are expected to be invoked.
+        final String expectedResultForSecondInvocation = ContainerInterceptorOne.class.getName() + " " + NonContainerInterceptor.class.getName() + " " + FlowTrackingBean.class.getName()
+                + " " + secondMessage;
+        final String secondResult = bean.echo(secondMessage);
+        Assert.assertEquals("Unexpected result after second invocation on remote view of bean", expectedResultForSecondInvocation, secondResult);
+
+    }
+
+    /**
+     * Tests that the container-interceptor(s) have access to the data that's passed by a remote client via the {@link javax.interceptor.InvocationContext#getContextData()}
+     */
+    @Test
+    // force real remote invocation so that the RemotingConnectionEJBReceiver is used instead of a LocalEJBReceiver
+    @RunAsClient
+    public void testDataPassingForContainerInterceptorsOnRemoteView() throws Exception {
+        // get hold of the EJBClientContext
+        final EJBClientContext ejbClientContext = EJBClientContext.requireCurrent();
+
+        // create some data that the client side interceptor will pass along during the EJB invocation
+        final Map<String, Object> interceptorData = new HashMap<String, Object>();
+        interceptorData.put(FlowTrackingBean.CONTEXT_DATA_KEY, ContainerInterceptorOne.class.getName());
+        final SimpleEJBClientInterceptor clientInterceptor = new SimpleEJBClientInterceptor(interceptorData);
+        // register the client side interceptor
+        ejbClientContext.registerInterceptor(CLIENT_INTERCEPTOR_ORDER, clientInterceptor);
+
+        final Hashtable jndiProps = new Hashtable();
+        jndiProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context jndiCtx = new InitialContext(jndiProps);
+        final FlowTracker bean = (FlowTracker) jndiCtx.lookup("ejb:/" + EJB_JAR_NAME + "/" + FlowTrackingBean.class.getSimpleName() + "!" + FlowTracker.class.getName());
+        final String message = "foo";
+        // we passed ContainerInterceptorOne as the value of the context data for the invocation, which means that we want the ContainerInterceptorOne
+        // to be skipped, so except that interceptor, the rest should be invoked.
+        final String expectedResultForFirstInvocation = NonContainerInterceptor.class.getName() + " " + FlowTrackingBean.class.getName()
+                + " " + message;
+        final String firstResult = bean.echo(message);
+        Assert.assertEquals("Unexpected result invoking on bean when passing context data via EJB client interceptor", expectedResultForFirstInvocation, firstResult);
+
+        // Now try another invocation, this time skip a different interceptor
+        interceptorData.clear();
+        interceptorData.put(FlowTrackingBean.CONTEXT_DATA_KEY, NonContainerInterceptor.class.getName());
+        final String secondMessage = "bar";
+        // we passed NonContainerInterceptor as the value of the context data for the invocation, which means that we want the NonContainerInterceptor
+        // to be skipped, so except that interceptor, the rest should be invoked.
+        final String expectedResultForSecondInvocation = ContainerInterceptorOne.class.getName() + " " + FlowTrackingBean.class.getName()
+                + " " + secondMessage;
+        final String secondResult = bean.echo(secondMessage);
+        Assert.assertEquals("Unexpected result invoking on bean when passing context data via EJB client interceptor", expectedResultForSecondInvocation, secondResult);
+
+    }
+
+    /**
+     * Tests that class level and method level container-interceptors (and other eligible interceptors) are invoked during a EJB invocation
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testClassAndMethodLevelContainerInterceptor() throws Exception {
+        final AnotherFlowTrackingBean bean = InitialContext.doLookup("java:module/" + AnotherFlowTrackingBean.class.getSimpleName() + "!" + AnotherFlowTrackingBean.class.getName());
+        final String message = "foo";
+        // all interceptors (container-interceptor and Java EE interceptor) are expected to be invoked.
+        final String expectedResultForFirstInvocation = ContainerInterceptorOne.class.getName() + " "
+                + ClassLevelContainerInterceptor.class.getName() + " "
+                + MethodSpecificContainerInterceptor.class.getName() + " "
+                + NonContainerInterceptor.class.getName() + " "
+                + AnotherFlowTrackingBean.class.getName() + " " + message;
+
+        // invoke on the specific method which has the container-interceptor eligible
+        final String firstResult = bean.echoWithMethodSpecificContainerInterceptor(message);
+        Assert.assertEquals("Unexpected result after invocation on bean", expectedResultForFirstInvocation, firstResult);
+
+        // now let's invoke on a method for which that method level container interceptor isn't applicable
+        final String expectedResultForSecondInvocation = ContainerInterceptorOne.class.getName() + " "
+                + ClassLevelContainerInterceptor.class.getName() + " "
+                + NonContainerInterceptor.class.getName() + " "
+                + AnotherFlowTrackingBean.class.getName() + " " + message;
+
+        final String secondResult = bean.echo(message);
+        Assert.assertEquals("Unexpected result after invocation on bean", expectedResultForSecondInvocation, secondResult);
+
+
+    }
+
+    /**
+     * Tests that the explicit ordering specified for container-interceptors in the jboss-ejb3.xml is honoured
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testContainerInterceptorOrdering() throws Exception {
+        final AnotherFlowTrackingBean bean = InitialContext.doLookup("java:module/" + AnotherFlowTrackingBean.class.getSimpleName() + "!" + AnotherFlowTrackingBean.class.getName());
+        final String message = "foo";
+        // all interceptors (container-interceptor and Java EE interceptor) are expected to be invoked in the order specified in the jboss-ejb3.xml
+        final String expectedResultForFirstInvocation = ClassLevelContainerInterceptor.class.getName() + " "
+                + MethodSpecificContainerInterceptor.class.getName() + " "
+                + ContainerInterceptorOne.class.getName() + " "
+                + NonContainerInterceptor.class.getName() + " "
+                + AnotherFlowTrackingBean.class.getName() + " " + message;
+
+        // invoke on the specific method which has the interceptor-order specified
+        final String firstResult = bean.echoInSpecificOrderOfContainerInterceptors(message);
+        Assert.assertEquals("Unexpected result after invocation on bean", expectedResultForFirstInvocation, firstResult);
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/FlowTracker.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/FlowTracker.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface FlowTracker {
+
+    String echo(String message);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/FlowTrackingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/FlowTrackingBean.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import org.jboss.logging.Logger;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptors;
+import javax.interceptor.InvocationContext;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Interceptors(NonContainerInterceptor.class)
+@Remote (FlowTracker.class)
+@LocalBean
+public class FlowTrackingBean implements FlowTracker {
+
+    private static final Logger logger = Logger.getLogger(FlowTrackingBean.class);
+
+    public static final String CONTEXT_DATA_KEY = "foo-bar";
+
+    @AroundInvoke
+    protected Object aroundInvoke(InvocationContext invocationContext) throws Exception {
+        logger.info("@AroundInvoke on bean invoked");
+        final String skipInterceptor = (String) invocationContext.getContextData().get(FlowTrackingBean.CONTEXT_DATA_KEY);
+        if (skipInterceptor != null && this.getClass().getName().equals(skipInterceptor)) {
+            return invocationContext.proceed();
+        }
+        return this.getClass().getName() + " " + invocationContext.proceed();
+    }
+
+    public String echo(final String msg) {
+        logger.info("EJB invoked!!!");
+        return msg;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/MethodSpecificContainerInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/MethodSpecificContainerInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class MethodSpecificContainerInterceptor {
+
+    @AroundInvoke
+    private Object iAmAroundInvoke(final InvocationContext invocationContext) throws Exception {
+        return this.getClass().getName() + " " + invocationContext.proceed();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/NonContainerInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/NonContainerInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import org.jboss.logging.Logger;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class NonContainerInterceptor {
+
+    private static final Logger logger = Logger.getLogger(NonContainerInterceptor.class);
+
+    @AroundInvoke
+    public Object someMethod(InvocationContext invocationContext) throws Exception {
+        logger.info("Invoked non-container interceptor!!!");
+        final String skipInterceptor = (String) invocationContext.getContextData().get(FlowTrackingBean.CONTEXT_DATA_KEY);
+        if (skipInterceptor != null && this.getClass().getName().equals(skipInterceptor)) {
+            return invocationContext.proceed();
+        }
+        return this.getClass().getName() + " " + invocationContext.proceed();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/SimpleEJBClientInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/SimpleEJBClientInterceptor.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.container.interceptor;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+import java.util.Map;
+
+/**
+ * An EJB client side interceptor
+ *
+ * @author Jaikiran Pai
+ */
+public class SimpleEJBClientInterceptor implements EJBClientInterceptor {
+
+    private final Map<String, Object> data;
+
+    SimpleEJBClientInterceptor(final Map<String, Object> data) {
+        this.data = data;
+    }
+
+    @Override
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        // add all the data to the EJB client invocation context so that it becomes available to the server side
+        context.getContextData().putAll(data);
+        // proceed "down" the invocation chain
+        context.sendRequest();
+    }
+
+    @Override
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        // we don't have anything special to do with the result so just return back the result
+        // "up" the invocation chain
+        return context.getResult();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/jboss-ejb3.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss xmlns="http://www.jboss.com/xml/ns/javaee"
+       xmlns:jee="http://java.sun.com/xml/ns/javaee"
+       xmlns:ci ="urn:container-interceptors:1.0">
+
+    <jee:assembly-descriptor>
+        <ci:container-interceptors>
+            <!-- Default interceptor -->
+            <jee:interceptor-binding>
+                <ejb-name>*</ejb-name>
+                <interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.ContainerInterceptorOne</interceptor-class>
+            </jee:interceptor-binding>
+            <!-- Class level container-interceptor -->
+            <jee:interceptor-binding>
+                <ejb-name>AnotherFlowTrackingBean</ejb-name>
+                <interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.ClassLevelContainerInterceptor</interceptor-class>
+            </jee:interceptor-binding>
+            <!-- Method specific container-interceptor -->
+            <jee:interceptor-binding>
+                <ejb-name>AnotherFlowTrackingBean</ejb-name>
+                <interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.MethodSpecificContainerInterceptor</interceptor-class>
+                <method>
+                    <method-name>echoWithMethodSpecificContainerInterceptor</method-name>
+                </method>
+            </jee:interceptor-binding>
+            <!-- container interceptors in a specific order -->
+            <jee:interceptor-binding>
+                <ejb-name>AnotherFlowTrackingBean</ejb-name>
+                <interceptor-order>
+                    <interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.ClassLevelContainerInterceptor</interceptor-class>
+                    <interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.MethodSpecificContainerInterceptor</interceptor-class>
+                    <interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.ContainerInterceptorOne</interceptor-class>
+                </interceptor-order>
+                <method>
+                    <method-name>echoInSpecificOrderOfContainerInterceptors</method-name>
+                </method>
+            </jee:interceptor-binding>
+        </ci:container-interceptors>
+    </jee:assembly-descriptor>
+</jboss>
+

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
@@ -71,6 +71,7 @@ public class AbstractValidationUnitTest {
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb3-2_0.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb3-spec-2_0.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-cache_1_0.xsd");
+        EXCLUDED_SCHEMA_FILES.add("jboss-ejb-container-interceptors_1_0.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-iiop_1_0.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-pool_1_0.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-resource-adapter-binding_1_0.xsd");


### PR DESCRIPTION
The commits here introduce support for the "container-interceptor" feature requested in https://issues.jboss.org/browse/AS7-5897.

User applications can now specify container-interceptors in their jboss-ejb3.xml and those interceptors will then run before some of the JBoss specific server side interceptors. This will allow the user application specific container-interceptors to pass along necessary information to the JBoss specific server interceptors during the invocation. These container-interceptors can even short-circuit the invocation if they want too. 

The container-interceptors have been supported keeping in mind that we don't want to introduce any dependency on any JBoss specific libraries so that the ability to support this feature, in future becomes easier from a user point of view. These container-interceptors are merely Java EE interceptors and can be specified in the jboss-ejb3.xml as shown in the testcase here  https://github.com/jaikiran/jboss-as/blob/a5aa71aa354e3fbcbb0ba19f49b16f10854f5619/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/jboss-ejb3.xml
