### PR TITLE
[AS7-6108] Fix to disable incorrectly allowing empty passwords when authenticating against LDAP.  

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_1_4.xsd
@@ -597,6 +597,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="allow-empty-passwords" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should users be allowed to supply an empty password?  Some LDAP servers will
+                    allow an anonymous bind so an empty password could appear as a successful authentication
+                    even though no password was sent to verify.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -39,6 +39,7 @@ public class ModelDescriptionConstants {
     public static final String ADMIN_ONLY = "admin-only";
     public static final String ADVANCED_FILTER = "advanced-filter";
     public static final String ALLOWED = "allowed";
+    public static final String ALLOW_EMPTY_PASSWORDS = "allow-empty-passwords";
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     public static final String ALTERNATIVES = "alternatives";
     public static final String ANY = "any";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -40,6 +40,7 @@ public enum Attribute {
 
     // domain attributes in alpha order
     ALIAS("alias"),
+    ALLOW_EMPTY_PASSWORDS("allow-empty-passwords"),
     ALLOWED_USERS("allowed-users"),
     ATTRIBUTE("attribute"),
     AUTO_START("auto-start"),

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -58,6 +58,7 @@ core.management.security-realm.authentication.ldap.connection=The name of the co
 core.management.security-realm.authentication.ldap.base-dn=The base distinguished name to commence the search for the user.
 core.management.security-realm.authentication.ldap.recursive=Whether the search should be recursive.
 core.management.security-realm.authentication.ldap.user-dn=The name of the attribute which is the user's distinguished name.
+core.management.security-realm.authentication.ldap.allow-empty-passwords=Should empty passwords be accepted from the user being authenticated.
 core.management.security-realm.authentication.ldap.username-attribute=The name of the attribute to search for the user. This filter will then perform a simple search where the username entered by the user matches the attribute specified here.
 core.management.security-realm.authentication.ldap.advanced-filter=The fully defined filter to be used to search for the user based on their entered user ID. The filter should contain a variable in the form {0} - this will be replaced with the username supplied by the user.
 core.management.security-realm.authentication.local=Configuration of the local authentication mechanism.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
@@ -73,6 +73,12 @@ public class LdapAuthenticationResourceDefinition extends SimpleResourceDefiniti
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
+    public static final SimpleAttributeDefinition ALLOW_EMPTY_PASSWORDS = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ALLOW_EMPTY_PASSWORDS, ModelType.BOOLEAN, true)
+            .setDefaultValue(new ModelNode(false))
+            .setAllowExpression(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
     public static final SimpleAttributeDefinition USERNAME_FILTER = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.USERNAME_ATTRIBUTE, ModelType.STRING, false)
             .setXmlName("attribute")
             .setAlternatives(ModelDescriptionConstants.ADVANCED_FILTER)
@@ -91,7 +97,7 @@ public class LdapAuthenticationResourceDefinition extends SimpleResourceDefiniti
             .build();
 
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {
-        CONNECTION, BASE_DN, RECURSIVE, USER_DN, USERNAME_FILTER, ADVANCED_FILTER
+        CONNECTION, BASE_DN, RECURSIVE, USER_DN, ALLOW_EMPTY_PASSWORDS, USERNAME_FILTER, ADVANCED_FILTER
     };
 
     public LdapAuthenticationResourceDefinition() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -243,8 +243,9 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
         node = LdapAuthenticationResourceDefinition.ADVANCED_FILTER.resolveModelAttribute(context, ldap);
         final String advancedFilter = node.isDefined() ? node.asString() : null;
         final boolean recursive = LdapAuthenticationResourceDefinition.RECURSIVE.resolveModelAttribute(context, ldap).asBoolean();
+        final boolean allowEmptyPasswords = LdapAuthenticationResourceDefinition.ALLOW_EMPTY_PASSWORDS.resolveModelAttribute(context, ldap).asBoolean();
         final String userDn = LdapAuthenticationResourceDefinition.USER_DN.resolveModelAttribute(context, ldap).asString();
-        UserLdapCallbackHandler ldapCallbackHandler = new UserLdapCallbackHandler(baseDn, usernameAttribute, advancedFilter, recursive, userDn);
+        UserLdapCallbackHandler ldapCallbackHandler = new UserLdapCallbackHandler(baseDn, usernameAttribute, advancedFilter, recursive, userDn, allowEmptyPasswords);
 
         ServiceBuilder<?> ldapBuilder = serviceTarget.addService(ldapServiceName, ldapCallbackHandler);
         String connectionManager = LdapAuthenticationResourceDefinition.CONNECTION.resolveModelAttribute(context, ldap).asString();


### PR DESCRIPTION
By default disable the acceptance of empty passwords from remote users attempting to authenticate.

Also added a new option 'allow-empty-passwords' on the LDAP authentication definition so that users that do have a valid use for empty passwords can reverse the change.
