### PR TITLE
[AS7-6531] The core model transformers tests for 7.1.3

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
@@ -50,7 +50,7 @@ public interface LegacyKernelServicesInitializer {
     public enum TestControllerVersion {
         MASTER("org.jboss.as:jboss-as-host-controller:" + VersionLocator.getCurrentVersion(), null),
         V7_1_2_FINAL("org.jboss.as:jboss-as-host-controller:7.1.2.Final", "7.1.2"),
-        V7_1_3_FINAL("org.jboss.as:jboss-as-host-controller:7.1.3.Final", "7.1.3");
+        V7_1_3_FINAL("org.jboss.as:jboss-as-host-controller:7.1.3.Final", "7.1.2");
 
         String mavenGav;
         String testControllerVersion;

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
@@ -56,7 +56,7 @@ public class TransformersTestParameters {
     public static List<Object[]> setupVersions(){
         List<Object[]> data = new ArrayList<Object[]>();
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), TestControllerVersion.V7_1_2_FINAL)});
-        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), TestControllerVersion.V7_1_2_FINAL)});
+        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), TestControllerVersion.V7_1_3_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), TestControllerVersion.MASTER)});
         for (int i = 0 ; i < data.size() ; i++) {
             Object[] entry = data.get(i);


### PR DESCRIPTION
The core model transformers tests were never actually being run against a 7.1.3 host controller. Due to the small bug fixed they were being run twice against 7.1.2 instead :-(
