### PR TITLE
Global valves authenticator ready to merge

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/AuthValveConstants.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/AuthValveConstants.java
@@ -1,0 +1,43 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+/**
+ *
+ * @author rhatlapa
+ */
+public class AuthValveConstants {
+    
+    public static final String CONTAINER = "default-jbossas";
+    
+    public static final Class AUTHENTICATOR = TestAuthenticator.class;
+    public static final String AUTH_VALVE_JAR = "testauthvalve.jar";
+    public static final String MODULENAME = "org.jboss.testvalve.authenticator";
+    
+    public static final String STANDARD_VALVE_JAR = "teststandardvalve.jar";
+    public static final String STANDARD_VALVE_MODULE = "org.jboss.testvalve.standard";
+    
+    public static final String STANDARD_VALVE = "classicValve";
+    
+    public static final String PARAM_NAME = "testparam";
+
+    public static final String DEFAULT_PARAM_VALUE = "default";
+    public static final String GLOBAL_PARAM_VALUE = "global";
+    public static final String WEB_PARAM_VALUE = "webdescriptor"; 
+    public static final String STANDARD_VALVE_DEFAULT_PARAM_VALUE = "simpleValve";
+    
+    public static final String WEB_APP_URL = "HelloServlet";
+    
+    public static final String CUSTOM_AUTHENTICATOR_1 = "MYAUTH";
+    public static final String CUSTOM_AUTHENTICATOR_2 = "MYAUTH_2";
+   
+    public static final String WEB_APP_URL_1 = "HelloServlet";
+    public static final String WEB_APP_URL_2 = "hello";
+    
+    public static String getBaseModulePath(String modulename) {
+        return "/../modules/" + modulename.replace(".", "/") + "/main";
+    }
+    
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/DescriptorValveAuthenticatorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/DescriptorValveAuthenticatorTestCase.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.http.Header;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.jboss.as.test.manualmode.web.valve.authenticator.AuthValveConstants.*;
+
+/**
+ * This class tests a global valve.
+ *
+ * @author Jean-Frederic Clere
+ * @author Ondrej Chaloupka
+ * @author Radim Hatlapatka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DescriptorValveAuthenticatorTestCase {
+
+    private static Logger log = Logger.getLogger(DescriptorValveAuthenticatorTestCase.class);
+    @ArquillianResource
+    private static ContainerController container;
+    @ArquillianResource
+    private Deployer deployer;
+    
+    private static final String DEPLOYMENT_NAME = "descriptorValveAuth";
+
+    @Deployment(name = DEPLOYMENT_NAME, managed = false)
+    @TargetsContainer(CONTAINER)
+    public static WebArchive Hello() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "web-descriptor-valve-test.war");
+        war.addClasses(HelloServlet.class);
+        war.addAsWebInfResource(DescriptorValveAuthenticatorTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.addAsWebInfResource(DescriptorValveAuthenticatorTestCase.class.getPackage(), "web-custom-auth.xml", "web.xml");
+        war.addAsManifestResource(DescriptorValveAuthenticatorTestCase.class.getPackage(), "MANIFEST.MF", "MANIFEST.MF");
+        return war;
+    }
+
+    @Test
+    @InSequence(-1)
+    public void startServer() throws Exception {
+        container.start(CONTAINER);
+    }
+
+    @Test
+    @InSequence(0)
+    public void createValveAndDeploy(@ArquillianResource ManagementClient client) throws Exception {
+        // as first test in sequence creating valve module
+        ValveUtil.createValveModule(client, MODULENAME, getBaseModulePath(MODULENAME), AUTH_VALVE_JAR, AUTHENTICATOR);
+
+        // authenticator valve is ready - let's deploy
+        deployer.deploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    @InSequence(1)
+    public void testWebDescriptor(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        String appUrl = url.toExternalForm() + WEB_APP_URL;
+        log.debug("Testing url " + appUrl + " against one authenticator valve defined in jboss-web.xml descriptor");
+        Header[] valveHeaders = ValveUtil.hitValve(new URL(appUrl));
+        assertEquals("There was one valve defined - it's missing now", 1, valveHeaders.length);
+        assertEquals(WEB_PARAM_VALUE, valveHeaders[0].getValue());
+    }
+
+    @Test
+    @InSequence(2)
+    public void testValveGlobal(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        // adding authenticator valve based on the created module
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(PARAM_NAME, GLOBAL_PARAM_VALUE);        
+        ValveUtil.addValve(client, CUSTOM_AUTHENTICATOR_1, MODULENAME, AUTHENTICATOR.getName(), params);        
+        ValveUtil.reload(client);
+
+        String appUrl = url.toExternalForm() + WEB_APP_URL;
+        log.debug("Testing url " + appUrl + " against two authenticators - one defined in web descriptor other is defined globally in server configuration and checking which one was used");
+        Header[] valveHeaders = ValveUtil.hitValve(new URL(appUrl));
+        assertEquals("There were two valves defined (but detected these valve headers: " + Arrays.toString(valveHeaders) + ")", 1, valveHeaders.length);
+        assertEquals(WEB_PARAM_VALUE, valveHeaders[0].getValue()); // testing that it is used authenticator defined in web descriptors valve
+    }
+
+    @Test
+    @InSequence(99)
+    public void cleanUp(@ArquillianResource ManagementClient client) throws Exception {
+        deployer.undeploy(DEPLOYMENT_NAME);
+        ValveUtil.removeValve(client, CUSTOM_AUTHENTICATOR_1);
+        container.stop(CONTAINER);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/GlobalAuthenticatorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/GlobalAuthenticatorTestCase.java
@@ -1,0 +1,193 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.http.Header;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.jboss.as.test.manualmode.web.valve.authenticator.AuthValveConstants.*;
+
+/**
+ * This class tests a global valve.
+ *
+ * @author Jean-Frederic Clere
+ * @author Ondrej Chaloupka
+ * @author Radim Hatlapatka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class GlobalAuthenticatorTestCase {
+
+    private static Logger log = Logger.getLogger(GlobalAuthenticatorTestCase.class);
+    @ArquillianResource
+    private static ContainerController container;
+    @ArquillianResource
+    private Deployer deployer;
+    private static final String DEPLOYMENT_NAME = "valveAuth";
+    private static final String DEPLOYMENT_NAME_2 = "valveAuth2";
+
+    @Deployment(name = DEPLOYMENT_NAME, managed = false)
+    @TargetsContainer(CONTAINER)
+    public static WebArchive Hello() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "global-authvalve-test.war");
+        war.addClasses(HelloServlet.class);
+        war.addAsWebInfResource(GlobalAuthenticatorTestCase.class.getPackage(), "web-custom-auth.xml", "web.xml");
+        return war;
+    }
+
+    @Deployment(name = DEPLOYMENT_NAME_2, managed = false)
+    @TargetsContainer(CONTAINER)
+    public static WebArchive Hello2() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "global-authvalve-second-test.war");
+        war.addClasses(HelloServlet.class);
+        war.addAsWebInfResource(GlobalAuthenticatorTestCase.class.getPackage(), "web-global-auth.xml", "web.xml");
+//        war.addAsManifestResource(GlobalAuthenticatorTestCase.class.getPackage(), "MANIFEST.MF", "MANIFEST.MF");
+        return war;
+    }
+
+    @Test
+    @InSequence(-1)
+    public void startServer() throws Exception {
+        container.start(CONTAINER);
+    }
+
+    @Test
+    @InSequence(0)
+    @OperateOnDeployment(value = DEPLOYMENT_NAME)
+    public void createValveAndDeploy(@ArquillianResource ManagementClient client) throws Exception {
+        // as first test in sequence creating valve module
+        ValveUtil.createValveModule(client, MODULENAME, getBaseModulePath(MODULENAME), AUTH_VALVE_JAR, AUTHENTICATOR);
+        // adding valve based on the created module
+        ValveUtil.addValve(client, CUSTOM_AUTHENTICATOR_1, MODULENAME, AUTHENTICATOR.getName(), null);
+
+        ValveUtil.reload(client);
+
+        // valve is ready - let's deploy
+        deployer.deploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    @InSequence(1)
+    @OperateOnDeployment(value = DEPLOYMENT_NAME_2)
+    public void createSecondValveAndDeploy(@ArquillianResource ManagementClient client) throws Exception {
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(PARAM_NAME, GLOBAL_PARAM_VALUE);
+        ValveUtil.addValve(client, CUSTOM_AUTHENTICATOR_2, MODULENAME, AUTHENTICATOR.getName(), params);
+        ValveUtil.reload(client);
+
+        // valve is ready - let's deploy
+        deployer.deploy(DEPLOYMENT_NAME_2);
+    }
+
+    @Test
+    @InSequence(2)
+    @OperateOnDeployment(value = DEPLOYMENT_NAME)
+    public void testValveAuthOne(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        String appUrl = url.toExternalForm() + WEB_APP_URL_1;
+        log.debug("Testing url " + appUrl + " against one global valve authenticator named " + CUSTOM_AUTHENTICATOR_1);
+        Header[] valveHeaders = ValveUtil.hitValve(new URL(appUrl));
+        assertEquals("There was one valve defined - it's missing now", 1, valveHeaders.length);
+        assertEquals("One valve with not defined param expecting default param value", DEFAULT_PARAM_VALUE, valveHeaders[0].getValue());
+    }
+
+    @Test
+    @InSequence(3)
+    @OperateOnDeployment(value = DEPLOYMENT_NAME_2)
+    public void testValveAuthTwo(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        String appUrl = url.toExternalForm() + WEB_APP_URL_2;
+        log.debug("Testing url " + appUrl + " against one global valve authenticator named " + CUSTOM_AUTHENTICATOR_2);
+        Header[] valveHeaders = ValveUtil.hitValve(new URL(appUrl));
+        assertEquals("There was one valve defined - it's missing now", 1, valveHeaders.length);
+        assertEquals("One valve with not defined param expecting default param value", GLOBAL_PARAM_VALUE, valveHeaders[0].getValue());
+    }
+
+    /**
+     * Testing that if authenticator valve is disabled then it is not used
+     */
+    @Test
+    @InSequence(10)
+    @OperateOnDeployment(value = DEPLOYMENT_NAME_2)
+    public void testValveAuthDisable(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        ValveUtil.activateValve(client, CUSTOM_AUTHENTICATOR_2, false);
+        ValveUtil.reload(client);
+        String appUrl = url.toExternalForm() + WEB_APP_URL_2;
+        Header[] valveHeaders = ValveUtil.hitValve(new URL(appUrl), HttpURLConnection.HTTP_NOT_FOUND);
+        assertEquals("Auth valve is disabled => expecting no valve headers: " + Arrays.toString(valveHeaders), 0, valveHeaders.length);
+    }
+
+    // test scenario when there is a standard valve + authenticator valve
+    // TODO: not yet functional, needs to be finished. It has problem to find a module
+    @Test
+    @InSequence(20) // put here in order to prevent potential influence for other tests by the standard global valve
+    @OperateOnDeployment(value = DEPLOYMENT_NAME)
+    public void authWithStandardValve(@ArquillianResource URL url, @ArquillianResource ManagementClient client) throws Exception {
+        // as first test in sequence creating valve module
+        ValveUtil.createValveModule(client, STANDARD_VALVE_MODULE, getBaseModulePath(STANDARD_VALVE_MODULE), STANDARD_VALVE_JAR, SimpleValve.class);
+
+        // adding valve based on the created module
+        ValveUtil.addValve(client, STANDARD_VALVE, STANDARD_VALVE_MODULE, SimpleValve.class.getName(), null);
+
+        ValveUtil.reload(client);
+        try {
+            String appUrl = url.toExternalForm() + WEB_APP_URL_1;
+            log.debug("Testing url " + appUrl + " against two valves defined, one standard valve and one global valve authenticator named " + CUSTOM_AUTHENTICATOR_1);
+            Header[] valveHeaders = ValveUtil.hitValve(new URL(appUrl));
+            assertEquals("There was one valve defined - it's missing now", 2, valveHeaders.length);
+//         TODO: test if valve headers contain correct values
+            assertEquals("Standard simple valve with not defined param expecting default param value", STANDARD_VALVE_DEFAULT_PARAM_VALUE, valveHeaders[0].getValue());
+            assertEquals("Authenticator valve with not defined param expecting default param value", DEFAULT_PARAM_VALUE, valveHeaders[1].getValue());
+        } finally {
+            ValveUtil.removeValve(client, STANDARD_VALVE);
+        }
+    }
+
+    @Test
+    @InSequence(99)
+    @OperateOnDeployment(value = DEPLOYMENT_NAME)
+    public void cleanUp(@ArquillianResource ManagementClient client) throws Exception {
+        deployer.undeploy(DEPLOYMENT_NAME);
+        deployer.undeploy(DEPLOYMENT_NAME_2);
+        ValveUtil.removeValve(client, CUSTOM_AUTHENTICATOR_1);
+        ValveUtil.removeValve(client, CUSTOM_AUTHENTICATOR_2);
+        container.stop(CONTAINER);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/HelloServlet.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/HelloServlet.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jboss.logging.Logger;
+
+@WebServlet(name="HelloServlet", urlPatterns={"/"})
+public class HelloServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static Logger log = Logger.getLogger(HelloServlet.class);
+
+    public void doGet(HttpServletRequest request,
+                      HttpServletResponse response)
+        throws IOException, ServletException {
+        PrintWriter out = response.getWriter();
+        out.println("HelloServlet");
+        log.info("HelloServlet");
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/MANIFEST.MF
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Dependencies: org.jboss.testvalve.authenticator

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/SimpleValve.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/SimpleValve.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.connector.Response;
+import org.apache.catalina.valves.ValveBase;
+import org.jboss.logging.Logger;
+
+public class SimpleValve extends ValveBase {
+    private static final Logger log = Logger.getLogger(SimpleValve.class);
+
+    private String testparam = AuthValveConstants.STANDARD_VALVE_DEFAULT_PARAM_VALUE;
+
+    public void setTestparam(String testparam) {
+        this.testparam = testparam;
+    }
+    
+    public String getTestparam() {
+        return this.testparam;
+    }
+
+    public void invoke(Request request, Response response)
+        throws IOException, ServletException {
+        response.addHeader("valve", testparam);
+        log.info("Valve " + SimpleValve.class.getName() + " was hit and adding header parameter 'valve' with value " + testparam);
+        getNext().invoke(request, response);
+    }
+}
+

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/TestAuthenticator.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/TestAuthenticator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright(c) 2012 Red Hat Middleware, LLC,
+ * and individual contributors as indicated by the @authors tag.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library in the file COPYING.LIB;
+ * if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+ *
+ * @author Jean-Frederic Clere
+ */
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+import java.io.IOException;
+import java.security.Principal;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.catalina.connector.Request;
+import org.apache.catalina.deploy.LoginConfig;
+import org.apache.catalina.authenticator.AuthenticatorBase;
+import org.apache.catalina.Realm;
+import org.jboss.logging.Logger;
+
+/*
+ * Test Authenticator.
+ */
+public class TestAuthenticator extends AuthenticatorBase {
+
+    private static Logger log = Logger.getLogger(TestAuthenticator.class);
+    
+    private String testparam = AuthValveConstants.DEFAULT_PARAM_VALUE;
+
+    public void setTestparam(String testparam) {
+        this.testparam = testparam;
+    }
+
+    public String getTestparam() {
+        return this.testparam;
+    }
+
+    @Override
+    public boolean authenticate(Request request, HttpServletResponse response, LoginConfig config) throws IOException {
+
+        Principal principal = request.getUserPrincipal();
+        if (principal != null) {
+            log.info("User " + principal.getName() + " is already autenticated");
+            return true;
+        }
+
+        Realm realm = request.getContext().getRealm();
+        log.info("Authentication against "+ realm.toString() + " realm: " + realm.getInfo());
+        principal = realm.authenticate("user1", "password1");
+        if (principal != null) {
+            request.setUserPrincipal(principal);
+            log.info("Authentication via custom valve authenticator");
+            response.addHeader("valve", testparam);
+            log.info("Valve " + TestAuthenticator.class.getName() + " was hit and adding header parameter 'authenticated' with value " + testparam);
+            return true;
+        }
+        log.warn("Login via global valve authenticator wasn't successfull");
+        return false;
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/ValveUtil.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/ValveUtil.java
@@ -1,0 +1,251 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.web.valve.authenticator;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * @author Jean-Frederic Clere
+ * @author Ondrej Chaloupka
+ */
+public class ValveUtil {
+
+    private static Logger log = Logger.getLogger(ValveUtil.class);
+
+    public static void createValveModule(final ManagementClient managementClient, String modulename, String baseModulePath, String jarName, Class valveClass) throws Exception {
+        log.info("Creating a valve module " + modulename);
+        String path = ValveUtil.readASPath(managementClient.getControllerClient());
+        File file = new File(path);
+        if (file.exists()) {
+            file = new File(path + baseModulePath);
+            file.mkdirs();
+            file = new File(path + baseModulePath + "/" + jarName);
+            if (file.exists()) {
+                file.delete();
+            }
+            createJar(file, valveClass);
+            file = new File(path + baseModulePath + "/module.xml");
+            if (file.exists()) {
+                file.delete();
+            }              
+            FileWriter fstream = new FileWriter(path + baseModulePath + "/module.xml");
+            BufferedWriter out = new BufferedWriter(fstream);
+            out.write("<module xmlns=\"urn:jboss:module:1.1\" name=\"" + modulename + "\">\n");
+            out.write("    <properties>\n");
+            out.write("        <property name=\"jboss.api\" value=\"private\"/>\n");
+            out.write("    </properties>\n");
+
+            out.write("    <resources>\n");
+            out.write("        <resource-root path=\""+ jarName + "\"/>\n");
+            out.write("    </resources>\n");
+
+            out.write("    <dependencies>\n");
+            out.write("        <module name=\"sun.jdk\"/>\n");
+            out.write("        <module name=\"javax.servlet.api\"/>\n");
+            out.write("        <module name=\"org.jboss.as.web\"/>\n");
+            out.write("       <module name=\"org.jboss.logging\"/>\n");
+            out.write("    </dependencies>\n");
+            out.write("</module>");
+            out.close();
+        }
+    }
+    
+    private static void createJar(File file, Class valveClass) {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "temporary-name.jar")
+                              .addClass(valveClass);       
+        log.info(archive.toString(true));
+        archive.as(ZipExporter.class).exportTo(file);
+    }
+    
+    /**
+     * Adding valve via DMR operation for jboss config file (standalone.xml)
+     */
+    public static void addValve(final ManagementClient managementClient, String valveName, String modulename, String classname, Map<String,String> params) throws Exception {
+        List<ModelNode> updates = new ArrayList<ModelNode>();
+
+        ModelNode op = new ModelNode();
+        op.get(OP).set(ADD);
+        op.get(OP_ADDR).set(getValveAddr(valveName));
+        // op.get(NAME).set(valveName);
+        op.get("enabled").set("true");
+        op.get("class-name").set(classname);
+        op.get("module").set(modulename);
+        updates.add(op);
+        
+        if(params != null) {
+            for (String paramName: params.keySet()) {
+                op = new ModelNode();
+                op.get(OP).set("add-param");
+                op.get(OP_ADDR).set(getValveAddr(valveName));
+                op.get("param-name").set(paramName);
+                op.get("param-value").set(params.get(paramName));
+                updates.add(op);
+            }
+        }
+
+        applyUpdates(managementClient.getControllerClient(), updates);
+    }
+    
+   
+    
+    public static void activateValve(final ManagementClient managementClient, String valveName, boolean isActive) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        op.get(OP_ADDR).set(getValveAddr(valveName));
+        op.get(NAME).set("enabled");
+        op.get(VALUE).set(Boolean.toString(isActive));
+        applyUpdate(managementClient, op);
+    }
+    
+    private static ModelNode getValveAddr(String valveName) {
+        ModelNode address = new ModelNode();
+        address.add(SUBSYSTEM, "web");
+        address.add("valve", valveName);
+        address.protect();
+        return address;
+    }    
+
+    public static void removeValve(final ManagementClient managementClient, String valveName) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(REMOVE);
+        op.get(OP_ADDR).set(getValveAddr(valveName));
+
+        applyUpdate(managementClient, op);
+    }
+
+    public static void applyUpdate(final ManagementClient client, final ModelNode update) throws Exception {
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+        updates.add(update);
+        applyUpdates(client.getControllerClient(), updates);
+    }
+    
+    public static void applyUpdates(final ModelControllerClient client, final List<ModelNode> updates) throws Exception {
+        for (ModelNode update : updates) {
+            log.info("+++ Update on " + client + ":\n" + update.toString());
+            ModelNode result = client.execute(new OperationBuilder(update).build());
+            log.info("Whole result: " + result);
+            if (result.hasDefined("outcome") && "success".equals(result.get("outcome").asString())) {
+                if (result.hasDefined("result")) {
+                    log.info(result.get("result"));
+                }
+            } else if (result.hasDefined("failure-description")) {
+                throw new RuntimeException(result.get("failure-description").toString());
+            } else {
+                throw new RuntimeException("Operation not successful; outcome = " + result.get("outcome"));
+            }
+        }
+    }
+    
+    /**
+     * Provide reload operation on server
+     * 
+     * @throws Exception
+     */
+    public static void reload(final ManagementClient managementClient) throws Exception {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("reload");
+        applyUpdate(managementClient, operation);
+        boolean reloaded = false;
+        int i = 0;
+        while (!reloaded) {
+            try {
+                Thread.sleep(5000);
+                if (managementClient.isServerInRunningState()) {
+                    reloaded = true;
+                }
+            } catch (Throwable t) {
+                // nothing to do, just waiting
+            } finally {
+                if (!reloaded && i++ > 10) {
+                    throw new Exception("Server reloading failed");
+                }
+            }
+        }
+    }
+    
+    public static String readASPath(final ModelControllerClient client) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set("read-attribute");
+        op.get(OP_ADDR).add("path", "jboss.home.dir");
+        op.get("name").set("path");
+        ModelNode result = client.execute(new OperationBuilder(op).build());
+        if (result.hasDefined("outcome") && "success".equals(result.get("outcome").asString())) {
+            if (result.hasDefined("result")) {
+                return result.get("result").asString();
+            }
+        } else if (result.hasDefined("failure-description")) {
+            throw new RuntimeException(result.get("failure-description").toString());
+        } else {
+            throw new RuntimeException("Operation not successful; outcome = " + result.get("outcome"));
+        }
+        return null;
+    }
+    
+     /**
+     * Access http://localhost/
+     * @return "valve" headers
+     */
+    public static Header[] hitValve(URL url, int expectedResponseCode) throws Exception {
+        HttpGet httpget = new HttpGet(url.toURI());
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+
+        log.info("executing request" + httpget.getRequestLine());
+        HttpResponse response = httpclient.execute(httpget);
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Header[] errorHeaders = response.getHeaders("X-Exception");
+        assertEquals("Wrong response code: " + statusCode + " On " + url, expectedResponseCode, statusCode);
+        assertEquals("X-Exception(" + Arrays.toString(errorHeaders) + ") is null", 0, errorHeaders.length);
+        
+        return response.getHeaders("valve");
+    }
+    
+     public static Header[] hitValve(URL url) throws Exception {
+         return hitValve(url, HttpURLConnection.HTTP_OK);
+         
+     }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/jboss-web.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/jboss-web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+    <!--<security-domain>valve-tests</security-dsomain>-->
+    <valve>        
+        <class-name>org.jboss.as.test.manualmode.web.valve.authenticator.TestAuthenticator</class-name>
+        <param>
+            <param-name>testparam</param-name>
+            <param-value>webdescriptor</param-value>
+        </param>
+    </valve>
+</jboss-web>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/web-custom-auth.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/web-custom-auth.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">  
+
+    <login-config>
+        <auth-method>MYAUTH</auth-method>
+        <realm-name>ApplicationRealm</realm-name>
+    </login-config>
+  
+<!--    <welcome-file-list>
+        <welcome-file>index.jsp</welcome-file>
+    </welcome-file-list>
+-->
+    <servlet>
+        <servlet-name>HelloServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.manualmode.web.valve.authenticator.HelloServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>HelloServlet</servlet-name>
+        <url-pattern>/HelloServlet</url-pattern>
+    </servlet-mapping>
+    
+   <!--Security testings--> 
+   <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Security Tests</web-resource-name>
+            <url-pattern>/HelloServlet</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Users</role-name>
+        </auth-constraint>
+    </security-constraint><!--
+
+-->     
+    <!--Security roles referenced by this web application--> 
+    <security-role>
+        <description>
+            The role that is required to log in to the Manager Application
+        </description>
+        <role-name>Users</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/web-global-auth.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/valve/authenticator/web-global-auth.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">  
+
+    <login-config>
+        <auth-method>MYAUTH_2</auth-method>
+        <realm-name>ApplicationRealm</realm-name>
+    </login-config>
+  
+<!--    <welcome-file-list>
+        <welcome-file>index.jsp</welcome-file>
+    </welcome-file-list>
+
+     Security testings 
+-->    
+    <servlet>
+        <servlet-name>HelloServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.manualmode.web.valve.authenticator.HelloServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>HelloServlet</servlet-name>
+        <url-pattern>/hello</url-pattern>
+    </servlet-mapping>
+    
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Security Tests</web-resource-name>
+            <url-pattern>/hello</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Users</role-name>
+        </auth-constraint>
+    </security-constraint><!--
+
+-->     
+    <!--Security roles referenced by this web application--> 
+    <security-role>
+        <description>
+            The role that is required to log in to the Manager Application
+        </description>
+        <role-name>Users</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/shared/src/main/resources/application-users.properties
+++ b/testsuite/shared/src/main/resources/application-users.properties
@@ -1,3 +1,6 @@
+# guest=guest
+# user1=password1
+# user2=password2
 guest=b5d048a237bfd2874b6928e1f37ee15e
 user1=23624d2f74dfcb9688651a066d90b97e
 user2=ab3f9e12039435236d89de9023a304b7


### PR DESCRIPTION
Enhancing tests for global configuration of authenticators as valves.

Adding more tests on global configuration of authenticator valves based on feature request:
https://issues.jboss.org/browse/JBWEB-228 

In case of adding and disabling global authenticator valves it is necessary to reload server, therefore tests are put to manualmode.
