### PR TITLE
Minor addition to the JBOSS_HOME/bin/client/README.txt contents

### DIFF
--- a/build/src/main/resources/bin/client/README-EJB-JMS.txt
+++ b/build/src/main/resources/bin/client/README-EJB-JMS.txt
@@ -7,6 +7,7 @@ org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec
 org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec
 org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec
 
+org.jboss:jboss-ejb-client
 org.jboss:jboss-remote-naming
 org.jboss.logging:jboss-logging
 org.jboss.marshalling:jboss-marshalling


### PR DESCRIPTION
The Readme.txt in JBOSS_HOME/bin/client was missing the mention of org.jboss:jboss-ejb-client library. Updated the file to include it.
