### PR TITLE
[7.3] AS7-6514

### DIFF
--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -384,5 +384,30 @@
         </profile>
 
 
+        <!-- Enable using -Dts.noClustering. -->
+        <profile>
+            <id>ts.clust.do-nothing.profile</id>
+            <activation><property><name>ts.noClustering</name></property></activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+                            <!-- Disable default-test surefire execution which would fail otherwise. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
     </profiles>
 </project>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -63,7 +63,7 @@
         </profile>
         <!-- Define ts.integration uber-group. -->
         <profile>
-            <id>ts.integ.allGroups2</id>
+            <id>ts.integ.allGroupsNoOSGi</id>
             <activation><property><name>ts.integration</name></property></activation>
             <modules>
                 <module>smoke</module>


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-6514

Make -Dts.noClustering to really bypass clustering tests. Disables default-test surefire execution which would fail otherwise.
