### PR TITLE
[AS7-6645] fix message-expiry-thread-priority range

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -47,6 +47,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -488,11 +489,11 @@ public interface CommonAttributes {
             .setRestartAllServices()
             .build();
 
-    // FIXME add min/max size for thread priority (0-9)
     SimpleAttributeDefinition MESSAGE_EXPIRY_THREAD_PRIORITY = create("message-expiry-thread-priority", INT)
             .setDefaultValue(new ModelNode(HornetQDefaultConfiguration.DEFAULT_MESSAGE_EXPIRY_THREAD_PRIORITY))
             .setAllowNull(true)
             .setAllowExpression(true)
+            .setValidator(new IntRangeValidator(Thread.MIN_PRIORITY, Thread.MAX_PRIORITY, true, true))
             .setRestartAllServices()
             .build();
 


### PR DESCRIPTION
- add range validation to the message-expiry-thread-priority attribute
  (corresponding to Thread's MIN/MAX_PRIORITY)
