### PR TITLE
AS7-6038, Remove unused DeploymentScanner's bootTimeScan method

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -42,9 +42,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.server.deployment.DeploymentAddHandler;
 import org.jboss.as.server.deployment.DeploymentDeployHandler;
@@ -56,7 +54,6 @@ import org.jboss.as.server.deployment.scanner.ZipCompletionScanner.NonScannableZ
 import org.jboss.as.server.deployment.scanner.api.DeploymentScanner;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
-import org.jboss.msc.service.ServiceController;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ARCHIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
@@ -243,11 +240,6 @@ class FileSystemDeploymentService implements DeploymentScanner {
     @Override
     public void setDeploymentTimeout(long deploymentTimeout) {
         this.deploymentTimeout = deploymentTimeout;
-    }
-
-    @Override
-    public void bootTimeScan(final OperationContext context, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers) {
-
     }
 
     @Override

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/api/DeploymentScanner.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/api/DeploymentScanner.java
@@ -22,12 +22,7 @@
 
 package org.jboss.as.server.deployment.scanner.api;
 
-import java.util.List;
-
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.server.deployment.scanner.DeploymentOperations;
-import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -138,15 +133,4 @@ public interface DeploymentScanner {
      */
     void setDeploymentTimeout(long timeout);
 
-    /**
-     * Unused legacy method only retained to avoid breaking any custom implementations of this interface.
-     *
-     * @param context usage unspecified
-     * @param verificationHandler usage unspecified
-     * @param newControllers usage unspecified
-     *
-     * @deprecated not implemented in the standard implementation of this interface and not used in the server boot
-     */
-    @Deprecated
-    void bootTimeScan(OperationContext context, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers);
 }


### PR DESCRIPTION
Remove unimplemented and unused DeploymentScanner's bootTimeScan method
