### PR TITLE
CLI AS7-3208 command help formatting and terminal width

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -370,4 +370,21 @@ public interface CommandContext {
      */
     void setSilent(boolean silent);
 
+    /**
+     * Returns the current terminal window width in case the console
+     * has been initialized. Otherwise -1.
+     *
+     * @return  current terminal with if the console has been initialized,
+     *          -1 otherwise
+     */
+    int getTerminalWidth();
+
+    /**
+     * Returns the current terminal window height in case the console
+     * has been initialized. Otherwise -1.
+     *
+     * @return  current terminal height if the console has been initialized,
+     *          -1 otherwise
+     */
+    int getTerminalHeight();
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1224,6 +1224,16 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         this.silent = silent;
     }
 
+    @Override
+    public int getTerminalWidth() {
+        return console == null ? -1 : console.getTerminalWidth();
+    }
+
+    @Override
+    public int getTerminalHeight() {
+        return console == null ? -1 : console.getTerminalHeight();
+    }
+
     private class AuthenticationCallbackHandler implements CallbackHandler {
 
         // After the CLI has connected the physical connection may be re-established numerous times.

--- a/cli/src/main/java/org/jboss/as/cli/impl/Console.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Console.java
@@ -66,6 +66,10 @@ public interface Console {
 
     String readLine(String prompt, Character mask);
 
+    int getTerminalWidth();
+
+    int getTerminalHeight();
+
     static final class Factory {
 
         public static Console getConsole(CommandContext ctx) throws CliInitializationException {
@@ -183,6 +187,16 @@ public interface Console {
                         e.printStackTrace();
                         return null;
                     }
+                }
+
+                @Override
+                public int getTerminalWidth() {
+                    return console.getTerminalWidth();
+                }
+
+                @Override
+                public int getTerminalHeight() {
+                    return console.getTerminalHeight();
                 }
 
             class HistoryImpl implements CommandHistory {

--- a/cli/src/main/resources/help/batch-edit-line.txt
+++ b/cli/src/main/resources/help/batch-edit-line.txt
@@ -10,13 +10,16 @@ DESCRIPTION
 ARGUMENTS
 
  line_number    - the line number of the existing command line in the batch.
-                  Line numbers start with 1. So, the value of the argument must be
-                  in the range from 1 to the number of the last command in the batch.
+                  Line numbers start with 1. So, the value of the argument must
+                  be in the range from 1 to the number of the last command in
+                  the batch.
 					
- edited_line    - the new value for the command line which will replace the current one.
-                  The command must be available for the batch, i.e. this command must
-                  translate into an operation (or operations). (Commands like cd, pwd,
-                  connect, etc are not allowed in the batch, since they don't translate
-                  into operations). If the new command line isn't valid for some reason
-                  (syntax error or invalid arguments), edit-batch-line will fail and the
-                  current command line won't be replaced with the invalid one.					
+ edited_line    - the new value for the command line which will replace the
+                  current one. The new command must be available for the batch,
+                  i.e. this command must translate into an operation (or
+                  operations). (Commands like cd, pwd, connect, etc are not
+                  allowed in the batch, since they don't translate into
+                  operations). If the new command line isn't valid for some
+                  reason (syntax error or invalid arguments), edit-batch-line
+                  will fail and the current command line won't be replaced with
+                  the invalid one.					

--- a/cli/src/main/resources/help/batch-holdback.txt
+++ b/cli/src/main/resources/help/batch-holdback.txt
@@ -14,4 +14,5 @@ ARGUMENTS
                     If the name isn't provided, the batch will be saved unnamed.
                     If the holdback name is provided, the name must be unique.
                     If there already is a held back batch with the same name,
-                    holdback-batch will fail and the CLI will stay in the batch mode.
+                    holdback-batch will fail and the CLI will stay in the batch
+                    mode.

--- a/cli/src/main/resources/help/batch-move-line.txt
+++ b/cli/src/main/resources/help/batch-move-line.txt
@@ -9,9 +9,9 @@ DESCRIPTION
 				
 ARGUMENTS
 
- current_line_number    - the line number of the existing command line in the batch that
-                          should be moved. Line numbers start with 1.
+ current_line_number  - the line number of the existing command line in the
+                        batch that should be moved. Line numbers start with 1.
 							
- new_line_number        - the new line number the command line should be moved to.
-                          It should be in the range from 1 to the line number of the last
-                          command in the batch.
+ new_line_number      - the new line number the command line should be moved to.
+                        It should be in the range from 1 to the line number of
+                        the last command in the batch.

--- a/cli/src/main/resources/help/batch-run.txt
+++ b/cli/src/main/resources/help/batch-run.txt
@@ -1,6 +1,7 @@
 SYNOPSIS
 
-    run-batch [--help | [--file [--headers={operation_header (;operation_header)*}] ] ]
+    run-batch [--help |
+               [--file [--headers={operation_header (;operation_header)*}] ] ]
 
 DESCRIPTION
 
@@ -10,8 +11,8 @@ DESCRIPTION
     Otherwise, if there was an error, the CLI will remain in the batch mode
     to let the user modify the batch and run it again.
     
-    With --file argument the command must be executed while not in the batch mode.
-    The command will read the file and execute its content as a batch.
+    With --file argument the command must be executed while not in the batch
+    mode. The command will read the file and execute its content as a batch.
     After that, no matter whether there was an error or not, the CLI will
     exit the batch mode.
 
@@ -24,4 +25,5 @@ ARGUMENTS
               
  --headers  - a list of operation headers (for the resulting composite request)
               separated by a semicolon. For the list of supported
-              headers, please, refer to the domain management documentation or use tab-completion.
+              headers, please, refer to the domain management documentation or
+              use tab-completion.

--- a/cli/src/main/resources/help/batch.txt
+++ b/cli/src/main/resources/help/batch.txt
@@ -20,9 +20,9 @@ ARGUMENTS
 
  heldback_name  - optional, the name of a held back batch.
  
- --file			- optional, a file system path to a file containing
+ --file         - optional, a file system path to a file containing
                   commands and operations that should be added to the batch;
 
- -l				- optional, prints a list of currently held back batches;
+ -l             - optional, prints a list of currently held back batches;
  
- --help			- optional, prints this message.
+ --help         - optional, prints this message.

--- a/cli/src/main/resources/help/cn.txt
+++ b/cli/src/main/resources/help/cn.txt
@@ -7,10 +7,11 @@ DESCRIPTION
 
     Changes the current node path to the argument.
     The current node path is used as the address for operation requests that
-    don't contains the address part. If an operation request does include the address,
-    the included address is considered relative to the current node path.
-    The current node path may end on a node-type. In that case, to execute an operation
-    specifying a node-name would be sufficient (e.g. logging:read-resource).
+    don't contains the address part. If an operation request does include the
+    address, the included address is considered relative to the current node
+    path. The current node path may end on a node-type. In that case, to execute
+    an operation specifying a node-name would be sufficient
+    (e.g. logging:read-resource).
 
 ARGUMENTS
 

--- a/cli/src/main/resources/help/command.txt
+++ b/cli/src/main/resources/help/command.txt
@@ -1,63 +1,93 @@
 SYNOPSIS
 
-   command [add --node-type=node_path_to_the_type [--property-id=identifying_property] --command-name=name_for_the_command |
+   command [add --node-type=node_path_to_the_type
+                [--property-id=identifying_property]
+                --command-name=name_for_the_command |
             remove --command_name=command_to_remove |
             list]
 
 DESCRIPTION
-                Allows to add new, remove and list existing generic type commands.
-                A generic type command is a command that is assigned to a specific node type
-                and which allows to perform any operation available for an instance of that type
-                and/or modify any of the properties exposed by the type on any existing instance of that type.
 
-                For example, suppose there is a generic type command assigned to type /subsystem=datasources/data-source
-                and named data-source. Now, data-source command can be used to add new datasources to the server,
-                modify properties and perform any available operation on any existing datasource.
-                To do that, the command needs to identify the datasource that should be affected.
-                For that, there is a special argument, which can be a property exposed by the type and that
-                can be used to identify the instance, e.g. in case of datasource, this role can be given to
-                property 'jndi-name'. Or if there is no such property, generic type command will automatically
-                add argument 'name' which, as its value, will accept the instance name (the last name in the node path
-                of the instance)
+  Allows to add new, remove and list existing generic type commands.
+  A generic type command is a command that is assigned to a specific node type
+  and which allows to perform any operation available for an instance of that
+  type and/or modify any of the properties exposed by the type on any existing
+  instance of that type.
 
-                Here is an example of invoking operation 'flush-all-connection-in-pool' on datasource with jndi-name 'myds'.
+  For example, suppose there is a generic type command assigned to type
+  /subsystem=datasources/data-source and named data-source. Now, data-source
+  command can be used to add new datasources to the server, modify properties
+  and perform any available operation on any existing datasource. To do that,
+  the command needs to identify the datasource that should be affected. For
+  that, there is a special argument, which can be a property exposed by the type
+  and that can be used to identify the instance, e.g. in case of datasource,
+  this role can be given to property 'jndi-name'. Or if there is no such
+  property, generic type command will automatically add argument 'name' which,
+  as its value, will accept the instance name (the last name in the node path
+  of the instance)
 
-                data-source flush-all-connection-in-pool --jndi-name=myds
+  Here is an example of invoking operation 'flush-all-connection-in-pool' on
+  datasource with jndi-name 'myds'.
 
-                where flush-all-connection-in-pool is an operation name exposed by data-source type and jndi-name
-                is the property name that identifies the specific datasource to perform the operation on.
-                If the operation has properties, they can be added as command line arguments by prefixing property names
-                with '--' and supplying the values after '='. E.g. This is how a new datasource could be added
+  data-source flush-all-connection-in-pool --jndi-name=myds
 
-                data-source add --jndi-name=my-new-ds --driver-name=h2 --connection-url=db:url --pool-name=my-ds-pool
+  where flush-all-connection-in-pool is an operation name exposed by data-source
+  type and jndi-name is the property name that identifies the specific
+  datasource to perform the operation on. If the operation has properties, they
+  can be added as command line arguments by prefixing property names with '--'
+  and supplying the values after '='. E.g. This is how a new datasource could be
+  added
 
-                To modify properties of an existing type instance, just use property names as arguments
-                like the operation arguments in the example above. E.g.
+  data-source add --jndi-name=my-new-ds --driver-name=h2 \
+                  --connection-url=db:url --pool-name=my-ds-pool
 
-                data-source --jndi-name=my-new-ds --min-pool-size=11 --max-pool-size=22
+  To modify properties of an existing type instance, just use property names as
+  arguments like the operation arguments in the example above. E.g.
 
-                Tab-completion will help completing operation and property names.
+  data-source --jndi-name=my-new-ds --min-pool-size=11 --max-pool-size=22
 
-                Generic type commands support --help option. The content of the help will be generated from the
-                description of the operations and properties provided by the model on the server. E.g.
+  Tab-completion will help completing operation and property names.
 
-                data-source --help                                  # describes the type itself
-                data-source --help --commands                       # will list all the operations exposed by the type
-                data-source --help --properties                     # will list all the properties exposed by the type
-                data-source flush-all-connection-in-pool --help     # will describe the specific operation, in this case flush-all-connection-in-pool
+  Generic type commands support --help option. The content of the help will be
+  generated from the description of the operations and properties provided by
+  the model on the server. E.g. the following command will describe the type
+  itself:
+
+  data-source --help
+
+  The following will list all the operations exposed by the type:
+
+  data-source --help --commands
+
+  This will list all the properties exposed by the type:
+
+  data-source --help --properties
+
+  And this will describe the specific operation, in this case
+  flush-all-connection-in-pool:
+
+  data-source flush-all-connection-in-pool --help
 
 
 ARGUMENTS
 
- add            - adds a new generic type command. The following arguments are used to add a new command:
-                    --node-type     - (required) specifies the node path which ends on a type,
-                                      for which the generic command should be created.
-                    --property-id   - (optional) a property name exposed by the type that should be used
-                                      to identify instances of the type. If not specified, argument '--name'
-                                      will be used with the instance name as its value to identify the target instance.
-                    --command-name  - (required) the name for the command.
+  add     - adds a new generic type command. The following arguments are used to
+            add a new command:
 
- remove         - removes an existing generic type command. There is a single required argument --command-name
-                  which identifies the command that should be removed.
-				
- list           - lists existing generic type commands.
+              --node-type     - (required) specifies the node path which ends on
+                              a type, for which the generic command should be
+                              created;
+
+              --property-id   - (optional) a property name exposed by the type
+                              that should be used to identify instances of the
+                              type. If not specified, argument '--name' will be
+                              used with the instance name as its value to
+                              identify the target instance.
+
+              --command-name  - (required) the name for the command.
+
+  remove  - removes an existing generic type command. There is a single required
+            argument --command-name which identifies the command that should be
+            removed.
+			
+  list    - lists existing generic type commands.

--- a/cli/src/main/resources/help/connect.txt
+++ b/cli/src/main/resources/help/connect.txt
@@ -4,34 +4,37 @@ SYNOPSIS
 
 DESCRIPTION
 
-   connects to the controller on the specified host and port.
+  Connects to the controller on the specified host and port.
+
+  The default values can be customized by specifying the desired defaults as
+  command line arguments when launching the CLI. E.g.
+ 
+  jboss-cli.sh controller=controller-host.net:1234
+
+  Or
+
+  jboss-cli.sh controller=controller-host.net
+ 
+  In this case, the default port will be 9999.
+
+  Note, specifying controller argument will only set the default host and port
+  values for the connect command but will not automatically connect to the
+  specified controller.
+ 
+  To connect automatically after the launch, use '--connect' switch. E.g.
+ 
+  jboss-cli.sh --connect
+  jboss-cli.sh --connect controller=controller-host.net
+  jboss-cli.sh --connect controller=controller-host.net:1234
+ 
+  The host may be any of these formats:
+  - a host name, e.g. localhost
+  - an ipv4 address, e.g. 127.0.0.1
+  - an ipv6 address, e.g. [::1]
+
 
 ARGUMENTS
 
- host - optional, default value is localhost;
- port - optional, default value is 9999.
- 
-The default values can be customized by specifying the desired defaults as command line
-arguments when launching the CLI. E.g.
- 
- jboss-cli.sh controller=controller-host.net:1234
+  host  - optional, default value is localhost;
 
-Or
-
- jboss-cli.sh controller=controller-host.net
- 
-In this case, the default port will be 9999.
-
-Note, specifying controller argument will only set the default host and port values
-for the connect command but will not automatically connect to the specified controller.
- 
-To connect automatically after the launch, use '--connect' switch. E.g.
- 
- jboss-cli.sh --connect
- jboss-cli.sh --connect controller=controller-host.net
- jboss-cli.sh --connect controller=controller-host.net:1234
- 
- The host may be any of these formats:
--a host name, e.g. localhost
--an ipv4 address, e.g. 127.0.0.1
--an ipv6 address, e.g. [::1]
+  port  - optional, default value is 9999.

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -1,6 +1,7 @@
 SYNOPSIS
 
-    deploy (file_path [--script=script_name] [--name=deployment_name] [--runtime-name=deployment_runtime_name]
+    deploy (file_path [--script=script_name] [--name=deployment_name]
+                      [--runtime-name=deployment_runtime_name]
                       [--force | --disabled] [--unmanaged])
            | --name=deployment_name
            [--server-groups=group_name (,group_name)* | --all-server-groups]
@@ -8,62 +9,70 @@ SYNOPSIS
 
 DESCRIPTION
 
-    Deploys the application designated by the file_path or enables an already existing
-    but disabled in the repository deployment designated by the name argument.
-    If executed w/o arguments, will list all the existing deployments.
+  Deploys the application designated by the file_path or enables an already
+  existing but disabled in the repository deployment designated by the name
+  argument. If executed w/o arguments, will list all the existing deployments.
 
 ARGUMENTS
 
- file_path           - the path to the application to deploy. Required in case the deployment
-                       doesn't exist in the repository.
-                       The path can be either absolute or relative to the current directory.
+ file_path         - the path to the application to deploy. Required in case the
+                     deployment doesn't exist in the repository.
+                     The path can be either absolute or relative to the current
+                     directory.
 
- --name              - the unique name of the deployment. If the file path argument is specified
-                       the name argument is optional with the file name been the default value.
-                       If the file path argument isn't specified then the command is supposed to
-                       enable an already existing but disabled deployment, and in this case the
-                       name argument is required.
+ --name            - the unique name of the deployment. If the file path
+                     argument is specified the name argument is optional with
+                     the file name been the default value. If the file path
+                     argument isn't specified then the command is supposed to
+                     enable an already existing but disabled deployment, and in
+                     this case the name argument is required.
 
- --runtime-name      - optional, the runtime name for the deployment.
+ --runtime-name    - optional, the runtime name for the deployment.
 
- --force             - if the deployment with the specified name already exists, by default,
-                       deploy will be aborted and the corresponding message will printed.
-                       Switch --force (or -f) will force the replacement of the existing deployment
-                       with the one specified in the command arguments.
+ --force           - if the deployment with the specified name already exists,
+                     by default, deploy will be aborted and the corresponding
+                     message will printed. Switch --force (or -f) will force the
+                     replacement of the existing deployment with the one
+                     specified in the command arguments.
 
- --disabled          - indicates that the deployment has to be added to the repository disabled.
+ --disabled       - indicates that the deployment has to be added to the
+                    repository disabled.
  
- --unmanaged         - if this argument is not specified, the deployment content will be
-                       copied (i.e. uploaded) to the server's deployment repository
-                       before it is deployed.
-                       If the argument is present, the deployment content will remain
-                       at and be deployed directly from its original location specified
-                       with the file_path.
-                       NOTE: exploded deployments are supported only as unmanaged.
+ --unmanaged      - if this argument is not specified, the deployment content
+                    will be copied (i.e. uploaded) to the server's deployment
+                    repository before it is deployed. If the argument is
+                    present, the deployment content will remain at and be
+                    deployed directly from its original location specified with
+                    the file_path.
+                    NOTE: exploded deployments are supported only as unmanaged.
 
- --server-groups     - comma separated list of server group names the deploy command should apply to.
-                       Either server-groups or all-server-groups is required in the domain mode.
-                       This argument is not applicable in the standalone mode.
+ --server-groups  - comma separated list of server group names the deploy
+                    command should apply to. Either server-groups or
+                    all-server-groups is required in the domain mode. This
+                    argument is not applicable in the standalone mode.
 
- --all-server-groups - indicates that deploy should apply to all the available server groups.
-                       Either server-groups or all-server-groups is required in domain mode.
-                       This argument is not applicable in the standalone mode.
+ --all-server-groups  - indicates that deploy should apply to all the available
+                        server groups. Either server-groups or all-server-groups
+                        is required in domain mode. This argument is not
+                        applicable in the standalone mode.
 
- -l                  - in case none of the required arguments is specified the command will
-                       print all of the existing deployments in the repository. The presence of the -l switch
-                       will make the existing deployments printed one deployment per line, instead of
-                       in columns (the default).
+ -l               - in case none of the required arguments is specified the
+                    command will print all of the existing deployments in the
+                    repository. The presence of the -l switch will make the
+                    existing deployments printed one deployment per line,
+                    instead of in columns (the default).
 
- --headers           - a list of operation headers separated by a semicolon. For the list of supported
-                       headers, please, refer to the domain management documentation or use tab-completion.
+ --headers        - a list of operation headers separated by a semicolon. For
+                    the list of supported headers, please, refer to the domain
+                    management documentation or use tab-completion.
 
- --script            - optional, can appear only if the file_path points a cli archive.
-                       The value is the name of the script contained in a cli archive to execute.
-                       If not specified, defaults to 'deploy.scr'. 
-                       A cli archive is a zip archive containing script(s) as well as artifacts or applications 
-                       to deploy. To be recognized as a cli archive, the extension of the archive file should be '.cli'.
-                       The deploy command will execute the script given by the --script argument. 
-                       All paths in the scripts are relative to the root directory in the cli archive. 
-                       The script is executed as a batch.
-                                 
-               
+ --script         - optional, can appear only if the file_path points a cli
+                    archive. The value is the name of the script contained in a
+                    cli archive to execute. If not specified, defaults to
+                    'deploy.scr'. A cli archive is a zip archive containing
+                    script(s) as well as artifacts or applications to deploy.
+                    To be recognized as a cli archive, the extension of the
+                    archive file should be '.cli'. The deploy command will
+                    execute the script given by the --script argument. All paths
+                    in the scripts are relative to the root directory in the cli
+                    archive. The script is executed as a batch.

--- a/cli/src/main/resources/help/deployment-info.txt
+++ b/cli/src/main/resources/help/deployment-info.txt
@@ -48,9 +48,9 @@ DESCRIPTION
                 the next time the server starts.)
     
     - STATUS - the current runtime status of a deployment. Possible status
-               modes are OK, FAILED, and STOPPED.
-             FAILED indicates a dependency is missing or a service could not start.
-             STOPPED indicates that the deployment was manually stopped.
+               modes are OK, FAILED (indicates a dependency is missing or a
+               service could not start) and STOPPED (indicates that the
+               deployment was manually stopped).
 
     In the domain mode, the command can display information about either:
 

--- a/cli/src/main/resources/help/deployment-overlay.txt
+++ b/cli/src/main/resources/help/deployment-overlay.txt
@@ -16,88 +16,93 @@ NOTE: --server-group, --all-server-groups and --all-relevant-server-groups
       
 ACTION: add
 
-    Depending on the arguments the action
-    - always creates a new overlay with content;
-    - optionally links it to the specified existing deployments;
-    - also optionally re-deploys the affected (linked) deployments.
+  Depending on the arguments the action
+  - always creates a new overlay with content;
+  - optionally links it to the specified existing deployments;
+  - also optionally re-deploys the affected (linked) deployments.
 
-    deployment-overlay add --name=overlay_name
-        --content=archive_path=fs_path(,archive_path=fs_path)*
-        [--server-groups=server_group_name(,server-group-name)* | --all-server-groups]
-        [--deployments=deployment_name(,deployment_name)*]
-        [--wildcards=wildcard_name(,wildcard_name)*]
-        [--redeploy-affected]
-        [--headers={operation_header (;operation_header)*}]
+  deployment-overlay add --name=overlay_name
+      --content=archive_path=fs_path(,archive_path=fs_path)*
+      [--server-groups=server_group_name(,server-group-name)* |
+       --all-server-groups]
+      [--deployments=deployment_name(,deployment_name)*]
+      [--wildcards=wildcard_name(,wildcard_name)*]
+      [--redeploy-affected]
+      [--headers={operation_header (;operation_header)*}]
 
 ACTION: remove
 
-    Depending on the arguments the action may:
-    - unlink deployments (if --deployments or --wildcards argument is specified);
-    - remove content (if --content argument is specified);
-    - remove the overlay altogether with its content and links;
-    - re-deploy affected deployments.
+  Depending on the arguments the action may:
+  - unlink deployments (if --deployments or --wildcards argument is specified);
+  - remove content (if --content argument is specified);
+  - remove the overlay altogether with its content and links;
+  - re-deploy affected deployments.
     
-    deployment-overlay remove --name=overlay_name
-        [--content=archive_path=(,archive_path)*]
-        [--server-groups=server_group_name(,server_group_name)* | --all-relevant-server-groups]
-        [--deployments=deployment_name(,deployment_name)*]
-        [--wildcards=wildcard_name(,wildcard_name)*]
-        [--redeploy-affected]
-        [--headers={operation_header (;operation_header)*}]
+  deployment-overlay remove --name=overlay_name
+      [--content=archive_path=(,archive_path)*]
+      [--server-groups=server_group_name(,server_group_name)* |
+       --all-relevant-server-groups]
+      [--deployments=deployment_name(,deployment_name)*]
+      [--wildcards=wildcard_name(,wildcard_name)*]
+      [--redeploy-affected]
+      [--headers={operation_header (;operation_header)*}]
         
-    If the remove command specifies only the name of the overlay, the overlay
-    will be removed including its content and deployment links (from all server groups
-    in the domain mode). 
+  If the remove command specifies only the name of the overlay, the overlay
+  will be removed including its content and deployment links (from all server
+  groups in the domain mode). 
 
-    If in the domain mode remove command contains only --name and --server-groups
-    (or --all-relevant-server-groups), all the links to the overlay will be removed
-    from the specified server groups. The content will remain untouched.
+  If in the domain mode remove command contains only --name and --server-groups
+  (or --all-relevant-server-groups), all the links to the overlay will be
+  removed from the specified server groups. The content will remain untouched.
 
-    --content, --deployments and --wildcards target specific content and links
-    to the specified deployments and wildcards.
+  --content, --deployments and --wildcards target specific content and links
+  to the specified deployments and wildcards.
 
 ACTION: upload
 
-    Adds content to an existing overlay and optionally re-deploys the linked deployments.
+  Adds content to an existing overlay and optionally re-deploys the linked
+  deployments.
 
-    deployment-overlay upload --name=overlay_name
-        --content=archive_path=fs_path(,archive_path=fs_path)*
-        [--redeploy-affected]
-        [--headers={operation_header (;operation_header)*}]
+  deployment-overlay upload --name=overlay_name
+      --content=archive_path=fs_path(,archive_path=fs_path)*
+      [--redeploy-affected]
+      [--headers={operation_header (;operation_header)*}]
 
 ACTION: link
 
-    Creates links between an overlay and existing deployments and
-    optionally re-deploys linked deployments.
+  Creates links between an overlay and existing deployments and optionally
+  re-deploys linked deployments.
 
-    deployment-overlay link --name=overlay_name
-        [--server-groups=server_group_name(,server_group_name)* | --all-server-groups]
-        (--deployment=deployment_name(,deployment_name)* |
-         --wildcards=wildcard_name(,wildcard_name)*)
-        [--redeploy-affected]
-        [--headers={operation_header (;operation_header)*}]
+  deployment-overlay link --name=overlay_name
+      [--server-groups=server_group_name(,server_group_name)* |
+       --all-server-groups]
+      (--deployment=deployment_name(,deployment_name)* |
+       --wildcards=wildcard_name(,wildcard_name)*)
+      [--redeploy-affected]
+      [--headers={operation_header (;operation_header)*}]
 
 ACTION: redeploy-affected
 
-    Re-deploys all the linked deployments.
+  Re-deploys all the linked deployments.
     
-    deployment-overlay redeploy-affected --name=overlay_name
+  deployment-overlay redeploy-affected --name=overlay_name
         [--headers={operation_header (;operation_header)*}]
 
 ACTION: list-content
 
-    Lists content of the overlay.
+  Lists content of the overlay.
     
-    deployment-overlay list-content --name=overlay_name [-l]
+  deployment-overlay list-content --name=overlay_name [-l]
 
 ACTION: list-links
 
-    Lists deployments the overlay is linked to.
+  Lists deployments the overlay is linked to.
     
-    deployment-overlay list-links --name=overlay_name [-l]
-    [--server-groups=server_group_name(,server_group_name)*]
+  deployment-overlay list-links --name=overlay_name [-l]
+        [--server-groups=server_group_name(,server_group_name)*]
 
-NOTE: deployment-overlay executed without an action lists existing overlay names.
+NOTE: deployment-overlay executed without an action lists existing overlay
+      names.
 
     deployment-overlay [-l]
 
@@ -144,9 +149,9 @@ ARGUMENTS
 
  --all-relevant-server-groups  - may appear only in the domain mode and is not
                                  allowed in the standalone. The argument
-                                 does not expect any value. It signifies that
-                                 all the relevant (according to the other
-                                 specified arguments) server groups should be targeted.
+                       does not expect any value. It signifies that all the
+                       relevant (according to the other specified arguments)
+                       server groups should be targeted.
 
  --deployments       - a comma-separated list of deployment names that,
                        depending on the action, should be linked to or
@@ -165,4 +170,5 @@ ARGUMENTS
                        
  --headers           - a list of operation headers separated by a semicolon.
                        For the list of supported headers, please, refer to
-                       the domain management documentation or use tab-completion.
+                       the domain management documentation or use
+                       tab-completion.

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -1,68 +1,95 @@
-Usage: jboss-cli.sh/jboss-cli.bat [--help] [--version] [--controller=host:port]
-                                  [--connect] [--file=file_path]
-                                  [--commands=command_or_operation1,command_or_operation2...]
-                                  [--command=command_or_operation]
-                                  [--user=username --password=password]
-                                  [--timeout=timeout]
+Usage:
 
- --help (-h)          - prints (this) basic description of the command line utility.
- --version            - prints the version info of the JBoss AS release, JVM and system environment.
- --controller         - the default controller host and port to connect to when --connect option.
-                        (described below) is specified or when the connect command is issued w/o
-                        the arguments. The default controller host is localhost and the port is 9999.
- --connect (-c)       - instructs the CLI to connect to the controller on start-up (to avoid issuing
-                        a separate connect command later).
- --gui                - GUI built on top of the CLI, the only difference is that it brings up a GUI
-                        instead of a command line. In this mode, the CLI will automatically connect
-                        during start-up. You can optionally specify --controller, if necessary.
- --file               - specifies a path to a file which contains commands and operations (one per line)
-                        that should be executed (in a non-interactive mode). The CLI will terminate the
-                        session immediately after the last command has been executed or if some command
-                        or operation failed.
- --command            - specifies a single command or an operation that should be executed in the CLI session.
-                        The CLI will terminate the session immediately after the command or the operation
-                        has been executed. Note: --command argument is optional in a sense that
-                        any word (or phrase without whitespaces in it) will be assumed to be a command (or an operation).
- --commands           - specifies a comma-separated list (the list must not contain whitespaces)
-                        of commands and operations that should be executed in the CLI session.
-                        The CLI session will be automatically terminated as soon as
-                        the last command or operation has been executed or after the first error.
-                        Note: --commands argument is optional in a sense that any comma-separated list
-                        at the end of the argument list will be assumed to be the list of commands and operations.
- --user               - if the controller requires user authentication, this argument can be used to specify the user name
-                        as a command line argument. If the argument isn't specified and the authentication is required
-                        the user will be prompted to enter the user name when the connect command is issued.
- --password           - specifies the password for authentication while connecting to the controller as
-                        a command line argument. If the argument isn't specified and the authentication is required
-                        the user will be prompted to enter the password when the connect command is issued.
- --timeout            - specifies home many milliseconds to wait for a given command to return. The value provided
-                        must be a positive integer. Defaults to 5000 milliseconds when not provided.
+  jboss-cli.sh/jboss-cli.bat [--help] [--version] [--controller=host:port]
+                     [--connect] [--file=file_path]
+                     [--commands=command_or_operation1,command_or_operation2...]
+                     [--command=command_or_operation]
+                     [--user=username --password=password]
+                     [--timeout=timeout]
+
+ --help (-h)     - prints (this) basic description of the command line utility.
+
+ --version       - prints the version info of the JBoss AS release, JVM and
+                   system environment.
+
+ --controller    - the default controller host and port to connect to when
+                   --connect option (described below) is specified or when the
+                   connect command is issued w/o the arguments. The default
+                   controller host is localhost and the port is 9999.
+
+ --connect (-c)  - instructs the CLI to connect to the controller on start-up
+                   (to avoid issuing a separate connect command later).
+
+ --gui           - GUI built on top of the CLI, the only difference is that it
+                   brings up a GUI instead of a command line. In this mode, the
+                   CLI will automatically connect during start-up. You can
+                   optionally specify --controller, if necessary.
+
+ --file          - specifies a path to a file which contains commands and
+                   operations (one per line) that should be executed (in a
+                   non-interactive mode). The CLI will terminate the session
+                   immediately after the last command has been executed or if
+                   some command or operation failed.
+
+ --command       - specifies a single command or an operation that should be
+                   executed in the CLI session. The CLI will terminate the
+                   session immediately after the command or the operation has
+                   been executed. Note: --command argument is optional in a
+                   sense that any word (or phrase without whitespaces in it)
+                   will be assumed to be a command (or an operation).
+
+ --commands      - specifies a comma-separated list (the list must not contain
+                   whitespaces) of commands and operations that should be
+                   executed in the CLI session. The CLI session will be
+                   automatically terminated as soon as the last command or
+                   operation has been executed or after the first error. Note:
+                   --commands argument is optional in a sense that any
+                   comma-separated list at the end of the argument list will be
+                   assumed to be the list of commands and operations.
+
+ --user          - if the controller requires user authentication, this argument
+                   can be used to specify the user name as a command line
+                   argument. If the argument isn't specified and the
+                   authentication is required the user will be prompted to enter
+                   the user name when the connect command is issued.
+
+ --password      - specifies the password for authentication while connecting to
+                   the controller as a command line argument. If the argument
+                   isn't specified and the authentication is required the user
+                   will be prompted to enter the password when the connect
+                   command is issued.
+
+ --timeout       - specifies home many milliseconds to wait for a given command
+                   to return. The value provided must be a positive integer.
+                   Defaults to 5000 milliseconds when not provided.
 
 
-During the command line session for a list of commands available in the current context execute
+For a list of available commands execute
 
-help --commands
+  help --commands
 
-The resulting listing may depend on the current context. E.g. some of the commands
-require an established connection to the controller (standalone or domain).
-These commands won't appear in the listing unless the connection has been established.
-Other commands may depend on the availability of specific subsystems. E.g. if the messaging
-subsystem is not available, messaging-related commands will not be listed.
+The resulting listing may depend on the current context. E.g. some of the
+commands require an established connection to the controller (standalone or
+domain). These commands won't appear in the listing unless the connection has
+been established. Other commands may depend on the availability of specific
+subsystems. E.g. if the messaging subsystem is not available, messaging-related
+commands will not be listed.
 
 Here are some of the most basic supported commands:
 
  cn (or cd)             - change the current node path to the argument;
- connect                - connect to the specified host and port;
+ connect                - connect to the server or domain controller;
  deploy                 - deploy an application;
  help (or h)            - print this message;
- history                - print or disable/enable/clear the history expansion.
+ history                - print or disable/enable/clear the history expansion;
  ls                     - list the contents of the node path;
  pwn (or pwd)           - prints the current working node;
  quit (or q)            - quit the command line interface;
  undeploy               - undeploy an application;
  version                - prints the version and environment information.
 
-For a more detailed description of a specific command, execute the command with '--help' as the argument.
+For a more detailed description of a specific command, execute the command with
+'--help' as the argument.
 
 Tab-completion is supported for the commands, just press the tab key to start.
 
@@ -72,10 +99,11 @@ Operation requests start with './' or '/' and follow the format:
 
 e.g. /subsystem=web/connector=http:read-attribute(name=protocol)
 
-If the operation request doesn't require a node path then the request can start with ':'
-followed by an operation name and the property list if necessary ('/:' and './:' are also possible).
+If the operation request doesn't require a node path then the request can start
+with ':' followed by an operation name and the property list if necessary ('/:'
+and './:' are also possible).
 
 Whitespaces between the separators are insignificant.
 If the operation doesn't require arguments then the brackets '()' are optional.
-Tab-completion for operation requests supports node types and names, operation names, property names
-and, in some cases, values.
+Tab-completion for operation requests supports node types and names, operation
+names, property names and, in some cases, values.

--- a/cli/src/main/resources/help/history.txt
+++ b/cli/src/main/resources/help/history.txt
@@ -6,11 +6,15 @@ DESCRIPTION
 
     Manipulates the command (and operation request) history expansion.
     Without arguments prints the in-memory history of commands and operations
-    previously executed and a status whether the history expansion is enabled or disabled.
+    previously executed and a status whether the history expansion is enabled
+    or disabled.
 
 ARGUMENTS
 
- --disable    - will disable history expansion (but will not clear the previously recorded history);
- --enable     - will re-enable history expansion (starting from the last recorded command before
-                the history expansion was disabled);
+ --disable    - will disable history expansion (but will not clear the
+                previously recorded history);
+
+ --enable     - will re-enable history expansion (starting from the last
+                recorded command before the history expansion was disabled);
+
  --clear      - will clear the in-memory history (but not the file one).

--- a/cli/src/main/resources/help/ls.txt
+++ b/cli/src/main/resources/help/ls.txt
@@ -4,36 +4,43 @@ SYNOPSIS
 
 DESCRIPTION
 
-    Lists the contents of a node path. Which includes node types and attributes,
-    if the node path ends on a node name, or node names if the node path ends on a node type.
+  Lists the contents of a node path. Which includes node types and attributes,
+  if the node path ends on a node name, or node names if the node path ends on
+  a node type.
 
 ARGUMENTS
 
- node-path    - (optional) the node path the contents of which to print.
-                If not specified, the contents of the current node path (indicated in the prompt) will be printed.
-                The node path can end on either node type (in this case the contents will be the child node names)
-                or the node name (in this case the contents will be the child node types and attributes).
-                If the node path has no contents, nothing will be printed.
+ node-path  - (optional) the node path the contents of which to print.
+              If not specified, the contents of the current node path (indicated
+              in the prompt) will be printed. The node path can end on either
+              node type (in this case the contents will be the child node names)
+              or the node name (in this case the contents will be the child node
+              types and attributes). If the node path has no contents, nothing
+              will be printed.
 
-                If specified, the node-path is expected to follow format:
-                [node-type [=node-name (,node-type[=node-name])*]].
+              If specified, the node-path is expected to follow format:
+              [node-type [=node-name (,node-type[=node-name])*]].
 
- -l           - (optional) by default the result consists of a list of names and is printed in columns
-                using the whole width of the terminal.
-                If the node path ends on a node name, the -l switch will print two tables:
-                - one for attributes displaying the name, value and type of the attributes;
-                - one for child types displaying the type name, min and max allowed occurrences
-                  of instances of those types in the domain configuration.
-                If the node path ends on a node type, the -l switch will print all the available
-                child names one per line, i.e. in a column.  
+ -l         - (optional) by default the result consists of a list of names and
+              is printed in columns using the whole width of the terminal.
+              If the node path ends on a node name, the -l switch will print two
+              tables:
+                - one for attributes displaying the name, value and type of the
+                  attributes;
+                - one for child types displaying the type name, min and max
+                  allowed occurrences of instances of those types in the domain
+                  configuration.
+              If the node path ends on a node type, the -l switch will print all
+              the available child names one per line, i.e. in a column.  
 
- --attribute-description-property  - (optional) by default, -l will display attribute name, value and type.
-                                     Full attribute description (which you can see by executing
-                                     'read-attribute <attribute-name> --verbose') includes more
-                                     properties. To include those into the 'ls -l' results,
-                                     just list those properties as arguments to the ls command
-                                     prefixing their names with '--'. E.g.
-                                     'ls -l --nillable --storage'.
+ --attribute-description-property  - (optional) by default, -l will display
+                                     attribute name, value and type.
+              Full attribute description (which you can see by executing
+              'read-attribute <attribute-name> --verbose') includes more
+              properties. To include those into the 'ls -l' results,
+              just list those properties as arguments to the ls command
+              prefixing their names with '--'.
+              E.g. 'ls -l --nillable --storage'.
                                       
  
 The following navigation signs are supported in the node-path:

--- a/cli/src/main/resources/help/module.txt
+++ b/cli/src/main/resources/help/module.txt
@@ -4,7 +4,10 @@ SYNOPSIS
 
     module add --name=module_name [--slot=slot_name] --resources=list_of_jars
                (--module-xml=file_path |
-               [--dependencies=list_of_module_names] [--properties=list_of_properties] [--main-class=fully_qualified_class_name]])
+                ([--dependencies=list_of_module_names]
+                 [--properties=list_of_properties]
+                 [--main-class=fully_qualified_class_name]])
+               )
 
   To remove a module
 
@@ -13,23 +16,24 @@ SYNOPSIS
 
 DESCRIPTION
 
-    The command is used to add and remove modules.
+  The command is used to add and remove modules.
 
-    When a module is added, the corresponding to the module name directory structure
-    will be created in the AS7 module repository. The JAR files specified as resources
-    will be copied to the module's directory. Unless module.xml file was specified
-    as an argument, it will be automatically generated.
+  When a module is added, the corresponding to the module name directory
+  structure will be created in the AS7 module repository. The JAR files
+  specified as resources will be copied to the module's directory. Unless
+  module.xml file was specified as an argument, it will be automatically
+  generated.
 
-    When a module is removed, its module.xml and other resources will be removed
-    from the module repository as well as its directory structure up to the point
-    where other modules met.
+  When a module is removed, its module.xml and other resources will be removed
+  from the module repository as well as its directory structure up to the point
+  where other modules met.
 
-    NOTE: the command can generate only simple module.xml files.
-    More specifically, it supports:
-    - resources-root elements that point to files;
-    - modules dependencies as simple module names;
-    - module's main-class;
-    - module properties.
+  NOTE: the command can generate only simple module.xml files.
+  More specifically, it supports:
+  - resources-root elements that point to files;
+  - modules dependencies as simple module names;
+  - module's main-class;
+  - module properties.
 
 
 ARGUMENTS
@@ -37,30 +41,37 @@ ARGUMENTS
  --name          - (required) the name of the module to be added or removed.
                    NOTE: slot is not a part of the module name.
 
- --slot          - (optional) specifies a slot which should be created or removed.
-                   If this argument is not specified, "main" slot is assumed.
+ --slot          - (optional) specifies a slot which should be created or
+                   removed. If this argument is not specified, "main" slot is
+                   assumed.
 
  --resources     - (used with add, required unless module-xml is used) a list of
-                   filesystem paths (usually jar files) separated by a filesystem-specific
-                   path separator, i.e. java.io.File.pathSeparatorChar.
-                   The file(s) specified will be copied to the created module's directory.
+                   filesystem paths (usually jar files) separated by a
+                   filesystem-specific path separator, i.e.
+                   java.io.File.pathSeparatorChar. The file(s) specified will be
+                   copied to the created module's directory.
 
- --module-xml    - (used with add, optional) filesystem path to the module.xml file
-                   which should be used for the added module. The file will be copied
-                   to the created module's directory. If this argument is not specified,
-                   module.xml file will be generated in the new created module's directory.
+ --module-xml    - (used with add, optional) filesystem path to the module.xml
+                   file which should be used for the added module. The file will
+                   be copied to the created module's directory. If this argument
+                   is not specified, module.xml file will be generated in the
+                   new created module's directory.
 
- --dependencies  - (used with add, optional) a comma-separated list of module names
-                   the module being added depends on.
-                   NOTE: this argument makes sense only when the module.xml file is generated,
-                   i.e. when the --module-xml argument isn't specified
+ --dependencies  - (used with add, optional) a comma-separated list of module
+                   names the module being added depends on.
+                   NOTE: this argument makes sense only when the module.xml file
+                   is generated, i.e. when the --module-xml argument isn't
+                   specified.
 
- --properties    - (used with add, optional) a comma-separated list of property_name=property_value
-                   pairs that will define module properties.
-                   NOTE: this argument makes sense only when the module.xml file is generated,
-                   i.e. when the --module-xml argument isn't specified
+ --properties    - (used with add, optional) a comma-separated list of
+                   property_name=property_value pairs that will define module
+                   properties.
+                   NOTE: this argument makes sense only when the module.xml file
+                   is generated, i.e. when the --module-xml argument isn't
+                   specified.
 
- --main-class    - (used with add, optional) a fully qualified class name that declares
-                   the modules main method.
-                   NOTE: this argument makes sense only when the module.xml file is generated,
-                   i.e. when the --module-xml argument isn't specified
+ --main-class    - (used with add, optional) a fully qualified class name that
+                   declares the modules main method.
+                   NOTE: this argument makes sense only when the module.xml file
+                   is generated, i.e. when the --module-xml argument isn't
+                   specified.

--- a/cli/src/main/resources/help/read-attribute.txt
+++ b/cli/src/main/resources/help/read-attribute.txt
@@ -1,7 +1,8 @@
 SYNOPSIS
 
     read-attribute --help |
-                   [--node=node_path] <attribute_name> [--include-defaults=true|false] [--verbose]
+                   [--node=node_path] <attribute_name>
+                   [--include-defaults=true|false] [--verbose]
                    [--headers={operation_header (;operation_header)*}]
 
 DESCRIPTION
@@ -15,17 +16,19 @@ ARGUMENTS
  
  --node              - (optional) the node path of the managed resource
                        to which the target attribute belongs.
-                       If not present, the current node path (indicated in the prompt) is assumed.
+                       If not present, the current node path (indicated in the
+                       prompt) is assumed.
                 
  <attribute_name>    - (required) the name of the target attribute.
  
  --include-defaults  - (optional) boolean to enable/disable default reading.
-                       In case it is set to false only the values set by user are returned.
-                       Attributes that were not explicitly initialized, will appear
-                       as not having any value.
+                       In case it is set to false only the values set by user
+                       are returned. Attributes that were not explicitly
+                       initialized, will appear as not having any value.
  
- --verbose (-v)      - will print all the available meta information about the attribute
-                       in addition to the attribute value.
+ --verbose (-v)      - will print all the available meta information about the
+                       attribute in addition to the attribute value.
 
- --headers           - a list of operation headers separated by a semicolon. For the list of supported
-                       headers, please, refer to the domain management documentation or use tab-completion.
+ --headers           - a list of operation headers separated by a semicolon.
+                       For the list of supported headers, please, refer to the
+                       domain management documentation or use tab-completion.

--- a/cli/src/main/resources/help/read-operation.txt
+++ b/cli/src/main/resources/help/read-operation.txt
@@ -6,21 +6,24 @@ SYNOPSIS
 
 DESCRIPTION
 
-    If the operation name argument is not provided, lists all the operation names
-    available in the current context and for the current node path.
-    If the operation name is specified, prints the description of the operation,
-    detailed description of its parameters and response.
+  If the operation name argument is not provided, lists all the operation names
+  available in the current context and for the current node path.
+  If the operation name is specified, prints the description of the operation,
+  detailed description of its parameters and response.
 
 ARGUMENTS
 
- --help              - prints this message.
+ --help          - prints this message.
  
- --node              - (optional) the node path of the managed resource
-                       the target operation belongs to.
-                       If not present, the current node path (indicated in the prompt) is assumed.
+ --node          - (optional) the node path of the managed resource
+                   the target operation belongs to.
+                   If not present, the current node path (indicated in the
+                   prompt) is assumed.
 
- operation_name      - (optional) the name of the operation to describe.
-                       If not present, all the operations of the managed resource will be listed.
+ operation_name  - (optional) the name of the operation to describe.
+                   If not present, all the operations of the managed resource
+                   will be listed.
 
- --headers           - a list of operation headers separated by a semicolon. For the list of supported
-                       headers, please, refer to the domain management documentation or use tab-completion.
+ --headers       - a list of operation headers separated by a semicolon. For
+                   the list of supported headers, please, refer to the domain
+                   management documentation or use tab-completion.

--- a/cli/src/main/resources/help/reload.txt
+++ b/cli/src/main/resources/help/reload.txt
@@ -6,8 +6,10 @@ SYNOPSIS
 
    Domain mode:
 
-      reload --host=host_name [--admin-only=true|false] [--restart-servers=true|false]
-             [--user-current-domain-config=true|false] [--user-current-host-config=true|false]
+      reload --host=host_name [--admin-only=true|false]
+             [--restart-servers=true|false]
+             [--user-current-domain-config=true|false]
+             [--user-current-host-config=true|false]
       
 DESCRIPTION
 
@@ -37,11 +39,11 @@ ARGUMENTS
 
  --admin-only  - whether the controller should start in running mode ADMIN_ONLY
                  when it restarts. An ADMIN_ONLY controller will start any
-                 configured management interfaces and accept management requests,
-                 but will not start servers or, if this host controller is
-                 the master for the domain, accept incoming connections from
-                 slave host controllers.
-                 If not present, false value is assumed.
+                 configured management interfaces and accept management
+                 requests, but will not start servers or, if this host
+                 controller is the master for the domain, accept incoming
+                 connections from slave host controllers. If not present, false
+                 value is assumed.
 
  --host        - is allowed and required only in the domain mode, specifies
                  the host name to reload.

--- a/cli/src/main/resources/help/try.txt
+++ b/cli/src/main/resources/help/try.txt
@@ -6,13 +6,13 @@ DESCRIPTION
 
     Starts a try-catch-finally control flow.
     Each block, i.e. try, catch and finally, is executed as a separate batch.
-    Which means if any of the commands or operation from the corresponding block fails
-    then the whole block is rolled back.
+    Which means if any of the commands or operation from the corresponding block
+    fails then the whole block is rolled back.
     
     First try block is executed. The catch block, if present, is executed only
-    if the try block fails. I.e. if the response of try comes with outcome "failed".
-    If the was a java.io.IOException then the error is thrown immediately
-    w/o executing catch or finally.
+    if the try block fails. I.e. if the response of try comes with outcome
+    "failed". If the was a java.io.IOException then the error is thrown
+    immediately w/o executing catch or finally.
     The finally block, if present, is executed always.
     
     Unlike Java, there can only be one catch block.

--- a/cli/src/main/resources/help/undeploy.txt
+++ b/cli/src/main/resources/help/undeploy.txt
@@ -1,48 +1,56 @@
 SYNOPSIS
 
-    undeploy name [--server-groups=group_name (,group_name)* | --all-relevant-server-groups] [--keep-content]
+    undeploy name [--server-groups=group_name (,group_name)* |
+                   --all-relevant-server-groups] [--keep-content]
                   [--headers={operation_header (;operation_header)*}]
 
 DESCRIPTION
 
-    Undeploys the deployment with the given name and, depending on the arguments, removes
-    its content from the repository.
-    If the deployment name isn't specified, prints the list of all the existing deployments.
+    Undeploys the deployment with the given name and, depending on the
+    arguments, removes its content from the repository.
+    If the deployment name isn't specified, prints the list of all the existing
+    deployments.
 
 ARGUMENTS
 
- name                   - the name of the deployment to undeploy.
+ name             - the name of the deployment to undeploy.
 
- --server-groups        - comma separated list of server group names the undeploy command should apply to.
-                          Either server-groups or all-relevant-server-groups is required in the domain mode.
-                          This argument is not applicable in the standalone mode.
+ --server-groups  - comma separated list of server group names the undeploy
+                    command should apply to. Either server-groups or
+                    all-relevant-server-groups is required in the domain mode.
+                    This argument is not applicable in the standalone mode.
 
- --all-relevant-server-groups   - indicates that undeploy should apply to all the server groups
-                                  in which the deployment is enabled.
-                                  Either server-groups or all-relevant-server-groups is required in domain mode.
-                                  This argument is not applicable in the standalone mode.
+ --all-relevant-server-groups   - indicates that undeploy should apply to all
+                                  the server groups in which the deployment is
+                    enabled. Either server-groups or all-relevant-server-groups
+                    is required in domain mode. This argument is not applicable
+                    in the standalone mode.
 
- --keep-content         - by default undeploy, besides disabling the deployment, also removes its
-                          content from the repository. The presence of --keep-content will only disable
-                          the deployment w/o removing its content from the repository.
-                          This argument can be used in both standalone and domain modes.
+ --keep-content   - by default undeploy, besides disabling the deployment, also
+                    removes its content from the repository. The presence of
+                    --keep-content will only disable the deployment w/o removing
+                    its content from the repository. This argument can be used
+                    in both standalone and domain modes.
 						
- -l                     - in case the deployment name isn't specified, the presence of the -l switch
-                          will make the existing deployments printed one deployment per line, instead of
-                          in columns (the default).
+ -l               - in case the deployment name isn't specified, the presence of
+                    the -l switch will make the existing deployments printed one
+                    deployment per line, instead of in columns (the default).
 
- --headers              - a list of operation headers separated by a semicolon. For the list of supported
-                          headers, please, refer to the domain management documentation or use tab-completion.
+ --headers        - a list of operation headers separated by a semicolon. For
+                    the list of supported headers, please, refer to the domain
+                    management documentation or use tab-completion.
                           
- --path                 - optional, points to a cli archive.
-                          The path can be either absolute or relative to the current directory.
-                          A cli archive is a zip archive containing script(s) as well as artifacts or applications 
-                          to deploy. 
-                          To be recognized as a cli archive, the extension of the archive file should be '.cli'.
-                          The undeploy command will execute the script given by the --script argument.                          
+ --path           - optional, points to a cli archive. The path can be either
+                    absolute or relative to the current directory. A cli archive
+                    is a zip archive containing script(s) as well as artifacts
+                    or applications to deploy. To be recognized as a cli
+                    archive, the extension of the archive file should be '.cli'.
+                    The undeploy command will execute the script given by the
+                    --script argument.                          
                           
- --script               - optional, can appear only if the file_path points a cli archive.
-                          The value is the name of the script contained in a cli archive to execute.
-                          If not specified, defaults to 'undeploy.scr'. 
-                          All paths in the scripts are relative to the root directory in the cli archive. 
-                          The script is executed as a batch.
+ --script         - optional, can appear only if the file_path points a cli
+                    archive. The value is the name of the script contained in a
+                    cli archive to execute. If not specified, defaults to
+                    'undeploy.scr'. All paths in the scripts are relative to the
+                    root directory in the cli archive. The script is executed as
+                    a batch.

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -356,4 +356,14 @@ public class MockCommandContext implements CommandContext {
     public void setSilent(boolean silent) {
         this.silent = silent;
     }
+
+    @Override
+    public int getTerminalWidth() {
+        return -1;
+    }
+
+    @Override
+    public int getTerminalHeight() {
+        return -1;
+    }
 }


### PR DESCRIPTION
The static help files have been re-formatted to 80 characters lines, as requested in the issue. But this is not a proper fix yet, the actual terminal with should be taken into account.

The generated help content for the generic commands is now based on the current terminal width.

Thanks,
Alexey
