### PR TITLE
[AS7-6455] Attribute cluster-password can't be set using CLI

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -134,6 +134,7 @@ public interface CommonAttributes {
             .setDefaultValue(new ModelNode(HornetQDefaultConfiguration.DEFAULT_CLUSTER_PASSWORD))
             .setAllowNull(true)
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     SimpleAttributeDefinition CLUSTER_USER = create("cluster-user", ModelType.STRING)


### PR DESCRIPTION
during the expression refactoring, the cluster-password erroneously lost
its restartAllServices flag
