### PR TITLE
Fix usage of the DomainTestSuite utility methods

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
@@ -78,7 +78,7 @@ public class AdminOnlyModeTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = DomainTestSuite.createSupport(AdminOnlyModeTestCase.class.getSimpleName());
+        testSupport = DomainTestSupport.createAndStartDefaultSupport(AdminOnlyModeTestCase.class.getSimpleName());
 
         domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
         domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
@@ -86,7 +86,8 @@ public class AdminOnlyModeTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-        DomainTestSuite.stopSupport();
+        testSupport.stop();
+
         testSupport = null;
         domainMasterLifecycleUtil = null;
         domainSlaveLifecycleUtil = null;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
@@ -122,14 +122,14 @@ public class DomainDeploymentOverlayTestCase {
         }
 
         // Launch the domain
-        testSupport = DomainTestSuite.createSupport(DomainDeploymentOverlayTestCase.class.getSimpleName());
+        testSupport = DomainTestSupport.createAndStartDefaultSupport(DomainDeploymentOverlayTestCase.class.getSimpleName());
     }
 
     @AfterClass
     public static void after() throws Exception {
         try {
+            testSupport.stop();
             testSupport = null;
-            DomainTestSuite.stopSupport();
         } finally {
             war1.delete();
             war2.delete();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -22,9 +22,7 @@
 
 package org.jboss.as.test.integration.domain.suites;
 
-import org.jboss.as.test.integration.domain.AdminOnlyModeTestCase;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
-import org.jboss.as.test.integration.domain.management.util.JBossAsManagedConfigurationParameters;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -59,22 +57,19 @@ import org.junit.runners.Suite;
 })
 public class DomainTestSuite {
 
-    private static final DomainTestSupport.Configuration CONFIGURATION;
     private static boolean initializedLocally = false;
     private static volatile DomainTestSupport support;
 
-    static {
-        CONFIGURATION = DomainTestSupport.Configuration.create("domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml", JBossAsManagedConfigurationParameters.STANDARD, JBossAsManagedConfigurationParameters.STANDARD);
-    }
-
-    public static synchronized DomainTestSupport createSupport(final String testName) {
+    // This can only be called from tests as part of this suite
+    static synchronized DomainTestSupport createSupport(final String testName) {
         if(support == null) {
             start(testName);
         }
         return support;
     }
 
-    public static synchronized void stopSupport() {
+    // This can only be called from tests as part of this suite
+    static synchronized void stopSupport() {
         if(! initializedLocally) {
             stop();
         }
@@ -82,10 +77,7 @@ public class DomainTestSuite {
 
     private synchronized static void start(final String name) {
         try {
-            final DomainTestSupport testSupport = DomainTestSupport.create(name, CONFIGURATION);
-            // Start!
-            testSupport.start();
-            support = testSupport;
+            support = DomainTestSupport.createAndStartDefaultSupport(name);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -53,12 +53,36 @@ import org.junit.Assert;
  */
 public class DomainTestSupport {
 
+
+    private static final Configuration DEFAULT_CONFIG;
+
     private static final Logger log = Logger.getLogger("org.jboss.as.test.integration.domain");
 
     public static final String masterAddress = System.getProperty("jboss.test.host.master.address", "127.0.0.1");
     public static final String slaveAddress = System.getProperty("jboss.test.host.slave.address", "127.0.0.1");
     public static final long domainBootTimeout = Long.valueOf(System.getProperty("jboss.test.domain.boot.timeout", "60000"));
     public static final long domainShutdownTimeout = Long.valueOf(System.getProperty("jboss.test.domain.shutdown.timeout", "20000"));
+
+    static {
+        DEFAULT_CONFIG = DomainTestSupport.Configuration.create("domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml", JBossAsManagedConfigurationParameters.STANDARD, JBossAsManagedConfigurationParameters.STANDARD);
+    }
+
+    /**
+     * Create and start a default configuration for the domain tests.
+     *
+     * @param testName the test name
+     * @return a started domain test support
+     */
+    public static DomainTestSupport createAndStartDefaultSupport(final String testName) {
+        try {
+            final DomainTestSupport testSupport = DomainTestSupport.create(testName, DEFAULT_CONFIG);
+            // Start!
+            testSupport.start();
+            return testSupport;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     public static JBossAsManagedConfiguration getMasterConfiguration(String domainConfigPath, String hostConfigPath, String testName, JBossAsManagedConfigurationParameters params) throws URISyntaxException {
         final String hostName = "master";


### PR DESCRIPTION
This fixes an issue when running the domain tests in a different order that sometimes containers don't get shutdown.
