### PR TITLE
[AS7-6694] Fix RemoteConnectionFactory for HA profiles

### DIFF
--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -70,6 +70,7 @@
                    <entries>
                        <entry name="java:jboss/exported/jms/RemoteConnectionFactory"/>
                    </entries>
+                   <?HA-REMOTE-CONNECTION-FACTORY?>
                </connection-factory>
                <pooled-connection-factory name="hornetq-ra">
                    <transaction mode="xa"/>
@@ -115,6 +116,13 @@
        </replacement>
        <replacement placeholder="REDISTRIBUTION-DELAY">
            <redistribution-delay>1000</redistribution-delay>
+       </replacement>
+       <replacement placeholder="HA-REMOTE-CONNECTION-FACTORY">
+           <ha>true</ha>
+           <block-on-acknowledge>true</block-on-acknowledge>
+           <retry-interval>1000</retry-interval>
+           <retry-interval-multiplier>1.0</retry-interval-multiplier>
+           <reconnect-attempts>-1</reconnect-attempts>
        </replacement>
    </supplement>
 


### PR DESCRIPTION
add a HA-REMOTE-CONNECTION-FACTORY placeholder in messaging
subsystem configuration to set HA related attributes that allows clients
using this connection factory to failover to backup.
