### PR TITLE
Revert "get rid of (now) useless dependency"

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -82,6 +82,13 @@
             <artifactId>byteman-bmunit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+            <scope>system</scope>
+            <version>1.6</version>
+            <systemPath>${com.sun.tools.path}</systemPath>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,8 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
 
+        <!-- tools.jar location, this needs to be overriden on OSX -->
+        <com.sun.tools.path>${java.home}/../lib/tools.jar</com.sun.tools.path>
     </properties>
 
     <modules>
@@ -1308,6 +1310,14 @@
                         <artifactId>jsr305</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun</groupId>
+                <artifactId>tools</artifactId>
+                <scope>system</scope>
+                <version>1.6</version>
+                <systemPath>${com.sun.tools.path}</systemPath>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This reverts commit df51fdf50cbf19ff9b6ed372f3f8ec7f7574f51e.

This is needed to build on Mac JDK7
