### PR TITLE
[AS7-6582] Clear PU references to validator factory on undeploy.

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/validator/SerializableValidatorFactory.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/validator/SerializableValidatorFactory.java
@@ -54,7 +54,7 @@ public class SerializableValidatorFactory implements ValidatorFactory, Serializa
      */
     private transient volatile ValidatorFactory delegate = new JPALazyValidatorFactory();
 
-    public static ValidatorFactory validatorFactory() {
+    public static SerializableValidatorFactory validatorFactory() {
         return new SerializableValidatorFactory();
     }
 
@@ -112,6 +112,13 @@ public class SerializableValidatorFactory implements ValidatorFactory, Serializa
      */
     public TraversableResolver getTraversableResolver() {
         return delegate.getTraversableResolver();
+    }
+
+     /**
+      * Release the delegate
+      */
+    public void clean() {
+       this.delegate = null;
     }
 
     /**


### PR DESCRIPTION
After undeploying an artifact the JPA service may still hold a reference to the modules classloader.

![jpa-reference](https://f.cloud.github.com/assets/1113687/172513/05ee72f4-7abe-11e2-9b75-f2384776be34.png)
