### PR TITLE
AS7-6651 Fix marshalling of domain controller discovery options

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
@@ -725,4 +725,7 @@ public interface HostControllerMessages {
 
     @Message(id=16533, value="Cannot instantiate discovery option class '%s': %s")
     IllegalStateException cannotInstantiateDiscoveryOptionClass(String className, String message);
+
+    @Message(id=16538, value="Invalid value for %s. Must only contain all of the existing discovery options")
+    String invalidDiscoveryOptionsOrdering(String name);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/discovery/DiscoveryOptionsResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/discovery/DiscoveryOptionsResourceDefinition.java
@@ -23,11 +23,17 @@
 package org.jboss.as.host.controller.discovery;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTIONS;
 
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.PropertyValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.host.controller.descriptions.HostResolver;
+import org.jboss.as.host.controller.operations.DiscoveryOptionsWriteAttributeHandler;
+import org.jboss.dmr.ModelType;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for a resource representing discovery options.
@@ -38,7 +44,18 @@ public class DiscoveryOptionsResourceDefinition extends SimpleResourceDefinition
 
     public static DiscoveryOptionsResourceDefinition INSTANCE = new DiscoveryOptionsResourceDefinition();
 
+    public static final PrimitiveListAttributeDefinition DISCOVERY_OPTIONS = new PrimitiveListAttributeDefinition.Builder(ModelDescriptionConstants.DISCOVERY_OPTIONS, ModelType.PROPERTY)
+        .setAllowNull(true)
+        .setValidator(new PropertyValidator(false, new StringLengthValidator(1)))
+        .build();
+
     private DiscoveryOptionsResourceDefinition() {
-        super(PathElement.pathElement(CORE_SERVICE, DISCOVERY_OPTIONS), HostResolver.getResolver(DISCOVERY_OPTIONS));
+        super(PathElement.pathElement(CORE_SERVICE, ModelDescriptionConstants.DISCOVERY_OPTIONS), HostResolver.getResolver(ModelDescriptionConstants.DISCOVERY_OPTIONS));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        super.registerAttributes(resourceRegistration);
+        resourceRegistration.registerReadWriteAttribute(DISCOVERY_OPTIONS, null, new DiscoveryOptionsWriteAttributeHandler());
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/AbstractDiscoveryOptionAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/AbstractDiscoveryOptionAddHandler.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.host.controller.operations;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Abstract superclass of handlers for a discovery option resource's add operation.
+ *
+ * @author Farah Juma
+ */
+public abstract class AbstractDiscoveryOptionAddHandler extends AbstractAddStepHandler {
+
+    public static final String OPERATION_NAME = ADD;
+
+    protected void updateDiscoveryOptionsOrdering(OperationContext context, ModelNode operation,
+            String type) {
+        PathAddress operationAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
+        PathAddress discoveryOptionsAddress = operationAddress.subAddress(0, operationAddress.size() - 1);
+        ModelNode discoveryOptions = Resource.Tools.readModel(context.readResourceFromRoot(discoveryOptionsAddress));
+
+        // Get the current list of discovery options and add the new discovery option to
+        // this list to maintain the order
+        ModelNode discoveryOptionsOrdering = discoveryOptions.get(DISCOVERY_OPTIONS).clone();
+        if (!discoveryOptionsOrdering.isDefined()) {
+            discoveryOptionsOrdering.setEmptyList();
+        }
+        discoveryOptionsOrdering.add(type, Util.getNameFromAddress(operation.get(OP_ADDR)));
+
+        ModelNode writeOp = Util.getWriteAttributeOperation(discoveryOptionsAddress, DISCOVERY_OPTIONS, discoveryOptionsOrdering);
+        OperationStepHandler writeHandler = context.getRootResourceRegistration().getSubModel(discoveryOptionsAddress).getOperationHandler(PathAddress.EMPTY_ADDRESS, WRITE_ATTRIBUTE_OPERATION);
+        context.addStep(new ModelNode(), writeOp, writeHandler, OperationContext.Stage.MODEL, true);
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/AbstractDiscoveryOptionRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/AbstractDiscoveryOptionRemoveHandler.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.host.controller.operations;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Abstract superclass of handlers for a discovery option resource's remove operation.
+ *
+ * @author Farah Juma
+ */
+public abstract class AbstractDiscoveryOptionRemoveHandler extends AbstractRemoveStepHandler {
+
+    public static final String OPERATION_NAME = REMOVE;
+
+    protected void updateDiscoveryOptionsOrdering(OperationContext context, ModelNode operation,
+            String type) {
+        PathAddress operationAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
+        PathAddress discoveryOptionsAddress = operationAddress.subAddress(0, operationAddress.size() - 1);
+        ModelNode discoveryOptions = Resource.Tools.readModel(context.readResourceFromRoot(discoveryOptionsAddress));
+
+        // Get the current list of discovery options and remove the given discovery option
+        // from the list to maintain the order
+        ModelNode discoveryOptionsOrdering = discoveryOptions.get(DISCOVERY_OPTIONS);
+        String name = Util.getNameFromAddress(operation.get(OP_ADDR));
+
+        ModelNode newDiscoveryOptionsOrdering = new ModelNode() ;
+        for (Property prop : discoveryOptionsOrdering.asPropertyList()) {
+            String discoveryOptionType = prop.getName();
+            String discoveryOptionName = prop.getValue().asString();
+            if (!(discoveryOptionName.equals(name) && discoveryOptionType.equals(type))) {
+                newDiscoveryOptionsOrdering.add(discoveryOptionType, discoveryOptionName);
+            }
+        }
+
+        ModelNode writeOp = Util.getWriteAttributeOperation(discoveryOptionsAddress, DISCOVERY_OPTIONS, newDiscoveryOptionsOrdering);
+        OperationStepHandler writeHandler = context.getRootResourceRegistration().getSubModel(discoveryOptionsAddress).getOperationHandler(PathAddress.EMPTY_ADDRESS, WRITE_ATTRIBUTE_OPERATION);
+        context.addStep(new ModelNode(), writeOp, writeHandler, OperationContext.Stage.MODEL, true);
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DiscoveryOptionAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DiscoveryOptionAddHandler.java
@@ -21,18 +21,18 @@
  */
 package org.jboss.as.host.controller.operations;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTION;
 import static org.jboss.as.host.controller.HostControllerMessages.MESSAGES;
 
 import java.lang.reflect.Constructor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.host.controller.discovery.DiscoveryOption;
 import org.jboss.as.host.controller.discovery.DiscoveryOptionResourceDefinition;
 import org.jboss.dmr.ModelNode;
@@ -45,9 +45,8 @@ import org.jboss.msc.service.ServiceController;
  *
  * @author Farah Juma
  */
-public class DiscoveryOptionAddHandler extends AbstractAddStepHandler {
+public class DiscoveryOptionAddHandler extends AbstractDiscoveryOptionAddHandler {
 
-    public static final String OPERATION_NAME = ADD;
     private final LocalHostControllerInfoImpl hostControllerInfo;
 
     /**
@@ -77,9 +76,18 @@ public class DiscoveryOptionAddHandler extends AbstractAddStepHandler {
 
     @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        // no-op
+    }
+
+    @Override
+    protected void populateModel(final OperationContext context, final ModelNode operation,
+            final Resource resource) throws  OperationFailedException {
+        final ModelNode model = resource.getModel();
         for (final AttributeDefinition attribute : DiscoveryOptionResourceDefinition.DISCOVERY_ATTRIBUTES) {
             attribute.validateAndSet(operation, model);
         }
+
+        updateDiscoveryOptionsOrdering(context, operation, DISCOVERY_OPTION);
     }
 
     protected void populateHostControllerInfo(LocalHostControllerInfoImpl hostControllerInfo, OperationContext context,

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DiscoveryOptionRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DiscoveryOptionRemoveHandler.java
@@ -21,23 +21,28 @@
  */
 package org.jboss.as.host.controller.operations;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTION;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Handler for a discovery resource's remove operation.
  *
  * @author Farah Juma
  */
-public class DiscoveryOptionRemoveHandler extends AbstractRemoveStepHandler {
-
-    public static final String OPERATION_NAME = REMOVE;
+public class DiscoveryOptionRemoveHandler extends AbstractDiscoveryOptionRemoveHandler {
 
     /**
      * Create the DiscoveryOptionRemoveHandler.
      */
     public DiscoveryOptionRemoveHandler() {
+    }
+
+    @Override
+    protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performRemove(context, operation, model);
+        updateDiscoveryOptionsOrdering(context, operation, DISCOVERY_OPTION);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DiscoveryOptionsWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DiscoveryOptionsWriteAttributeHandler.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.host.controller.operations;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DISCOVERY_OPTIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATIC_DISCOVERY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.host.controller.HostControllerMessages.MESSAGES;
+
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.host.controller.discovery.DiscoveryOptionsResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Handles changes to the discovery-options attribute that maintains the order
+ * of the discovery options.
+ *
+ * @author Farah Juma
+ */
+public class DiscoveryOptionsWriteAttributeHandler extends ModelOnlyWriteAttributeHandler {
+
+    public DiscoveryOptionsWriteAttributeHandler() {
+        super(DiscoveryOptionsResourceDefinition.DISCOVERY_OPTIONS);
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        ModelNode newValue = operation.hasDefined(VALUE) ? operation.get(VALUE) : new ModelNode();
+        if (!isValidAttributeValue(context, newValue)) {
+            throw new OperationFailedException(MESSAGES.invalidDiscoveryOptionsOrdering(DISCOVERY_OPTIONS));
+        }
+
+        if (!context.isBooting()) {
+            context.reloadRequired();
+        }
+        super.execute(context, operation);
+    }
+
+    protected boolean isValidAttributeValue(OperationContext context, ModelNode newValue) throws OperationFailedException {
+        final ModelNode model = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+        DiscoveryOptionsResourceDefinition.DISCOVERY_OPTIONS.getValidator()
+            .validateParameter(DISCOVERY_OPTIONS, newValue);
+
+        // Get the existing discovery option types and names
+        ModelNode unorderedDiscoveryOptions = new ModelNode();
+        if (model.hasDefined(DISCOVERY_OPTION)) {
+            final ModelNode discoveryOptions = model.get(DISCOVERY_OPTION);
+            for (Property prop : discoveryOptions.asPropertyList()) {
+                unorderedDiscoveryOptions.add(DISCOVERY_OPTION, prop.getName());
+            }
+        }
+        if (model.hasDefined(STATIC_DISCOVERY)) {
+            final ModelNode staticDiscoveryOptions = model.get(STATIC_DISCOVERY);
+            for (Property prop : staticDiscoveryOptions.asPropertyList()) {
+                unorderedDiscoveryOptions.add(STATIC_DISCOVERY, prop.getName());
+            }
+        }
+
+        // Make sure the new value is only made up of existing discovery options
+        List<ModelNode> newValueList = newValue.isDefined() ? newValue.asList() : Collections.<ModelNode>emptyList();
+        List<ModelNode> unorderedDiscoveryOptionsList = unorderedDiscoveryOptions.isDefined() ? unorderedDiscoveryOptions.asList() : Collections.<ModelNode>emptyList();
+        return (newValueList.size() == unorderedDiscoveryOptionsList.size()) && newValueList.containsAll(unorderedDiscoveryOptionsList);
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/StaticDiscoveryAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/StaticDiscoveryAddHandler.java
@@ -21,18 +21,18 @@
  */
 package org.jboss.as.host.controller.operations;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATIC_DISCOVERY;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.host.controller.discovery.StaticDiscovery;
 import org.jboss.as.host.controller.discovery.StaticDiscoveryResourceDefinition;
 import org.jboss.dmr.ModelNode;
@@ -43,9 +43,8 @@ import org.jboss.msc.service.ServiceController;
  *
  * @author Farah Juma
  */
-public class StaticDiscoveryAddHandler extends AbstractAddStepHandler {
+public class StaticDiscoveryAddHandler extends AbstractDiscoveryOptionAddHandler {
 
-    public static final String OPERATION_NAME = ADD;
     private final LocalHostControllerInfoImpl hostControllerInfo;
 
     /**
@@ -75,9 +74,18 @@ public class StaticDiscoveryAddHandler extends AbstractAddStepHandler {
 
     @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        // no-op
+    }
+
+    @Override
+    protected void populateModel(final OperationContext context, final ModelNode operation,
+            final Resource resource) throws  OperationFailedException {
+        final ModelNode model = resource.getModel();
         for (final SimpleAttributeDefinition attribute : StaticDiscoveryResourceDefinition.STATIC_DISCOVERY_ATTRIBUTES) {
             attribute.validateAndSet(operation, model);
         }
+
+        updateDiscoveryOptionsOrdering(context, operation, STATIC_DISCOVERY);
     }
 
     protected void populateHostControllerInfo(LocalHostControllerInfoImpl hostControllerInfo, OperationContext context,

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/StaticDiscoveryRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/StaticDiscoveryRemoveHandler.java
@@ -21,23 +21,28 @@
  */
 package org.jboss.as.host.controller.operations;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATIC_DISCOVERY;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
-
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Handler for a static discovery resource's remove operation.
  *
  * @author Farah Juma
  */
-public class StaticDiscoveryRemoveHandler extends AbstractRemoveStepHandler {
-
-    public static final String OPERATION_NAME = REMOVE;
+public class StaticDiscoveryRemoveHandler extends AbstractDiscoveryOptionRemoveHandler {
 
     /**
      * Create the StaticDiscoveryRemoveHandler.
      */
     public StaticDiscoveryRemoveHandler() {
+    }
+
+    @Override
+    protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performRemove(context, operation, model);
+        updateDiscoveryOptionsOrdering(context, operation, STATIC_DISCOVERY);
     }
 }

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -179,6 +179,7 @@ jvm.environment-variable.value=The value of the jvm environment variable.
 
 # Discovery options
 discovery-options=A list of domain controller discovery options.
+discovery-options.discovery-options=The ordered list of domain controller discovery options.
 discovery-options.discovery-option=A list of domain controller discovery options.
 discovery-option=A domain controller discovery option.
 discovery-option.name=The name for this domain controller discovery option.


### PR DESCRIPTION
Fixed marshalling of domain controller discovery options so that they are now marshalled in the order they were provided in. 

More details in https://issues.jboss.org/browse/AS7-6651.
