### PR TITLE
Reject logging profile child resources instead of discarding them

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
@@ -147,8 +147,8 @@ class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, QUEUE_LENGTH, OVERFLOW_ACTION)
                 .end();
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(ASYNC_HANDLER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(ASYNC_HANDLER_PATH);
 
         return registerTransformers(child);
     }

--- a/logging/src/main/java/org/jboss/as/logging/ConsoleHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/ConsoleHandlerResourceDefinition.java
@@ -74,8 +74,8 @@ class ConsoleHandlerResourceDefinition extends AbstractHandlerDefinition {
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, TARGET)
                 .end();
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(CONSOLE_HANDLER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(CONSOLE_HANDLER_PATH);
 
         return registerTransformers(child);
     }

--- a/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
@@ -99,8 +99,8 @@ class CustomHandlerResourceDefinition extends AbstractHandlerDefinition {
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, PROPERTIES)
                 .end();
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(CUSTOM_HANDLE_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(CUSTOM_HANDLE_PATH);
 
         return registerTransformers(child);
     }

--- a/logging/src/main/java/org/jboss/as/logging/FileHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/FileHandlerResourceDefinition.java
@@ -65,8 +65,8 @@ class FileHandlerResourceDefinition extends AbstractFileHandlerDefinition {
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE)
                 .end();
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(FILE_HANDLER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(FILE_HANDLER_PATH);
 
         return registerTransformers(child);
     }

--- a/logging/src/main/java/org/jboss/as/logging/LoggerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggerResourceDefinition.java
@@ -186,8 +186,8 @@ public class LoggerResourceDefinition extends SimpleResourceDefinition {
                         // Set the custom resource transformer
                 .setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY, FILTER_SPEC));
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(LOGGER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(LOGGER_PATH);
 
         return child;
     }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -121,8 +121,8 @@ public class LoggingExtension implements Extension {
 
         // Create the transformer builder
         final ResourceTransformationDescriptionBuilder subsystemBuilder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        // Add discard before add the logging-profile child resource builder
-        subsystemBuilder.discardChildResource(LOGGING_PROFILE_PATH);
+        // Add reject before add the logging-profile child resource builder
+        subsystemBuilder.rejectChildResource(LOGGING_PROFILE_PATH);
         ResourceTransformationDescriptionBuilder loggingProfileBuilder = subsystemBuilder.addChildResource(LOGGING_PROFILE_PATH);
 
         // Add resource transformers to the subsystem

--- a/logging/src/main/java/org/jboss/as/logging/PeriodicHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PeriodicHandlerResourceDefinition.java
@@ -73,8 +73,8 @@ class PeriodicHandlerResourceDefinition extends AbstractFileHandlerDefinition {
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, SUFFIX)
                 .end();
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(PERIODIC_HANDLER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(PERIODIC_HANDLER_PATH);
 
         return registerTransformers(child);
     }

--- a/logging/src/main/java/org/jboss/as/logging/RootLoggerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/RootLoggerResourceDefinition.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.logging.LoggingOperations.ReadFilterOperationStepHandler;
@@ -183,8 +182,8 @@ public class RootLoggerResourceDefinition extends SimpleResourceDefinition {
                         // Set the custom resource transformer
                 .setCustomResourceTransformer(new LoggingResourceTransformer(NAME, FILTER_SPEC));
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(ROOT_LOGGER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(ROOT_LOGGER_PATH);
 
         return child;
     }

--- a/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
@@ -87,8 +87,8 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, MAX_BACKUP_INDEX, ROTATE_SIZE)
                 .end();
 
-        // Discard logging profile resources
-        loggingProfileBuilder.discardChildResource(SIZE_ROTATING_HANDLER_PATH);
+        // Reject logging profile resources
+        loggingProfileBuilder.rejectChildResource(SIZE_ROTATING_HANDLER_PATH);
 
         return registerTransformers(child);
     }


### PR DESCRIPTION
Use the new `ResourceTransformationDescriptionBuilder.rejectChildResource()` instead of the discard option.
