### PR TITLE
[AS7-6334] Nicer error message if attempt to use deployment-scanner in d...

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerExtension.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerExtension.java
@@ -22,18 +22,19 @@
 
 package org.jboss.as.server.deployment.scanner;
 
+import static org.jboss.as.server.deployment.scanner.DeploymentScannerLogger.ROOT_LOGGER;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
-import org.jboss.as.controller.services.path.ResolvePathHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-
-import static org.jboss.as.server.deployment.scanner.DeploymentScannerLogger.ROOT_LOGGER;
+import org.jboss.as.controller.services.path.ResolvePathHandler;
 
 /**
  * @author Emanuel Muckenhuber
@@ -59,6 +60,10 @@ public class DeploymentScannerExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         ROOT_LOGGER.debug("Initializing Deployment Scanner Extension");
+
+        if (context.getProcessType() == ProcessType.HOST_CONTROLLER) {
+            throw DeploymentScannerMessages.MESSAGES.deploymentScannerNotForDomainMode();
+        }
 
         final SubsystemRegistration subsystem = context.registerSubsystem(CommonAttributes.DEPLOYMENT_SCANNER, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerMessages.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerMessages.java
@@ -22,11 +22,11 @@
 
 package org.jboss.as.server.deployment.scanner;
 
+import java.io.File;
+
+import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
-import org.jboss.logging.Messages;
-
-import java.io.File;
 
 /**
  * Date: 05.11.2011
@@ -164,4 +164,7 @@ public interface DeploymentScannerMessages {
     @Message(id = 15060, value = "File %2$s was configured for auto-deploy but could not be safely auto-deployed. The reason the file " +
             "could not be auto-deployed was: %1$s.  To enable deployment of this file create a file called %2$s%3$s")
     String unsafeAutoDeploy(String errorMsg, String fileName, String marker);
+
+    @Message(id = 15061, value = "Extension with module 'org.jboss.as.deployment-scanner' cannot be installed on a domain controller. Please remove it and any subsystem referencing it")
+    IllegalStateException deploymentScannerNotForDomainMode();
 }

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerMessages.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerMessages.java
@@ -165,6 +165,6 @@ public interface DeploymentScannerMessages {
             "could not be auto-deployed was: %1$s.  To enable deployment of this file create a file called %2$s%3$s")
     String unsafeAutoDeploy(String errorMsg, String fileName, String marker);
 
-    @Message(id = 15061, value = "Extension with module 'org.jboss.as.deployment-scanner' cannot be installed on a domain controller. Please remove it and any subsystem referencing it")
+    @Message(id = 15061, value = "Extension with module 'org.jboss.as.deployment-scanner' cannot be installed in a managed domain. Please remove it and any subsystem referencing it")
     IllegalStateException deploymentScannerNotForDomainMode();
 }


### PR DESCRIPTION
...omain mode

The deployment-scanner cannot be used in domain mode, and failed during extension initialization on the DC due to a missing path manager service. I replaced that with a nicer error message saying to remove that extension and any associated subsystem.
