### PR TITLE
[AS7-testsuite] Change order of maven profiles to make -Dtest= option work with clustering tests.

### DIFF
--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -273,44 +273,6 @@
             </build>
         </profile>
 
-        <!--
-           Disable Surefire and AntRun executions when using -Dtest=... which would cause it running twice.
-        -->
-        <profile>
-            <id>ts.clust.prevent-2nd-run-on-Dtest.profile</id>
-            <activation><property><name>test</name></property></activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>ts.config-as.clust.jdbc-store</id> 
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>ts.surefire.clust.jdbc-store</id>  
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>ts.surefire.clust.single-node</id> 
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        
-
         <profile>
             <id>ts.clust.jdbc-cachestore.profile</id>
             <activation><property><name>!ts.noClustering</name></property></activation>
@@ -383,6 +345,41 @@
             </build>
         </profile>
 
+        <!--
+            Disable Surefire and AntRun executions when using -Dtest=... which would cause it running twice.
+         -->
+         <profile>
+             <id>ts.clust.prevent-2nd-run-on-Dtest.profile</id>
+             <activation><property><name>test</name></property></activation>
+             <build>
+                 <plugins>
+                     <plugin>
+                         <groupId>org.apache.maven.plugins</groupId>
+                         <artifactId>maven-antrun-plugin</artifactId>
+                         <executions>
+                             <execution>
+                                 <id>ts.config-as.clust.jdbc-store</id>
+                                 <phase>none</phase>
+                             </execution>
+                         </executions>
+                     </plugin>
+                     <plugin>
+                         <groupId>org.apache.maven.plugins</groupId>
+                         <artifactId>maven-surefire-plugin</artifactId>
+                         <executions>
+                             <execution>
+                                 <id>ts.surefire.clust.jdbc-store</id>
+                                 <phase>none</phase>
+                             </execution>
+                             <execution>
+                                 <id>ts.surefire.clust.single-node</id>
+                                 <phase>none</phase>
+                             </execution>
+                         </executions>
+                     </plugin>
+                 </plugins>
+             </build>
+         </profile>
 
     </profiles>
 </project>


### PR DESCRIPTION
Profiles to enable use of -Dtest= in the clustering testsuite were getting executed in the wrong order, resulting in, for example, multi-node tests being executed against a single node configuration.
When two profiles are defined and affect the same pom setting, order is important. This change just swaps the order in which the profiles are defined to fix the problem.
