### PR TITLE
less intrusive way for getting current as version

### DIFF
--- a/core-model-test/framework/pom.xml
+++ b/core-model-test/framework/pom.xml
@@ -37,12 +37,10 @@
     <build>
         <resources>
             <resource>
-                <directory>src/main</directory>
+                <directory>src/main/resources</directory>
                 <filtering>true</filtering>
-                <targetPath>../filtered-sources</targetPath>
             </resource>
         </resources>
-        <sourceDirectory>target/filtered-sources</sourceDirectory>
     </build>
     <dependencies>
         <dependency>

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
@@ -21,6 +21,8 @@
 */
 package org.jboss.as.core.model.test;
 
+import java.util.Properties;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.dmr.ModelNode;
@@ -69,11 +71,16 @@ public interface LegacyKernelServicesInitializer {
     }
 
     static final class VersionLocator {
-        private static String VERSION = "${project.version}"; //is going to be replaced by maven during build
+        private static String VERSION;
 
         static {
-            if (VERSION.contains("${")) {
-                VERSION = "8.0.0.Alpha1-SNAPSHOT"; //to make it work from IDE
+            try {
+                Properties props = new Properties();
+                props.load(LegacyKernelServicesInitializer.class.getResourceAsStream("version.properties"));
+                VERSION = props.getProperty("as.version");
+            } catch (Exception e) {
+                VERSION = "8.0.0.Alpha1-SNAPSHOT";
+                e.printStackTrace();
             }
         }
 

--- a/core-model-test/framework/src/main/resources/org/jboss/as/core/model/test/version.properties
+++ b/core-model-test/framework/src/main/resources/org/jboss/as/core/model/test/version.properties
@@ -1,0 +1,25 @@
+#
+# /*
+# * JBoss, Home of Professional Open Source.
+# * Copyright 2013, Red Hat, Inc., and individual contributors
+# * as indicated by the @author tags. See the copyright.txt file in the
+# * distribution for a full listing of individual contributors.
+# *
+# * This is free software; you can redistribute it and/or modify it
+# * under the terms of the GNU Lesser General Public License as
+# * published by the Free Software Foundation; either version 2.1 of
+# * the License, or (at your option) any later version.
+# *
+# * This software is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# * Lesser General Public License for more details.
+# *
+# * You should have received a copy of the GNU Lesser General Public
+# * License along with this software; if not, write to the Free
+# * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# */
+#
+
+as.version=${project.version}


### PR DESCRIPTION
I tried with org.jboss.as.version.Version.AS_VERSION but it does not work, at least not in this scenario.
This version is lest intrusive and wont cause problems with eclipse.
@kabir this should make it work for you.
