### PR TITLE
AS7-6215 Add ability to mark an EJB as having an 'implicit depends on'

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentDescription.java
@@ -128,6 +128,11 @@ public class ComponentDescription implements ResourceInjectionTarget {
     private String beanDeploymentArchiveId;
 
     /**
+     * If this is set then then view service will depend on the components start service
+     */
+    private boolean viewDependsOnStart = false;
+
+    /**
      * Construct a new instance.
      *
      * @param componentName             the component name
@@ -530,6 +535,14 @@ public class ComponentDescription implements ResourceInjectionTarget {
      */
     public boolean isOptional() {
         return false;
+    }
+
+    public boolean isViewDependsOnStart() {
+        return viewDependsOnStart;
+    }
+
+    public void setViewDependsOnStart(final boolean viewDependsOnStart) {
+        this.viewDependsOnStart = viewDependsOnStart;
     }
 
     private static InterceptorFactory weaved(final Collection<InterceptorFactory> interceptorFactories) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/ImplicitDependsOnMetaData.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/ImplicitDependsOnMetaData.java
@@ -1,0 +1,25 @@
+package org.jboss.as.ejb3.component;
+
+import org.jboss.metadata.ejb.parser.jboss.ejb3.AbstractEJBBoundMetaData;
+
+/**
+ *
+ * Metadata for implicit-depends-on
+ *
+ * If this is set then the EJB's views have a dependency on the EJB's start service,
+ * so other components that inject the EJB will end up with an implicit dependency on the EJB
+ *
+ * @author Stuart Douglas
+ */
+public class ImplicitDependsOnMetaData extends AbstractEJBBoundMetaData {
+
+    private boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/ImplicitDependsOnParser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/ImplicitDependsOnParser.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.jboss.metadata.ejb.parser.jboss.ejb3.AbstractEJBBoundMetaDataParser;
+import org.jboss.metadata.property.PropertyReplacer;
+
+/**
+ * Responsible for parsing the <code>implicit-depends-on</code> in jboss-ejb3.xml
+ *
+ * If this is set then the EJB's views have a dependency on the EJB's start service,
+ * so other components that inject the EJB will end up with an implicit dependency on the EJB
+ *
+ * @author Stuart Douglas
+ */
+public class ImplicitDependsOnParser extends AbstractEJBBoundMetaDataParser<ImplicitDependsOnMetaData> {
+
+    public static final ImplicitDependsOnParser INSTANCE = new ImplicitDependsOnParser();
+    public static final String NAMESPACE_URI_1_0 = "urn:implicit-depends-on:1.0";
+
+    private static final String ELEMENT_IMPLICIT_DEPENDS_ON = "implicit-depends-on";
+    private static final String ELEMENT_ENABLED = "enabled";
+
+    @Override
+    public ImplicitDependsOnMetaData parse(XMLStreamReader reader, PropertyReplacer propertyReplacer) throws XMLStreamException {
+        // make sure it's the right namespace
+        if (!reader.getNamespaceURI().equals(NAMESPACE_URI_1_0)) {
+            throw unexpectedElement(reader);
+        }
+        // only process relevant elements
+        if (!reader.getLocalName().equals(ELEMENT_IMPLICIT_DEPENDS_ON)) {
+            throw unexpectedElement(reader);
+        }
+
+        final ImplicitDependsOnMetaData metaData = new ImplicitDependsOnMetaData();
+        processElements(metaData, reader, propertyReplacer);
+        return metaData;
+    }
+
+    @Override
+    protected void processElement(final ImplicitDependsOnMetaData metaData, final XMLStreamReader reader, final PropertyReplacer propertyReplacer) throws XMLStreamException {
+        final String localName = reader.getLocalName();
+        if (!NAMESPACE_URI_1_0.equals(reader.getNamespaceURI())) {
+            super.processElement(metaData, reader, propertyReplacer);
+            return;
+        }
+        if (!localName.equals(ELEMENT_ENABLED)) {
+            throw unexpectedElement(reader);
+        }
+        metaData.setEnabled(Boolean.parseBoolean(reader.getElementText()));
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
@@ -42,6 +42,7 @@ import org.jboss.as.ee.structure.SpecDescriptorPropertyReplacement;
 import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.cache.EJBBoundCacheParser;
 import org.jboss.as.ejb3.clustering.EJBBoundClusteringMetaDataParser;
+import org.jboss.as.ejb3.component.ImplicitDependsOnParser;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.deployment.EjbJarDescription;
 import org.jboss.as.ejb3.interceptor.ContainerInterceptorsParser;
@@ -303,6 +304,7 @@ public class EjbJarParsingDeploymentUnitProcessor implements DeploymentUnitProce
         parsers.put(EJBBoundPoolParser.NAMESPACE_URI, new EJBBoundPoolParser());
         parsers.put(EJBBoundCacheParser.NAMESPACE_URI, new EJBBoundCacheParser());
         parsers.put(ContainerInterceptorsParser.NAMESPACE_URI_1_0, ContainerInterceptorsParser.INSTANCE);
+        parsers.put(ImplicitDependsOnParser.NAMESPACE_URI_1_0, ImplicitDependsOnParser.INSTANCE);
         return parsers;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/ContainerInterceptorBindingsDDProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/ContainerInterceptorBindingsDDProcessor.java
@@ -22,6 +22,13 @@
 
 package org.jboss.as.ejb3.deployment.processors.dd;
 
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.EEModuleDescription;
@@ -36,19 +43,11 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.invocation.proxy.MethodIdentifier;
-import org.jboss.logging.Logger;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
 import org.jboss.metadata.ejb.spec.InterceptorBindingMetaData;
 import org.jboss.metadata.ejb.spec.InterceptorBindingsMetaData;
 import org.jboss.metadata.ejb.spec.NamedMethodMetaData;
 import org.jboss.modules.Module;
-
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 
@@ -59,8 +58,6 @@ import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
  * @author Jaikiran Pai
  */
 public class ContainerInterceptorBindingsDDProcessor implements DeploymentUnitProcessor {
-
-    private static final Logger logger = Logger.getLogger(ContainerInterceptorBindingsDDProcessor.class);
 
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/ImplicitDependsOnDDProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/ImplicitDependsOnDDProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.deployment.processors.dd;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.ee.component.Attachments;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.ejb3.component.ImplicitDependsOnMetaData;
+import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.metadata.ejb.spec.EjbJarMetaData;
+
+/**
+ * @author Stuart Douglas
+ */
+public class ImplicitDependsOnDDProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final EjbJarMetaData metaData = deploymentUnit.getAttachment(EjbDeploymentAttachmentKeys.EJB_JAR_METADATA);
+        if (metaData == null || metaData.getAssemblyDescriptor() == null) {
+            return;
+        }
+        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+
+        // fetch the container-interceptors
+        final List<ImplicitDependsOnMetaData> implicitDependsOn = metaData.getAssemblyDescriptor().getAny(ImplicitDependsOnMetaData.class);
+        if (implicitDependsOn == null || implicitDependsOn.isEmpty()) {
+            return;
+        }
+        Boolean defaultSetting = null;
+        Map<String, Boolean> perEjbSetting = new HashMap<String, Boolean>();
+        for (final ImplicitDependsOnMetaData dependsOn : implicitDependsOn) {
+            if (dependsOn.getEjbName().equals("*")) {
+                defaultSetting = dependsOn.isEnabled();
+            } else {
+                perEjbSetting.put(dependsOn.getEjbName(), dependsOn.isEnabled());
+            }
+        }
+        // Now process container interceptors for each EJB
+        for (final ComponentDescription componentDescription : eeModuleDescription.getComponentDescriptions()) {
+            if (!(componentDescription instanceof EJBComponentDescription)) {
+                continue;
+            }
+            if (perEjbSetting.containsKey(componentDescription.getComponentName())) {
+                componentDescription.setViewDependsOnStart(perEjbSetting.get(componentDescription.getComponentName()));
+            } else if (defaultSetting != null) {
+                componentDescription.setViewDependsOnStart(defaultSetting);
+            }
+        }
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -22,16 +22,8 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
-
 import java.util.List;
+
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
@@ -76,6 +68,7 @@ import org.jboss.as.ejb3.deployment.processors.dd.AssemblyDescriptorProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.ContainerInterceptorBindingsDDProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.DeploymentDescriptorInterceptorBindingsProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.DeploymentDescriptorMethodProcessor;
+import org.jboss.as.ejb3.deployment.processors.dd.ImplicitDependsOnDDProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.InterceptorClassDeploymentDescriptorProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.SecurityRoleRefDDProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.SessionBeanXmlDescriptorProcessor;
@@ -137,6 +130,15 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.omg.PortableServer.POA;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
 
 /**
  * Add operation handler for the EJB3 subsystem.
@@ -258,6 +260,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_ENTITY_POOL_NAME_MERGE, new EntityBeanPoolMergingProcessor());
                     // Add the deployment unit processor responsible for processing the user application specific container interceptors configured in jboss-ejb3.xml
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_USER_APP_SPECIFIC_CONTAINER_INTERCEPTORS, new ContainerInterceptorBindingsDDProcessor());
+                    processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_IMPLICIT_DEPENDS_ON, new ImplicitDependsOnDDProcessor());
 
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_DEPENDS_ON_ANNOTATION, new EjbDependsOnMergingProcessor());
                     processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_DEPLOYMENT_REPOSITORY, new DeploymentRepositoryProcessor());

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -385,6 +385,7 @@ public enum Phase {
     public static final int POST_MODULE_EJB_SECURITY_PRINCIPAL_ROLE_MAPPING_MERGE   = 0x0612;
     public static final int POST_MODULE_EJB_CACHE                       = 0x0614;
     public static final int POST_MODULE_EJB_CLUSTERED                   = 0x0615;
+    public static final int POST_MODULE_EJB_IMPLICIT_DEPENDS_ON         = 0x0616;
     public static final int POST_MODULE_WELD_WEB_INTEGRATION            = 0x0700;
     public static final int POST_MODULE_WELD_COMPONENT_INTEGRATION      = 0x0800;
     public static final int POST_MODULE_INSTALL_EXTENSION               = 0x0A00;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/ImplicitDependsOnTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/ImplicitDependsOnTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.injection.implicitDependsOn;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ImplicitDependsOnTestCase {
+
+    private static final Logger logger = Logger.getLogger(ImplicitDependsOnTestCase.class);
+    public static final String IMPLICIT_DEPLOYMENT = "implicitDeployment";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment
+    public static Archive createTestDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb-test.jar");
+        jar.addClasses(StaticDataClass.class, ImplicitDependsOnTestCase.class);
+        return jar;
+    }
+
+    @Deployment(managed = false, testable = false, name = IMPLICIT_DEPLOYMENT)
+    public static Archive createImplicitDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "implicit-depends-on.jar");
+        jar.addClasses(ServiceEjb.class, ShutdownSingleton.class);
+        jar.addAsManifestResource(ImplicitDependsOnTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
+        jar.addAsManifestResource(new StringAsset("Dependencies: deployment.ejb-test.jar\n"), "MANIFEST.MF");
+        return jar;
+    }
+
+
+    @Test
+    public void testImplicitDependsOn() throws IOException {
+        deployer.deploy(IMPLICIT_DEPLOYMENT);
+        deployer.undeploy(IMPLICIT_DEPLOYMENT);
+        Assert.assertEquals("hello", StaticDataClass.servletPreDestroyResult);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/ServiceEjb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/ServiceEjb.java
@@ -1,0 +1,17 @@
+package org.jboss.as.test.integration.ejb.injection.implicitDependsOn;
+
+import javax.ejb.Stateless;
+
+/**
+ *
+ *
+ * @author Stuart Douglas
+ */
+@Stateless
+public class ServiceEjb {
+
+   public String sayHello() {
+       return "hello";
+   }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/ShutdownSingleton.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/ShutdownSingleton.java
@@ -1,0 +1,30 @@
+package org.jboss.as.test.integration.ejb.injection.implicitDependsOn;
+
+import javax.annotation.PreDestroy;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.servlet.http.HttpServlet;
+
+/**
+ * @author Stuart Douglas
+ */
+@Singleton
+@Startup
+public class ShutdownSingleton extends HttpServlet {
+
+    @EJB
+    private ServiceEjb serviceEjb;
+
+
+    @PreDestroy
+    public void preDestroy() {
+        //we sleep to allow the other EJB to shut down if the service dependencies were not correct
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        StaticDataClass.servletPreDestroyResult = serviceEjb.sayHello();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/StaticDataClass.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/StaticDataClass.java
@@ -1,0 +1,13 @@
+package org.jboss.as.test.integration.ejb.injection.implicitDependsOn;
+
+/**
+ *
+ *
+ * @author Stuart Douglas
+ */
+public class StaticDataClass {
+
+    public static volatile String servletPreDestroyResult;
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/injection/implicitDependsOn/jboss-ejb3.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:i="urn:implicit-depends-on:1.0">
+    <assembly-descriptor>
+        <i:implicit-depends-on>
+            <ejb-name>ServiceEjb</ejb-name>
+            <i:enabled>true</i:enabled>
+        </i:implicit-depends-on>
+    </assembly-descriptor>
+</jboss>


### PR DESCRIPTION
This means that the EJB will have a dependencies on its view services,
rather than the other way around. Other EJB's that inject this EJB using
@EJB will then have an implicit depencncy on this EJB, guarenteeing that
this EJB will be availble in their @PreDestroy methods.
