### PR TITLE
[AS7-6478] Upgrade netty to 3.6.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <version.commons-pool>1.6</version.commons-pool>
         <version.dom4j>1.6.1</version.dom4j>
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
-        <version.io.netty>3.4.5.Final</version.io.netty>
+        <version.io.netty>3.6.2.Final</version.io.netty>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>1.0-SP4</version.javax.enterprise>
         <version.javax.faces>1.2_15-jbossorg-2</version.javax.faces>


### PR DESCRIPTION
Please merge this netty version update. It's because HornetQ was upgraded to 2.3.0.CR1 (with dependency on netty 3.6.2.Final), see https://issues.jboss.org/browse/AS7-6478.
