### PR TITLE
Don't add Java EE common annotations jar to the endorsed path of testsuite

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -291,36 +291,10 @@
                 </executions>
             </plugin>
 
-            <!--
-                Provide jboss-annotations-api_1.2_spec to compiler as endorsed.
-                Big complex hack just to get @Resource(lookup="foo").  AS7-3123
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <inherited>true</inherited>  <!-- Needed for compilation of all submodules. -->
-                <executions combine.children="append">
-                    <execution>
-                        <id>copy-annotations-endorsed</id>
-                        <goals><goal>copy</goal></goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.jboss.spec.javax.annotation</groupId>
-                                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
-                                </artifactItem>
-                            </artifactItems>
-                            <outputDirectory>${project.build.directory}/endorsed</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>-Djava.endorsed.dirs=${project.build.directory}/endorsed</compilerArgument>
-                </configuration>
                 <!-- Don't compile src/main/java - nothing to do. -->
                 <executions><execution><id>default-compile</id><phase>none</phase></execution></executions>
             </plugin>


### PR DESCRIPTION
We had a hack in our testsuite pom to allow usage of @Resource(lookup=...) in testcases for Java 6. Now that we have mandated Java 7 for building AS, we no longer need it. The commit here removes that plugin configuration.

As for the reason why we had those plugin configurations for Java 6, the details are here http://www.jaitechwriteups.blogspot.in/2011/02/resource-and-new-lookup-attribute-how.html
