### PR TITLE
Allow login modules with duplicate code within same security domain

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-security_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-security_1_2.xsd
@@ -247,6 +247,7 @@
       <xs:sequence>
          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="flag" type="module-option-flag" use="required"/>
       <xs:attribute name="module" type="xs:string" use="optional"/>
@@ -282,6 +283,7 @@
       <xs:sequence>
          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="flag" type="module-option-flag" use="optional"/>
       <xs:attribute name="login-module-stack-ref" type="xs:string" use="optional"/>
@@ -299,6 +301,7 @@
       <xs:sequence>
          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="flag" type="module-option-flag" use="required"/>
       <xs:attribute name="module" type="xs:string" use="optional"/>
@@ -315,6 +318,7 @@
       <xs:sequence>
          <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="flag" type="module-option-flag" use="required"/>
       <xs:attribute name="module" type="xs:string" use="optional"/>
@@ -331,6 +335,7 @@
       <xs:sequence>
           <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="type" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="module" type="xs:string" use="optional"/>
@@ -347,6 +352,7 @@
       <xs:sequence>
           <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="module" type="xs:string" use="optional"/>
    </xs:complexType>
@@ -362,6 +368,7 @@
       <xs:sequence>
           <xs:element name="module-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="optional"/>
       <xs:attribute name="code" type="xs:string" use="required"/>
       <xs:attribute name="flag" type="module-option-flag" use="required"/>
       <xs:attribute name="module" type="xs:string" use="optional"/>

--- a/security/src/test/resources/org/jboss/as/security/test/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/test/securitysubsystemv12.xml
@@ -5,6 +5,8 @@
                 <login-module code="Remoting" flag="optional">
                   <module-option name="password-stacking" value="useFirstPass"/>
                 </login-module>
+                 <login-module code="Duplicate" flag="optional" />
+                 <login-module name="duplicate-module" code="Duplicate" flag="optional" />
                 <login-module code="Anon" flag="optional"/>
                 <login-module code="RealmUsersRoles" flag="required">
                   <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>


### PR DESCRIPTION
- if user declares duplicate login module with same code we generate optional name and then persist it.
