### PR TITLE
Remove hardcoded "current" version in testsuite

### DIFF
--- a/core-model-test/framework/pom.xml
+++ b/core-model-test/framework/pom.xml
@@ -34,7 +34,16 @@
 
     <artifactId>jboss-as-core-model-test-framework</artifactId>
     <name>JBoss Application Server: Core Model Test Framework</name>
-
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main</directory>
+                <filtering>true</filtering>
+                <targetPath>../filtered-sources</targetPath>
+            </resource>
+        </resources>
+        <sourceDirectory>target/filtered-sources</sourceDirectory>
+    </build>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -550,12 +550,13 @@ public class CoreModelTestDelegate {
                 classLoaderBuilder.createFromFile(file);
                 legacyCl = classLoaderBuilder.build();
             } else {
-                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-framework:7.2.0.Alpha1-SNAPSHOT");
-                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-model-test:7.2.0.Alpha1-SNAPSHOT");
+                String version = LegacyKernelServicesInitializer.VersionLocator.getCurrentVersion();
+                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-framework:"+version);
+                classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-model-test:"+version);
 
                 if (testControllerVersion != TestControllerVersion.MASTER) {
                     classLoaderBuilder.addRecursiveMavenResourceURL(testControllerVersion.getLegacyControllerMavenGav());
-                    classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-controller-" + testControllerVersion.getTestControllerVersion() + ":" + VERSION);
+                    classLoaderBuilder.addMavenResourceURL("org.jboss.as:jboss-as-core-model-test-controller-" + testControllerVersion.getTestControllerVersion() + ":" +version);
                 }
                 legacyCl = classLoaderBuilder.build(file);
             }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
@@ -26,12 +26,9 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.dmr.ModelNode;
 
 /**
- *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public interface LegacyKernelServicesInitializer {
-
-    String VERSION = "7.2.0.Alpha1-SNAPSHOT";
 
     LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model);
 
@@ -49,12 +46,13 @@ public interface LegacyKernelServicesInitializer {
 
 
     public enum TestControllerVersion {
-        MASTER ("org.jboss.as:jboss-as-host-controller:" + VERSION, null),
-        V7_1_2_FINAL ("org.jboss.as:jboss-as-host-controller:7.1.2.Final", "7.1.2"),
-        V7_1_3_FINAL ("org.jboss.as:jboss-as-host-controller:7.1.3.Final", "7.1.3");
+        MASTER("org.jboss.as:jboss-as-host-controller:" + VersionLocator.getCurrentVersion(), null),
+        V7_1_2_FINAL("org.jboss.as:jboss-as-host-controller:7.1.2.Final", "7.1.2"),
+        V7_1_3_FINAL("org.jboss.as:jboss-as-host-controller:7.1.3.Final", "7.1.3");
 
         String mavenGav;
         String testControllerVersion;
+
         private TestControllerVersion(String mavenGav, String testControllerVersion) {
             this.mavenGav = mavenGav;
             this.testControllerVersion = testControllerVersion;
@@ -66,6 +64,21 @@ public interface LegacyKernelServicesInitializer {
 
         String getTestControllerVersion() {
             return testControllerVersion;
+        }
+
+    }
+
+    static final class VersionLocator {
+        private static String VERSION = "${project.version}"; //is going to be replaced by maven during build
+
+        static {
+            if (VERSION.contains("${")) {
+                VERSION = "8.0.0.Alpha1-SNAPSHOT"; //to make it work from IDE
+            }
+        }
+
+        static String getCurrentVersion() {
+            return VERSION;
         }
     }
 }


### PR DESCRIPTION
since moving from 7.2.0.Alpha1-SNAPSHOT version core-model-testsuite started to fail
