### PR TITLE
[AS7-6120] Expand support for System Property substitution

### DIFF
--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
@@ -3,7 +3,7 @@
 <host name="master" xmlns="urn:jboss:domain:1.4">
 
     <vault code="${vault.code:somevault}">
-        <vault-option name="abc" value="def"/>
+        <vault-option name="abc" value="${vault-option:def}"/>
     </vault>
 
     <management>

--- a/server/src/main/java/org/jboss/as/server/controller/resources/VaultResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/VaultResourceDefinition.java
@@ -59,7 +59,8 @@ public class VaultResourceDefinition extends SimpleResourceDefinition {
             .addFlag(Flag.RESTART_ALL_SERVICES)
             //.setValidator(new MapValidator(new StringLengthValidator(1), true, 0, Integer.MAX_VALUE))
             .setCorrector(MapAttributeDefinition.LIST_TO_MAP_CORRECTOR)
-            .setValidator(new StringLengthValidator(1))
+            .setValidator(new StringLengthValidator(1, true, true))
+            .setAllowExpression(true)
             .build();
 
     public static AttributeDefinition[] ALL_ATTRIBUTES = new AttributeDefinition[] {CODE, VAULT_OPTIONS};


### PR DESCRIPTION
- allow expression for core-service vault's vault-options attribute

I've checked manually that when the options passed to the vault reader to create the vault have been correctly resolved beforehands.
