### PR TITLE
Update controller/src/test/java/org/jboss/as/controller/interfaces/Inter...

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/interfaces/InterfaceCriteriaTestUtil.java
+++ b/controller/src/test/java/org/jboss/as/controller/interfaces/InterfaceCriteriaTestUtil.java
@@ -69,7 +69,10 @@ public class InterfaceCriteriaTestUtil {
                 Set<InetAddress> addresses = new HashSet<InetAddress>();
                 Enumeration<InetAddress> addressEnumeration = nic.getInetAddresses();
                 while (addressEnumeration.hasMoreElements()) {
-                    addresses.add(addressEnumeration.nextElement());
+                    InetAddress inetAddress = addressEnumeration.nextElement();
+                    if (inetAddress != null) {
+                        addresses.add(inetAddress);
+                    }
                 }
                 if (addresses.size() > 0) {
                     candidates.put(nic, Collections.unmodifiableSet(addresses));


### PR DESCRIPTION
...faceCriteriaTestUtil.java

NICs without a cable attached are 'up' in Windows (isUp() returns true), but return a NULL address. That causes an NPE in some tests (in this same file, line 116, from e.g. OverallInterfaceCriteriaUnitTestCase.testMultipleCriteria() )
This patch prevents adding NULL addresses.

A workaround is to disable network interfaces with no cable attached.
