### PR TITLE
[AS7-6549] remote JNDI support for HornetQ-only JMS bridge

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/main/module.xml
@@ -39,6 +39,9 @@
         <module name="org.jboss.jboss-transaction-spi"/>
         <!--this reverse dependency is here so integration classes in the AS code base can be instantiated by HornetQ-->
         <module name="org.jboss.as.messaging"/>
+        <!-- this optional dependency is required to be able to use this module from a jms-bridge to connect to a remote
+             AS7 server [AS7-6549] -->
+        <module name="org.jboss.remote-naming" optional="true"/>
         <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
         <module name="sun.jdk"/>
     </dependencies>


### PR DESCRIPTION
- add an optional dependency to org.jboss.remote-naming in the
  org.hornetq module so that it can be used by jms-bridge resources
  to connect to a remote AS7 server
