### PR TITLE
AS7-6436 reverse order of ServerSetupTask.tearDown calls

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ServerSetupObserver.java
@@ -127,8 +127,8 @@ public class ServerSetupObserver {
             if (container.getValue() == 0) {
                 if (active.containsKey(container.getKey())) {
                     ManagementClient client = active.get(container.getKey());
-                    for (final ServerSetupTask instance : current) {
-                        instance.tearDown(client, container.getKey());
+                    for (int i = current.size() - 1; i >= 0; i--) {
+                        current.get(i).tearDown(client, container.getKey());
                     }
                     active.remove(container.getKey());
                     it.remove();


### PR DESCRIPTION
ServerSetupTask's tearDown methods should be called in reverse order (compared to setup) to avoid service dependencies problems.
