### PR TITLE
[AS7-6413] Fix up JGroups subsystem remove operation.

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemAdd.java
@@ -36,7 +36,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.InjectedValue;
@@ -90,18 +89,6 @@ public class JGroupsSubsystemAdd extends AbstractAddStepHandler {
         if (newControllers != null) {
             newControllers.add(dcfsController);
         }
-    }
-
-    protected void removeRuntimeServices(OperationContext context, ModelNode operation, ModelNode model)
-            throws OperationFailedException {
-
-        // remove the ProtocolDefaultsService
-        ServiceName protocolDefaultsService = ProtocolDefaultsService.SERVICE_NAME;
-        context.removeService(protocolDefaultsService);
-
-        // remove the DefaultChannelFactoryServiceAlias
-        ServiceName defaultChannelFactoryService = ChannelFactoryService.getServiceName(null);
-        context.removeService(defaultChannelFactoryService);
     }
 
     protected ServiceController<ProtocolDefaults> installProtocolDefaultsService(ServiceTarget target, ServiceVerificationHandler verificationHandler) {

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemRemove.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemRemove.java
@@ -21,13 +21,18 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+
 import java.util.List;
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
+import org.jboss.dmr.Property;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * Handler for JGroups subsystem add operations.
@@ -38,8 +43,32 @@ public class JGroupsSubsystemRemove extends AbstractRemoveStepHandler {
 
     public static final JGroupsSubsystemRemove INSTANCE = new JGroupsSubsystemRemove();
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) {
-        context.removeService(ProtocolDefaultsService.SERVICE_NAME);
-        context.removeService(ChannelFactoryService.getServiceName(null));
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+        throws OperationFailedException {
+
+        removeRuntimeServices(context, operation, model);
+    }
+
+    protected void removeRuntimeServices(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        // remove any existing child stacks
+        if (model.hasDefined(ModelKeys.STACK)) {
+            List<Property> stacks = model.get(ModelKeys.STACK).asPropertyList() ;
+            for (Property stack: stacks) {
+                PathAddress address = PathAddress.pathAddress(JGroupsExtension.SUBSYSTEM_PATH).append(ModelKeys.STACK, stack.getName());
+                ModelNode removeStack = Util.createOperation(REMOVE, address);
+                // just need to remove the existing stack services
+                ProtocolStackAdd.INSTANCE.removeRuntimeServices(context, removeStack, stack.getValue());
+            }
+        }
+
+        // remove the ProtocolDefaultsService
+        ServiceName protocolDefaultsService = ProtocolDefaultsService.SERVICE_NAME;
+        context.removeService(protocolDefaultsService);
+
+        // remove the DefaultChannelFactoryServiceAlias
+        ServiceName defaultChannelFactoryService = ChannelFactoryService.getServiceName(null);
+        context.removeService(defaultChannelFactoryService);
     }
 }

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
@@ -51,7 +51,7 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return compositeOp ;
     }
 
-    protected static ModelNode getSubsystemAddOperation() {
+    protected static ModelNode getSubsystemAddOperation(String defaultStack) {
         // create the address of the subsystem
         PathAddress subsystemAddress =  PathAddress.pathAddress(
                 PathElement.pathElement(SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME));
@@ -59,7 +59,7 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         addOp.get(OP).set(ADD);
         addOp.get(OP_ADDR).set(subsystemAddress.toModelNode());
         // required attributes
-        addOp.get(ModelKeys.DEFAULT_STACK).set("maximal2");
+        addOp.get(ModelKeys.DEFAULT_STACK).set(defaultStack);
         return addOp ;
     }
 
@@ -86,6 +86,16 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         writeOp.get(NAME).set(name);
         writeOp.get(VALUE).set(value);
         return writeOp ;
+    }
+
+    protected static ModelNode getSubsystemRemoveOperation() {
+        // create the address of the subsystem
+        PathAddress subsystemAddress =  PathAddress.pathAddress(
+                PathElement.pathElement(SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME));
+        ModelNode removeOp = new ModelNode() ;
+        removeOp.get(OP).set(REMOVE);
+        removeOp.get(OP_ADDR).set(subsystemAddress.toModelNode());
+        return removeOp ;
     }
 
     protected static ModelNode getProtocolStackAddOperation(String stackName) {


### PR DESCRIPTION
Problem here was that performing a remove on the JGroups subsystem would leave behind MSC services associated with existing stacks in the subsystem.
