### PR TITLE
[AS7-6551] Add version 2.0 of jboss-as-config schema.  

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
@@ -86,20 +86,18 @@ public class AppClientXml extends CommonXml {
 
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
         switch (readerNS) {
-            case DOMAIN_1_0: {
+            case DOMAIN_1_0:
                 readServerElement_1_0(reader, address, operationList);
                 break;
-            }
-            case DOMAIN_1_1:
-            case DOMAIN_1_2:
-            case DOMAIN_1_3:
-            case DOMAIN_1_4:{
-                readServerElement_1_1(readerNS, reader, address, operationList);
-                break;
-            }
-            default: {
-              throw unexpectedElement(reader);
-            }
+            default:
+                // Instead of having to list the remaining versions we just check it is actually a valid version.
+                for (Namespace current : Namespace.domainValues()) {
+                    if (readerNS.equals(current)) {
+                        readServerElement_1_1(readerNS, reader, address, operationList);
+                        return;
+                    }
+                }
+                throw unexpectedElement(reader);
         }
     }
 

--- a/build/src/main/resources/appclient/configuration/appclient.xml
+++ b/build/src/main/resources/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/build/src/main/resources/configuration/domain/template.xml
+++ b/build/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/configuration/standalone/template-osgi.xml
+++ b/build/src/main/resources/configuration/standalone/template-osgi.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
@@ -1,0 +1,2390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:2.0"
+           targetNamespace="urn:jboss:domain:2.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+
+    <xs:element name="domain">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the master document specifying the core configuration
+                for the servers in a domain. There should be one such master
+                document per domain, available to the host controller that
+                is configured to act as the domain controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="paths" type="named-pathsType" minOccurs="0" maxOccurs="1" />
+                <xs:element name="profiles" type="profilesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="interfaces" type="named-interfacesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="socket-binding-groups" type="socket-binding-groupsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployments" type="domain-deploymentsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="domain-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="server-groups" type="server-groupsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management-client-content" type="management-client-contentType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional" default="Unnamed Domain">
+               <xs:annotation>
+                  <xs:documentation>
+                     The name to use for the domain controller. Useful for administrators who need to work with multiple domains.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="host">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for a document configuring a host controller and
+                the group of servers under the control of that host controller.
+                The standard usage would be for a domain to have one such host controller
+                on each physical (or virtual) host machine. Emphasis in this
+                document is on enumerating the servers, configuring items that
+                are specific to the host environment (e.g. IP addresses), and
+                on any server-specific configuration settings.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0"/>
+                <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1" />
+                <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management" type="host-managementType" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="domain-controller" type="domain-controllerType"/>
+                <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0"/>
+                <xs:element name="jvms" type="jvmsType" minOccurs="0"/>
+                <xs:element name="servers" type="serversType" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for this host's host controller. Must be unique across the domain.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="server">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for a document specifying the configuration
+                of a single "standalone" server that does not operate
+                as part of a domain.
+
+                Note that this element is distinct from the 'serverType'
+                specified in this schema. The latter type forms part of the
+                configuration of a server that operates as part of a domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="extensions" type="extensionsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="system-properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="vault" type="vaultType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management" type="server-managementType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="profile" type="standalone-profileType" minOccurs="0"/>
+                <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="socket-binding-group" type="standalone-socket-binding-groupType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployments" type="server-deploymentsType" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="deployment-overlays" type="standalone-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name to use for this server.
+                        If not set, defaults to the runtime value "HOSTNAME" or "COMPUTERNAME" environment variables,
+                        or, if neither environment variable is present, to the value of InetAddress.getLocalHost().getHostName().
+
+                        If the special value "jboss.domain.uuid" is used, a java.util.UUID will be created
+                        and used, based on the value of InetAddress.getLocalHost().
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="domain-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                Domain-wide default configuration settings for the management of standalone servers and a Host Controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="security-realms" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="security-realm" type="security-realmType" minOccurs="1"
+                                    maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="outbound-connections" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                      <xs:element name="ldap" type="ldapType" minOccurs="1" /> <!-- TODO minOccurs only while ldap is only supported connection. -->
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="host-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for the management of a Host Controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="domain-managementType">
+                <xs:sequence>
+                    <xs:element name="management-interfaces" type="host-management-interfacesType" minOccurs="1"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="server-managementType">
+        <xs:annotation>
+            <xs:documentation>
+                The centralized configuration for the management of standalone server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="domain-managementType">
+                <xs:sequence>
+                    <xs:element name="management-interfaces" type="server-management-interfacesType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ldapType">
+        <xs:annotation>
+            <xs:documentation>
+                The LDAP connection definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The URL to connect to ldap.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The distinguished name to use when connecting to LDAP to perform searches.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-credential" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The credential to use when connecting to perform a search.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a security realm to obtain an initialised SSLContext to use when establishing a
+                    connection to the LDAP server.
+
+                    The realm referenced here MUST NOT be a realm that is also configured to use this connection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-context-factory" type="xs:string" default="com.sun.jndi.ldap.LdapCtxFactory">
+            <xs:annotation>
+                <xs:documentation>
+                    The initial context factory to establish the LdapContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="security-realmType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a security realm for securing access to the management interfaces.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="plug-ins" type="plug-insType" minOccurs="0" />
+            <xs:element name="server-identities" type="server-identitiesType" minOccurs="0" />
+            <xs:element name="authentication" type="authenticationType" minOccurs="0" />
+            <xs:element name="authorization" type="authorizationType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this security-realm, each security-realm must be assigned a unique name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="plug-insType">
+        <xs:annotation>
+            <xs:documentation>
+                List of modules to be searched for supported security realm plug-ins.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="plug-in" type="plug-inType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="plug-inType">
+        <xs:attribute name="module" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The name of the module.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="plug-inAuthType">
+        <xs:annotation>
+            <xs:documentation>
+                This type defines which plug in will be used to handle either the loading of the
+                authentication data or authorization data during the authentication process.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The properties to be made available to the plug-in.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The short name of the plug-in as already dynamically registered by being referenced
+                    in the plug-ins element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="mechanism" default="DIGEST" use="optional">
+           <xs:annotation>
+              <xs:documentation>
+                   By default plug-ins will be assumed to be used with the DIGEST authentication mechanism,
+                   this attribute can override the plug-in for use with the PLAIN mechanism.
+              </xs:documentation>
+           </xs:annotation>
+           <xs:simpleType>
+              <xs:restriction base="xs:string">
+                 <xs:enumeration value="DIGEST" />
+                 <xs:enumeration value="PLAIN" />
+              </xs:restriction>
+           </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authorizationType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration defining how to load the authorization information for the authenticated user.
+
+                After a user has been authenticated additional information such as roles can be loaded and
+                associated with the user for subsequent authorization checks, this type is used to define
+                how the roles are loaded.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="properties" type="propertiesFileType" minOccurs="0" />
+            <xs:element name="plug-in" type="plug-inAuthType" minOccurs="0" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="server-identitiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the identities that represent the server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+          <xs:element name="ssl" type="sslType" minOccurs="0" />
+          <xs:element name="secret" type="secretType" minOccurs="0" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="secretType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the secret/password-based identity of this server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The secret / password - Base64 Encoded
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="sslType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the SSL identity of this server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="keystore" type="extendedKeyStoreType" />
+        </xs:sequence>
+        <xs:attribute name="protocol" type="xs:string" default="TLS">
+            <xs:annotation>
+                <xs:documentation>
+                    The protocol to use when creating the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                The keystore configuration for the server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The path of the keystore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keystore-password" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The password to open the keystore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="extendedKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                This is a more complex keystore definition which also allows for an alias
+                and key password to be specified.
+            </xs:documentation>
+        </xs:annotation>
+	    <xs:complexContent>
+            <xs:extension base="keyStoreType">
+                <xs:attribute name="alias" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The alias of the entry to use from the keystore, if specified all remaining
+                            entries in the keystore will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-password" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The password to use when loading keys from the keystore.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+		    </xs:extension>
+	    </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="localType">
+        <xs:annotation>
+            <xs:documentation>
+                This type definition is used to control the local authentication mechanism.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="default-user" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    When using the local mechanism it is optional for the client side to send an
+                    authentication user name - this attribute specifies the user name to be assumed
+                    if the remote client does not send one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="allowed-users" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A comma separated list of users that can be specified by the client when connecting
+                    using the local authentication mechanism.
+
+                    If a default user has been specified then that user is automatically added to the
+                    allowed list.  If both default-user and allowed-users are ommitted despite the mechanism
+                    being enabled no incomming connection attemps using the mechanism will succeed.
+
+                    If any user name should be accepted the value should be set to "*".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the server side authentication mechanisms.
+
+                Optionally one truststore can be defined and one username/password based store can be defined.
+                Authentication will first attempt to use the truststore and if this is not available will fall back
+                to the username/password authentication.
+
+                If none of these are specified the only available mechanism will be the local mechanism for the
+                Native interface and the HTTP interface will not be accessible.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="truststore" type="keyStoreType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of a keystore to use to create a trust manager to verify clients.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="local" type="localType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration to enable the local authentication mechanism, if this element
+                        is ommitted then local authentication will be disabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0">
+                <xs:element name="jaas" type="jaasAuthenticationType" minOccurs="0" />
+                <xs:element name="ldap" type="ldapAuthenticationType" minOccurs="0" />
+                <xs:element name="properties" type="propertiesAuthenticationType" minOccurs="0" />
+                <xs:element name="users" type="usersAuthenticationType" minOccurs="0" />
+                <xs:element name="plug-in" type="plug-inAuthType" minOccurs="0" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jaasAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to use a JAAS based configuration for authentication.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name identifying the jaas configuration of LoginModules.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition to use LDAP as the user repository.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="username-filter">
+                <xs:complexType>
+                    <xs:attribute name="attribute" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The name of the attribute to search for the user, this filter will then perform
+                                a simple search where the username entered by the user matches the attribute
+                                specified here.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="advanced-filter">
+                <xs:complexType>
+                    <xs:attribute name="filter" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully defined filter to be used to search for the user based on their entered
+                                user ID. The filter should contain a variable in the form {0} - this will be
+                                replaced with the username supplied by the user.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+
+        <xs:attribute name="connection" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the connection to use to connect to LDAP.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="base-dn" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The base distinguished name to commence the search for the user.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recursive" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should the search be recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="user-dn" type="xs:string" default="dn">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the attribute which is the users distinguished name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="allow-empty-passwords" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should users be allowed to supply an empty password?  Some LDAP servers will
+                    allow an anonymous bind so an empty password could appear as a successful authentication
+                    even though no password was sent to verify.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="usersAuthenticationType">
+           <xs:annotation>
+            <xs:documentation>
+                A set of users
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="user" type="userType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="userType">
+        <xs:annotation>
+            <xs:documentation>
+                A single user.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="password" type="xs:string" />
+        </xs:choice>
+        <xs:attribute name="username" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The users username.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesFileType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of a location of a properties file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of another previously named path, or of one of the
+                    standard paths provided by the system. If 'relative-to' is
+                    provided, the value of the 'path' attribute is treated as
+                    relative to the path specified by this attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The path of the properties file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesAuthenticationType">
+        <xs:annotation>
+            <xs:documentation>
+                Declaration of users stored within properties files.
+
+                The entries within the properties file are username={credentials} with each user
+                being specified on it's own line.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="propertiesFileType">
+                <xs:attribute name="plain-text" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Are the credentials within the properties file stored in plain text, if not
+                            the {credential} is expected to be the hex encoded Digest hash
+                            of 'username : realm : password'.
+                        </xs:documentation>
+                    </xs:annotation>
+            </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-management-interfacesType">
+        <xs:sequence>
+            <xs:element name="native-interface" type="host-native-management-interfaceType"/>
+            <xs:element name="http-interface" type="host-http-management-interfaceType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="management-interfaceType">
+        <xs:attribute name="security-realm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The security realm to use for this management interface, the capabilities
+                    of the security realm will be queried to identify the authentication mechanism(s) to
+                    offer.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="host-native-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a host's exposed native management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="socket" type="native-management-socketType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Network interface on which the host's socket for
+                    management communication should be opened.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-socketType">
+                <xs:attribute name="port" type="xs:int" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for native
+                            management communication should be opened.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="host-http-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a host's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:sequence>
+                    <xs:element name="socket" type="http-management-socketType"/>
+                </xs:sequence>
+                <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-socketType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-socketType">
+                <xs:attribute name="port" type="xs:int" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for
+                            management communication should be opened.
+
+                            If not specified the port will not be opened.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="secure-port" type="xs:int" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Port on which the host's socket for HTTPS
+                            management communication should be opened.
+
+                            If not specified the port will not be opened.
+
+                            If specified the security-realm will be required to obtain
+                            the SSL configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="server-management-interfacesType">
+        <xs:sequence>
+            <xs:element name="native-remoting-interface" type="management-remoting-interfaceType" minOccurs="0"/>
+            <xs:element name="native-interface" type="server-native-management-interfaceType" minOccurs="0"/>
+            <xs:element name="http-interface" type="server-http-management-interfaceType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-native-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of the socket used by host or standalone server's exposed HTTP management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the socket to use for the native management interface is a choice
+                        between a direct configuration of the address and port, or a reference to a socket-binding
+                        configuration in the server's socket-binding-group element. The latter is the recommended
+                        approach is it makes it easier to avoid port conflicts by taking advantage of the
+                        socket-binding-group's port-offset configuration. Direct configuration of the address and
+                        ports is provided to preserve backward compatibility.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:choice>
+                    <xs:element name="socket" type="native-management-socketType"/>
+                    <xs:element name="socket-binding" type="native-management-socket-binding-refType"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="native-management-socket-binding-refType">
+        <xs:annotation>
+            <xs:documentation>
+                Reference to the configuration of the socket to be used by a standalone server's exposed native management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="native" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-http-management-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration of a standalone server's exposed HTTP/HTTPS management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="management-interfaceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration of the socket to use for the HTTP/HTTPS management interface is a choice
+                        between a direct configuration of the address and ports, or a reference to socket-binding
+                        configurations in the server's socket-binding-group element. The latter is the recommended
+                        approach is it makes it easier to avoid port conflicts by taking advantage of the
+                        socket-binding-group's port-offset configuration. Direct configuration of the address and
+                        ports is provided to preserve backward compatibility.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:choice>
+                    <xs:element name="socket" type="http-management-socketType"/>
+                    <xs:element name="socket-binding" type="http-management-socket-binding-refType"/>
+                </xs:choice>
+                <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-management-socket-binding-refType">
+        <xs:annotation>
+            <xs:documentation>
+                Reference to the configurations of the sockets to be used by a standalone server's exposed HTTP and HTTPS management interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="http" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group to use for a HTTP socket.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="https" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of a socket-binding configuration declared in the server's socket-binding-group to use for a HTTPS socket.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="management-remoting-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                Makes the native management interface available via the connectors set up in the remoting subsystem,
+                using the remoting subsystem's endpoint. This should only be used for a server not for a HC/DC.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controllerType">
+        <xs:choice>
+            <xs:element name="local" type="domain-controller-localType"/>
+            <xs:element name="remote" type="domain-controller-remoteType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="domain-controller-localType" />
+
+    <xs:complexType name="domain-controller-remoteType">
+        <xs:sequence>
+            <xs:element name="ignored-resources" type="ignored-resourcesType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="host" type="xs:string" use="required" />
+        <xs:attribute name="port" type="xs:integer" use="required" />
+        <xs:attribute name="security-realm" type="xs:string" use="optional" />
+        <xs:attribute name="username" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="ignored-resourcesType">
+        <xs:annotation>
+            <xs:documentation>
+                Provides names of direct child resources of the domain root resource requests for which the
+                Host Controller should ignore. Only relevant on a slave Host Controller. Configuring such
+                "ignored resources" may help allow a Host Controller from an earlier release to function as a
+                slave to a master Host Controller running a later release, by letting the slave ignore portions
+                of the configuration its version of the software cannot understand. This strategy can only be
+                successful if the servers managed by the slave Host Controller do not reference any of the
+                ignored configuration.
+
+                Supports the following attributes:
+
+                type -- the type of resource (e.g. 'profile' or 'socket-binding-group') certain instances of which
+                        should be ignored. The value corresponds to the 'key' portion of the first element in the
+                        resource's address (e.g. 'profile' in the address /profile=ha/subsystem=web)
+
+                wildcard -- if 'true', all resources of the given type should be ignored.
+
+                Child elements list the names of specific instances of the given type of resource
+                that should be ignored. Each element in the list corresponds to the 'value' portion of
+                the first element in the resource's address (e.g. 'ha' in the address /profile=ha/subsystem=web.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="instance" type="ignored-resource-instanceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:attribute name="wildcard" type="xs:boolean" use="optional" default="false" />
+        <xs:attribute name="names" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="ignored-resource-instanceType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a specific instances of a particular type of resource that should be ignored.
+                The 'name' attribute corresponds to the 'value' portion of the first element in the resource's address
+                (e.g. 'ha' in the address /profile=ha/subsystem=web.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="serversType">
+        <xs:sequence>
+            <xs:element name="server" type="serverType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="directory-grouping" default="by-server" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="by-server">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Indicates each server's writable directories should be grouped under the server's name
+                                in the domain/servers directory. This is the default option.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="by-type">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Indicates each server's writable directories should be grouped based on their "type"
+                                (i.e. "data", "log", "tmp") with directories of a given type for all servers appearing
+                                in the domain level directory for that type, e.g. domain/data/servers/server-name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverType">
+        <xs:all>
+            <xs:element name="paths" type="specified-pathsType" minOccurs="0" maxOccurs="1" />
+
+            <xs:element name="interfaces" type="specified-interfacesType" minOccurs="0"/>
+            <xs:element name="socket-bindings" type="server-socket-bindingsType" minOccurs="0"/>
+
+            <!--<xs:element name="loggers" type="loggersType" minOccurs="0"/>-->
+            <xs:element name="system-properties" type="properties-with-boottime" minOccurs="0"/>
+            <xs:element name="jvm" minOccurs="0" type="serverJvmType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="group" type="xs:string" use="required"/>
+        <xs:attribute name="auto-start" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="server-socket-bindingsType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Server-specific overrides to the default socket binding configuration inherited from the server group.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding-group" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                <![CDATA[
+                    The socket binding group to use for the server. If undefined, the socket binding group
+                    specified for the server group is used.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" default="0" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                <![CDATA[
+                    Increment to apply to the base port values defined in the
+                    referenced socket binding group to derive the values to use on this
+                    server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="extensionsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of extension modules.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="extension" type="extensionType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="extensionType">
+        <xs:annotation>
+            <xs:documentation>
+                A module that extends the standard capabilities of a domain
+                or a standalone server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="module" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>The name of the module</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupsType">
+        <xs:sequence>
+            <xs:element name="server-group" type="server-groupType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupType">
+        <xs:sequence>
+            <xs:element name="jvm" type="namedJvmType" minOccurs="0"/>
+            <xs:element name="socket-binding-group" type="socket-binding-group-refType" minOccurs="1"/>
+
+            <xs:element name="deployments" type="server-groupDeploymentsType" minOccurs="0"/>
+            <xs:element name="deployment-overlays" type="server-group-deployment-overlaysType" minOccurs="0" maxOccurs="1"/>
+
+            <xs:element name="system-properties" minOccurs="0" type="properties-with-boottime"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the server group
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="profile" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the profile this server is running.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="management-subsystem-endpoint" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Set to true to have servers belonging to the server group connect back to the host controller using the
+                    endpoint from their remoting subsystem. The subsystem must be preset for this to
+                    work.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupDeploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of deployments that have been mapped to a server-group.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="base-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-groupDeploymentType">
+        <xs:annotation>
+            <xs:documentation>A deployment that has been mapped to a server group.</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-deploymentType">
+                <!--  TODO clarify what a value of 'false' means -->
+                <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>Whether the deployment deploy automatically when the server starts up.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-deploymentType">
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>Unique identifier of the deployment. Must be unique across all deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="runtime-name" use="required">
+            <xs:annotation>
+                <xs:documentation>Name by which the deployment will be known within a running server.of the deployment.
+                    Does not need to be unique across all deployments in the domain, although it must be unique within
+                    an individual server. For example, two different deployments running on different servers in
+                    the domain could both have a 'runtime-name' of 'example.war', with one having a 'name'
+                    of 'example.war_v1' and another with an 'name' of 'example.war_v2'.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="server-deploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of deployments that have been mapped to a server.</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="server-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-deploymentType">
+        <xs:annotation>
+            <xs:documentation>A deployment that has been mapped to a server.</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-deploymentType">
+                <xs:sequence>
+                    <!-- TODO: maxOccurs should be unbounded once overlays are in place -->
+                    <xs:choice maxOccurs="1">
+                        <xs:element name="content" type="contentType"/>
+                        <xs:element name="fs-archive" type="fs-archiveType"/>
+                        <xs:element name="fs-exploded" type="fs-explodedType"/>
+                    </xs:choice>
+                </xs:sequence>
+                <!--  TODO clarify what a value of 'false' means -->
+                <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>Whether the deployment deploy automatically when the server starts up.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="contentType">
+        <xs:attribute name="sha1" use="required">
+            <xs:annotation>
+                <xs:documentation>The checksum of the content</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="fs-archiveType">
+        <xs:annotation>
+            <xs:documentation>Archived content found on the filesystem</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fs-baseType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="fs-baseType">
+        <xs:complexContent>
+            <xs:extension base="pathType"/>
+        </xs:complexContent>
+        <!-- TODO: make path required
+        <xs:complexContent>
+            <xs:restriction base="pathType">
+                <xs:attribute name="path" use="required"/>
+            </xs:restriction>
+        </xs:complexContent>
+        -->
+    </xs:complexType>
+
+    <xs:complexType name="fs-explodedType">
+        <xs:annotation>
+            <xs:documentation>Exploded content found on the filesystem</xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fs-baseType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deploymentsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of domain-level deployments</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment" type="domain-deploymentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deploymentType">
+        <xs:annotation>
+            <xs:documentation>Deployment represents anything that can be deployed (e.g. an application such as EJB-JAR,
+                WAR, EAR,
+                any kind of standard archive such as RAR or JBoss-specific deployment),
+                which can be enabled or disabled on a domain level.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-deploymentType">
+                <xs:sequence>
+                    <!-- TODO: maxOccurs should be unbounded once overlays are in place -->
+                    <xs:choice maxOccurs="1">
+                        <xs:element name="content" type="contentType"/>
+                        <xs:element name="fs-archive" type="fs-archiveType"/>
+                        <xs:element name="fs-exploded" type="fs-explodedType"/>
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- TODO this is not used anywhere yet -->
+    <xs:complexType name="clustersType">
+        <xs:complexContent>
+            <xs:extension base="server-groupType">
+                <xs:sequence>
+                    <xs:element name="partition-name" type="xs:string"/>
+                    <xs:element name="state-transfer-timeout" type="xs:integer"/>
+                    <xs:element name="method-call-timeout" type="xs:integer"/>
+                </xs:sequence>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- domain-configuration related definitions -->
+    <xs:complexType name="domain-configurationType">
+        <xs:annotation>
+            <xs:documentation>The domain controller/server bootstrap configuration</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element ref="bootstrapURI"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="bootstrapURI" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>The URI for bootstrapping a domain server</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="profilesType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of profiles available for use in the domain</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="profile" type="domain-profileType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>A profile declaration may include configuration
+                        elements from other namespaces for the subsystems that make up the profile.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:any>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Name of the profile</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-profileType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of subsystems</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:any namespace="##other">
+                    <xs:annotation>
+                        <xs:documentation>A profile declaration may include configuration
+                            elements from other namespaces for the subsystems that make up the profile.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:any>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- general socket definition -->
+    <xs:complexType name="socket-binding-groupsType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket binding groups</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding-group" type="socket-binding-groupType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-socket-binding-groupType">
+        <xs:annotation>
+            <xs:documentation>Contains a list of socket configurations</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="socket-binding" type="socket-bindingType" maxOccurs="unbounded"/>
+            <xs:element name="outbound-socket-binding" type="outbound-socket-bindingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="default-interface" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+	    <xs:attribute name="port-offset" type="xs:int" use="optional" default="0">
+	        <xs:annotation>
+                <xs:documentation>
+	                    Increment to apply to the base port values defined in the
+	                    socket group to derive the values to use on this
+	                    server.
+	            </xs:documentation>
+	        </xs:annotation>
+	    </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-bindingType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a socket.</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="client-mapping" type="socket-binding-client-mappingType"
+                        minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies zero or more client mappings for this socket binding.
+                        A client connecting to this socket should use the destination address
+                        specified in the mapping that matches its desired outbound interface.
+                        This allows for advanced network topologies that use either network
+                        address translation, or have bindings on multiple network interfaces
+                        to function.
+
+                        Each mapping should be evaluated in declared order, with the first successful
+                        match used to determine the destination.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the interface to which the socket should be bound, or, for multicast
+                    sockets, the interface on which it should listen. This should
+                    be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:unsignedShort" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Number of the port to which the socket should be bound.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the port value should remain fixed even if numerically offsets
+                    are applied to the other sockets in the socket group..
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-address" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Multicast address on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Port on which the socket should receive multicast
+                    traffic. Must be configured if 'multicast-address' is configured.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-client-mappingType">
+        <xs:annotation>
+                <xs:documentation>
+                    Type definition for a client mapping on a socket binding. A client
+                    mapping specifies how external clients should connect to this
+                    socket's port, provided that the client's outbound interface
+                    match the specified source network value.
+                </xs:documentation>
+            </xs:annotation>
+        <xs:attribute name="source-network" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Source network the client connection binds on. This value is in
+                    the form of ip/netmask. A client should match this value against
+                    the desired client host network interface, and if matched the
+                    client should connect to the corresponding destination values.
+
+                    If omitted this mapping should match any interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="destination-address" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The destination address that a client should connect to if the
+                    source-network matches. This value can either be a hostname or
+                    an ip address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="destination-port" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The destination port that a client should connect to if the
+                    source-network matches.
+
+                    If omitted this mapping will reuse the effective socket binding
+                    port.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-socket-bindingType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a outbound socket.</xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="remote-destination" type="remote-destinationType" maxOccurs="1"/>
+            <xs:element name="local-destination" type="local-destinationType" maxOccurs="1"/>
+        </xs:choice>
+
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the outbound socket binding
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="source-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the interface that should be used for setting up the source address of the
+                    outbound socket. This should be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+
+        </xs:attribute>
+        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    source-interface attribute has been specified and the source-port attribute is absent,
+                    then the system uses a ephemeral port while binding the socket to a source address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-source-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the source-port value should remain fixed even if the socket binding group specifies
+                    a port offset
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remote-destinationType">
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote server address to which the outbound socket has to be connect.
+                    The address can be either a IP address of the host server of the hostname of the server
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:positiveInteger" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remote port to which the outbound socket has to connect.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="local-destinationType">
+        <xs:attribute name="socket-binding-ref" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The reference to a socket binding that has to be used as the destination for the outbound
+                    socket binding. This socket binding name should belong to the same socket binding group
+                    to which this local destination client socket belongs.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="socket-binding-group-refType">
+        <xs:attribute name="ref" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The socket group to use for the server group or server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port-offset" type="xs:int" default="0" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Increment to apply to the base port values defined in the
+                    referenced socket group to derive the values to use on this
+                    server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="named-interfacesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named network interfaces. The interfaces may or may
+                not be fully specified (i.e. include criteria on how to determine
+                their IP address.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="named-interfaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- TODO make this and specified-interfaceType the same except for interface-criteriaGroup minOccurs -->
+    <xs:complexType name="named-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named network interface, but without any criteria
+                for determining the IP address to associate with that interface.
+                Acts as a placeholder in the model (e.g. at the domain level)
+                until a fully specified interface definition is applied at a
+                lower level (e.g. at the server level, where available addresses
+                are known.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="interface-criteriaGroup" minOccurs="0"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="specified-interfacesType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of fully specified named network interfaces.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="specified-interfaceType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-interfaceType">
+        <xs:annotation>
+            <xs:documentation>
+                A named network interface, along with required criteria
+                for determining the IP address to associate with that interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:group ref="interface-criteriaGroup" minOccurs="1"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:group name="interface-criteriaGroup">
+        <xs:annotation>
+            <xs:documentation>
+                A set of criteria that can be used at runtime to determine
+                what IP address to use for an interface.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="any-address" type="any-addressType"/>
+            <xs:element name="any-ipv6-address" type="any-ipv6-addressType"/>
+            <xs:element name="any-ipv4-address" type="any-ipv4-addressType"/>
+            <xs:choice maxOccurs="unbounded">
+                <xs:element name="inet-address" type="inet-addressType"/>
+                <xs:element name="loopback" type="loopbackType"/>
+                <xs:element name="loopback-address" type="loopback-addressType"/>
+                <xs:element name="multicast" type="multicastType"/>
+                <xs:element name="point-to-point" type="point-to-pointType"/>
+                <xs:element name="virtual" type="interface-virtualType"/>
+                <xs:element name="up" type="interface-upType"/>
+                <xs:element name="public-address" type="public-addressType"/>
+                <xs:element name="link-local-address" type="link-local-addressType"/>
+                <xs:element name="site-local-address" type="site-local-addressType"/>
+                <xs:element name="nic" type="nicType"/>
+                <xs:element name="nic-match" type="nic-matchType"/>
+                <xs:element name="subnet-match" type="subnet-matchType"/>
+                <xs:element name="not" type="address-exclusionType"/>
+                <xs:element name="any" type="address-exclusionType"/>
+            </xs:choice>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="inet-addressType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Either a IP address in IPv6 or IPv4 dotted decimal notation,
+                    or a hostname that can be resolved to an IP address.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="nicType">
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a network interface (e.g. eth0, eth1, lo).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="nic-matchType">
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A regular expression against which the names of the network
+                    interfaces available on the machine can be matched to find
+                    an acceptable interface.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="subnet-matchType">
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A network IP address and the number of bits in the
+                    address' network prefix, written in "slash notation";
+                    e.g. "192.168.0.0/16".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="address-exclusionType">
+        <xs:choice>
+            <xs:element name="inet-address" type="inet-addressType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="loopback" type="loopbackType"/>
+            <xs:element name="loopback-address" type="loopback-addressType"/>
+            <xs:element name="multicast" type="multicastType"/>
+            <xs:element name="point-to-point" type="point-to-pointType"/>
+            <xs:element name="virtual" type="interface-virtualType"/>
+            <xs:element name="up" type="interface-upType"/>
+            <xs:element name="public-address" type="public-addressType"/>
+            <xs:element name="link-local-address" type="link-local-addressType"/>
+            <xs:element name="site-local-address" type="site-local-addressType"/>
+            <xs:element name="nic" type="nicType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="nic-match" type="nic-matchType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="subnet-match" type="subnet-matchType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="loopbackType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a loopback
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="loopback-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                A loopback address that may not actually be configured on the machine's loopback interface.
+                Differs from inet-addressType in that the given value will be used even if no NIC can
+                be found that has the IP address associated with it.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An IP address in IPv6 or IPv4 dotted decimal notation.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="multicastType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it supports
+                multicast.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="point-to-pointType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a point-to-point
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="interface-upType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is currently up.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="interface-virtualType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it is a virtual
+                interface.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="public-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not it has a publicly
+                routable address.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="site-local-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not an address associated
+                with it is site-local.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="link-local-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that part of the selection criteria
+                for an interface should be whether or not an address associated
+                with it is link-local.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-ipv6-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to the IPv6 wildcard address (::).
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-ipv4-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to the IPv4 wildcard address (0.0.0.0).
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="any-addressType">
+        <xs:annotation>
+            <xs:documentation>
+                Empty element indicating that sockets using this interface
+                should be bound to a wildcard address. The IPv6 wildcard
+                address (::) will be used unless the java.net.preferIpV4Stack
+                system property is set to true, in which case the IPv4
+                wildcard address (0.0.0.0) will be used. If a socket is
+                bound to an IPv6 anylocal address on a dual-stack machine,
+                it can accept both IPv6 and IPv4 traffic; if it is bound to
+                an IPv4 (IPv4-mapped) anylocal address, it can only accept
+                IPv4 traffic.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="socketType">
+        <xs:annotation>
+            <xs:documentation>Configuration information for a socket.</xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the interface to which the socket should be bound, or, for multicast
+                    sockets, the interface on which it should listen. This should
+                    be one of the declared interfaces.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:unsignedShort" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Number of the port to which the socket should be bound.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fixed-port" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the port value should remain fixed even if numerically offsets
+                    are applied to the other sockets in the socket group..
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-address" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Multicast address on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="multicast-port" type="xs:positiveInteger" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Port on which the socket should receive multicast
+                    traffic. If unspecified, the socket will not be configured
+                    to receive multicast.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Path configurations -->
+    <xs:complexType name="named-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named filesystem paths. The paths may or may
+                not be fully specified (i.e. include the actual paths.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="named-pathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="named-pathType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem path, but without a requirement to specify
+                the actual path. If no actual path is specified, acts as a
+                as a placeholder in the model (e.g. at the domain level)
+                until a fully specified path definition is applied at a
+                lower level (e.g. at the host level, where available addresses
+                are known.)
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="pathType">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                        The name of the path. Cannot be one of the standard fixed paths
+                        provided by the system:
+
+                        jboss.home.dir - the root directory of the JBoss AS distribution
+                        user.home - user's home directory
+                        user.dir - user's current working directory
+                        java.home - java installation directory
+                        jboss.server.base.dir - root directory for an individual server
+                                                instance
+
+                        Note that the system provides other standard paths that can be
+                        overridden by declaring them in the configuration file. See
+                        the 'relative-to' attribute documentation for a complete
+                        list of standard paths.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="path">
+            <xs:annotation>
+                <xs:documentation>
+                The actual filesystem path. Treated as an absolute path, unless the
+                'relative-to' attribute is specified, in which case the value
+                is treated as relative to that path.
+
+                If treated as an absolute path, the actual runtime pathname specified
+                by the value of this attribute will be determined as follows:
+
+                If this value is already absolute, then the value is directly
+                used.  Otherwise the runtime pathname is resolved in a
+                system-dependent way.  On UNIX systems, a relative pathname is
+                made absolute by resolving it against the current user directory.
+                On Microsoft Windows systems, a relative pathname is made absolute
+                by resolving it against the current directory of the drive named by the
+                pathname, if any; if not, it is resolved against the current user
+                directory.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                The name of another previously named path, or of one of the
+                standard paths provided by the system. If 'relative-to' is
+                provided, the value of the 'path' attribute is treated as
+                relative to the path specified by this attribute. The standard
+                paths provided by the system include:
+
+                jboss.home.dir - the root directory of the JBoss AS distribution
+                user.home - user's home directory
+                user.dir - user's current working directory
+                java.home - java installation directory
+                jboss.server.base.dir - root directory for an individual server
+                                        instance
+                jboss.server.config.dir - directory in which server configuration
+                                          files are stored.
+                jboss.server.data.dir - directory the server will use for persistent
+                                        data file storage
+                jboss.server.log.dir - directory the server will use for
+                                       log file storage
+                jboss.server.temp.dir - directory the server will use for
+                                       temporary file storage
+                jboss.domain.servers.dir - directory under which a host controller
+                                           will create the working area for
+                                           individual server instances
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="specified-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                A list of named filesystem paths.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="specified-pathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-pathType">
+        <xs:annotation>
+            <xs:documentation>
+                A named filesystem path.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                The name of the path. Cannot be one of the standard fixed paths
+                provided by the system:
+
+                jboss.home.dir - the root directory of the JBoss AS distribution
+                user.home - user's home directory
+                user.dir - user's current working directory
+                java.home - java installation directory
+                jboss.server.base.dir - root directory for an individual server
+                                        instance
+
+                Note that the system provides other standard paths that can be
+                overridden by declaring them in the configuration file. See
+                the 'relative-to' attribute documentation for a complete
+                list of standard paths.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                The actual filesystem path. Treated as an absolute path, unless the
+                'relative-to' attribute is specified, in which case the value
+                is treated as relative to that path.
+
+                If treated as an absolute path, the actual runtime pathname specified
+                by the value of this attribute will be determined as follows:
+
+                If this value is already absolute, then the value is directly
+                used.  Otherwise the runtime pathname is resolved in a
+                system-dependent way.  On UNIX systems, a relative pathname is
+                made absolute by resolving it against the current user directory.
+                On Microsoft Windows systems, a relative pathname is made absolute
+                by resolving it against the current directory of the drive named by the
+                pathname, if any; if not, it is resolved against the current user
+                directory.
+
+                Note relative path declarations have to use '/' as file separator.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                The name of another previously named path, or of one of the
+                standard paths provided by the system. If 'relative-to' is
+                provided, the value of the 'path' attribute is treated as
+                relative to the path specified by this attribute. The standard
+                paths provided by the system include:
+
+                jboss.home.dir - the root directory of the JBoss AS distribution
+                user.home - user's home directory
+                user.dir - user's current working directory
+                java.home - java installation directory
+                jboss.server.base.dir - root directory for an individual server
+                                        instance
+                jboss.server.config.dir - directory in which server configuration
+                                          files are stored.
+                jboss.server.data.dir - directory the server will use for persistent
+                                        data file storage
+                jboss.server.log.dir - directory the server will use for
+                                       log file storage
+                jboss.server.temp.dir - directory the server will use for
+                                       temporary file storage
+                jboss.domain.servers.dir - directory under which a host controller
+                                           will create the working area for
+                                           individual server instances
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--  JVM configurations -->
+    <xs:complexType name="jvmsType">
+        <xs:sequence>
+            <xs:element name="jvm" type="namedJvmType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jvmType">
+        <xs:all minOccurs="0" maxOccurs="1">
+            <xs:element name="heap" type="heapType" minOccurs="0"/>
+            <!-- XX:PermSize, XX:MaxPermSize -->
+            <xs:element name="permgen" type="bounded-memory-sizeType" minOccurs="0"/>
+            <!-- Xss -->
+            <xs:element name="stack" type="memory-sizeType" minOccurs="0"/>
+            <xs:element name="agent-lib" type="jvm-agentLibType" minOccurs="0"/>
+            <xs:element name="agent-path" type="jvm-agentPathType" minOccurs="0"/>
+            <xs:element name="java-agent" type="jvm-javaagentType" minOccurs="0"/>
+            <xs:element name="jvm-options" type="jvm-optionsType" minOccurs="0"/>
+            <xs:element name="environment-variables" type="environmentVariablesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="java-home" type="xs:string"/>
+        <xs:attribute name="type" default="SUN">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="SUN">
+			            <xs:annotation>
+			                <xs:documentation>Allows the full set of JVM options to be set via the jvm schema elements</xs:documentation>
+			            </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="IBM">
+                        <xs:annotation>
+                            <xs:documentation>Sets a subset of the JVM options via the jvm schema elements</xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="env-classpath-ignored" default="true" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedJvmType">
+        <xs:complexContent>
+            <xs:extension base="jvmType">
+                <xs:attribute name="name" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serverJvmType">
+        <xs:complexContent>
+            <xs:extension base="namedJvmType">
+                <xs:attribute name="debug-enabled" type="xs:boolean" default="false"/>
+                <xs:attribute name="debug-options" type="xs:string" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="heapType">
+        <xs:attribute name="size" use="optional">
+            <xs:annotation>
+                <xs:documentation>Initial JVM heap size</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-size" use="optional">
+            <xs:annotation>
+                <xs:documentation>Maximum JVM heap size</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-optionsType">
+        <xs:sequence>
+            <xs:element name="option" type="jvm-optionType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-optionType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM option value</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-agentLibType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM agent lib value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-agentPathType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM agent path value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jvm-javaagentType">
+        <xs:attribute name="value" use="required">
+            <xs:annotation>
+                <xs:documentation>JVM javaagent value </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bounded-memory-sizeType">
+        <xs:attribute name="size" type="xs:string"/>
+        <xs:attribute name="max-size" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="memory-sizeType">
+        <xs:attribute name="size" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="properties-with-boottime">
+        <xs:sequence>
+            <xs:element name="property" type="boottimePropertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="properties">
+        <xs:sequence>
+            <xs:element name="property" type="propertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="environmentVariablesType">
+        <xs:sequence>
+            <xs:element name="variable" type="propertyType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:attribute name="name" use="required"/>
+        <xs:attribute name="value" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="boottimePropertyType">
+        <xs:complexContent>
+            <xs:extension base="propertyType">
+                <xs:attribute name="boot-time" type="xs:boolean" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+   <xs:complexType name="vaultType">
+      <xs:annotation>
+         <xs:documentation>
+               <![CDATA[
+                    Vault Configuration.
+                ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+          <xs:element name="vault-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="code" type="xs:string" use="optional"/>
+   </xs:complexType>
+
+    <xs:complexType name="management-client-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Storage information about re-usable chunks of data useful to management clients that are stored
+                   in the domain content repository.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="rollout-plans" type="contentType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                           Storage information about a set of named management update rollout plans useful to management
+                           clients that are stored in the domain content repository. The management API exposed by the domain
+                           controller provides access to these plans to management clients, allowing clients to use the plans
+                           by referencing them by name, avoiding the need to recreate them for each use.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="standalone-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="standalone-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="deployment" type="deployment-overlay-deploymentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="domain-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="domain-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="content" type="deployment-overlay-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
+    </xs:complexType>
+
+    <xs:complexType name="server-group-deployment-overlaysType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                   Stores information about deployment overlays that can be used to override deployment content.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="deployment-overlay" type="server-group-deployment-overlayType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="server-group-deployment-overlayType">
+        <xs:sequence>
+            <xs:element name="deployment" type="deployment-overlay-deploymentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:token"/>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-contentType">
+        <xs:attribute name="path" type="xs:token" use="required"/>
+        <xs:attribute name="content" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="deployment-overlay-deploymentType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+
+</xs:schema>

--- a/build/src/main/resources/domain/configuration/host-master.xml
+++ b/build/src/main/resources/domain/configuration/host-master.xml
@@ -4,7 +4,7 @@
    A simple configuration for a Host Controller that only acts as the master domain controller
    and does not itself directly control any servers.
 -->
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>

--- a/build/src/main/resources/domain/configuration/host-slave.xml
+++ b/build/src/main/resources/domain/configuration/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:1.4">
+<host xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>

--- a/build/src/main/resources/domain/configuration/host.xml
+++ b/build/src/main/resources/domain/configuration/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Namespace.java
@@ -49,15 +49,16 @@ public enum Namespace {
 
     DOMAIN_1_3("urn:jboss:domain:1.3"),
 
-    DOMAIN_1_4("urn:jboss:domain:1.4");
+    DOMAIN_1_4("urn:jboss:domain:1.4"),
+
+    DOMAIN_2_0("urn:jboss:domain:2.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DOMAIN_1_4;
+    public static final Namespace CURRENT = DOMAIN_2_0;
 
-
-    public static final Namespace[] ALL_NAMESPACES = new Namespace[] {DOMAIN_1_0, DOMAIN_1_1, DOMAIN_1_2, DOMAIN_1_3, DOMAIN_1_4};
+    public static final Namespace[] ALL_NAMESPACES = new Namespace[] {DOMAIN_1_0, DOMAIN_1_1, DOMAIN_1_2, DOMAIN_1_3, DOMAIN_1_4, DOMAIN_2_0};
 
     private final String name;
 

--- a/core-model-test/src/test/resources/org/jboss/as/core/model/test/socketbinding/standalone.xml
+++ b/core-model-test/src/test/resources/org/jboss/as/core/model/test/socketbinding/standalone.xml
@@ -23,7 +23,7 @@
   ~ */
   -->
 
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain-no-servergroup-overlay.xml
@@ -4,7 +4,7 @@
 This is the shipped configuration with the extensions and profiles removed  
  -->
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <deployment-overlays>
         <deployment-overlay name="test-overlay">
             <content path="/test/123" content="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/domain.xml
@@ -4,7 +4,7 @@
 This is the shipped configuration with the extensions and profiles removed  
  -->
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <deployment-overlays>
         <deployment-overlay name="test-overlay">
             <content path="/test/123" content="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deploymentoverlay/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
     <deployment-overlays>
         <deployment-overlay name="test-overlay">
             <content path="/test/123" content="12345678901234567890"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-expressions.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <vault code="${vault.code:somevault}">
         <vault-option name="abc" value="${vault-option:def}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain-empty.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <interfaces>
     </interfaces>
 </domain>        

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <interfaces>
         <interface name="loopback">
             <inet-address value="127.0.0.1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:1.4">
+<host xmlns="urn:jboss:domain:2.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/interfaces/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
     <interfaces>
         <interface name="loopback">
             <inet-address value="127.0.0.1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-empty.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
    <server-groups>
 	  <server-group name="test" profile="test">
          <jvm name="empty"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-full.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-full.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
    <server-groups>
 	  <server-group name="test" profile="test">
          <jvm name="full" java-home="javaHome" type="SUN" env-classpath-ignored="true">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-with-expressions.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <server-groups>
         <server-group name="test" profile="test">
             <jvm name="default" java-home="${mytest.java-home:javaHome}" env-classpath-ignored="${mytest.env-classpath-ignored:true}">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-without-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/domain-without-expressions.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <server-groups>
         <server-group name="test" profile="test">
             <jvm name="default">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-global.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-global.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-empty.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-full.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/jvm/host-server-full.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-empty.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-empty.xml
@@ -1,4 +1,4 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <paths/>
 </domain>        

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <paths>
         <path name="empty"/>
         <path name="absolute" path="${test.exp:/}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <paths>
          <path name="empty"/>
          <path name="absolute" path="/"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:1.4">
+<host xmlns="urn:jboss:domain:2.0">
 
     <paths>
        <path name="absolute" path="${test.exp:/}"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/paths/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
     <paths>
          <path name="absolute" path="${test.exp:/}"/>
          <path name="relative" path="${test.exp:test}" relative-to="path"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/profile/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/profile/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <profiles>
         <profile name="testA">
         </profile>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
     <deployments>
         <deployment name="test-deployment" runtime-name="foo.war">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
     <deployments>
         <deployment name="test-deployment" runtime-name="foo.war">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/domain.xml
@@ -4,7 +4,7 @@
 This is the shipped configuration with the extensions and profiles removed  
  -->
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <system-properties>
         <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
         <property name="java.net.preferIPv4Stack" value="true"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- This is the shipped configuration as-is -->
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/standalone.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- This is the shipped configuration with the extensions and subsystems removed -->
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain-transformers-1.3.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain-transformers-1.3.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <interfaces>
         <interface name="public"/>
         <interface name="management"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/domain.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <interfaces>
         <interface name="public"/>
         <interface name="management"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
     <interfaces>
         <interface name="public"/>
         <interface name="management"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties-with-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
    <server-groups>
      <server-group name="test" profile="test">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
    <server-groups>
      <server-group name="test" profile="test">

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties-with-expressions.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
     <system-properties>
         <property name="sys.prop.test.one" value="ONE"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
 
     <system-properties>
         <property name="sys.prop.test.one" value="1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-server-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-server-systemproperties.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <!--  The native interface is always required by the parser -->
     <management>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-systemproperties.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
     <system-properties>
         <property name="sys.prop.test.one" value="1"/>
         <property name="sys.prop.test.two" value="2" boot-time="true"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/standalone-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/standalone-systemproperties.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
 
     <system-properties>
         <property name="sys.prop.test.one" value="1"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-host.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<host xmlns="urn:jboss:domain:1.4">
+<host xmlns="urn:jboss:domain:2.0">
 
     <vault code="somevault">
         <vault-option name="xyz" value="zxc"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/vault/vault-standalone.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<server xmlns="urn:jboss:domain:1.4">
+<server xmlns="urn:jboss:domain:2.0">
 
     <vault code="somevault">
         <vault-option name="xyz" value="zxc"/>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -122,10 +122,9 @@ public class DomainXml extends CommonXml {
         }
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
         switch (readerNS) {
-            case DOMAIN_1_0: {
+            case DOMAIN_1_0:
                 readDomainElement1_0(reader, new ModelNode(), readerNS, nodes);
                 break;
-            }
             case DOMAIN_1_1:
             case DOMAIN_1_2:
                 readDomainElement1_1(reader, new ModelNode(), readerNS, nodes);
@@ -133,13 +132,15 @@ public class DomainXml extends CommonXml {
             case DOMAIN_1_3:
                 readDomainElement1_3(reader, new ModelNode(), readerNS, nodes);
                 break;
-            case DOMAIN_1_4: {
-                readDomainElement1_4(reader, new ModelNode(), readerNS, nodes);
-                break;
-            }
-            default: {
+            default:
+                // Instead of having to list the remaining versions we just check it is actually a valid version.
+                for (Namespace current : Namespace.domainValues()) {
+                    if (readerNS.equals(current)) {
+                        readDomainElement1_4(reader, new ModelNode(), readerNS, nodes);
+                        return;
+                    }
+                }
                 throw unexpectedElement(reader);
-            }
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -118,20 +118,18 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
         }
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
         switch (readerNS) {
-            case DOMAIN_1_0: {
+            case DOMAIN_1_0:
                 readHostElement_1_0(reader, address, operationList);
                 break;
-            }
-            case DOMAIN_1_1:
-            case DOMAIN_1_2:
-            case DOMAIN_1_3:
-            case DOMAIN_1_4:{
-                readHostElement_1_1(readerNS, reader, address, operationList);
-                break;
-            }
-            default: {
+            default:
+                // Instead of having to list the remaining versions we just check it is actually a valid version.
+                for (Namespace current : Namespace.domainValues()) {
+                    if (readerNS.equals(current)) {
+                        readHostElement_1_1(readerNS, reader, address, operationList);
+                        return;
+                    }
+                }
                 throw unexpectedElement(reader);
-            }
         }
     }
 

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -122,23 +122,29 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
         }
 
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
+
         switch (readerNS) {
-            case DOMAIN_1_0: {
+            case DOMAIN_1_0:
                 readServerElement_1_0(reader, address, operationList);
                 break;
-            }
             case DOMAIN_1_1:
             case DOMAIN_1_2:
             case DOMAIN_1_3:
                 readServerElement_1_1(readerNS, reader, address, operationList);
                 break;
-            case DOMAIN_1_4: {
-                readServerElement_1_4(readerNS, reader, address, operationList);
-                break;
-            }
-            default: {
-                throw unexpectedElement(reader);
-            }
+            default:
+                // Instead of having to list the remaining versions we just check it is actually a valid version.
+                boolean validNamespace = false;
+                for (Namespace current : Namespace.domainValues()) {
+                    if (readerNS.equals(current)) {
+                        validNamespace = true;
+                        readServerElement_1_4(readerNS, reader, address, operationList);
+                        break;
+                    }
+                }
+                if (validNamespace == false) {
+                    throw unexpectedElement(reader);
+                }
         }
 
         if (ROOT_LOGGER.isDebugEnabled()) {

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.4"
+<domain xmlns="urn:jboss:domain:2.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:1.4"
+<domain xmlns="urn:jboss:domain:2.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.4"
+<host xmlns="urn:jboss:domain:2.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.4 jboss-as-config_1_4.xsd"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
       name="failover-h1">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.4"
+<host xmlns="urn:jboss:domain:2.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.4 jboss-as-config_1_4.xsd"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
       name="failover-h2">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.4"
+<host xmlns="urn:jboss:domain:2.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.4 jboss-as-config_1_4.xsd"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
       name="failover-h3">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.4"
+<host xmlns="urn:jboss:domain:2.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.4 jboss-as-config_1_4.xsd"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.4"
+<host xmlns="urn:jboss:domain:2.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.4 jboss-as-config_1_4.xsd"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:1.4"
+<host xmlns="urn:jboss:domain:2.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:1.4 jboss-as-config_1_4.xsd"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/integration/basic/src/test/xslt/passwdMaskConfig.xsl
+++ b/testsuite/integration/basic/src/test/xslt/passwdMaskConfig.xsl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Edited by XMLSpy® -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:do="urn:jboss:domain:1.4"
+                xmlns:do="urn:jboss:domain:2.0"
                 xmlns:ds="urn:jboss:domain:datasources:1.1"
-                xmlns="urn:jboss:domain:1.4"
+                xmlns="urn:jboss:domain:2.0"
         >
     <xsl:output indent="yes"/>
 

--- a/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
+++ b/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.4">
+                xmlns:d="urn:jboss:domain:2.0">
     <xsl:output method="xml" indent="yes"/>
 
     <xsl:param name="realmName"/>

--- a/testsuite/integration/src/test/xslt/addPortOffset.xsl
+++ b/testsuite/integration/src/test/xslt/addPortOffset.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.4">
+                xmlns:d="urn:jboss:domain:2.0">
 
     <!--
         An XSLT style sheet which will add a port offset to a standalone-ha.xml config.

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.4"
+                xmlns:d="urn:jboss:domain:2.0"
                 xmlns:r="urn:jboss:domain:remoting:1.1">
     <xsl:output method="xml" indent="yes"/>
 

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns="urn:jboss:domain:1.4"
-                xmlns:d="urn:jboss:domain:1.4"
+                xmlns="urn:jboss:domain:2.0"
+                xmlns:d="urn:jboss:domain:2.0"
                 xmlns:ws11="urn:jboss:domain:webservices:1.1"
                 xmlns:ws12="urn:jboss:domain:webservices:1.2"
                 xmlns:xts="urn:jboss:domain:xts:1.0"

--- a/testsuite/integration/src/test/xslt/changeTransportStack.xsl
+++ b/testsuite/integration/src/test/xslt/changeTransportStack.xsl
@@ -2,7 +2,7 @@
 <!-- Author: Radoslav Husar, Version: March 2012 -->
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:domain="urn:jboss:domain:1.4"
+                xmlns:domain="urn:jboss:domain:2.0"
                 xmlns:jgroups="urn:jboss:domain:jgroups:1.1"
 >
 

--- a/testsuite/integration/src/test/xslt/configAdminPopulate.xsl
+++ b/testsuite/integration/src/test/xslt/configAdminPopulate.xsl
@@ -24,7 +24,7 @@
  -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:ca="urn:jboss:domain:configadmin:1.0"
-                xmlns="urn:jboss:domain:1.4">
+                xmlns="urn:jboss:domain:2.0">
     <xsl:output indent="yes"/>
 
     <xsl:template match="ca:subsystem" priority="100" xmlns="urn:jboss:domain:configadmin:1.0">

--- a/testsuite/integration/src/test/xslt/enableOSGi.xsl
+++ b/testsuite/integration/src/test/xslt/enableOSGi.xsl
@@ -1,7 +1,7 @@
 <xsl:stylesheet version="2.0"
 		xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns="urn:jboss:domain:1.4"
-		xmlns:d="urn:jboss:domain:1.4"
+		xmlns="urn:jboss:domain:2.0"
+		xmlns:d="urn:jboss:domain:2.0"
                 xmlns:o='urn:jboss:domain:osgi:1.2'> 
 
  <!-- Copy everything else. -->

--- a/testsuite/integration/src/test/xslt/enableTrace.xsl
+++ b/testsuite/integration/src/test/xslt/enableTrace.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:1.4"
+                xmlns:d="urn:jboss:domain:2.0"
                 xmlns:l="urn:jboss:domain:logging:1.1"
                 exclude-result-prefixes="l d"
         >

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:1.4">
+<domain xmlns="urn:jboss:domain:2.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:1.4">
+<host name="master" xmlns="urn:jboss:domain:2.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
Also update existing configuration based on 1.4 to use 2.0.

For the parsers affected when parsing begins we ensure that the version is one of the supported namespaces by listing them all, this has also been updated to check that dynamically instead.
