### PR TITLE
Improve the error message thrown when a MDB deployment fails while processing the deployment descriptor

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -1233,12 +1233,12 @@ public interface EjbMessages {
     DeploymentUnitProcessingException failToFindMethodWithParameterTypes(String name, String methodName, MethodParametersMetaData methodParams);
 
     /**
-     * Creates an exception indicating Could not load component class
+     * Creates an exception indicating could not load component class
      *
      * @return a {@link DeploymentUnitProcessingException} for the error.
      */
-    @Message(id = 14400, value = "Could not load component class")
-    DeploymentUnitProcessingException failToLoadComponentClass(@Cause Throwable t);
+    @Message(id = 14400, value = "Could not load component class for component %s")
+    DeploymentUnitProcessingException failToLoadComponentClass(@Cause Throwable t, String componentName);
 
     /**
      * Creates an exception indicating Could not load EJB view class

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/DeploymentDescriptorMethodProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/dd/DeploymentDescriptorMethodProcessor.java
@@ -76,7 +76,7 @@ public class DeploymentDescriptorMethodProcessor implements DeploymentUnitProces
                             handleStatelessSessionBean((EJBComponentDescription) component, classIndex, reflectionIndex);
                         }
                     } catch (ClassNotFoundException e) {
-                        throw MESSAGES.failToLoadComponentClass(e);
+                        throw MESSAGES.failToLoadComponentClass(e, component.getComponentName());
                     }
                 }
             }


### PR DESCRIPTION
The commits here fix an issue with the error message that gets thrown in certain cases when a MDB deployment fails while processing the deployment descriptor. This was raised in the forums here https://community.jboss.org/thread/222170?tstart=0
