### PR TITLE
Enhancing global valve tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/valve/ValveUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/valve/ValveUnitTestCase.java
@@ -47,6 +47,8 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * This class tests a global valve.
+ * A note: some more tests are in manualmode testsuite module 
+ *         reload is required for adding parameters and disabling valve 
  *
  * @author Jean-Frederic Clere
  */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/valve/ValveUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/valve/ValveUtil.java
@@ -22,12 +22,9 @@
 package org.jboss.as.test.integration.web.valve;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.junit.Assert.assertTrue;
@@ -42,7 +39,6 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.util.EntityUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.dmr.ModelNode;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/GlobalValveTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/GlobalValveTestCase.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.web.valve;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * This class tests a global valve.
+ *
+ * @author Jean-Frederic Clere
+ * @author Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class GlobalValveTestCase {
+    private static Logger log = Logger.getLogger(GlobalValveTestCase.class);
+    
+    public static final String CONTAINER = "default-jbossas";
+    
+    @ArquillianResource
+    private static ContainerController container;
+    
+    private static final String modulename = "org.jboss.testvalve";
+    private static final String classname = TestValve.class.getName();
+    private static final String baseModulePath = "/../modules/" + modulename.replace(".", "/") + "/main";
+    private static final String jarName = "testvalve.jar";
+    private static final String VALVE_NAME_1 = "testvalve1";
+    private static final String VALVE_NAME_2 = "testvalve2";
+    private static final String PARAM_NAME = "testparam";
+    /** the default value is hardcoded in {@link TestValve} */
+    private static final String DEFAULT_PARAM_VALUE = "DEFAULT_VALUE";
+
+    @Deployment(name = "valve")
+    @TargetsContainer(CONTAINER)
+    public static WebArchive Hello() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "global-valve-test.war");
+        war.addClasses(HelloServlet.class);
+        return war;
+    }
+    
+    @Test
+    @InSequence(0)
+    public void startServer() throws Exception {
+        container.start(CONTAINER);
+    }
+
+    
+    @Test
+    @InSequence(1)
+    public void testValveOne(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        // as first test in sequence creating valve module
+        ValveUtil.createValveModule(client, modulename, baseModulePath, jarName);
+        // adding valve based on the created module
+        ValveUtil.addValve(client, VALVE_NAME_1, modulename, classname, null);
+        ValveUtil.reload(client);
+        
+        log.debug("Testing url " + url + " against one global valve named " + VALVE_NAME_1);
+        Header[] valveHeaders = ValveUtil.hitValve(url);
+        assertEquals("There was one valve defined - it's missing now", 1, valveHeaders.length);
+        assertEquals("One valve with not defined param expecting default param value", DEFAULT_PARAM_VALUE, valveHeaders[0].getValue());
+    }
+
+    @Test
+    @InSequence(2)
+    public void testValveTwo(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        Map<String,String> params = new HashMap<String, String>();
+        params.put(PARAM_NAME, VALVE_NAME_2); //as param of valve defining its name
+        ValveUtil.addValve(client, VALVE_NAME_2, modulename, classname, params);
+        ValveUtil.reload(client);
+        
+        log.debug("Testing url " + url + " against two valves named " + VALVE_NAME_1 + " and " + VALVE_NAME_2);
+        Header[] valveHeaders = ValveUtil.hitValve(url);
+        assertEquals("There were two global valves defined - they're missing now", 2, valveHeaders.length);
+        // valve execution is not ordered - consulted with jfclere
+        if(DEFAULT_PARAM_VALUE.equals(valveHeaders[0].getValue())) {
+            assertEquals("First header has default parameter second has to have from param", VALVE_NAME_2, valveHeaders[1].getValue());
+        }
+        else if(VALVE_NAME_2.equals(valveHeaders[0].getValue())) {
+            assertEquals("First header has parametrized value the second has to have default one", DEFAULT_PARAM_VALUE, valveHeaders[1].getValue());    
+        } else {
+            fail("The first header has value neither default nor parametrized. The value is: " + valveHeaders[0].getValue() + " what is not correct.");
+        }
+    }
+    
+    @Test
+    @InSequence(3)
+    public void testValveDisabled(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {       
+        ValveUtil.activateValve(client, VALVE_NAME_1, false);
+        ValveUtil.reload(client);
+        
+        log.debug("Testing url " + url + " against one global valve named " + VALVE_NAME_2 + ". The second one "+ VALVE_NAME_1 +" is disabled");
+        Header[] valveHeaders = ValveUtil.hitValve(url);
+        assertEquals("There is one active valve defined", 1, valveHeaders.length);
+        assertEquals("Just second parametrized valve is active - defined param value is expected to be returned", VALVE_NAME_2, valveHeaders[0].getValue());
+    }
+    
+    
+    @Test
+    @InSequence(99)
+    public void cleanUp(@ArquillianResource ManagementClient client) throws Exception {
+        ValveUtil.removeValve(client, VALVE_NAME_1);
+        ValveUtil.removeValve(client, VALVE_NAME_2);
+        container.stop(CONTAINER);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/HelloServlet.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/HelloServlet.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+
+package org.jboss.as.test.manualmode.web.valve;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(name="HelloServlet", urlPatterns={"/"})
+public class HelloServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    public void doGet(HttpServletRequest request,
+                      HttpServletResponse response)
+        throws IOException, ServletException {
+        PrintWriter out = response.getWriter();
+        out.println("HelloServlet");
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/MANIFEST.MF
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Dependencies: org.jboss.testvalve

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/TestValve.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/TestValve.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.web.valve;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+import org.jboss.logging.Logger;
+
+public class TestValve extends ValveBase {
+    private static final Logger log = Logger.getLogger(TestValve.class);
+
+    private String testparam = "DEFAULT_VALUE";
+
+    public void setTestparam(String testparam) {
+        this.testparam = testparam;
+    }
+    
+    public String getTestparam() {
+        return this.testparam;
+    }
+
+    public void invoke(Request request, Response response)
+        throws IOException, ServletException {
+        response.addHeader("valve", testparam);
+        log.info("Valve " + TestValve.class.getName() + " was hit and adding header parameter 'valve' with value " + testparam);
+        getNext().invoke(request, response);
+    }
+}
+

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/ValveUtil.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/ValveUtil.java
@@ -1,0 +1,237 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.web.valve;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * @author Jean-Frederic Clere
+ * @author Ondrej Chaloupka
+ */
+public class ValveUtil {
+
+    private static Logger log = Logger.getLogger(ValveUtil.class);
+
+    public static void createValveModule(final ManagementClient managementClient, String modulename, String baseModulePath, String jarName) throws Exception {
+        String path = ValveUtil.readASPath(managementClient.getControllerClient());
+        File file = new File(path);
+        if (file.exists()) {
+            file = new File(path + baseModulePath);
+            file.mkdirs();
+            file = new File(path + baseModulePath + "/" + jarName);
+            if (file.exists())
+                file.delete();
+            createJar(file);
+            file = new File(path + baseModulePath + "/module.xml");
+            if (file.exists())
+                file.delete();              
+            FileWriter fstream = new FileWriter(path + baseModulePath + "/module.xml");
+            BufferedWriter out = new BufferedWriter(fstream);
+            out.write("<module xmlns=\"urn:jboss:module:1.1\" name=\"" + modulename + "\">\n");
+            out.write("    <properties>\n");
+            out.write("        <property name=\"jboss.api\" value=\"private\"/>\n");
+            out.write("    </properties>\n");
+
+            out.write("    <resources>\n");
+            out.write("        <resource-root path=\""+ jarName + "\"/>\n");
+            out.write("    </resources>\n");
+
+            out.write("    <dependencies>\n");
+            out.write("        <module name=\"sun.jdk\"/>\n");
+            out.write("        <module name=\"javax.servlet.api\"/>\n");
+            out.write("        <module name=\"org.jboss.as.web\"/>\n");
+            out.write("       <module name=\"org.jboss.logging\"/>\n");
+            out.write("    </dependencies>\n");
+            out.write("</module>");
+            out.close();
+        }
+    }
+    
+    private static void createJar(File file) {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "temporary-name.jar")
+                              .addClass(TestValve.class);       
+        log.info(archive.toString(true));
+        archive.as(ZipExporter.class).exportTo(file);
+    }
+    
+    /**
+     * Adding valve via DMR operation for jboss config file (standalone.xml)
+     */
+    public static void addValve(final ManagementClient managementClient, String valveName, String modulename, String classname, Map<String,String> params) throws Exception {
+        List<ModelNode> updates = new ArrayList<ModelNode>();
+
+        ModelNode op = new ModelNode();
+        op.get(OP).set(ADD);
+        op.get(OP_ADDR).set(getValveAddr(valveName));
+        // op.get(NAME).set(valveName);
+        op.get("enabled").set("true");
+        op.get("class-name").set(classname);
+        op.get("module").set(modulename);
+        updates.add(op);
+        
+        if(params != null) {
+            for (String paramName: params.keySet()) {
+                op = new ModelNode();
+                op.get(OP).set("add-param");
+                op.get(OP_ADDR).set(getValveAddr(valveName));
+                op.get("param-name").set(paramName);
+                op.get("param-value").set(params.get(paramName));
+                updates.add(op);
+            }
+        }
+
+        applyUpdates(managementClient.getControllerClient(), updates);
+    }
+    
+    public static void activateValve(final ManagementClient managementClient, String valveName, boolean isActive) throws Exception {
+        ModelNode op = new ModelNode();
+        op = new ModelNode();
+        op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        op.get(OP_ADDR).set(getValveAddr(valveName));
+        op.get(NAME).set("enabled");
+        op.get(VALUE).set(Boolean.toString(isActive));
+        applyUpdate(managementClient, op);
+    }
+    
+    private static ModelNode getValveAddr(String valveName) {
+        ModelNode address = new ModelNode();
+        address.add(SUBSYSTEM, "web");
+        address.add("valve", valveName);
+        address.protect();
+        return address;
+    }    
+
+    public static void removeValve(final ManagementClient managementClient, String valveName) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(REMOVE);
+        op.get(OP_ADDR).set(getValveAddr(valveName));
+
+        applyUpdate(managementClient, op);
+    }
+
+    public static void applyUpdate(final ManagementClient client, final ModelNode update) throws Exception {
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+        updates.add(update);
+        applyUpdates(client.getControllerClient(), updates);
+    }
+    
+    public static void applyUpdates(final ModelControllerClient client, final List<ModelNode> updates) throws Exception {
+        for (ModelNode update : updates) {
+            log.info("+++ Update on " + client + ":\n" + update.toString());
+            ModelNode result = client.execute(new OperationBuilder(update).build());
+            if (result.hasDefined("outcome") && "success".equals(result.get("outcome").asString())) {
+                if (result.hasDefined("result"))
+                    log.info(result.get("result"));
+            } else if (result.hasDefined("failure-description")) {
+                throw new RuntimeException(result.get("failure-description").toString());
+            } else {
+                throw new RuntimeException("Operation not successful; outcome = " + result.get("outcome"));
+            }
+        }
+    }
+    
+    /**
+     * Provide reload operation on server
+     * 
+     * @throws Exception
+     */
+    public static void reload(final ManagementClient managementClient) throws Exception {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("reload");
+        applyUpdate(managementClient, operation);
+        boolean reloaded = false;
+        int i = 0;
+        while (!reloaded) {
+            try {
+                Thread.sleep(5000);
+                if (managementClient.isServerInRunningState())
+                    reloaded = true;
+            } catch (Throwable t) {
+                // nothing to do, just waiting
+            } finally {
+                if (!reloaded && i++ > 10)
+                    throw new Exception("Server reloading failed");
+            }
+        }
+    }
+    
+    public static String readASPath(final ModelControllerClient client) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set("read-attribute");
+        op.get(OP_ADDR).add("path", "jboss.home.dir");
+        op.get("name").set("path");
+        ModelNode result = client.execute(new OperationBuilder(op).build());
+        if (result.hasDefined("outcome") && "success".equals(result.get("outcome").asString())) {
+            if (result.hasDefined("result"))
+                return result.get("result").asString();
+        } else if (result.hasDefined("failure-description")) {
+            throw new RuntimeException(result.get("failure-description").toString());
+        } else {
+            throw new RuntimeException("Operation not successful; outcome = " + result.get("outcome"));
+        }
+        return null;
+    }
+    
+    /**
+     * Access http://localhost/
+     * @return "valve" headers
+     */
+    public static Header[] hitValve(URL url) throws Exception {
+        HttpGet httpget = new HttpGet(url.toURI());
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+
+        log.info("executing request" + httpget.getRequestLine());
+        HttpResponse response = httpclient.execute(httpget);
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Header[] errorHeaders = response.getHeaders("X-Exception");
+        assertEquals("Wrong response code: " + statusCode + " On " + url, HttpURLConnection.HTTP_OK, statusCode);
+        assertEquals("X-Exception(" + Arrays.toString(errorHeaders) + ") is null", 0, errorHeaders.length);
+        
+        return response.getHeaders("valve");
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/WebDescriptorValveTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/WebDescriptorValveTestCase.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.web.valve;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+/**
+ * This class tests a web descriptor valve definition and global valve defined in server conf.
+ *
+ * @author Ondrej Chaloupka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class WebDescriptorValveTestCase {
+    private static Logger log = Logger.getLogger(WebDescriptorValveTestCase.class);
+    
+    @ArquillianResource
+    private static ContainerController container;
+    
+    @ArquillianResource
+    private Deployer deployer;
+    
+    private static final String DEPLOYMENT_NAME = "valve";
+    private static final String modulename = "org.jboss.testvalve";
+    private static final String classname = TestValve.class.getName();
+    private static final String baseModulePath = "/../modules/" + modulename.replace(".", "/") + "/main";
+    private static final String jarName = "testvalve.jar";
+    private static final String VALVE_NAME = "testvalve";
+    private static final String PARAM_NAME = "testparam";
+    private static final String WEB_PARAM_VALUE = "webdescriptor";
+    private static final String GLOBAL_PARAM_VALUE = "global";
+
+    @Deployment(name = DEPLOYMENT_NAME, managed = false)
+    public static WebArchive Hello() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "web-descriptor-valve-test.war");
+        war.addClasses(HelloServlet.class);
+        war.addAsWebInfResource(WebDescriptorValveTestCase.class.getPackage(),"jboss-web.xml", "jboss-web.xml");
+        war.addAsManifestResource(WebDescriptorValveTestCase.class.getPackage(),"MANIFEST.MF", "MANIFEST.MF");
+        return war;
+    }
+    
+    @Test
+    @InSequence(-1)
+    public void startServer() throws Exception {
+        container.start(GlobalValveTestCase.CONTAINER);
+    }
+
+    @Test
+    @InSequence(0)
+    public void createValveAndDeploy(@ArquillianResource ManagementClient client) throws Exception {
+        // as first test in sequence creating valve module
+        ValveUtil.createValveModule(client, modulename, baseModulePath, jarName);
+        // valve is ready - let's deploy
+        deployer.deploy(DEPLOYMENT_NAME);
+    }
+    
+        
+    @Test
+    @InSequence(1)
+    public void testWebDescriptor(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {        
+        log.debug("Testing url " + url + " against one valve defined in jboss-web.xml descriptor");
+        Header[] valveHeaders = ValveUtil.hitValve(url);
+        assertEquals("There was one valve defined - it's missing now", 1, valveHeaders.length);
+        assertEquals(WEB_PARAM_VALUE, valveHeaders[0].getValue());
+    }
+
+    @Test
+    @InSequence(2)
+    public void testValveOne(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        Map<String,String> params = new HashMap<String, String>();
+        params.put(PARAM_NAME, GLOBAL_PARAM_VALUE);
+        ValveUtil.addValve(client, VALVE_NAME, modulename, classname, params);
+        ValveUtil.reload(client);
+        
+        log.debug("Testing url " + url + " against two valves - one defined in web descriptor other is defined globally in server configuration");
+        Header[] valveHeaders = ValveUtil.hitValve(url);
+        assertEquals("There were two valves defined", 2, valveHeaders.length);
+        assertEquals(GLOBAL_PARAM_VALUE, valveHeaders[0].getValue());
+        assertEquals(WEB_PARAM_VALUE, valveHeaders[1].getValue());
+    }
+    
+    
+    @Test
+    @InSequence(99)
+    public void cleanUp(@ArquillianResource ManagementClient client) throws Exception {
+        ValveUtil.removeValve(client, VALVE_NAME);
+        deployer.undeploy(DEPLOYMENT_NAME);
+        container.stop(GlobalValveTestCase.CONTAINER);
+    }    
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/jboss-web.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/jboss-web.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+ <valve>
+   <class-name>org.jboss.as.test.manualmode.web.valve.TestValve</class-name>
+     <param>
+        <param-name>testparam</param-name>
+        <param-value>webdescriptor</param-value>
+     </param>
+   </valve>
+</jboss-web>


### PR DESCRIPTION
Adding more tests on global valve feature based on document https://community.jboss.org/wiki/AddAGlobalValveInAS772x.
Because of necessity of :reload server configuration in case of adding valve params and disabling it I put tests to manualmode. The original test on global valve is left in integration.basic part.
