### PR TITLE
AS7-6531 Reverse operations tests

### DIFF
--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTransformerTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTransformerTestCase.java
@@ -78,7 +78,9 @@ public class InfinispanSubsystemTransformerTestCase extends OperationTestCaseBas
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXml(getSubsystemXml());
         builder.createLegacyKernelServicesBuilder(null, version)
-            .addMavenResourceURL("org.jboss.as:jboss-as-clustering-infinispan:" + asVersion);
+            .addMavenResourceURL("org.jboss.as:jboss-as-clustering-infinispan:" + asVersion)
+            //TODO https://issues.jboss.org/browse/AS7-6533
+            .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot()); ;

--- a/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem11TestCase.java
+++ b/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem11TestCase.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.List;
 
 import junit.framework.Assert;
+
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -54,6 +55,7 @@ import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.as.subsystem.test.LegacyKernelServicesInitializer;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 
@@ -119,13 +121,23 @@ public class CmpKeyGeneratorSubsystem11TestCase extends CmpKeyGeneratorSubsystem
     }
 
     @Test
-    public void testTransformers() throws Exception {
+    public void testTransformers7_1_2() throws Exception {
+        testTransformers_1_0_0("7.1.2.Final");
+    }
+
+    @Test
+    public void testTransformers7_1_3() throws Exception {
+        testTransformers_1_0_0("7.1.3.Final");
+    }
+
+
+    private void testTransformers_1_0_0(String asVersion) throws Exception {
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
 
-        builder.createLegacyKernelServicesBuilder(null, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-cmp:7.1.2.Final")
-                .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.2.Final")
+        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(null, modelVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-cmp:" + asVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-controller:" + asVersion)
                 .addParentFirstClassPattern("org.jboss.as.controller.*");
 
         KernelServices mainServices = builder.build();

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -113,7 +113,9 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
             // Add legacy subsystems
             builder.createLegacyKernelServicesBuilder(null, modelVersion)
                     .addMavenResourceURL("org.jboss.as:jboss-as-connector:" + mavenVersion)
-                    .setExtensionClassName("org.jboss.as.connector.subsystems.datasources.DataSourcesExtension");
+                    .setExtensionClassName("org.jboss.as.connector.subsystems.datasources.DataSourcesExtension")
+                    //TODO https://issues.jboss.org/browse/AS7-6535
+                    .skipReverseControllerCheck();
 
             KernelServices mainServices = builder.build();
             Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -81,7 +81,9 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         // Add legacy subsystems
         builder.createLegacyKernelServicesBuilder(null, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + mavenVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + mavenVersion);
+                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + mavenVersion)
+                //TODO https://issues.jboss.org/browse/AS7-6536
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);

--- a/jacorb/src/test/java/org/jboss/as/jacorb/JacORBTransformersTestCase.java
+++ b/jacorb/src/test/java/org/jboss/as/jacorb/JacORBTransformersTestCase.java
@@ -142,7 +142,9 @@ public class JacORBTransformersTestCase extends AbstractSubsystemTest {
         // Add legacy subsystems
         ModelVersion version_1_1_0 = ModelVersion.create(1, 1, 0);
         builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, version_1_1_0)
-                .addMavenResourceURL("org.jboss.as:jboss-as-jacorb:" + asVersion);
+                .addMavenResourceURL("org.jboss.as:jboss-as-jacorb:" + asVersion)
+                //TODO https://issues.jboss.org/browse/AS7-6532
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());

--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -49,8 +49,8 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
@@ -488,7 +488,10 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
                 .setSubsystemXml(subsystemXml);
         builder.createLegacyKernelServicesBuilder(null, oldVersion)
                 .setExtensionClassName(JMXExtension.class.getName())
-                .addMavenResourceURL(mavenGAV);
+                .addMavenResourceURL(mavenGAV)
+                //TODO https://issues.jboss.org/browse/AS7-6530
+                .skipReverseControllerCheck();
+
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);
         Assert.assertNotNull(legacyServices);

--- a/logging/src/test/java/org/jboss/as/logging/LoggingOperationsSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingOperationsSubsystemTestCase.java
@@ -21,7 +21,9 @@
 */
 package org.jboss.as.logging;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -131,7 +133,9 @@ public class LoggingOperationsSubsystemTestCase extends AbstractLoggingSubsystem
         // Note this is running in ADMIN_ONLY meaning runtime changes won't take effect. Can't confirm the
         // handlers actually get disabled.
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-logging:7.1.2.Final");
+                .addMavenResourceURL("org.jboss.as:jboss-as-logging:7.1.2.Final")
+                //TODO https://issues.jboss.org/browse/AS7-6538
+                .skipReverseControllerCheck();
 
         final KernelServices kernelServices = builder.build();
         assertTrue(kernelServices.isSuccessfulBoot());

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -115,7 +115,9 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
 
         // Create the legacy kernel
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), modelVersion)
-                .addMavenResourceURL(gav);
+                .addMavenResourceURL(gav)
+                //TODO https://issues.jboss.org/browse/AS7-6538
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem13TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem13TestCase.java
@@ -99,7 +99,10 @@ public class MessagingSubsystem13TestCase extends AbstractSubsystemBaseTest {
                 .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.2.Final")
                 .addMavenResourceURL("org.hornetq:hornetq-core:2.2.16.Final")
                 .addMavenResourceURL("org.hornetq:hornetq-jms:2.2.16.Final")
-                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.16.Final");
+                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.16.Final")
+                //TODO https://issues.jboss.org/browse/AS7-6539
+                .skipReverseControllerCheck();
+
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         assertTrue(mainServices.getLegacyServices(VERSION_1_1_0).isSuccessfulBoot());
@@ -114,7 +117,10 @@ public class MessagingSubsystem13TestCase extends AbstractSubsystemBaseTest {
                 .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.3.Final")
                 .addMavenResourceURL("org.hornetq:hornetq-core:2.2.21.Final")
                 .addMavenResourceURL("org.hornetq:hornetq-jms:2.2.21.Final")
-                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.21.Final");
+                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.21.Final")
+                //TODO https://issues.jboss.org/browse/AS7-6539
+                .skipReverseControllerCheck();
+
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         assertTrue(mainServices.getLegacyServices(VERSION_1_1_0).isSuccessfulBoot());
@@ -134,7 +140,9 @@ public class MessagingSubsystem13TestCase extends AbstractSubsystemBaseTest {
                 .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.16.Final")
                 .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.2.Final")
                 .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.2.Final")
-                .addParentFirstClassPattern("org.jboss.as.controller.*");
+                .addParentFirstClassPattern("org.jboss.as.controller.*")
+                //TODO https://issues.jboss.org/browse/AS7-6539 (perhaps not as important as for the testTransformersAS71x tests)
+                .skipReverseControllerCheck();
 
         doTestRejectExpressions_1_1_0(builder);
     }
@@ -153,7 +161,9 @@ public class MessagingSubsystem13TestCase extends AbstractSubsystemBaseTest {
                 .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.21.Final")
                 .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.3.Final")
                 .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.3.Final")
-                .addParentFirstClassPattern("org.jboss.as.controller.*");
+                .addParentFirstClassPattern("org.jboss.as.controller.*")
+                //TODO https://issues.jboss.org/browse/AS7-6539 (perhaps not as important as for the testTransformersAS71x tests)
+                .skipReverseControllerCheck();
 
         doTestRejectExpressions_1_1_0(builder);
     }

--- a/modcluster/src/test/java/org/jboss/as/modcluster/ModClusterSubsystemTestCase.java
+++ b/modcluster/src/test/java/org/jboss/as/modcluster/ModClusterSubsystemTestCase.java
@@ -84,7 +84,9 @@ public class ModClusterSubsystemTestCase extends AbstractSubsystemBaseTest {
                 .setSubsystemXml(subsystemXml);
 
         builder.createLegacyKernelServicesBuilder(null, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-modcluster:" + version);
+                .addMavenResourceURL("org.jboss.as:jboss-as-modcluster:" + version)
+                //TODO https://issues.jboss.org/browse/AS7-6540
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);

--- a/naming/src/test/java/org/jboss/as/naming/subsystem/Naming110TransformersTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/subsystem/Naming110TransformersTestCase.java
@@ -30,7 +30,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.model.test.ModelTestUtils.checkFailedTransformedBootOperations;
 import static org.jboss.as.naming.subsystem.NamingExtension.SUBSYSTEM_NAME;
-import static org.jboss.as.naming.subsystem.NamingExtension.SUBSYSTEM_PATH;
 import static org.jboss.as.naming.subsystem.NamingExtension.VERSION_1_1_0;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING_TYPE;
@@ -90,7 +89,9 @@ public class Naming110TransformersTestCase extends AbstractSubsystemBaseTest {
         builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), VERSION_1_1_0)
                 .addMavenResourceURL("org.jboss.as:jboss-as-naming:7.1.3.Final")
                 .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.3.Final")
-                .addParentFirstClassPattern("org.jboss.as.controller.*");
+                .addParentFirstClassPattern("org.jboss.as.controller.*")
+                //TODO get rid of this https://issues.jboss.org/browse/AS7-6528
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_1_0);
@@ -114,7 +115,9 @@ public class Naming110TransformersTestCase extends AbstractSubsystemBaseTest {
         builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), VERSION_1_1_0)
                 .addMavenResourceURL("org.jboss.as:jboss-as-naming:7.1.2.Final")
                 .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.2.Final")
-                .addParentFirstClassPattern("org.jboss.as.controller.*");
+                .addParentFirstClassPattern("org.jboss.as.controller.*")
+                //TODO get rid of this https://issues.jboss.org/browse/AS7-6528
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_1_0);

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiSubsystemTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiSubsystemTestCase.java
@@ -274,6 +274,8 @@ public class OSGiSubsystemTestCase extends AbstractSubsystemBaseTest {
         for (String mavenGAV : mavenGAVs) {
             legacyInitializer.addMavenResourceURL(mavenGAV);
         }
+        //TODO https://issues.jboss.org/browse/AS7-6541
+        legacyInitializer.skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
+++ b/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
@@ -160,7 +160,9 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
         // Add legacy subsystems
         ModelVersion version_1_1 = ModelVersion.create(1, 1);
         builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), version_1_1)
-                .addMavenResourceURL(gav);
+                .addMavenResourceURL(gav)
+                //TODO https://issues.jboss.org/browse/AS7-6542
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());

--- a/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
@@ -133,7 +133,10 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
                 .addMavenResourceURL("org.jboss.as:jboss-as-security:" + version)
                 .addMavenResourceURL("org.jboss.as:jboss-as-controller:" + version)
                 .addParentFirstClassPattern("org.jboss.as.controller.*")
-                .dontPersistXml();
+                .dontPersistXml()
+                //TODO https://issues.jboss.org/browse/AS7-6534
+                .skipReverseControllerCheck();
+
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());
@@ -157,7 +160,9 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
                 .addMavenResourceURL("org.jboss.as:jboss-as-security:" + version)
                 .addMavenResourceURL("org.jboss.as:jboss-as-controller:" + version)
                 .addParentFirstClassPattern("org.jboss.as.controller.*")
-                .dontPersistXml();
+                .dontPersistXml()
+                //TODO https://issues.jboss.org/browse/AS7-6534
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/LegacyKernelServicesInitializer.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/LegacyKernelServicesInitializer.java
@@ -25,6 +25,8 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.jboss.as.model.test.ModelFixer;
+
 
 /**
  * Contains the initialization of a controller containing a legacy version of a subsystem.
@@ -109,4 +111,25 @@ public interface LegacyKernelServicesInitializer {
      * @return this initializer
      */
     LegacyKernelServicesInitializer dontPersistXml();
+
+    /**
+     * By default the {@link KernelServicesBuilder#build()} method will use the boot operations passed into the
+     * legacy controller and try to boot up the current controller with those. This is for checking that e.g. cli scripts written
+     * against the legacy controller still work with the current one. To turn this check off call this method.
+     *
+     * @return this initializer
+     */
+    LegacyKernelServicesInitializer skipReverseControllerCheck();
+
+    /**
+     * By default the {@link KernelServicesBuilder#build()} method will use the boot operations passed into the
+     * legacy controller and try to boot up the current controller with those. This is for checking that e.g. cli scripts written
+     * against the legacy controller still work with the current one. To turn this check off call this method.
+     *
+     * @param additionalInit the additional initialization to use
+     * @param modelFixer a model fixer to fix up the booted subsystem model
+     * @return this initializer
+     */
+    LegacyKernelServicesInitializer configureReverseControllerCheck(AdditionalInitialization additionalInit, ModelFixer modelFixer);
+
 }

--- a/subsystem-test/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -717,6 +717,13 @@ final class SubsystemTestDelegate {
             KernelServices reverseServices = createKernelServicesBuilder(reverseCheckConfig)
                 .setBootOperations(bootOperations)
                 .build();
+            if (reverseServices.getBootError() != null) {
+                Throwable t = reverseServices.getBootError();
+                if (t instanceof Exception) {
+                    throw (Exception)t;
+                }
+                throw new Exception(t);
+            }
             Assert.assertTrue(reverseServices.isSuccessfulBoot());
 
             ModelNode reverseSubsystem = reverseServices.readWholeModel().get(SUBSYSTEM, getMainSubsystemName());

--- a/subsystem-test/src/test/java/org/jboss/as/subsystem/test/transformers/TransformerSubsystemTestCase.java
+++ b/subsystem-test/src/test/java/org/jboss/as/subsystem/test/transformers/TransformerSubsystemTestCase.java
@@ -78,7 +78,8 @@ public class TransformerSubsystemTestCase extends AbstractSubsystemBaseTest {
                 .setSubsystemXml(getSubsystemXml());
         builder.createLegacyKernelServicesBuilder(null, oldVersion)
                 .setExtensionClassName(VersionedExtension1.class.getName())
-                .addSimpleResourceURL("target/legacy-archive.jar");
+                .addSimpleResourceURL("target/legacy-archive.jar")
+                .skipReverseControllerCheck();
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);
         Assert.assertNotNull(legacyServices);

--- a/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemTestCase.java
+++ b/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemTestCase.java
@@ -82,7 +82,9 @@ public class ThreadsSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         // Add legacy subsystems
         builder.createLegacyKernelServicesBuilder(null, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + mavenVersion);
+                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + mavenVersion)
+                //TODO get rid of this https://issues.jboss.org/browse/AS7-6528
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);

--- a/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
+++ b/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
@@ -129,7 +129,9 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
             .addMavenResourceURL("org.jboss.as:jboss-as-web:7.1.2.Final")
             .addMavenResourceURL("org.jboss.as:jboss-as-controller:7.1.2.Final")
             .addParentFirstClassPattern("org.jboss.as.controller.*")
-            .addChildFirstClassPattern("org.jboss.as.controller.alias.*");
+            .addChildFirstClassPattern("org.jboss.as.controller.alias.*")
+            //TODO https://issues.jboss.org/browse/AS7-6537
+            .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());


### PR DESCRIPTION
Make the legacy controller initializer use its transformed boot operations to start up a current controller to ensure that older scripts will still work on the current version.
