### PR TITLE
[AS7-6524] For a duplicate user do not reject the addition in non-interactive mode - instead just update the existing user.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -367,16 +367,6 @@ public interface DomainManagementMessages {
     String unableToLoadUsers(String file, String error);
 
     /**
-     * The error message if the user is already in at least one file.
-     *
-     * @param user - The name of the user.
-     *
-     * @return a {@link String} for the message.
-     */
-    @Message(id = 15243, value = "The user '%s' already exists in at least one properties file.")
-    String duplicateUser(String user);
-
-    /**
      * The error message header.
      *
      * @return a {@link String} for the message.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ValidateUserState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/ValidateUserState.java
@@ -105,14 +105,13 @@ public class ValidateUserState extends AbstractValidationState {
                 if (stateValues.getKnownUsers().contains(stateValues.getUserName())) {
                     State duplicateContinuing = stateValues.isSilentOrNonInteractive() ? null : new PromptNewUserState(
                             theConsole, stateValues);
+                    stateValues.setExistingUser(true);
                     if (stateValues.isSilentOrNonInteractive()) {
-                        return new ErrorState(theConsole, MESSAGES.duplicateUser(stateValues.getUserName()),
-                                duplicateContinuing, stateValues);
+                        return ValidateUserState.this;
                     } else {
                         String message = MESSAGES.aboutToUpdateUser(stateValues.getUserName());
                         String prompt = MESSAGES.isCorrectPrompt() + " " + MESSAGES.yes() + "/" + MESSAGES.no() + "?";
 
-                        stateValues.setExistingUser(true);
                         return new ConfirmationChoice(theConsole, message, prompt, ValidateUserState.this, duplicateContinuing);
                     }
                 } else {


### PR DESCRIPTION
This is to bring the behaviour in-line with the documentation and the behaviour from previous releases.
