### PR TITLE
[AS7-6539] fix messaging transformers

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -38,18 +38,12 @@ import static org.jboss.dmr.ModelType.BOOLEAN;
 import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 
-import java.util.List;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
-
 import org.hornetq.api.config.HornetQDefaultConfiguration;
 import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.core.config.impl.ConfigurationImpl;
 import org.hornetq.core.config.impl.FileConfiguration;
 import org.hornetq.core.server.JournalType;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.operations.validation.EnumValidator;
@@ -126,8 +120,7 @@ public interface CommonAttributes {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(false))
             .setDeprecated(VERSION_1_2_0)
-            .setAttributeMarshaller(NOOP_MARSHALLER)
-            .setStorageRuntime()
+            .setRestartAllServices()
             .build();
 
     SimpleAttributeDefinition CLUSTER_PASSWORD = create("cluster-password", ModelType.STRING)
@@ -826,7 +819,7 @@ public interface CommonAttributes {
     String XA = "xa";
     String XA_TX = "XATransaction";
 
-    AttributeDefinition[] SIMPLE_ROOT_RESOURCE_ATTRIBUTES = { PERSISTENCE_ENABLED, SCHEDULED_THREAD_POOL_MAX_SIZE,
+    AttributeDefinition[] SIMPLE_ROOT_RESOURCE_ATTRIBUTES = { CLUSTERED, PERSISTENCE_ENABLED, SCHEDULED_THREAD_POOL_MAX_SIZE,
             THREAD_POOL_MAX_SIZE, SECURITY_DOMAIN, SECURITY_ENABLED, SECURITY_INVALIDATION_INTERVAL, WILD_CARD_ROUTING_ENABLED,
             MANAGEMENT_ADDRESS, MANAGEMENT_NOTIFICATION_ADDRESS, CLUSTER_USER, CLUSTER_PASSWORD, JMX_MANAGEMENT_ENABLED,
             JMX_DOMAIN, MESSAGE_COUNTER_ENABLED, MESSAGE_COUNTER_SAMPLE_PERIOD, MESSAGE_COUNTER_MAX_DAY_HISTORY,

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlHandler.java
@@ -372,9 +372,6 @@ public class HornetQServerControlHandler extends AbstractRuntimeOnlyHandler {
         } else if (VERSION.getName().equals(name)) {
             String version = serverControl.getVersion();
             context.getResult().set(version);
-        } else if (CommonAttributes.CLUSTERED.getName().equals(name)) {
-            boolean clustered = getClusterConnectionCount(context, operation) > 0;
-            context.getResult().set(clustered);
         } else {
             // Bug
             throw MESSAGES.unsupportedAttribute(name);
@@ -389,15 +386,5 @@ public class HornetQServerControlHandler extends AbstractRuntimeOnlyHandler {
         }
         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
         return hqServer.getHornetQServerControl();
-    }
-
-    private int getClusterConnectionCount(final OperationContext context, ModelNode operation) throws OperationFailedException {
-        final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
-        ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
-        if (hqService == null || hqService.getState() != ServiceController.State.UP) {
-            throw MESSAGES.hornetQServerNotInstalled(hqServiceName.getSimpleName());
-        }
-        HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
-        return hqServer.getClusterManager().getClusterConnections().size();
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -189,4 +189,16 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 11612, value = "Attribute %s of the resource at %s is deprecated and setting its value will not be taken into account")
     void deprecatedAttribute(String name, PathAddress address);
 
+    /**
+     * Logs a warning message indicating the clustered attribute can not be set to false since the
+     * hornetq-server at the given {@code address} is clustered (because it has cluster-connections children resources).
+     *
+     * @param address the path address of the hornetq server.
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11613, value = "Can not change the clustered attribute to false: The hornetq-server resource at %s has cluster-connection children resources and will remain clustered.")
+    void canNotChangeClusteredAttribute(PathAddress address);
+
+
+
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -296,9 +296,8 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                     }
                     break;
                 case CLUSTERED:
+                    // log that the attribute is deprecated but handle it anyway
                     MessagingLogger.ROOT_LOGGER.deprecatedXMLElement(element.toString());
-                    skipElementText(reader);
-                    break;
                 default:
                     if (SIMPLE_ROOT_RESOURCE_ELEMENTS.contains(element)) {
                         AttributeDefinition attributeDefinition = element.getDefinition();

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -79,18 +79,6 @@ public class MessagingTransformers {
                         .addRejectCheck(DEFINED, HornetQServerResourceDefinition.ATTRIBUTES_ADDED_IN_1_2_0)
                         .setDiscard(UNDEFINED, HornetQServerResourceDefinition.ATTRIBUTES_ADDED_IN_1_2_0)
                         .setValueConverter(AttributeConverter.Factory.createHardCoded(ID_CACHE_SIZE.getDefaultValue(), true), ID_CACHE_SIZE)
-                .end()
-                .addOperationTransformationOverride(ADD)
-                        .inheritResourceAttributeDefinitions()
-                        // add default value for clustered
-                        // TODO AS7-6539 this is broken
-                        .setCustomOperationTransformer(new OperationTransformer() {
-                            @Override
-                            public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
-                                operation.get(CLUSTERED.getName()).set(CLUSTERED.getDefaultValue());
-                                return new TransformedOperation(operation, ORIGINAL_RESULT);
-                            }
-                        })
                 .end();
 
         for (String path : MessagingPathHandlers.PATHS.keySet()) {

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
@@ -1,6 +1,7 @@
 
     <subsystem xmlns="urn:jboss:domain:messaging:1.3">
         <hornetq-server>
+            <clustered>true</clustered>
             <!-- disable messaging persistence -->
             <persistence-enabled>false</persistence-enabled>
             <scheduled-thread-pool-max-size>${messaging.scheduled.thread.pool.max.size:6}</scheduled-thread-pool-max-size>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
@@ -1,6 +1,7 @@
 
     <subsystem xmlns="urn:jboss:domain:messaging:1.3">
         <hornetq-server>
+            <clustered>true</clustered>
             <!-- disable messaging persistence -->
             <persistence-enabled>${persistence.enabled:false}</persistence-enabled>
             <scheduled-thread-pool-max-size>${messaging.scheduled.thread.pool.max.size:6}</scheduled-thread-pool-max-size>


### PR DESCRIPTION
- revert the transformation of the CLUSTERED attribute to be compatible
  with legacy versions. On new version, writing to the attribute is
  ignored
  - the attribute is again stored in the configuration (but remains
    deprecated)
- add a model fixer to the transformation tests to remove the
  description of messaging path resources with default values that are
  always created since 7.2.x (AS7-5417)
