### PR TITLE
[AS7-6334] jsf subsystem resource transformation

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerLogger.java
@@ -436,7 +436,7 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 13400, value = "No operation named '%s' exists at address %s")
     void noHandlerForOperation(String operationName, PathAddress address);
 
-    @Message(id = 13403, value = "There ware some problems during transformation process for target host: '%s' \n Problems found: %s")
+    @Message(id = 13403, value = "There were some problems during transformation process for target host: '%s' \n Problems found: %s")
     @LogMessage(level = WARN)
     void tranformationWarnings(String hostName, Set<String> problems);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CON
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_SERIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -563,6 +564,15 @@ public interface DomainControllerMessages {
      * @param slot the non-default value of the slot attribute
      * @return the message
      */
-    @Message(id = 10878, value = "Invalid JSF slot value: %s. The host controller is not able to use a JSF slot value different from its default. This resource will be ignored on that host")
+    @Message(id = 10878, value = "Invalid JSF slot value: '%s'. The host controller is not able to use a JSF slot value different from its default. This resource will be ignored on that host")
     String invalidJSFSlotValue(String slot);
+
+    /**
+     * Warning messages when a transformer detects that an operation defines unknown attributes for a legacy subsystem.
+     *
+     * @param attributes the name of the attributes unknown from the legacy version
+     * @return the message
+     */
+    @Message(id = 10879, value = "Operation '%s' fails because the attributes are not known from the subsytem '%s' model version '%s': %s")
+    String unknownAttributesFromSubsystemVersion(String operationName, String subsystemName, ModelVersion version, Collection<String> attributes);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RunningMode;
@@ -556,4 +557,12 @@ public interface DomainControllerMessages {
     @Message(id = 10877, value = "Failed to load module '%s'.")
     OperationFailedException failedToLoadModule(@Cause ModuleLoadException e,String module);
 
+    /**
+     * Warning messages when a transformer detects that the JSF subsystem uses a non-default value to setup on a legacy host controller.
+     *
+     * @param slot the non-default value of the slot attribute
+     * @return the message
+     */
+    @Message(id = 10878, value = "Invalid JSF slot value: %s. The host controller is not able to use a JSF slot value different from its default. This resource will be ignored on that host")
+    String invalidJSFSlotValue(String slot);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -22,20 +22,11 @@
 
 package org.jboss.as.domain.controller.transformers;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.domain.controller.DomainControllerMessages.MESSAGES;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
-import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -45,17 +36,11 @@ import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.SubsystemInformation;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.AddNameFromAddressResourceTransformer;
-import org.jboss.as.controller.transform.OperationRejectionPolicy;
-import org.jboss.as.controller.transform.OperationResultTransformer;
-import org.jboss.as.controller.transform.OperationTransformer;
 import org.jboss.as.controller.transform.ResourceTransformationContext;
 import org.jboss.as.controller.transform.ResourceTransformer;
-import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.TransformationTarget;
 import org.jboss.as.controller.transform.TransformerRegistry;
 import org.jboss.as.controller.transform.TransformersSubRegistration;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 
 /**
  * Global transformation rules for the domain, host and server-config model.
@@ -67,7 +52,6 @@ public class DomainTransformers {
     /** Dummy version for ignored subsystems. */
     static final ModelVersion IGNORED_SUBSYSTEMS = ModelVersion.create(-1);
 
-    private static final String JSF_SUBSYSTEM = "jsf";
     private static final PathElement JSF_EXTENSION = PathElement.pathElement(ModelDescriptionConstants.EXTENSION, "org.jboss.as.jsf");
 
     //AS 7.1.2.Final
@@ -93,71 +77,8 @@ public class DomainTransformers {
         if (modelVersion == VERSION_1_2 || modelVersion == VERSION_1_3) {
             // Discard all operations to the newly introduced jsf extension
             domain.registerSubResource(JSF_EXTENSION, IGNORED_EXTENSIONS);
-            // Ignore the jsf subsystem as well
-            final String slotAttributeName = "default-jsf-impl-slot";
-            final String slotDefaultValue = "main";
-            registry.registerSubsystemTransformers(JSF_SUBSYSTEM, IGNORED_SUBSYSTEMS, new ResourceTransformer() {
-                @Override
-                public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
 
-                    ModelNode model = resource.getModel();
-                    if (model.hasDefined(slotAttributeName)) {
-                        ModelNode slot = model.get(slotAttributeName);
-                        if (!slotDefaultValue.equals(slot.asString())) {
-                            context.getLogger().logWarning(address, slotAttributeName, MESSAGES.invalidJSFSlotValue(slot.asString()));
-                        }
-                    }
-                    Set<String> attributes = new HashSet<String>();
-                    for (Property prop : resource.getModel().asPropertyList()) {
-                        attributes.add(prop.getName());
-                    }
-                    attributes.remove(slotAttributeName);
-                    if (!attributes.isEmpty()) {
-                        context.getLogger().logWarning(address, ControllerMessages.MESSAGES.attributesAreNotUnderstoodAndWillBeIgnored(), attributes);
-                    }
-                }
-            });
-            TransformersSubRegistration jsfSubsystem = domain.registerSubResource(PathElement.pathElement(SUBSYSTEM, JSF_SUBSYSTEM));
-            jsfSubsystem.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, new OperationTransformer() {
-                @Override
-                public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
-                    final String name = operation.require(NAME).asString();
-                    final ModelNode value = operation.get(ModelDescriptionConstants.VALUE);
-                    if (!slotAttributeName.equals(name)) {
-                        context.getLogger().logWarning(address, ControllerMessages.MESSAGES.attributesAreNotUnderstoodAndWillBeIgnored(), name);
-                        return DISCARD.transformOperation(context, address, operation);
-                    }
-                    if (value.isDefined() && value.equals(slotDefaultValue)) {
-                        return DISCARD.transformOperation(context, address, operation);
-                    } else {
-                        OperationRejectionPolicy rejectionPolicy = new OperationRejectionPolicy() {
-                            @Override
-                            public boolean rejectOperation(ModelNode preparedResult) {
-                                return true;
-                            }
-
-                            @Override
-                            public String getFailureDescription() {
-                                return MESSAGES.invalidJSFSlotValue(value.asString());
-                            }
-                        };
-                        return new TransformedOperation(operation, rejectionPolicy, OperationResultTransformer.ORIGINAL_RESULT);
-                    }
-                }
-            });
-            jsfSubsystem.registerOperationTransformer(UNDEFINE_ATTRIBUTE_OPERATION, new OperationTransformer() {
-                @Override
-                public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
-                    String attributeName = operation.require(NAME).asString();
-                    if (!slotAttributeName.equals(attributeName)) {
-                        return DEFAULT.transformOperation(context, address, operation);
-                    } else {
-                        context.getLogger().logWarning(address, ControllerMessages.MESSAGES.attributesAreNotUnderstoodAndWillBeIgnored(), attributeName);
-                        return DISCARD.transformOperation(context, address, operation);
-                    }
-                }
-            });
-
+            JSFSubsystemTransformers.registerTransformers120(registry, domain);
             PathsTransformers.registerTransformers120(domain);
             DeploymentTransformers.registerTransformers120(domain);
             SystemPropertyTransformers.registerTransformers120(domain);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JSFSubsystemTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JSFSubsystemTransformers.java
@@ -1,0 +1,127 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2013, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.domain.controller.transformers;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.domain.controller.DomainControllerMessages.MESSAGES;
+import static org.jboss.as.domain.controller.transformers.DomainTransformers.IGNORED_SUBSYSTEMS;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.OperationRejectionPolicy;
+import org.jboss.as.controller.transform.OperationResultTransformer;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.ResourceTransformationContext;
+import org.jboss.as.controller.transform.ResourceTransformer;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.as.controller.transform.TransformerRegistry;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
+ */
+class JSFSubsystemTransformers {
+
+    private static final String JSF_SUBSYSTEM = "jsf";
+    private static final String SLOT_ATTRIBUTE_NAME = "default-jsf-impl-slot";
+    private static final String SLOT_DEFAULT_VALUE = "main";
+
+    static void registerTransformers120(TransformerRegistry registry, TransformersSubRegistration parent) {
+        registry.registerSubsystemTransformers(JSF_SUBSYSTEM, IGNORED_SUBSYSTEMS, new ResourceTransformer() {
+            @Override
+            public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
+
+                ModelNode model = resource.getModel();
+                if (model.hasDefined(SLOT_ATTRIBUTE_NAME)) {
+                    ModelNode slot = model.get(SLOT_ATTRIBUTE_NAME);
+                    if (!SLOT_DEFAULT_VALUE.equals(slot.asString())) {
+                        context.getLogger().logWarning(address, SLOT_ATTRIBUTE_NAME, MESSAGES.invalidJSFSlotValue(slot.asString()));
+                    }
+                }
+                Set<String> attributes = new HashSet<String>();
+                for (Property prop : resource.getModel().asPropertyList()) {
+                    attributes.add(prop.getName());
+                }
+                attributes.remove(SLOT_ATTRIBUTE_NAME);
+                if (!attributes.isEmpty()) {
+                    context.getLogger().logWarning(address, ControllerMessages.MESSAGES.attributesAreNotUnderstoodAndWillBeIgnored(), attributes);
+                }
+            }
+        });
+
+        TransformersSubRegistration jsfSubsystem = parent.registerSubResource(PathElement.pathElement(SUBSYSTEM, JSF_SUBSYSTEM));
+        jsfSubsystem.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, new OperationTransformer() {
+            @Override
+            public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
+                final String name = operation.require(NAME).asString();
+                final ModelNode value = operation.get(ModelDescriptionConstants.VALUE);
+                if (!SLOT_ATTRIBUTE_NAME.equals(name)) {
+                    context.getLogger().logWarning(address, ControllerMessages.MESSAGES.attributesAreNotUnderstoodAndWillBeIgnored(), name);
+                    return DISCARD.transformOperation(context, address, operation);
+                }
+                if (value.isDefined() && value.equals(SLOT_DEFAULT_VALUE)) {
+                    return DISCARD.transformOperation(context, address, operation);
+                } else {
+                    OperationRejectionPolicy rejectionPolicy = new OperationRejectionPolicy() {
+                        @Override
+                        public boolean rejectOperation(ModelNode preparedResult) {
+                            return true;
+                        }
+
+                        @Override
+                        public String getFailureDescription() {
+                            return MESSAGES.invalidJSFSlotValue(value.asString());
+                        }
+                    };
+                    return new TransformedOperation(operation, rejectionPolicy, OperationResultTransformer.ORIGINAL_RESULT);
+                }
+            }
+        });
+        jsfSubsystem.registerOperationTransformer(UNDEFINE_ATTRIBUTE_OPERATION, new OperationTransformer() {
+            @Override
+            public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
+                String attributeName = operation.require(NAME).asString();
+                if (!SLOT_ATTRIBUTE_NAME.equals(attributeName)) {
+                    return DEFAULT.transformOperation(context, address, operation);
+                } else {
+                    context.getLogger().logWarning(address, ControllerMessages.MESSAGES.attributesAreNotUnderstoodAndWillBeIgnored(), attributeName);
+                    return DISCARD.transformOperation(context, address, operation);
+                }
+            }
+        });
+    }
+
+
+
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -23,6 +23,9 @@
 package org.jboss.as.host.controller.mgmt;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.host.controller.HostControllerLogger.DOMAIN_LOGGER;
 import static org.jboss.as.process.protocol.ProtocolUtils.expectHeader;
 
@@ -349,7 +352,11 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
                 try {
                     // The domain model is going to be sent as part of the prepared notification
                     final OperationStepHandler handler = new HostRegistrationStepHandler(transformerRegistry, this);
-                    operationExecutor.execute(READ_DOMAIN_MODEL, OperationMessageHandler.logging, this, OperationAttachments.EMPTY, handler);
+                    ModelNode result = operationExecutor.execute(READ_DOMAIN_MODEL, OperationMessageHandler.logging, this, OperationAttachments.EMPTY, handler);
+                    if (FAILED.equals(result.get(OUTCOME).asString())) {
+                        failed(SlaveRegistrationException.ErrorCode.UNKNOWN, result.get(FAILURE_DESCRIPTION).asString());
+                        return;
+                    }
                 } catch (Exception e) {
                     failed(e);
                     return;

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -186,7 +186,7 @@
             <subsystem xmlns="urn:jboss:domain:jpa:1.1">
                 <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jsf:1.0" default-jsf-impl-slot="myslot"/>
             <subsystem xmlns="urn:jboss:domain:mail:1.0">
                 <mail-session jndi-name="java:jboss/mail/Default">
                     <smtp-server outbound-socket-binding-ref="mail-smtp"/>


### PR DESCRIPTION
- discard the jsf subsystem resource from the legacy version only if
  its slot value is undefined or the default value.
- in HostControllerRegistrationHandler, check for the outcome of the
  read-master-domain-model which may fail (as is the case when the jsf subsystem
  has a non-default slot and is transformed for a legacy controller)

I manually checked the fix using the test suite/mixed-domain tests.
