### PR TITLE
[8.0] stabilize intermittent test failures

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerBean.java
@@ -42,7 +42,8 @@ import org.jboss.msc.service.StartException;
 @Remote(ViewChangeListener.class)
 @Listener(sync = false)
 public class ViewChangeListenerBean implements ViewChangeListener {
-    public static final long TIMEOUT = 15000;
+    // TODO lower this timeout; workarounds issue when AS process became stale and FD kicks in after 30 seconds
+    public static final long TIMEOUT = 35000;
 
     @Override
     public void establishView(String cluster, String... names) throws InterruptedException {


### PR DESCRIPTION
workaround issues when AS process became stale and FD kicks in only after 30 seconds

&#27;[0m&#27;[31m14:21:55,839 ERROR [org.apache.catalina.core.ContainerBase.[jboss.web].[default-host].[/stateful].[org.jboss.as.test.clustering.ViewChangeListenerServlet]](http-/127.0.0.1:8180-1) JBWEB000236: Servlet.service() for servlet org.jboss.as.test.clustering.ViewChangeListenerServlet threw exception: java.lang.InterruptedException: Cluster 'ejb' failed to establish view [node-1/ejb] within 15000 ms.  Current view is: [node-0/ejb, node-1/ejb]
