### PR TITLE
[AS7-6128] Revert Infinispan FILE_STORE attribute expression support.

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/FileStoreResource.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/FileStoreResource.java
@@ -61,7 +61,7 @@ public class FileStoreResource extends BaseStoreResource {
     static final SimpleAttributeDefinition RELATIVE_TO =
             new SimpleAttributeDefinitionBuilder(ModelKeys.RELATIVE_TO, ModelType.STRING, true)
                     .setXmlName(Attribute.RELATIVE_TO.getLocalName())
-                    .setAllowExpression(true)
+                    .setAllowExpression(false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode().set(ServerEnvironment.SERVER_DATA_DIR))
                     .build();

--- a/clustering/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer_1_4-expressions.xml
+++ b/clustering/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer_1_4-expressions.xml
@@ -32,7 +32,7 @@
             <transaction mode="FULL_XA" stop-timeout="${test.xxx:60000}"  locking="${tst.xxx:OPTIMISTIC}"/>
             <eviction max-entries="${test.xxx:20000}" strategy="${test.xxx:LIRS}"/>
             <expiration interval="${test.xxx:10000}" lifespan="${test.xxx:10}" max-idle="${test.xxx:10}"/>
-            <file-store fetch-state="${test.xxx:false}" passivation="${test.xxx:false}" path="${test.xxx:path}" preload="${test.xxx:true}" purge="${test.xxx:false}" relative-to="${test.xxx:jboss.server.temp.dir}" shared="${test.xxx:true}" singleton="${tst.xxx:true}">
+            <file-store fetch-state="${test.xxx:false}" passivation="${test.xxx:false}" path="${test.xxx:path}" preload="${test.xxx:true}" purge="${test.xxx:false}" relative-to="jboss.server.temp.dir" shared="${test.xxx:true}" singleton="${tst.xxx:true}">
                 <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}" />
             </file-store>
             <indexing index="${test.xxx:LOCAL}">


### PR DESCRIPTION
The Infinispan file-store=FILE_STORE resource attribute relative-to was erroneously allowed to support expressions. This change reverts that.
