### PR TITLE
[8.0] Clustering testsuite on Windows mega fix 

### DIFF
--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -41,6 +41,8 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
 
     private int startupTimeoutInSeconds = 60;
 
+    private int stopTimeoutInSeconds = 60;
+
     private boolean outputToConsole = true;
 
     private String serverConfig = System.getProperty("jboss.server.config.file.name", "standalone.xml");
@@ -93,6 +95,18 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
      */
     public int getStartupTimeoutInSeconds() {
         return startupTimeoutInSeconds;
+    }
+
+    public void setStopTimeoutInSeconds(int stopTimeoutInSeconds) {
+        this.stopTimeoutInSeconds = stopTimeoutInSeconds;
+    }
+
+    /**
+     * @return stopTimeoutInSeconds number of seconds to wait for the container process to shutdown;
+     *                              defaults to 60
+     */
+    public int getStopTimeoutInSeconds() {
+        return stopTimeoutInSeconds;
     }
 
     /**

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/PortAcquisitionTimeoutException.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/PortAcquisitionTimeoutException.java
@@ -22,7 +22,7 @@ import org.jboss.arquillian.container.spi.client.container.LifecycleException;
  * Denotes that a port could not be obtained within a designated timeout period.
  *
  * @author <a href="mailto:alr@jboss.org">ALR</a>
- * @see https://issues.jboss.org/browse/AS7-4070
+ * @see {@link https://issues.jboss.org/browse/AS7-4070}
  */
 public class PortAcquisitionTimeoutException extends LifecycleException {
     private static final long serialVersionUID = 1L;
@@ -30,7 +30,7 @@ public class PortAcquisitionTimeoutException extends LifecycleException {
     /**
      * Constructs a new instance noting the port that could not be acquired in the designated amount of time
      *
-     * @param ports
+     * @param port
      * @param timeoutSeconds
      */
     public PortAcquisitionTimeoutException(final int port, final int timeoutSeconds) {

--- a/arquillian/container-managed/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed/src/test/resources/arquillian.xml
@@ -12,7 +12,9 @@
                         <property name="allowConnectingToRunningServer">false</property>
 
 			<!--
-			
+            Time to wait for shutdown to complete
+            <property name="stopTimeoutInSeconds">60</property>
+
 			Space-delimited list of ports on which to wait 
 			<property name="waitForPorts">2222</property>
 			


### PR DESCRIPTION
The problem is that Managed*DeployableContainer kills the managed server instead of regular shutdown in stop() on Windows. ARQ's stop is supposed to shutdown the server 'nicely', for abrupt termination there is jvmKill(). 

This was probably implemented like this incorrectly assuming that on windows, the process is sent SIGTERM like on *NIX-based OSes but there is no such thing on windows and the process is terminated immediately.

This shows up only in clustered tests, compared to other tests which dont rely on the shutdown sequence to be completed, but clustering testsuite relies on shutdown to disconnect the channel and leave the cluster without FD having to kick in.

https://issues.jboss.org/browse/AS7-6620
