### PR TITLE
resource transformation

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JSFSubsystemTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/JSFSubsystemTransformers.java
@@ -67,7 +67,7 @@ class JSFSubsystemTransformers {
                 if (model.hasDefined(SLOT_ATTRIBUTE_NAME)) {
                     ModelNode slot = model.get(SLOT_ATTRIBUTE_NAME);
                     if (!SLOT_DEFAULT_VALUE.equals(slot.asString())) {
-                        context.getLogger().logAttributeWarning(address, SLOT_ATTRIBUTE_NAME, MESSAGES.invalidJSFSlotValue(slot.asString()));
+                        context.getLogger().logAttributeWarning(address, MESSAGES.invalidJSFSlotValue(slot.asString()), SLOT_ATTRIBUTE_NAME);
                     }
                 }
                 Set<String> attributes = new HashSet<String>();

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -68,10 +68,10 @@ public class MessagingTransformers {
         final ResourceTransformationDescriptionBuilder subsystemRoot = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
 
         // discard JMS bridge resources added in 1.2.0
-        subsystemRoot.discardChildResource(JMSBridgeDefinition.PATH);
+        subsystemRoot.rejectChildResource(JMSBridgeDefinition.PATH);
         // discard runtime resources
-        subsystemRoot.discardChildResource(CoreAddressDefinition.PATH);
-        subsystemRoot.discardChildResource(PathElement.pathElement(RUNTIME_QUEUE));
+        subsystemRoot.rejectChildResource(CoreAddressDefinition.PATH);
+        subsystemRoot.rejectChildResource(PathElement.pathElement(RUNTIME_QUEUE));
 
         ResourceTransformationDescriptionBuilder hornetqServer = subsystemRoot.addChildResource(PathElement.pathElement(HORNETQ_SERVER))
                 .getAttributeBuilder()

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem13TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem13TestCase.java
@@ -302,7 +302,7 @@ public class MessagingSubsystem13TestCase extends AbstractSubsystemBaseTest {
                                 new RejectExpressionsConfig(JMSTopicDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
                         .addFailedAttribute(
                                 subsystemAddress.append(JMSBridgeDefinition.PATH),
-                                FailedOperationTransformationConfig.DISCARDED_RESOURCE));
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
 

--- a/web/src/main/java/org/jboss/as/web/WebExtension.java
+++ b/web/src/main/java/org/jboss/as/web/WebExtension.java
@@ -90,7 +90,7 @@ public class WebExtension implements Extension {
 
     protected static final PathElement REWRITECOND_PATH = PathElement.pathElement(Constants.CONDITION);
 
-    protected static final PathElement VALVE_PATH = PathElement.pathElement(Constants.VALVE);
+    public static final PathElement VALVE_PATH = PathElement.pathElement(Constants.VALVE);
 
     protected static final PathElement PARAM = PathElement.pathElement(Constants.PARAM);
 
@@ -186,7 +186,7 @@ public class WebExtension implements Extension {
         final ResourceTransformationDescriptionBuilder subsystemRoot = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
 
         // Discard valve
-        subsystemRoot.discardChildResource(VALVE_PATH);
+        subsystemRoot.rejectChildResource(VALVE_PATH);
 
         // Reject expressions for configuration
         subsystemRoot.addChildResource(JSP_CONFIGURATION_PATH).getAttributeBuilder()

--- a/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
+++ b/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
@@ -34,6 +34,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.model.test.FailedOperationTransformationConfig.REJECTED_RESOURCE;
 import static org.jboss.as.web.Constants.ACCESS_LOG;
 import static org.jboss.as.web.Constants.CONFIGURATION;
 import static org.jboss.as.web.Constants.CONNECTOR;
@@ -44,23 +45,18 @@ import static org.jboss.as.web.Constants.SSL;
 import static org.jboss.as.web.Constants.SSO;
 import static org.jboss.as.web.Constants.VIRTUAL_SERVER;
 import static org.jboss.as.web.WebExtension.SUBSYSTEM_NAME;
+import static org.jboss.as.web.WebExtension.VALVE_PATH;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import junit.framework.Assert;
 
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
@@ -175,6 +171,8 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, xmlOps,
                 new FailedOperationTransformationConfig()
+                        // valve
+                        .addFailedAttribute(subsystem.append(VALVE_PATH), REJECTED_RESOURCE)
                         // configuration=container
                         .addFailedAttribute(subsystem.append(PathElement.pathElement("configuration", "container")),
                                 new FailedOperationTransformationConfig.RejectExpressionsConfig("welcome-file"))


### PR DESCRIPTION
- use rejectChildResource instead of discardChildResource for messaging & web subsystems
- fix logAttributeWarning() arguments ordering
