### PR TITLE
Fix for AS7-6580

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RarDependencyProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RarDependencyProcessor.java
@@ -61,8 +61,8 @@ public class RarDependencyProcessor implements DeploymentUnitProcessor {
             return;  // Skip non ra deployments
         }
 
-        //if a module depends on a rar it also needs a dep on all the rar's dependencies
-        moduleSpecification.setRequiresTransitiveDependencies(true);
+        //if a module depends on a rar it also needs a dep on all the rar's "local dependencies"
+        moduleSpecification.setLocalDependenciesTransitive(true);
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JMS_ID, false, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, VALIDATION_ID, false, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, IRON_JACAMAR_ID, false, false, false, false));

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -170,15 +170,15 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
             addResourceRoot(specBuilder, resourceRoot);
         }
 
-        createDependencies(specBuilder, dependencies, moduleSpecification.isRequiresTransitiveDependencies());
-        createDependencies(specBuilder, userDependencies, moduleSpecification.isRequiresTransitiveDependencies());
+        createDependencies(specBuilder, dependencies, false);
+        createDependencies(specBuilder, userDependencies, false);
 
         if (moduleSpecification.isLocalLast()) {
-            createDependencies(specBuilder, localDependencies, moduleSpecification.isRequiresTransitiveDependencies());
+            createDependencies(specBuilder, localDependencies, moduleSpecification.isLocalDependenciesTransitive());
             specBuilder.addDependency(DependencySpec.createLocalDependencySpec());
         } else {
             specBuilder.addDependency(DependencySpec.createLocalDependencySpec());
-            createDependencies(specBuilder, localDependencies, moduleSpecification.isRequiresTransitiveDependencies());
+            createDependencies(specBuilder, localDependencies, moduleSpecification.isLocalDependenciesTransitive());
         }
 
         final DelegatingClassFileTransformer delegatingClassFileTransformer = new DelegatingClassFileTransformer();

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
@@ -53,6 +53,12 @@ public class ModuleSpecification extends SimpleAttachable {
      */
     private final List<ModuleDependency> localDependencies = new ArrayList<ModuleDependency>();
     /**
+     * If set to true this indicates that a dependency on this module requires a dependency on all it's local
+     * dependencies.
+     */
+    private boolean localDependenciesTransitive;
+
+    /**
      * User dependencies are dependencies that the user has specifically added, either via jboss-deployment-structure.xml
      * or via the manifest.
      * <p/>
@@ -83,12 +89,6 @@ public class ModuleSpecification extends SimpleAttachable {
      * Flag that indicates that this module should never be visible to other sub deployments
      */
     private boolean privateModule;
-
-    /**
-     * If set to true this indicates that a dependency on this module requires a dependency on all it's transitive
-     * dependencies.
-     */
-    private boolean requiresTransitiveDependencies;
 
     /**
      * Flag that indicates that local resources should come last in the dependencies list
@@ -227,12 +227,31 @@ public class ModuleSpecification extends SimpleAttachable {
         this.privateModule = privateModule;
     }
 
-    public boolean isRequiresTransitiveDependencies() {
-        return requiresTransitiveDependencies;
+    /**
+     * Returns true if the {@link #localDependencies} added for this {@link ModuleSpecification} should be made
+     * transitive (i.e. if any other module 'B' depends on the module 'A' represented by this {@link ModuleSpecification}, then
+     * module 'B' will be added with all "local dependencies" that are applicable for module "A"). Else returns false.
+     *
+     * @see {@link #localDependencies}
+     * @return
+     */
+    public boolean isLocalDependenciesTransitive() {
+        return localDependenciesTransitive;
     }
 
-    public void setRequiresTransitiveDependencies(final boolean requiresTransitiveDependencies) {
-        this.requiresTransitiveDependencies = requiresTransitiveDependencies;
+    /**
+     * Sets whether the {@link #localDependencies} applicable for this {@link ModuleSpecification} are to be treated as transitive dependencies
+     * for modules which depend on the module represented by this {@link ModuleSpecification}
+     *
+     * @param localDependenciesTransitive True if the {@link #localDependencies} added for this {@link ModuleSpecification} should be made
+     *                                    transitive (i.e. if any other module 'B' depends on the module 'A' represented by
+     *                                    this {@link ModuleSpecification}, then module 'B' will be added with
+     *                                    all "local dependencies" that are applicable for module "A"). False otherwise
+     * @see {@link #localDependencies}
+     * @return
+     */
+    public void setLocalDependenciesTransitive(final boolean localDependenciesTransitive) {
+        this.localDependenciesTransitive = localDependenciesTransitive;
     }
 
     public boolean isLocalLast() {

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecification.java
@@ -254,6 +254,24 @@ public class ModuleSpecification extends SimpleAttachable {
         this.localDependenciesTransitive = localDependenciesTransitive;
     }
 
+    /**
+     * @deprecated since AS 8.x. Use {@link #isLocalDependenciesTransitive()} instead
+     * @return
+     */
+    @Deprecated
+    public boolean isRequiresTransitiveDependencies() {
+        return localDependenciesTransitive;
+    }
+
+    /**
+     * @deprecated since AS 8.x. Use {@link #setLocalDependenciesTransitive(boolean)} instead
+     * @param requiresTransitiveDependencies
+     */
+    @Deprecated
+    public void setRequiresTransitiveDependencies(final boolean requiresTransitiveDependencies) {
+        this.localDependenciesTransitive = requiresTransitiveDependencies;
+    }
+
     public boolean isLocalLast() {
         return localLast;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/MANIFEST.MF
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/MANIFEST.MF
@@ -1,0 +1,1 @@
+Class-Path: transient.jar

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/RarTransientDependenciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/RarTransientDependenciesTestCase.java
@@ -21,78 +21,106 @@
  */
 package org.jboss.as.test.integration.deployment.classloading.transientdependencies;
 
-import org.jboss.as.test.integration.jca.beanvalidation.ra.ValidConnectionFactory;
-
 import junit.framework.Assert;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.jca.beanvalidation.ra.ValidConnectionFactory;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
 /**
- * Tests that a rar deployments transitive deps are made availble to a deployment that references the rar
+ * Tests that a rar deployments transitive deps are made available to a deployment that references the rar
  *
  * @author Stuart Douglas
- *
+ * @author Jaikiran Pai
  */
 @RunWith(Arquillian.class)
+@RunAsClient
 public class RarTransientDependenciesTestCase {
 
-    @Deployment(name="jar", order=1)
-    public static Archive<?> jar() {
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "transient.jar");
-        jar.addClass(JarClass.class);
-        return jar;
-    }
+    /**
+     * Creates a .ear which has the following packaging structure:
+     * <p/>
+     * rar-transient-dep.ear
+     * |
+     * |--- rardeployment.rar (RAR deployment)
+     * |		|
+     * |		|--- META-INF
+     * |		|		|
+     * |		|		|--- ra.xml
+     * |		|		|
+     * |		|		|--- MANIFEST.MF containing -> Class-Path: transient.jar (to point to the jar at the root of the .ear)
+     * |
+     * |
+     * |--- referenceingwebapp.war (war deployment)
+     * |		|
+     * |		|
+     * |		|--- org.jboss.as.test.integration.deployment.classloading.transientdependencies.Servlet (the servlet which tries to access the class in the transient.jar, when invoked)
+     * |
+     * |
+     * |--- transient.jar (simple jar file and NOT a deployment. this jar is referenced via the Class-Path manifest attribute in the .rar and as a result, is transitively expected to be available for access in the .war)
+     * |		|
+     * |		|--- org.jboss.as.test.integration.deployment.classloading.transientdependencies.JarClass
+     *
+     * @return
+     */
+    @Deployment
+    public static Archive<?> createDeployment() {
 
-    @Deployment(name="rar", order=2)
-    public static Archive<?> rar() {
-        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "rardeployment.rar");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "rar-transient-dep.ear");
+
+        final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "rardeployment.rar");
         JavaArchive jar1 = ShrinkWrap.create(JavaArchive.class, "main.jar");
         jar1.addPackage(ValidConnectionFactory.class.getPackage());
         rar.add(jar1, "/", ZipExporter.class);
+        rar.addAsManifestResource(RarTransientDependenciesTestCase.class.getPackage(), "MANIFEST.MF", "MANIFEST.MF");
+        rar.addAsManifestResource(RarTransientDependenciesTestCase.class.getPackage(), "ra.xml", "ra.xml");
 
-        rar.addAsManifestResource(new StringAsset(
-                "<jboss-deployment-structure>" +
-                        "<deployment>" +
-                        "<dependencies>" +
-                        "<module name=\"deployment.transient.jar\" />" +
-                        "</dependencies>" +
-                        "</deployment>" +
-                        "</jboss-deployment-structure>"),
-                "jboss-deployment-structure.xml");
-        rar.addAsManifestResource(RarTransientDependenciesTestCase.class.getPackage(),"ra.xml", "ra.xml");
-        return rar;
+        // add the .rar to the .ear
+        ear.addAsModule(rar);
+
+        // now create the transient.jar with the JarClass.class
+        final JavaArchive transientDepJar = ShrinkWrap.create(JavaArchive.class, "transient.jar");
+        transientDepJar.addClass(JarClass.class);
+        // add this jar to the root of the .ear as simple jar and not as a module. the .rar in the .ear will have a Class-Path reference
+        // to this jar
+        ear.add(transientDepJar, "/", ZipExporter.class);
+
+        // finally create and add the .war to the .ear
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "referenceingwebapp.war");
+        war.addClasses(RarTransientDependenciesTestCase.class, Servlet.class);
+        war.addAsWebInfResource(RarTransientDependenciesTestCase.class.getPackage(), "web.xml", "web.xml");
+        ear.addAsModule(war);
+
+        return ear;
     }
 
-    @Deployment(name="war", order=3)
-    public static Archive<?> war() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class,"referenceingwebapp.war");
-        war.addClasses(RarTransientDependenciesTestCase.class);
-        war.addAsWebInfResource(new StringAsset(
-                "<jboss-deployment-structure>" +
-                        "<deployment>" +
-                        "<dependencies>" +
-                        "<module name=\"deployment.rardeployment.rar\" />" +
-                        "</dependencies>" +
-                        "</deployment>" +
-                        "</jboss-deployment-structure>"),
-                "jboss-deployment-structure.xml");
-        return war;
-    }
-
+    /**
+     * Tests that a class available in a jar, which is added as a Class-Path manifest attribute of a .rar is available for access from within a class
+     * in a .war deployment, belonging to the same .ear top level deployment. This tests section 8.3 of Java EE6 spec
+     *
+     * @param baseUrl
+     * @throws Exception
+     */
     @Test
-    @OperateOnDeployment("war")
-    public void testRarClassLoading() {
-        Assert.assertTrue(JarClass.class.getClassLoader().toString().contains("transient.jar"));
+    public void testTransitiveDependencyAccessViaRar(@ArquillianResource URL baseUrl) throws Exception {
+        final String url = "http://" + baseUrl.getHost() + ":" + baseUrl.getPort() + "/referenceingwebapp/servlet?className=" + JarClass.class.getName();
+        final String res = HttpRequest.get(url, 2, TimeUnit.SECONDS);
+        Assert.assertEquals(Servlet.SUCCESS, res);
+
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/Servlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/Servlet.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.classloading.transientdependencies;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class Servlet extends HttpServlet {
+
+    static final String SUCCESS = "success";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final String className = req.getParameter("className");
+        try {
+            final Class<?> klass = Thread.currentThread().getContextClassLoader().loadClass(className);
+            resp.getOutputStream().print(SUCCESS);
+        } catch (ClassNotFoundException cnfe) {
+            throw new RuntimeException("Could not load a class: " + className + " which was expected to be available", cnfe);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/transientdependencies/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app version="2.5"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+   http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <servlet>
+        <servlet-name>Servlet</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.deployment.classloading.transientdependencies.Servlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Servlet</servlet-name>
+        <url-pattern>/servlet</url-pattern>
+    </servlet-mapping>
+</web-app>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-6580 and also fixes an incorrect testcase. 

Henceforth, only the "local dependencies" (i.e. dependencies added as a result of Class-Path manifest attribute) of a RAR deployment will be auto exported as transitive dependencies to any module (typically modules of other deployments) which has the RAR as a dependency.

Please see https://github.com/jbossas/jboss-as/pull/4108 which was the original PR for this bug fix.
