### PR TITLE
AS7-6368:  validate-on-match setting is not honored when specified in the datasource subsystem

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -512,7 +512,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
 
             final Validation validation = dataSourceConfig.getValidation();
             if (validation != null) {
-                if (validation.isValidateOnMatch()) {
+                if (validation.isValidateOnMatch() != null) {
                     managedConnectionFactory.setValidateOnMatch(validation.isValidateOnMatch());
                 }
                 if (validation.getCheckValidConnectionSql() != null) {


### PR DESCRIPTION
Proposed patch for AS7-6368
