### PR TITLE
[AS7-5737] When LDAP client searches for object in DIT containing

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -43,5 +43,6 @@
         <module name="org.jboss.remote-naming"/>
         <module name="org.jboss.remoting3"/>
         <module name="org.jboss.threads"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>

--- a/naming/src/main/java/org/jboss/as/naming/UrlReferenceObjectFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/UrlReferenceObjectFactory.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.naming;
+
+import java.net.URI;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NamingException;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.spi.ObjectFactory;
+
+/**
+ * @author pskopek
+ *
+ */
+public class UrlReferenceObjectFactory implements ObjectFactory {
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see javax.naming.spi.ObjectFactory#getObjectInstance(java.lang.Object, javax.naming.Name, javax.naming.Context,
+     * java.util.Hashtable)
+     */
+    @Override
+    public Object getObjectInstance(Object obj, Name name, Context nameCtx, Hashtable<?, ?> environment) throws Exception {
+        Reference reference = (Reference) obj;
+        RefAddr ra = reference.get("URL");
+        String referralUrl = (String) ra.getContent();
+        String scheme = new URI(referralUrl).getScheme();
+        // environment.remove(Context.URL_PKG_PREFIXES);
+        return getURLObject(scheme, referralUrl, name, nameCtx, environment);
+    }
+
+    private Object getURLObject(String scheme, String referralUrl, Name name, Context nameCtx, Hashtable<?, ?> environment)
+            throws NamingException {
+        return com.sun.jndi.ldap.LdapCtxFactory.getLdapCtxInstance(referralUrl, environment);
+    }
+}

--- a/naming/src/main/java/org/jboss/as/naming/context/ObjectFactoryBuilder.java
+++ b/naming/src/main/java/org/jboss/as/naming/context/ObjectFactoryBuilder.java
@@ -35,6 +35,7 @@ import javax.naming.spi.DirObjectFactory;
 import javax.naming.spi.ObjectFactory;
 
 import org.jboss.as.naming.ServiceAwareObjectFactory;
+import org.jboss.as.naming.UrlReferenceObjectFactory;
 import org.jboss.as.server.CurrentServiceContainer;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceContainer;
@@ -150,6 +151,12 @@ public class ObjectFactoryBuilder implements javax.naming.spi.ObjectFactoryBuild
         if (reference instanceof ModularReference) {
             return factoryFromModularReference(ModularReference.class.cast(reference), environment);
         }
+        if (reference != null && reference.get("URL") != null) {
+            ObjectFactory referralObjectFactory = factoryFromUrlReference(reference, environment);
+            if (referralObjectFactory != null) {
+                return referralObjectFactory;
+            }
+        }
         return factoryFromReference(reference, SecurityActions.getContextClassLoader(), environment);
     }
 
@@ -172,6 +179,9 @@ public class ObjectFactoryBuilder implements javax.naming.spi.ObjectFactoryBuild
         }
     }
 
+    private ObjectFactory factoryFromUrlReference(final Reference reference, final Hashtable<?, ?> environment) throws Exception {
+        return new UrlReferenceObjectFactory();
+    }
 
     private static ServiceContainer currentServiceContainer() {
         return AccessController.doPrivileged(new PrivilegedAction<ServiceContainer>() {


### PR DESCRIPTION
referrals, referral object is not resolved. This change creates new
UrlRefereOjectFactory which fixes the problem.
