### PR TITLE
AS7-6561 EJB 3.2 spec support - TimerService#getAllTimers()

### DIFF
--- a/arquillian/container-managed-domain/pom.xml
+++ b/arquillian/container-managed-domain/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/arquillian/container-managed/pom.xml
+++ b/arquillian/container-managed/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/build/build.xml
+++ b/build/build.xml
@@ -428,7 +428,7 @@
         </module-def>
 
         <module-def name="javax.ejb.api">
-            <maven-resource group="org.jboss.spec.javax.ejb" artifact="jboss-ejb-api_3.1_spec"/>
+            <maven-resource group="org.jboss.spec.javax.ejb" artifact="jboss-ejb-api_3.2_spec"/>
         </module-def>
 
         <module-def name="javax.el.api">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1497,7 +1497,7 @@
 
                 <dependency>
                     <groupId>org.jboss.spec.javax.ejb</groupId>
-                    <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                    <artifactId>jboss-ejb-api_3.2_spec</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1961,7 +1961,7 @@
 
                                         <include>org.jboss.resteasy:jaxrs-api</include>
                                         <include>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</include>
-                                        <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec</include>
+                                        <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec</include>
                                         <include>org.jboss.spec.javax.el:jboss-el-api_2.2_spec</include>
                                         <include>org.jboss.spec.javax.faces:jboss-jsf-api_2.1_spec</include>
                                         <include>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec</include>

--- a/build/src/license/licenses.xml
+++ b/build/src/license/licenses.xml
@@ -2875,7 +2875,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ejb</groupId>
-      <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License, Version 2.1</name>

--- a/build/src/main/resources/bin/client/README-EJB-JMS.txt
+++ b/build/src/main/resources/bin/client/README-EJB-JMS.txt
@@ -5,7 +5,7 @@ This jar contains the classes required for remote JMS and EJB usage, and consist
 
 org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec
 org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec
-org.jboss.spec.javax.ejb:jboss-ejb-api_3.1_spec
+org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec
 
 org.jboss:jboss-ejb-client
 org.jboss:jboss-remote-naming

--- a/client/ejb/pom.xml
+++ b/client/ejb/pom.xml
@@ -89,7 +89,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -156,7 +156,7 @@ projects that depend on this project.-->
 
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/TimerServiceRegistry.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/TimerServiceRegistry.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component;
+
+import javax.ejb.Timer;
+import javax.ejb.TimerService;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A registry to which individual {@link javax.ejb.TimerService timer services} can register to (and un-register from). The main purpose
+ * of this registry is to provide an implementation of {@link #getAllActiveTimers()} which returns all
+ * {@link javax.ejb.TimerService#getTimers() active timers} after querying each of the {@link javax.ejb.TimerService timer services} registered
+ * with this {@link TimerServiceRegistry registry}.
+ * <p/>
+ * Typical use of this registry is to maintain one instance of this registry, per deployment unit (also known as EJB module) and register the timer
+ * services of all EJB components that belong to that deployment unit. Effectively, such an instance can then be used to fetch all active timers
+ * that are applicable to that deployment unit (a.k.a EJB module).
+ *
+ * @author Jaikiran Pai
+ */
+public class TimerServiceRegistry {
+
+    private final Set<TimerService> timerServices = Collections.synchronizedSet(new HashSet<TimerService>());
+
+    public void registerTimerService(final TimerService timerService) {
+        if (timerService == null) {
+            return;
+        }
+        timerServices.add(timerService);
+    }
+
+    public boolean unRegisterTimerService(final TimerService timerService) {
+        if (timerService == null) {
+            return false;
+        }
+        return timerServices.remove(timerService);
+    }
+
+    public Collection<Timer> getAllActiveTimers() {
+        final Collection<Timer> activeTimers = new HashSet<>();
+        synchronized (timerServices) {
+            for (final TimerService timerService : timerServices) {
+                activeTimers.addAll(timerService.getTimers());
+            }
+        }
+        return activeTimers;
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/NonFunctionalTimerService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/NonFunctionalTimerService.java
@@ -113,6 +113,13 @@ public class NonFunctionalTimerService implements TimerService {
         return Collections.emptySet();
     }
 
+    @Override
+    public Collection<Timer> getAllTimers() throws IllegalStateException, EJBException {
+        // NonFunctionalTimerService isn't expected to return any timers, we just invoke the getTimers() so that it can
+        // do the necessary state checks before returning an empty collection
+        return this.getTimers();
+    }
+
     private void assertInvocationAllowed() {
         AllowedMethodsInformation.checkAllowed(MethodType.TIMER_SERVICE_METHOD);
         final InterceptorContext currentInvocationContext = CurrentInvocationContext.get();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/FileTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/FileTimerPersistence.java
@@ -21,26 +21,6 @@
  */
 package org.jboss.as.ejb3.timerservice.persistence.filestore;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import javax.transaction.Status;
-import javax.transaction.Synchronization;
-import javax.transaction.SystemException;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.ejb3.component.stateful.CurrentSynchronizationCallback;
 import org.jboss.as.ejb3.timerservice.CalendarTimer;
@@ -63,6 +43,25 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+
+import javax.transaction.Status;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
@@ -324,8 +323,9 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
                             .setNextDate(entity.getNextDate())
                             .setPreviousRun(entity.getPreviousRun())
                             .setInfo(entity.getInfo())
-                            .setPrimaryKey(entity.getPreviousRun())
-                            .setTimerState(entity.getTimerState());
+                            .setPrimaryKey(entity.getPrimaryKey())
+                            .setTimerState(entity.getTimerState())
+                            .setPersistent(true);
 
                     timers.put(entity.getId(), builder.build(timerService));
                     unmarshaller.finish();

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -82,7 +82,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <!-- TODO: move EJB Embeddable to a separate artifact -->
             <optional>true</optional>
         </dependency>

--- a/jpa/spi/pom.xml
+++ b/jpa/spi/pom.xml
@@ -86,7 +86,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
-        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Alpha1-SNAPSHOT</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
+        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>1.0.2.Final</version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>
         <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.1_spec>2.1.18.Final</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.1_spec>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.1_spec>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
-        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec>
+        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Alpha1-SNAPSHOT</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>1.0.2.Final</version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>
         <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.1_spec>2.1.18.Final</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.1_spec>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.1_spec>
@@ -4257,7 +4257,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.ejb</groupId>
-                        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                        <artifactId>jboss-ejb-api_3.2_spec</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.remoting</groupId>
@@ -4401,7 +4401,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.ejb</groupId>
-                        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                        <artifactId>jboss-ejb-api_3.2_spec</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.remoting</groupId>
@@ -4666,7 +4666,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.ejb</groupId>
-                        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                        <artifactId>jboss-ejb-api_3.2_spec</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.remoting</groupId>
@@ -5241,8 +5241,8 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.ejb</groupId>
-                <artifactId>jboss-ejb-api_3.1_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.1_spec}</version>
+                <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec}</version>
             </dependency>
 
             <dependency>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ejb</groupId>
-      <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+      <artifactId>jboss-ejb-api_3.2_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.el</groupId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/ActiveTimerServiceCountTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/ActiveTimerServiceCountTestCase.java
@@ -1,0 +1,141 @@
+package org.jboss.as.test.integration.ejb.timerservice.count;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ejb.Timer;
+import javax.naming.InitialContext;
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * Testcase for the {@link javax.ejb.TimerService#getAllTimers()} API introduced in EJB 3.2 spec
+ *
+ * @author: Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+public class ActiveTimerServiceCountTestCase {
+
+    private static final String APP_NAME = "ejb-3.2-active-timers";
+    private static final String MODULE_ONE_NAME = "ejb-3.2-active-timers-one";
+    private static final String MODULE_TWO_NAME = "ejb-3.2-active-timers-two";
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive ejbJarOne = ShrinkWrap.create(JavaArchive.class, MODULE_ONE_NAME + ".jar");
+        ejbJarOne.addClasses(ActiveTimerServiceCountTestCase.class, SimpleTimerBean.class, OtherTimerBeanInSameModule.class);
+
+        final JavaArchive ejbJarTwo = ShrinkWrap.create(JavaArchive.class, MODULE_TWO_NAME + ".jar");
+        ejbJarTwo.addClasses(TimerBeanInOtherModule.class);
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
+        ear.addAsModules(ejbJarOne, ejbJarTwo);
+
+        return ear;
+    }
+
+    /**
+     * Tests that the {@link javax.ejb.TimerService#getAllTimers()} API introduced in EJB 3.2 works as expected
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testActiveTimersCountInEJBModule() throws Exception {
+        final SimpleTimerBean timerBean = InitialContext.doLookup("java:module/" + SimpleTimerBean.class.getSimpleName() + "!" + SimpleTimerBean.class.getName());
+        final String infoOne = "gangnam style";
+        timerBean.createTimerForNextDay(false, infoOne);
+        final String infoTwo = "PSY";
+        timerBean.createTimerForNextDay(true, infoTwo);
+
+        final OtherTimerBeanInSameModule otherTimerBean = InitialContext.doLookup("java:module/" + OtherTimerBeanInSameModule.class.getSimpleName() + "!" + OtherTimerBeanInSameModule.class.getName());
+        final String infoThree = "hello world!";
+        otherTimerBean.createTimerForNextDay(false, infoThree);
+
+        final TimerBeanInOtherModule timerBeanInOtherModule = InitialContext.doLookup("java:global/" + APP_NAME + "/" + MODULE_TWO_NAME + "/" + TimerBeanInOtherModule.class.getSimpleName() + "!" + TimerBeanInOtherModule.class.getName());
+        final String infoForTimerBeanInOtherModule = "irrelevant";
+        timerBeanInOtherModule.createTimerForNextDay(false, infoForTimerBeanInOtherModule);
+
+        final Collection<Timer> activeTimers = timerBean.getAllActiveTimersInEJBModule();
+
+        // now start testing
+        Assert.assertFalse("No active timers found in EJB module " + MODULE_ONE_NAME, activeTimers.isEmpty());
+
+        // now make sure that the active timers are indeed the one we expected
+        Assert.assertTrue("@Schedule timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers", this.removeSheduleOneTimerOfSimpleTimerBean(activeTimers));
+        Assert.assertTrue("@Schedule timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers", this.removeSheduleTwoTimerOfSimpleTimerBean(activeTimers));
+        Assert.assertTrue("@Schedule timer on " + OtherTimerBeanInSameModule.class.getSimpleName() + " not found in active timers", this.removeSheduleOneTimerOfOtherTimerBean(activeTimers));
+        Assert.assertTrue("Programmatic timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers", this.removeProgramaticTimer(activeTimers, infoOne, false));
+        Assert.assertTrue("Programmatic timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers", this.removeProgramaticTimer(activeTimers, infoTwo, true));
+        Assert.assertTrue("Programmatic timer on " + OtherTimerBeanInSameModule.class.getSimpleName() + " not found in active timers", this.removeProgramaticTimer(activeTimers, infoThree, false));
+
+        // make sure there isn't an unexpected timer in the active timers
+        for (final Timer remainingTimer : activeTimers) {
+            Assert.assertNotEquals("Unexpectedly found a timer from other EJB module " + MODULE_TWO_NAME, TimerBeanInOtherModule.SCHEDULE_ONE_INFO.equals(remainingTimer.getInfo()));
+            Assert.assertNotEquals("Unexpectedly found a timer from other EJB module " + MODULE_TWO_NAME, infoForTimerBeanInOtherModule.equals(remainingTimer.getInfo()));
+        }
+
+    }
+
+    private boolean removeSheduleOneTimerOfSimpleTimerBean(final Collection<Timer> timers) {
+        for (final Timer activeTimer : timers) {
+            // see if it's @Schedule one in SimpleTimerBean
+            final Serializable info = activeTimer.getInfo();
+            if (SimpleTimerBean.SCHEDULE_ONE_INFO.equals(info)) {
+                Assert.assertTrue("Unexpected timer type of timer on " + SimpleTimerBean.class.getSimpleName(), activeTimer.isCalendarTimer());
+                Assert.assertFalse("Unexpected persistence type of timer on " + SimpleTimerBean.class.getSimpleName(), activeTimer.isPersistent());
+                // remove this matched timer from the collection
+                return timers.remove(activeTimer);
+            }
+        }
+        return false;
+    }
+
+    private boolean removeSheduleTwoTimerOfSimpleTimerBean(final Collection<Timer> timers) {
+        for (final Timer activeTimer : timers) {
+            // see if it's @Schedule two in SimpleTimerBean
+            final Serializable info = activeTimer.getInfo();
+            if (SimpleTimerBean.SCHEDULE_TWO_INFO.equals(info)) {
+                Assert.assertTrue("Unexpected timer type of timer on " + SimpleTimerBean.class.getSimpleName(), activeTimer.isCalendarTimer());
+                Assert.assertTrue("Unexpected persistence type of timer on " + SimpleTimerBean.class.getSimpleName(), activeTimer.isPersistent());
+                // remove this matched timer from the collection
+                return timers.remove(activeTimer);
+            }
+        }
+        return false;
+    }
+
+    private boolean removeSheduleOneTimerOfOtherTimerBean(final Collection<Timer> timers) {
+        for (final Timer activeTimer : timers) {
+            // see if it's @Schedule one in OtherTimerBeanInSameModule
+            final Serializable info = activeTimer.getInfo();
+            if (OtherTimerBeanInSameModule.SCHEDULE_ONE_INFO.equals(info)) {
+                Assert.assertTrue("Unexpected timer type of timer on " + OtherTimerBeanInSameModule.class.getSimpleName(), activeTimer.isCalendarTimer());
+                Assert.assertFalse("Unexpected persistence type of timer on " + OtherTimerBeanInSameModule.class.getSimpleName(), activeTimer.isPersistent());
+                // remove this matched timer from the collection
+                return timers.remove(activeTimer);
+            }
+        }
+        return false;
+    }
+
+    private boolean removeProgramaticTimer(final Collection<Timer> timers, final String timerInfo, final boolean persistent) {
+        for (final Timer activeTimer : timers) {
+            // see if it's the programatic timer we are looking for
+            final Serializable info = activeTimer.getInfo();
+            if (timerInfo.equals(info)) {
+                Assert.assertFalse("Unexpected timer type of timer", activeTimer.isCalendarTimer());
+                Assert.assertEquals("Unexpected persistence type of timer", persistent, activeTimer.isPersistent());
+                // remove this matched timer from the collection
+                return timers.remove(activeTimer);
+            }
+        }
+        return false;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/OtherTimerBeanInSameModule.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/OtherTimerBeanInSameModule.java
@@ -1,0 +1,36 @@
+package org.jboss.as.test.integration.ejb.timerservice.count;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.Schedule;
+import javax.ejb.Stateless;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+import java.util.Date;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateless
+@LocalBean
+public class OtherTimerBeanInSameModule {
+    static final String SCHEDULE_ONE_INFO = "foo-bar";
+
+    private static final Logger logger = Logger.getLogger(OtherTimerBeanInSameModule.class);
+
+    @Resource
+    private TimerService timerService;
+
+    @Schedule(second="*", minute = "*", hour = "*", year = "2100", persistent = false, info = SCHEDULE_ONE_INFO)
+    private void scheduleOne(final Timer timer) {
+    }
+
+    public void createTimerForNextDay(final boolean persistent, final String info) {
+        this.timerService.createSingleActionTimer(new Date(System.currentTimeMillis() + (60 * 60 * 24 * 1000)) , new TimerConfig(info, persistent));
+        logger.info("Created a timer persistent = " + persistent + " info = " + info);
+    }
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/SimpleTimerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/SimpleTimerBean.java
@@ -1,0 +1,48 @@
+package org.jboss.as.test.integration.ejb.timerservice.count;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.Schedule;
+import javax.ejb.Stateless;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+import java.util.Collection;
+import java.util.Date;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateless
+@LocalBean
+public class SimpleTimerBean {
+
+    static final String SCHEDULE_ONE_INFO = "foo-bar";
+    static final String SCHEDULE_TWO_INFO = "schedule-two";
+
+    private static final Logger logger = Logger.getLogger(SimpleTimerBean.class);
+
+    @Resource
+    private TimerService timerService;
+
+    @Schedule(second="*", minute = "*", hour = "*", year = "2100", persistent = false, info = SCHEDULE_ONE_INFO)
+    private void scheduleOne(final Timer timer) {
+    }
+
+    @Schedule(second="*", minute = "*", hour = "*", year = "2100", persistent = true, info = SCHEDULE_TWO_INFO)
+    private void scheduleTwo(final Timer timer) {
+    }
+
+
+    public void createTimerForNextDay(final boolean persistent, final String info) {
+        this.timerService.createSingleActionTimer(new Date(System.currentTimeMillis() + (60 * 60 * 24 * 1000)) , new TimerConfig(info, persistent));
+        logger.info("Created a timer persistent = " + persistent + " info = " + info);
+    }
+
+    public Collection<Timer> getAllActiveTimersInEJBModule() {
+        return this.timerService.getAllTimers();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/TimerBeanInOtherModule.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/TimerBeanInOtherModule.java
@@ -1,0 +1,35 @@
+package org.jboss.as.test.integration.ejb.timerservice.count;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.Schedule;
+import javax.ejb.Stateless;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+import java.util.Date;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateless
+@LocalBean
+public class TimerBeanInOtherModule {
+
+    static final String SCHEDULE_ONE_INFO = "foo-bar";
+    private static final Logger logger = Logger.getLogger(TimerBeanInOtherModule.class);
+
+    @Resource
+    private TimerService timerService;
+
+    @Schedule(second="*", minute = "*", hour = "*", persistent = false, info = SCHEDULE_ONE_INFO)
+    private void scheduleOne(final Timer timer) {
+    }
+
+    public void createTimerForNextDay(final boolean persistent, final String info) {
+        this.timerService.createSingleActionTimer(new Date(System.currentTimeMillis() + (60 * 60 * 24 * 1000)), new TimerConfig(info, persistent));
+        logger.info("Created a timer persistent = " + persistent + " info = " + info);
+    }
+}


### PR DESCRIPTION
The commit here adds support to the new API introduced in EJB 3.2 for TimerService. This also includes a testcase for testing that API.

There's one commit in here, which fixes a bug unrelated to this feature, but it was exposed by the testcase that was added for this feature. I believe that bug only affects "master" since it appears to have been related to the recent refactoring we did in timers.
