### PR TITLE
[AS7-6520] Use the server.log instead of a boot.log when booting domain servers

### DIFF
--- a/build/src/main/resources/domain/configuration/default-server-logging.properties
+++ b/build/src/main/resources/domain/configuration/default-server-logging.properties
@@ -1,0 +1,71 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional loggers to configure (the root logger is always configured)
+loggers=com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
+
+logger.level=INFO
+logger.handlers=CONSOLE,FILE
+
+logger.com.arjuna.level=WARN
+logger.com.arjuna.useParentHandlers=true
+
+logger.jacorb.level=WARN
+logger.jacorb.useParentHandlers=true
+
+logger.org.jboss.as.config.level=DEBUG
+logger.org.jboss.as.config.useParentHandlers=true
+
+logger.org.apache.tomcat.util.modeler.level=WARN
+logger.org.apache.tomcat.util.modeler.useParentHandlers=true
+
+logger.sun.rmi.level=WARN
+logger.sun.rmi.useParentHandlers=true
+
+logger.jacorb.config.level=ERROR
+logger.jacorb.config.useParentHandlers=true
+
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.level=INFO
+handler.CONSOLE.formatter=CONSOLE
+handler.CONSOLE.properties=autoFlush,target
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.target=SYSTEM_OUT
+
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=ALL
+handler.FILE.formatter=FILE
+handler.FILE.properties=autoFlush,append,fileName,suffix
+handler.FILE.constructorProperties=fileName,append
+handler.FILE.autoFlush=true
+handler.FILE.append=true
+handler.FILE.fileName=${org.jboss.boot.log.file:boot.log}
+handler.FILE.suffix=.yyyy-MM-dd
+
+formatter.CONSOLE=org.jboss.logmanager.formatters.PatternFormatter
+formatter.CONSOLE.properties=pattern
+formatter.CONSOLE.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+
+formatter.FILE=org.jboss.logmanager.formatters.PatternFormatter
+formatter.FILE.properties=pattern
+formatter.FILE.constructorProperties=pattern
+formatter.FILE.pattern=%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
@@ -220,10 +220,13 @@ class ManagedServerBootCmdFactory implements ManagedServerBootConfiguration {
         if (loggingConfig.exists()) {
             path = "file:" + loggingConfig.getAbsolutePath();
         } else {
-            command.add("-Dorg.jboss.boot.log.file=" + getAbsolutePath(new File(logDir), "boot.log"));
+            // Sets the initial log file to use
+            command.add("-Dorg.jboss.boot.log.file=" + getAbsolutePath(new File(logDir), "server.log"));
             final String fileName = SecurityActions.getSystemProperty("logging.configuration");
             if (fileName == null) {
-                path = "file:" + getAbsolutePath(environment.getDomainConfigurationDir(), "logging.properties");
+                // If nothing else is defined use a default logging configuration that matches the default from the
+                // standalone server. This allows a single log file to be used.
+                path = "file:" + getAbsolutePath(environment.getDomainConfigurationDir(), "default-server-logging.properties");
             } else {
                 path = fileName;
             }


### PR DESCRIPTION
Removes the boot.log from the initial boot of a domain server. Defaults it to use the server.log like a standalone server does.
