### PR TITLE
[AS7-6648] Persist pooled CF's inbound-config

### DIFF
--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
@@ -325,6 +325,13 @@
 				 <group-id>myGroup</group-id>
               </connection-factory>
               <pooled-connection-factory name="hornetq-ra">
+                 <inbound-config>
+                     <use-jndi>false</use-jndi>
+                     <jndi-params>whatever</jndi-params>
+                     <use-local-tx>true</use-local-tx>
+                     <setup-attempts>123</setup-attempts>
+                     <setup-interval>456</setup-interval>
+                 </inbound-config>
                  <transaction mode="xa"/>
                  <user>alice</user>
                  <password>alicepassword</password>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_3.xml
@@ -343,6 +343,13 @@
 				 <group-id>${group.id:myGroup}</group-id>
               </connection-factory>
               <pooled-connection-factory name="hornetq-ra">
+                 <inbound-config>
+                     <use-jndi>${use.jndi:false}</use-jndi>
+                     <jndi-params>${jndi.params:whatever}</jndi-params>
+                     <use-local-tx>${use.local.tx:true}</use-local-tx>
+                     <setup-attempts>${setup-attempts:123}</setup-attempts>
+                     <setup-interval>${setup-interval:456}</setup-interval>
+                 </inbound-config>
                  <transaction mode="${transaction:xa}"/>
                  <user>${user:alice}</user>
                  <password>${password:alicepassword}</password>


### PR DESCRIPTION
fix the persistence of pooled-connection-factory's inbound-config
(its ModelNode layout does not have an intermediate inbound-config
node).
