### PR TITLE
[AS7-6182] Upgrade slf4j and slf4j components to work with 1.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,8 +197,8 @@
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.0.0</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.shrinkwrap.resolver>1.0.0-beta-5</version.org.jboss.shrinkwrap.resolver>
-        <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.1.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
-        <version.org.jboss.logging.jul-to-slf4j-stub>1.0.0.Final</version.org.jboss.logging.jul-to-slf4j-stub>
+        <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.2.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
+        <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.1_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>
@@ -252,7 +252,7 @@
         <version.org.powermock>1.4.11</version.org.powermock>
         <version.org.projectodd.stilts>0.1.26</version.org.projectodd.stilts>
         <version.org.scannotation>1.0.2</version.org.scannotation>
-        <version.org.slf4j>1.6.1</version.org.slf4j>
+        <version.org.slf4j>1.7.2</version.org.slf4j>
         <version.org.sonatype.aether>1.13.1</version.org.sonatype.aether>
         <version.org.testng>6.1.1</version.org.testng>
         <version.org.yaml.snakeyaml>1.8</version.org.yaml.snakeyaml>


### PR DESCRIPTION
Upgrades slf4j to 1.7.2. Also upgrades JBoss slf4j logging components to be compliant with the upgrade.
