### PR TITLE
[AS7-6546] Check the class name when adding a names handler that might already exist

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
@@ -142,4 +142,13 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11510, value = "The configuration file in '%s' appears to be a J.U.L. configuration file. The log manager does not allow this type of configuration file.")
     void julConfigurationFileFound(String fileName);
+
+    /**
+     * Logs a warning message indicating the handler is being replaced due to a different type or module name.
+     *
+     * @param name the name of the handler
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11511, value = "Replacing handler '%s' during add operation. Either the handler type or the module name differs from the initial configuration.")
+    void replacingNamedHandler(String name);
 }


### PR DESCRIPTION
Check the class name when adding a names handler that might already exist. This happens at the switch between the boot logging configuration and subsystem logging configuration. Subsystem logging always overrides boot logging.

An example is when a user changes the `periodic-rotating-file-handler` in the `standalone.xml` to a `file-handler`.

The XML configuration will always override the `logging.properties` configuration.
