### PR TITLE
Revert initial boot log system property name

### DIFF
--- a/build/src/main/resources/appclient/configuration/logging.properties
+++ b/build/src/main/resources/appclient/configuration/logging.properties
@@ -52,7 +52,7 @@ handler.FILE.properties=autoFlush,append,fileName,suffix
 handler.FILE.constructorProperties=fileName,append
 handler.FILE.autoFlush=true
 handler.FILE.append=true
-handler.FILE.fileName=${org.jboss.server.log.file:appclient.log}
+handler.FILE.fileName=${org.jboss.boot.log.file:boot.log}
 handler.FILE.suffix=.yyyy-MM-dd
 
 formatter.CONSOLE=org.jboss.logmanager.formatters.PatternFormatter

--- a/build/src/main/resources/bin/appclient.bat
+++ b/build/src/main/resources/bin/appclient.bat
@@ -87,7 +87,7 @@ if "x%JBOSS_MODULEPATH%" == "x" (
 
 
 "%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.server.log.file=%JBOSS_HOME%\appclient\log\appclient.log" ^
+ "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\appclient.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^

--- a/build/src/main/resources/bin/appclient.sh
+++ b/build/src/main/resources/bin/appclient.sh
@@ -117,7 +117,7 @@ CLASSPATH="$CLASSPATH:$JBOSS_HOME/jboss-modules.jar"
 # Execute the JVM in the foreground
 eval \"$JAVA\" $JAVA_OPTS \
  -cp "$CLASSPATH" \
- \"-Dorg.jboss.server.log.file=$JBOSS_HOME/appclient/log/appclient.log\" \
+ \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/appclient/log/appclient.log\" \
  \"-Dlogging.configuration=file:$JBOSS_HOME/appclient/configuration/logging.properties\" \
  org.jboss.modules.Main \
  -mp \"${JBOSS_MODULEPATH}\" \

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -195,7 +195,7 @@ echo.
 
 :RESTART
 "%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.server.log.file=%JBOSS_LOG_DIR%\server.log" ^
+ "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -215,7 +215,7 @@ while true; do
    if [ "x$LAUNCH_JBOSS_IN_BACKGROUND" = "x" ]; then
       # Execute the JVM in the foreground
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
-         \"-Dorg.jboss.server.log.file=$JBOSS_LOG_DIR/server.log\" \
+         \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
@@ -228,7 +228,7 @@ while true; do
    else
       # Execute the JVM in the background
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
-         \"-Dorg.jboss.server.log.file=$JBOSS_LOG_DIR/server.log\" \
+         \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
          -jar \"$JBOSS_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \

--- a/build/src/main/resources/standalone/configuration/logging.properties
+++ b/build/src/main/resources/standalone/configuration/logging.properties
@@ -58,7 +58,7 @@ handler.FILE.properties=autoFlush,append,fileName,suffix
 handler.FILE.constructorProperties=fileName,append
 handler.FILE.autoFlush=true
 handler.FILE.append=true
-handler.FILE.fileName=${org.jboss.server.log.file:server.log}
+handler.FILE.fileName=${org.jboss.boot.log.file:boot.log}
 handler.FILE.suffix=.yyyy-MM-dd
 
 formatter.CONSOLE=org.jboss.logmanager.formatters.PatternFormatter


### PR DESCRIPTION
Reverts the initial logging.properties file name to use the property name from previous AS 7 releases.
