### PR TITLE
Add XML declarations to schemas

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-cmp_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cmp_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-cmp_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cmp_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-configadmin_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-configadmin_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ee_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ee_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ee_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ee_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_3.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_1_4.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jaxr_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jaxr_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:jaxr:1.0"
            xmlns="urn:jboss:domain:jaxr:1.0"

--- a/build/src/main/resources/docs/schema/jboss-as-jaxr_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jaxr_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:jaxr:1.1"
            xmlns="urn:jboss:domain:jaxr:1.1"

--- a/build/src/main/resources/docs/schema/jboss-as-jaxrs_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jaxrs_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jdr_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jdr_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jmx_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jmx_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jmx_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jmx_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jmx_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jmx_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jpa_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jpa_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jpa_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jpa_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jsf_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jsf_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-jsr77_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jsr77_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-mail_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-mail_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:1.0"
            targetNamespace="urn:jboss:domain:mail:1.0"

--- a/build/src/main/resources/docs/schema/jboss-as-mail_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-mail_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:1.1"
            targetNamespace="urn:jboss:domain:mail:1.1"

--- a/build/src/main/resources/docs/schema/jboss-as-messaging-deployment_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging-deployment_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_3.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-naming_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-naming_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-naming_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-naming_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_1_3.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-osgi_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-osgi_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-osgi_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-osgi_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-osgi_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-osgi_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-pojo_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-pojo_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-remoting_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-remoting_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-remoting_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-remoting_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-sar_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-sar_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-threads_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-threads_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-threads_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-threads_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-txn_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-txn_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-txn_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-txn_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-txn_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-txn_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-txn_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-txn_1_3.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-as-weld_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-weld_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_1.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_2.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-jpa_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-jpa_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss-xts.xsd
+++ b/build/src/main/resources/docs/schema/jboss-xts.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/build/src/main/resources/docs/schema/jboss_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/ejb3/src/main/resources/jboss-ejb-iiop_1_0.xsd
+++ b/ejb3/src/main/resources/jboss-ejb-iiop_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/ejb3/src/main/resources/jboss-ejb-security-role_1_0.xsd
+++ b/ejb3/src/main/resources/jboss-ejb-security-role_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/ejb3/src/main/resources/jboss-ejb-security_1_0.xsd
+++ b/ejb3/src/main/resources/jboss-ejb-security_1_0.xsd
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors


### PR DESCRIPTION
this adds XML declarations (<?xml version="1.0" encoding="UTF-8"?>) to JBoss's *.xsd files. 

(my motivation: I use Chrome to browse XML, but Chrome won't recognize XML files without the XML declaration.)
