### PR TITLE
AS7-6346 Use the correct classloader during creation of EJBClientContext

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -88,7 +88,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
         // create the client configuration from the metadata
         final EJBClientConfiguration ejbClientConfiguration = this.createClientConfiguration(phaseContext.getServiceRegistry(), module.getClassLoader(), ejbClientDescriptorMetaData);
         // create the service
-        final DescriptorBasedEJBClientContextService service = new DescriptorBasedEJBClientContextService(ejbClientConfiguration);
+        final DescriptorBasedEJBClientContextService service = new DescriptorBasedEJBClientContextService(ejbClientConfiguration, module.getClassLoader());
         // add the service
         final ServiceBuilder serviceBuilder = serviceTarget.addService(ejbClientContextServiceName, service);
         // add the remoting connection reference dependencies

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbDependencyDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbDependencyDeploymentUnitProcessor.java
@@ -79,7 +79,7 @@ public class EjbDependencyDeploymentUnitProcessor implements DeploymentUnitProce
         final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
 
         //we always give them the EJB client
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_CLIENT, false, false, false, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_CLIENT, false, false, true, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_IIOP_CLIENT, false, false, false, false));
 
         //we always have to add this, as even non-ejb deployments may still lookup IIOP ejb's


### PR DESCRIPTION
The commit here fixes the issue that was discovered while working on a quickstart as part of https://issues.jboss.org/browse/AS7-6346. The EJBClientContext creation wasn't using the correct classloader and furthermore the default META-INF/services of the auto-added org.jboss.ejb.client  module dependency wasn't visible to the deployment. This PR fixes these issues.
