### PR TITLE
Fix for AS7-6616 - Make sure the unit test sets up the NamingStore

### DIFF
--- a/naming/src/test/java/org/jboss/as/naming/InitialContextTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/InitialContextTestCase.java
@@ -31,11 +31,19 @@ import javax.naming.spi.ObjectFactory;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.junit.Before;
+
 
 /**
  * @author David Bosschaert
  */
 public class InitialContextTestCase {
+
+    @Before
+    public void before() {
+        NamingContext.setActiveNamingStore(new InMemoryNamingStore());
+    }
+
     @Test
     public void testRegisterURLSchemeHandler() throws Exception {
         InitialContext ictx = new InitialContext(null);


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-6616. The testcase was failing because a different testcase (NamingSubsystemTestCase) ends up running before the InitialContextTestCase and the NamingSubsystemTestCase ends up setting a static variable which InitialContextTestCase relies on, to null.

The fix here makes sure that the InitialContextTestCase sets up the naming store appropriately before running the tests.
