### PR TITLE
AS7-6479 Upgrade JGroups to 3.2.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <version.org.jboss.xnio>3.0.7.GA</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
-        <version.org.jgroups>3.2.6.Final</version.org.jgroups>
+        <version.org.jgroups>3.2.7.Final</version.org.jgroups>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.8.5</version.org.mockito>
         <version.org.opensaml.opensaml>2.5.1-1</version.org.opensaml.opensaml>


### PR DESCRIPTION
AS7-6467 Default jgroups thread naming logic lost when default thread factory is overridden.
