### PR TITLE
Use default JAVA_OPTS from the conf file when using --debug option.

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -58,10 +58,6 @@ if not "x%DEBUG_ARG" == "x" (
 rem $Id$
 )
 
-if "%DEBUG_MODE%" == "true" (
-   set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
-)
-
 pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
@@ -93,6 +89,17 @@ if exist "%STANDALONE_CONF%" (
    call "%STANDALONE_CONF%" %*
 ) else (
    echo Config file not found "%STANDALONE_CONF%"
+)
+
+
+rem Set debug settings if not already set
+if "%DEBUG_MODE%" == "true" (
+   echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
+  if errorlevel == 1 (
+     echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
+  ) else (
+     set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
+  )
 )
 
 set DIRNAME=

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -55,11 +55,6 @@ case "`uname`" in
         ;;
 esac
 
-
-if [ "$DEBUG_MODE" = "true" ]; then
-    JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n"
-fi
-
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
     [ -n "$JBOSS_HOME" ] &&
@@ -94,6 +89,16 @@ if [ "x$RUN_CONF" = "x" ]; then
 fi
 if [ -r "$RUN_CONF" ]; then
     . "$RUN_CONF"
+fi
+
+# Set debug settings if not already set
+if [ "$DEBUG_MODE" = "true" ]; then
+    DEBUG_OPT=`echo $JAVA_OPTS | $GREP "\-agentlib:jdwp"`
+    if [ "x$DEBUG_OPT" = "x" ]; then
+        JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_PORT,server=y,suspend=n"
+    else
+        echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
+    fi
 fi
 
 # Setup the JVM


### PR DESCRIPTION
The `--debug` option was ignoring the conf file. Moved adding the debug options after the conf file was loaded. Also check that there are no debug options already present in the `JAVA_OPTS`.
