### PR TITLE
fix hanging jdr.sh script

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
@@ -96,5 +96,6 @@ public class CommandLineMain {
         System.out.println("JDR started: " + response.getStartTime().toString());
         System.out.println("JDR ended: " + response.getEndTime().toString());
         System.out.println("JDR location: " + response.getLocation());
+        System.exit(0);
     }
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -62,6 +62,7 @@ public class JdrRunner implements JdrReportCollector {
             this.env.setClient(ctx.getModelControllerClient());
         }
         catch (Exception e) {
+            ctx.terminateSession();
             // the server isn't available, carry on
         }
     }
@@ -120,6 +121,7 @@ public class JdrRunner implements JdrReportCollector {
                 PrintWriter pw = new PrintWriter(new StringWriter());
                 t.printStackTrace(pw);
                 skips.append(pw.toString());
+                pw.close();
             }
         }
 


### PR DESCRIPTION
Calling System.exit() at the end of main() for jdr.sh execution
to address this bug:

https://bugzilla.redhat.com/show_bug.cgi?id=906287

Also adding a little resource cleanup.
