### PR TITLE
AS7-5211 RemoteStatelessFailoverTestCase intermittently fails

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterHttpClientUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterHttpClientUtil.java
@@ -24,10 +24,17 @@ package org.jboss.as.test.clustering;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
 import javax.servlet.http.HttpServletResponse;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.junit.Assert;
 
 /**
  * Helper class to start and stop container including a deployment.
@@ -36,6 +43,16 @@ import org.apache.http.client.methods.HttpGet;
  * @version April 2012
  */
 public final class ClusterHttpClientUtil {
+
+    public static void establishView(final HttpClient client, final URL baseURL, final String cluster, final String... members) throws URISyntaxException, IOException {
+        URI uri = ViewChangeListenerServlet.createURI(baseURL, cluster, members);
+        HttpResponse response = client.execute(new HttpGet(uri));
+        try {
+            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+        } finally {
+            HttpClientUtils.closeQuietly(response);
+        }
+    }
 
     /**
      * Tries a get on the provided client with default GRACE_TIME_TO_MEMBERSHIP_CHANGE.

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
@@ -66,8 +66,6 @@ public class ClusteringTestConstants {
     /**
      * Timeouts.
      */
-    public static final long GRACE_TIME_TO_MEMBERSHIP_CHANGE = 5000;
-    public static final int GRACE_TIME = 20000;
     public static final int GRACE_TIME_TO_REPLICATE = 3000;
 
     public static final int CLUSTER_ESTABLISHMENT_WAIT_MS = TimeoutUtil.adjust(100);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBDirectory.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/EJBDirectory.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.clustering;
 
+import javax.ejb.EJBHome;
+import javax.ejb.SessionBean;
 import javax.naming.NamingException;
 
 /**
@@ -29,9 +31,17 @@ import javax.naming.NamingException;
  * @author Paul Ferraro
  */
 public interface EJBDirectory {
+    <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException;
     <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
 
+    <T> T lookupStateless(String beanName, Class<T> beanInterface) throws NamingException;
     <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
 
+    <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws NamingException;
     <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+
+    <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) throws NamingException;
+    <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws NamingException;
+
+    void close() throws NamingException;
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/RemoteEJBDirectory.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/RemoteEJBDirectory.java
@@ -44,7 +44,7 @@ public class RemoteEJBDirectory extends AbstractEJBDirectory {
         this.module = module;
     }
 
-    protected <T> String createJndiName(Class<? extends T> beanClass, Class<T> beanInterface, Type type) {
-        return String.format("ejb:/%s/%s!%s%s", this.module, beanClass.getSimpleName(), beanInterface.getName(), (type == Type.STATEFUL) ? "?stateful" : "");
+    protected <T> String createJndiName(String beanName, Class<T> beanInterface, Type type) {
+        return String.format("ejb:/%s/%s!%s%s", this.module, beanName, beanInterface.getName(), (type == Type.STATEFUL) ? "?stateful" : "");
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListener.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListener.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2013, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,9 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.as.test.clustering;
 
-import java.util.Properties;
 
-import javax.naming.NamingException;
-
-/**
- * @author Paul Ferraro
- *
- */
-public class LocalEJBDirectory extends AbstractEJBDirectory {
-    private final String module;
-    
-    public LocalEJBDirectory(String module) throws NamingException {
-        super(new Properties());
-        this.module = module;
-    }
-
-    protected <T> String createJndiName(String beanName, Class<T> beanInterface, Type type) {
-        return String.format("java:app/%s/%s!%s", this.module, beanName, beanInterface.getName());
-    }
+public interface ViewChangeListener {
+    void establishView(String cluster, String... members) throws InterruptedException;
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerBean.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.StartException;
+
+@Stateless
+@Remote(ViewChangeListener.class)
+@Listener(sync = false)
+public class ViewChangeListenerBean implements ViewChangeListener {
+    public static final long TIMEOUT = 15000;
+
+    @Override
+    public void establishView(String cluster, String... names) throws InterruptedException {
+        Set<String> expectedMembers = new TreeSet<String>();
+        if (names != null) {
+            for (String name: names) {
+                expectedMembers.add(name + "/" + cluster);
+            }
+        }
+        ServiceRegistry registry = ServiceContainerHelper.getCurrentServiceContainer();
+        ServiceController<?> controller = registry.getService(ServiceName.JBOSS.append("infinispan", cluster));
+        if (controller == null) {
+            throw new IllegalStateException(String.format("Failed to locate service for cluster '%s'", cluster));
+        }
+        try {
+            EmbeddedCacheManager manager = ServiceContainerHelper.getValue(controller, EmbeddedCacheManager.class);
+            manager.addListener(this);
+            try
+            {
+                long start = System.currentTimeMillis();
+                long now = start;
+                long timeout = start + TIMEOUT;
+                synchronized (this) {
+                    Set<String> members = this.getMembers(manager);
+                    while (!expectedMembers.equals(members)) {
+                        System.out.println(String.format("%s != %s, waiting for a view change event...", expectedMembers, members));
+                        this.wait(timeout - now);
+                        now = System.currentTimeMillis();
+                        if (now >= timeout) {
+                            throw new InterruptedException(String.format("Cluster '%s' failed to establish view %s within %d ms.  Current view is: %s", cluster, expectedMembers, TIMEOUT, members));
+                        }
+                        members = this.getMembers(manager);
+                    }
+                    System.out.println(String.format("Cluster '%s' successfully established view %s within %d ms.", cluster, expectedMembers, now - start));
+                }
+            } finally {
+                manager.removeListener(this);
+            }
+        } catch (StartException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Set<String> getMembers(EmbeddedCacheManager manager) {
+        Set<String> members = new TreeSet<String>();
+        for (Address address: manager.getMembers()) {
+            members.add(address.toString());
+        }
+        return members;
+    }
+
+    @ViewChanged
+    public void viewChanged(ViewChangedEvent event) {
+        synchronized (this) {
+            this.notify();
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerServlet.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.ejb.EJB;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Utility servlet that waits until the specified cluster establishes a specific cluster membership.
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { ViewChangeListenerServlet.SERVLET_PATH })
+public class ViewChangeListenerServlet extends HttpServlet {
+    private static final long serialVersionUID = -4382952409558738642L;
+    private static final String SERVLET_NAME = "membership";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    public static final String CLUSTER = "cluster";
+    public static final String MEMBERS = "members";
+
+    @EJB
+    private ViewChangeListener listener;
+
+    public static URI createURI(URL baseURL, String cluster, String... members) throws URISyntaxException {
+        StringBuilder builder = new StringBuilder(baseURL.toURI().resolve(SERVLET_NAME).toString());
+        builder.append('?').append(CLUSTER).append('=').append(cluster);
+        for (String member: members) {
+            builder.append('&').append(MEMBERS).append('=').append(member);
+        }
+        return URI.create(builder.toString());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+
+        String cluster = req.getParameter(CLUSTER);
+        if (cluster == null) {
+            throw new ServletException(String.format("No '%s' parameter specified", CLUSTER));
+        }
+        String[] members = req.getParameterValues(MEMBERS);
+        try {
+            this.listener.establishView(cluster, members);
+        } catch (InterruptedException e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/passivation/ClusterPassivationTestCase.java
@@ -22,18 +22,32 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateful.passivation;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_LOOP_COUNT;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_WAIT_MS;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_NAME;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.HTTP_REQUEST_WAIT_TIME_S;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.WAIT_FOR_PASSIVATION_MS;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import javax.naming.NamingException;
 
 import junit.framework.Assert;
 
-import org.jboss.arquillian.container.test.api.*;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -54,12 +68,11 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 
 /**
  * Clustering ejb passivation simple test.
@@ -81,6 +94,11 @@ public class ClusterPassivationTestCase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         context = new RemoteEJBDirectory(ARCHIVE_NAME);
+    }
+
+    @AfterClass
+    public static void destroy() throws NamingException {
+        context.close();
     }
 
     @ArquillianResource

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/dd/RemoteEJBClientDDBasedSFSBFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/dd/RemoteEJBClientDDBasedSFSBFailoverTestCase.java
@@ -22,12 +22,21 @@
 
 package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover.dd;
 
-import org.jboss.arquillian.container.test.api.*;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
+
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeNameGetter;
@@ -40,6 +49,7 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -91,6 +101,11 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         context = new RemoteEJBDirectory(MODULE_NAME);
+    }
+
+    @AfterClass
+    public static void destroy() throws NamingException {
+        context.close();
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServiceServlet.java
@@ -22,6 +22,9 @@
 package org.jboss.as.test.clustering.cluster.singleton.service;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -31,9 +34,15 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.jboss.as.server.CurrentServiceContainer;
 
-@WebServlet(urlPatterns = { "/service" })
+@WebServlet(urlPatterns = { MyServiceServlet.SERVLET_PATH })
 public class MyServiceServlet extends HttpServlet {
     private static final long serialVersionUID = -592774116315946908L;
+    private static final String SERVLET_NAME = "service";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    
+    public static URI createURI(URL baseURL) throws URISyntaxException {
+        return baseURL.toURI().resolve(SERVLET_NAME);
+    }
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -21,7 +21,15 @@
  */
 package org.jboss.as.test.clustering.cluster.web;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
+
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -29,7 +37,9 @@ import java.util.concurrent.ExecutionException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -38,18 +48,12 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusterHttpClientUtil;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
-import org.jboss.as.test.http.util.HttpClientUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.GRACE_TIME_TO_MEMBERSHIP_CHANGE;
 
 /**
  * Test that failover and undeploy works.
@@ -98,72 +102,97 @@ public abstract class ClusteredWebFailoverAbstractCase {
      *
      * @throws IOException
      * @throws InterruptedException
+     * @throws URISyntaxException 
      */
     @Test
     @InSequence(2)
     public void testGracefulSimpleFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException, InterruptedException, ExecutionException {
+            throws IOException, InterruptedException, ExecutionException, URISyntaxException {
 
-        DefaultHttpClient client = HttpClientUtils.relaxedCookieHttpClient();
+        DefaultHttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
 
         String url1 = baseURL1.toString() + "simple";
         String url2 = baseURL2.toString() + "simple";
 
         try {
-            HttpResponse response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            this.establishView(client, baseURL1, NODE_1, NODE_2);
+            
+            HttpResponse response = client.execute(new HttpGet(url1));
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Gracefully shutdown the 1st container.
             controller.stop(CONTAINER_1);
 
+            this.establishView(client, baseURL2, NODE_2);
+            
             // Now check on the 2nd server
 
             // Note that this DOES rely on the fact that both servers are running on the "same" domain,
             // which is '127.0.0.0'. Otherwise you will have to spoof cookies. @Rado
 
-            response = tryGet(client, url2);
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            response = client.execute(new HttpGet(url2));
+            try {
+                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Lets do one more check.
             response = client.execute(new HttpGet(url2));
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            try {
+                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             controller.start(CONTAINER_1);
 
+            this.establishView(client, baseURL2, NODE_1, NODE_2);
+            
             // Lets wait for the cluster to update membership and tranfer state.
 
-            response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            response = client.execute(new HttpGet(url1));
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
         } finally {
-            client.getConnectionManager().shutdown();
+            HttpClientUtils.closeQuietly(client);
         }
 
         // Is would be done automatically, keep for 2nd test is added
@@ -198,70 +227,95 @@ public abstract class ClusteredWebFailoverAbstractCase {
      *
      * @throws IOException
      * @throws InterruptedException
+     * @throws URISyntaxException 
      */
     @Test
     @InSequence(4)
     public void testGracefulUndeployFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException, InterruptedException {
+            throws IOException, InterruptedException, URISyntaxException {
 
-        DefaultHttpClient client = HttpClientUtils.relaxedCookieHttpClient();
+        DefaultHttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
 
         String url1 = baseURL1.toString() + "simple";
         String url2 = baseURL2.toString() + "simple";
 
         try {
-            HttpResponse response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            this.establishView(client, baseURL1, NODE_1, NODE_2);
+            
+            HttpResponse response = client.execute(new HttpGet(url1));
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Gracefully undeploy from the 1st container.
             deployer.undeploy(DEPLOYMENT_1);
 
+            this.establishView(client, baseURL2, NODE_2);
+            
             // Now check on the 2nd server
 
             // Note that this DOES rely on the fact that both servers are running on the "same" domain,
             // which is '127.0.0.1'. Otherwise you will have to spoof cookies. @Rado
-            response = tryGet(client, url2);
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            response = client.execute(new HttpGet(url2));
+            try {
+                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Lets do one more check.
-            response = tryGet(client, url2);
-            System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            response = client.execute(new HttpGet(url2));
+            try {
+                System.out.println("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Redeploy
             deployer.deploy(DEPLOYMENT_1);
 
-            response = tryGet(client, url1);
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            this.establishView(client, baseURL2, NODE_1, NODE_2);
+            
+            response = client.execute(new HttpGet(url1));
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
 
             // Lets do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(url1));
-            System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
-            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-            Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
-            response.getEntity().getContent().close();
+            try {
+                System.out.println("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader("value").getValue()));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
         } finally {
-            client.getConnectionManager().shutdown();
+            HttpClientUtils.closeQuietly(client);
         }
 
         // Is would be done automatically, keep for when 3nd test is added
@@ -273,13 +327,7 @@ public abstract class ClusteredWebFailoverAbstractCase {
         // Assert.fail("Show me the logs please!");
     }
 
-    private HttpResponse tryGet(final DefaultHttpClient client, final String url1) throws IOException {
-        final long startTime;
-        HttpResponse response = client.execute(new HttpGet(url1));
-        startTime = System.currentTimeMillis();
-        while(response.getStatusLine().getStatusCode() != HttpServletResponse.SC_OK && startTime + GRACE_TIME_TO_MEMBERSHIP_CHANGE > System.currentTimeMillis()) {
-            response = client.execute(new HttpGet(url1));
-        }
-        return response;
+    private void establishView(HttpClient client, URL baseURL, String... members) throws URISyntaxException, IOException {
+        ClusterHttpClientUtil.establishView(client, baseURL, "web", members);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributionWebFailoverTestCase.java
@@ -23,9 +23,13 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ViewChangeListener;
+import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.ViewChangeListenerServlet;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
@@ -40,6 +44,8 @@ public class DistributionWebFailoverTestCase extends ClusteredWebFailoverAbstrac
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
+        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         System.out.println(war.toString(true));
         return war;
     }
@@ -51,6 +57,8 @@ public class DistributionWebFailoverTestCase extends ClusteredWebFailoverAbstrac
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_dist.xml", "jboss-web.xml");
+        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         System.out.println(war.toString(true));
         return war;
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -23,9 +23,13 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ViewChangeListener;
+import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.ViewChangeListenerServlet;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
@@ -44,6 +48,8 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
+        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         System.out.println(war.toString(true));
         return war;
     }
@@ -55,6 +61,8 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
+        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         System.out.println(war.toString(true));
         return war;
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationWebFailoverTestCase.java
@@ -23,9 +23,13 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ViewChangeListener;
+import org.jboss.as.test.clustering.ViewChangeListenerBean;
+import org.jboss.as.test.clustering.ViewChangeListenerServlet;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
@@ -39,6 +43,8 @@ public class ReplicationWebFailoverTestCase extends ClusteredWebFailoverAbstract
         war.addClass(SimpleServlet.class);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
+        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         System.out.println(war.toString(true));
         return war;
     }
@@ -49,6 +55,8 @@ public class ReplicationWebFailoverTestCase extends ClusteredWebFailoverAbstract
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClass(SimpleServlet.class);
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
+        war.addClasses(ViewChangeListenerServlet.class, ViewChangeListener.class, ViewChangeListenerBean.class);
+        war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         System.out.println(war.toString(true));
         return war;
     }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -22,24 +22,33 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_LOOP_COUNT;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_ESTABLISHMENT_WAIT_MS;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CLUSTER_NAME;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.WAIT_FOR_PASSIVATION_MS;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import javax.naming.InitialContext;
+
+import javax.naming.NamingException;
 
 import junit.framework.Assert;
 
-import org.jboss.arquillian.container.test.api.*;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.clustering.DMRUtil;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
+import org.jboss.as.test.clustering.EJBDirectory;
+import org.jboss.as.test.clustering.RemoteEJBDirectory;
 import org.jboss.ejb.client.ClusterContext;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
-
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 /**
  * Base class for passivation tests on EJB2 beans.
@@ -50,8 +59,18 @@ public abstract class ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestBase.class);
     public static final String ARCHIVE_NAME = "cluster-passivation-test";
     public static final String ARCHIVE_NAME_HELPER = "cluster-passivation-test-helper";
-   
-    protected static InitialContext context;
+
+    protected static EJBDirectory directory;
+
+    @BeforeClass
+    public static void beforeClass() throws NamingException {
+        directory = new RemoteEJBDirectory(ARCHIVE_NAME);
+    }
+
+    @AfterClass
+    public static void destroy() throws NamingException {
+        directory.close();
+    }
 
     // Properties pass amongst tests
     protected static ContextSelector<EJBClientContext> previousSelector;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
@@ -23,11 +23,7 @@
 package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation;
 
 import java.net.URL;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.*;
 import org.jboss.arquillian.junit.Arquillian;
@@ -42,7 +38,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,13 +53,6 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 @RunAsClient
 public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestCase.class);
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        Properties env = new Properties();
-        env.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        context = new InitialContext(env);
-    }
 
     @ArquillianResource
     private ContainerController controller;
@@ -149,8 +137,7 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
         // Setting context from .properties file to get ejb:/ remote context
         setupEJBClientContextSelector();
         
-        StatefulRemoteHome home = (StatefulRemoteHome) context.lookup("ejb:/" + ARCHIVE_NAME + "//" + StatefulBean.class.getSimpleName() + "!"
-                + StatefulRemoteHome.class.getName());
+        StatefulRemoteHome home = directory.lookupHome(StatefulBean.class, StatefulRemoteHome.class);
         StatefulRemote statefulBean = home.create();
 
         runPassivation(statefulBean, controller, deployer);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
@@ -23,11 +23,7 @@
 package org.jboss.as.test.clustering.extended.ejb2.stateful.passivation.dd;
 
 import java.net.URL;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.*;
 import org.jboss.arquillian.junit.Arquillian;
@@ -46,7 +42,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,13 +57,6 @@ import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 @RunAsClient
 public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationDDTestCase.class);
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        Properties env = new Properties();
-        env.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        context = new InitialContext(env);
-    }
 
     @ArquillianResource
     private ContainerController controller;
@@ -150,8 +138,7 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
         // Setting context from .properties file to get ejb:/ remote context
         setupEJBClientContextSelector();
         
-        StatefulRemoteHome home = (StatefulRemoteHome) context.lookup("ejb:/" + ARCHIVE_NAME + "//" + StatefulBeanDD.class.getSimpleName() + "!"
-                + StatefulRemoteHome.class.getName());
+        StatefulRemoteHome home = directory.lookupHome(StatefulBeanDD.class, StatefulRemoteHome.class);
         StatefulRemote statefulBean = home.create();
 
         runPassivation(statefulBean, controller, deployer);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -22,23 +22,26 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
 
-import java.util.Properties;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
 
-import javax.naming.Context;
-import javax.naming.InitialContext;
-
-import org.jboss.arquillian.container.test.api.*;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
 import org.jboss.as.test.clustering.NodeNameGetter;
+import org.jboss.as.test.clustering.ViewChangeListener;
+import org.jboss.as.test.clustering.ViewChangeListenerBean;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -89,14 +92,9 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClient
         jar.addClasses(CounterBaseBean.class, CounterBean.class, CounterRemote.class, CounterRemoteHome.class, CounterResult.class);
         jar.addClass(NodeNameGetter.class);
         jar.addAsManifestResource(new StringAsset("Dependencies: deployment." + ARCHIVE_NAME_SINGLE + ".jar\n"), "MANIFEST.MF");
+        jar.addClasses(ViewChangeListener.class, ViewChangeListenerBean.class);
+        jar.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         return jar;
-    }
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        Properties env = new Properties();
-        env.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        context = new InitialContext(env);
     }
     
     @Override

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -24,11 +24,6 @@ package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.dd;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
 
-import java.util.Properties;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
-
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -48,7 +43,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,13 +94,6 @@ public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBCli
         log.info(jar.toString(true));
         return jar;
     }   
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        Properties env = new Properties();
-        env.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        context = new InitialContext(env);
-    }
     
     @Ignore("JBPAPP-8726")
     @Override

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -22,14 +22,20 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateless;
 
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
+import static org.jboss.as.test.clustering.ClusteringTestConstants.NODES;
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.naming.Context;
-import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -39,21 +45,23 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
+import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.NodeNameGetter;
+import org.jboss.as.test.clustering.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.ViewChangeListener;
+import org.jboss.as.test.clustering.ViewChangeListenerBean;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-import static org.junit.Assert.assertEquals;
 
 /**
  * EJB2 stateless bean - basic cluster tests - failover and load balancing.
@@ -67,12 +75,11 @@ import static org.junit.Assert.assertEquals;
 public class RemoteStatelessFailoverTestCase {
     private static final Logger log = Logger.getLogger(RemoteStatelessFailoverTestCase.class);
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
-    private static InitialContext context;
+    private static EJBDirectory directoryAnnotation;
+    private static EJBDirectory directoryDD;
 
     private static final String ARCHIVE_NAME = "stateless-ejb2-failover-test";
     private static final String ARCHIVE_NAME_DD = "stateless-ejb2-failover-dd-test";
-    private static String jndiAnnotation;
-    private static String jndiDD;
 
     private static final Integer PORT_2 = 4547;
     private static final String HOST_2 = System.getProperty("node1");
@@ -86,9 +93,10 @@ public class RemoteStatelessFailoverTestCase {
     private static final Map<String, Boolean> started = new HashMap<String, Boolean>();
     private static final Map<String, List<String>> container2deployment = new HashMap<String, List<String>>();
     
-    static {
-        jndiAnnotation = "ejb:/" + ARCHIVE_NAME + "//" + StatelessBean.class.getSimpleName() + "!" + StatelessRemoteHome.class.getName();
-        jndiDD = "ejb:/" + ARCHIVE_NAME_DD + "//" + StatelessBean.class.getSimpleName() + "!" + StatelessRemoteHome.class.getName();
+    @BeforeClass
+    public static void init() throws NamingException {
+        directoryAnnotation = new RemoteEJBDirectory(ARCHIVE_NAME);
+        directoryDD = new RemoteEJBDirectory(ARCHIVE_NAME_DD);
 
         deployed.put(DEPLOYMENT_1, false);
         deployed.put(DEPLOYMENT_2, false);
@@ -105,6 +113,12 @@ public class RemoteStatelessFailoverTestCase {
         deployments2.add(DEPLOYMENT_2);
         deployments2.add(DEPLOYMENT_2_DD);
         container2deployment.put(CONTAINER_2, deployments2);
+    }
+
+    @AfterClass
+    public static void destroy() throws NamingException {
+        directoryAnnotation.close();
+        directoryDD.close();
     }
 
     @ArquillianResource
@@ -140,6 +154,8 @@ public class RemoteStatelessFailoverTestCase {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addClasses(StatelessBeanBase.class, StatelessBean.class, StatelessRemote.class, StatelessRemoteHome.class);
         jar.addClass(NodeNameGetter.class);
+        jar.addClasses(ViewChangeListener.class, ViewChangeListenerBean.class);
+        jar.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         log.info(jar.toString(true));
         return jar;
     }
@@ -150,66 +166,61 @@ public class RemoteStatelessFailoverTestCase {
         jar.addClass(NodeNameGetter.class);
         jar.addAsManifestResource(RemoteStatelessFailoverTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
         jar.addAsManifestResource(RemoteStatelessFailoverTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
+        jar.addClasses(ViewChangeListener.class, ViewChangeListenerBean.class);
+        jar.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         log.info(jar.toString(true));
         return jar;
     }
 
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        Properties env = new Properties();
-        env.setProperty(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
-        context = new InitialContext(env);
-    }
-    
-    @AfterClass
-    public static void tearDown() throws Exception {
-        context.close();
-    }
-
     @Test
     public void testFailoverOnStopAnnotatedBean() throws Exception {        
-        doFailover(true, jndiAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);
+        doFailover(true, directoryAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);
     }
 
     @Test
     public void testFailoverOnStopBeanSpecifiedByDescriptor() throws Exception {
-        doFailover(true, jndiDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
+        doFailover(true, directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
     }
 
     @Test
     public void testFailoverOnUndeployAnnotatedBean() throws Exception {
-        doFailover(false, jndiAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);     
+        doFailover(false, directoryAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);     
     }
     
     @Test
     public void testFailoverOnUndeploySpecifiedByDescriptor() throws Exception {
-        doFailover(false, jndiDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
+        doFailover(false, directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
     }
     
-    private void doFailover(boolean isStop, String jndi, String deployment1, String deployment2) throws Exception {
+    private void doFailover(boolean isStop, EJBDirectory directory, String deployment1, String deployment2) throws Exception {
         this.start(CONTAINER_1);
         this.deploy(CONTAINER_1, deployment1);
         
         final ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
         try {
-            StatelessRemoteHome home = (StatelessRemoteHome) context.lookup(jndi);
+            ViewChangeListener listener = directory.lookupStateless(ViewChangeListenerBean.class, ViewChangeListener.class);
+            
+            this.establishView(listener, NODES[0]);
+            
+            StatelessRemoteHome home = directory.lookupHome(StatelessBean.class, StatelessRemoteHome.class);
             StatelessRemote bean = home.create();
 
             assertEquals("The only " + NODES[0] + " is active. Bean had to be invoked on it but it wasn't.", NODES[0], bean.getNodeName());
 
             this.start(CONTAINER_2);
             this.deploy(CONTAINER_2, deployment2);
-
-            // Allow ample time for topology change to propagate to client
-            Thread.sleep(GRACE_TIME_TO_MEMBERSHIP_CHANGE);
-
+            
+            this.establishView(listener, NODES);
+            
             if(isStop) {
                 this.stop(CONTAINER_1);
             } else {
                 this.undeploy(CONTAINER_1, deployment1);
             }
-
+            
+            this.establishView(listener, NODES[1]);
+            
             assertEquals("Only " + NODES[1] + " is active. The bean had to be invoked on it but it wasn't.", NODES[1], bean.getNodeName());
         } finally {
             // reset the selector
@@ -226,18 +237,18 @@ public class RemoteStatelessFailoverTestCase {
 
     @Test
     public void testLoadbalanceAnnotatedBean() throws Exception {
-        loadbalance(jndiAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);
+        loadbalance(directoryAnnotation, DEPLOYMENT_1, DEPLOYMENT_2);
     }
 
     @Test
     public void testLoadbalanceSpecifiedByDescriptor() throws Exception {
-        loadbalance(jndiDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
+        loadbalance(directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
     }
     
     /**
      * Basic load balance testing. A random distribution is used amongst nodes for client now.
      */
-    private void loadbalance(String jndi, String deployment1, String deployment2) throws Exception {
+    private void loadbalance(EJBDirectory directory, String deployment1, String deployment2) throws Exception {
         this.start(CONTAINER_1);
         this.deploy(CONTAINER_1, deployment1);
         this.start(CONTAINER_2);
@@ -251,7 +262,7 @@ public class RemoteStatelessFailoverTestCase {
         double serversProccessedAtLeast = 0.2;
 
         try {
-            StatelessRemoteHome home = (StatelessRemoteHome) context.lookup(jndi);
+            StatelessRemoteHome home = directory.lookupHome(StatelessBean.class, StatelessRemoteHome.class);
             StatelessRemote bean = home.create();
 
             String node = bean.getNodeName();
@@ -348,5 +359,9 @@ public class RemoteStatelessFailoverTestCase {
             this.container.stop(container);
             started.put(container, false);
         }
+    }
+
+    private void establishView(ViewChangeListener listener, String... members) throws InterruptedException {
+        listener.establishView("ejb", members);
     }
 }


### PR DESCRIPTION
Add view change listener hooks to all failover tests. This should also clean up the random timing-related failures especially seen on windows.
Cleanup EJBDirectory usage.  Add methods to handle home interface and non-default bean names.
