### PR TITLE
AS7-6639 synchronize getCache() calls to workaround ISPN-2796

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
@@ -64,10 +64,7 @@ public class DefaultEmbeddedCacheManager extends AbstractDelegatingEmbeddedCache
     @Deprecated
     @Override
     public org.infinispan.config.Configuration defineConfiguration(String cacheName, org.infinispan.config.Configuration configurationOverride) {
-        // Synchronize to workaround ISPN-2866 to fix AS7-6639
-        synchronized (cm) {
-            return this.cm.defineConfiguration(this.getCacheName(cacheName), configurationOverride);
-        }
+        return this.cm.defineConfiguration(this.getCacheName(cacheName), configurationOverride);
     }
 
     /**
@@ -77,18 +74,12 @@ public class DefaultEmbeddedCacheManager extends AbstractDelegatingEmbeddedCache
     @Deprecated
     @Override
     public org.infinispan.config.Configuration defineConfiguration(String cacheName, String templateCacheName, org.infinispan.config.Configuration configurationOverride) {
-        // Synchronize to workaround ISPN-2866 to fix AS7-6639
-        synchronized (cm) {
-            return this.cm.defineConfiguration(this.getCacheName(cacheName), this.getCacheName(templateCacheName), configurationOverride);
-        }
+        return this.cm.defineConfiguration(this.getCacheName(cacheName), this.getCacheName(templateCacheName), configurationOverride);
     }
 
     @Override
     public Configuration defineConfiguration(String cacheName, Configuration configuration) {
-        // Synchronize to workaround ISPN-2866 to fix AS7-6639
-        synchronized (cm) {
-            return this.cm.defineConfiguration(this.getCacheName(cacheName), configuration);
-        }
+        return this.cm.defineConfiguration(this.getCacheName(cacheName), configuration);
     }
 
     /**

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/DefaultEmbeddedCacheManager.java
@@ -109,9 +109,9 @@ public class DefaultEmbeddedCacheManager extends AbstractDelegatingEmbeddedCache
      * @see org.infinispan.manager.EmbeddedCacheManager#getCache(java.lang.String, boolean)
      */
     @Override
-    public <K, V> Cache<K, V> getCache(String cacheName, boolean start) {
+    public <K, V> Cache<K, V> getCache(String cacheName, boolean createIfAbsent) {
         // Synchronize to workaround ISPN-2796 / AS7-6639
-        if (start) {
+        if (createIfAbsent) {
             return this.getCache(cacheName);
         }
 


### PR DESCRIPTION
Fixes intermittent failures such as seen here:

http://lightning.mw.lab.eng.bos.redhat.com/jenkins/job/as7-param-pull/6228/testReport/junit/org.jboss.as.test.integration.jpa.secondlevelcache/JPA2LCTestCase/org_jboss_as_test_integration_jpa_secondlevelcache_JPA2LCTestCase/

until next Infinispan release is available.
