### PR TITLE
AS7-6393 update commons-codec version (1.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <version.com.sun.xsom>20110809</version.com.sun.xsom>
         <version.commons-beanutils>1.8.3</version.commons-beanutils>
         <version.commons-cli>1.2</version.commons-cli>
-        <version.commons-codec>1.4</version.commons-codec>
+        <version.commons-codec>1.6</version.commons-codec>
         <version.commons-collections>3.2.1</version.commons-collections>
         <version.commons-io>2.1</version.commons-io>
         <version.commons-configuration>1.6</version.commons-configuration>


### PR DESCRIPTION
Apache HttpClient (4.2.1) library depends on commons-codec version 1.6, but we used version 1.4 which was not fully compatible - e.g. changed behavior of the default constructor in Base64 class (chunked/not-chunked).
Update fixes problem with HttpClient's SPNEGO authentication.
