### PR TITLE
[AS7-6533] Add virtual-nodes attribute to Infinispan's distributed cache add and write handlers.

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
@@ -105,7 +105,7 @@ public interface InfinispanLogger extends BasicLogger {
      * Logs a warning message stating that the 'virtual-nodes' attribute is deprecated.
      */
     @LogMessage(level = WARN)
-    @Message(id = 10286, value = "Attribute 'virtual-nodes' has been deprecated and has no effect.")
+    @Message(id = 10286, value = "Attribute 'virtual-nodes' has been deprecated - converting legacy 'virtual-nodes' value to 'segments' value")
     void virtualNodesAttributeDeprecated();
 
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAdd.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
-import org.jboss.as.clustering.infinispan.InfinispanMessages;
+import org.jboss.as.clustering.infinispan.InfinispanLogger;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.common.Util;
@@ -60,7 +60,12 @@ public class DistributedCacheAdd extends SharedStateCacheAdd {
         final String deprecatedKey = ModelKeys.VIRTUAL_NODES;
         if (fromModel.hasDefined(deprecatedKey)
                 && fromModel.get(deprecatedKey).asInt() != 1) {
-            throw InfinispanMessages.MESSAGES.attributeDeprecated(deprecatedKey);
+            // log a WARN
+            InfinispanLogger.ROOT_LOGGER.virtualNodesAttributeDeprecated();
+            // convert the virtual-nodes value to segments and update the incoming model
+            // TBD: what to do it both values are coded?
+            ModelNode convertedValue = SegmentsAndVirtualNodeConverter.virtualNodesToSegments(fromModel.get(deprecatedKey));
+            fromModel.get(ModelKeys.SEGMENTS).set(convertedValue) ;
         }
 
         DistributedCacheResource.OWNERS.validateAndSet(fromModel, toModel);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SegmentsAndVirtualNodeConverter.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SegmentsAndVirtualNodeConverter.java
@@ -23,6 +23,8 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 
+import org.jboss.dmr.ModelNode;
+
 /**
  * Convert the 1.4 SEGMENTS value to VIRTUAL_NODES in model and operations, if defined and not an expression
  * Remove the 1.4 attributes INDEXING_PROPERTIES and SEGMENTS from model and operations
@@ -34,14 +36,31 @@ public class SegmentsAndVirtualNodeConverter  {
 
     // ratio of segments to virtual nodes to convert between the two
     public static final int SEGMENTS_PER_VIRTUAL_NODE = 6;
+    public static final int VIRTUAL_NODES_DEFAULT = DistributedCacheResource.VIRTUAL_NODES.getDefaultValue().asInt();
+    public static final int SEGMENTS_DEFAULT = DistributedCacheResource.SEGMENTS.getDefaultValue().asInt();
 
     /*
      * Convert a 1.3 virtual nodes value to a 1.4 segments value
      */
+    public static int virtualNodesToSegments(int virtualNodes) {
+        return virtualNodes * SEGMENTS_PER_VIRTUAL_NODE;
+    }
+
+    /*
+     * Convert a 1.4 segments value to a 1.3 virtual nodes value
+     */
+    public static int segmentsToVirtualNodes(int segments) {
+        // divide by zero should not occur as segments is required to be > 0
+        return segments / SEGMENTS_PER_VIRTUAL_NODE;
+    }
+
+    /*
+     * Helper methods
+     */
     public static String virtualNodesToSegments(String virtualNodesValue) {
-        int segments = 0 ;
+        int segments = SEGMENTS_DEFAULT ;
         try {
-            segments =  Integer.parseInt(virtualNodesValue) * SEGMENTS_PER_VIRTUAL_NODE;
+            segments =  virtualNodesToSegments(Integer.parseInt(virtualNodesValue));
         }
         catch(NumberFormatException nfe) {
             // in case of expression
@@ -49,14 +68,10 @@ public class SegmentsAndVirtualNodeConverter  {
         return Integer.toString(segments);
     }
 
-    /*
-     * Convert a 1.4 segments value to a 1.3 virtual nodes value
-     */
     public static String segmentsToVirtualNodes(String segmentsValue) {
-        int virtualNodes = 0 ;
+        int virtualNodes = VIRTUAL_NODES_DEFAULT ;
         try {
-            // divide by zero should not occur as segments is required to be > 0
-            virtualNodes =  Integer.parseInt(segmentsValue) / SEGMENTS_PER_VIRTUAL_NODE;
+            virtualNodes =  segmentsToVirtualNodes(Integer.parseInt(segmentsValue));
         }
         catch(NumberFormatException nfe) {
             // in case of expression
@@ -64,5 +79,20 @@ public class SegmentsAndVirtualNodeConverter  {
         return Integer.toString(virtualNodes);
     }
 
+    public static ModelNode virtualNodesToSegments(ModelNode virtualNodes) {
+        int segments = SEGMENTS_DEFAULT ;
+        if (virtualNodes.isDefined()) {
+           segments = virtualNodesToSegments(virtualNodes.asInt());
+        }
+        return new ModelNode(segments) ;
+    }
+
+    public static ModelNode segmentsToVirtualNodes(ModelNode segments) {
+        int virtualNodes = VIRTUAL_NODES_DEFAULT ;
+        if (segments.isDefined()) {
+           virtualNodes = segmentsToVirtualNodes(segments.asInt());
+        }
+        return new ModelNode(virtualNodes) ;
+    }
 }
 

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationsTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationsTestCase.java
@@ -150,4 +150,28 @@ public class OperationsTestCase extends OperationTestCaseBase {
         return stringKeyedTable ;
     }
 
+    /*
+     * Tests adding dist cache with deprecated virtual nodes attribute
+     */
+    @Test
+    public void testDistCacheAddOperationWithVirtualNodes() throws Exception {
+
+        // Parse and install the XML into the controller
+        String subsystemXml = getSubsystemXml() ;
+        KernelServices servicesA = createKernelServicesBuilder(null).setSubsystemXml(subsystemXml).build();
+
+        // add the distributed cache with virtual-nodes = 6, should lead to segments value of 36 (6*6)
+        ModelNode distCacheAddOp = getCacheAddOperation("maximal", ModelKeys.DISTRIBUTED_CACHE, "new-dist-cache");
+        distCacheAddOp.get(ModelKeys.MODE).set("SYNC");
+        distCacheAddOp.get(ModelKeys.VIRTUAL_NODES).set(6);
+        ModelNode result = servicesA.executeOperation(distCacheAddOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+
+        // read the segments attribute
+        ModelNode readDistCacheSegmentsOp = getCacheReadOperation("maximal", ModelKeys.DISTRIBUTED_CACHE, "new-dist-cache", "segments");
+        result = servicesA.executeOperation(readDistCacheSegmentsOp);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals("36", result.get(RESULT).asString());
+    }
+
 }


### PR DESCRIPTION
This pull request:
- adds virtual-nodes attribute to Infinispan's distributed cache add and write handlers,  logging an warning that the attribute is deprecated, as well as converting the attribute to a corresponding segments attribute value
- adds a a test case to verify conversion
