### PR TITLE
[AS7-6664] Set the enabled attribute in the legacy enable/disable operations

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -408,7 +408,8 @@ final class HandlerOperations {
     public static LoggingOperations.LoggingUpdateOperationStepHandler ENABLE_HANDLER = new LoggingOperations.LoggingUpdateOperationStepHandler() {
         @Override
         public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            // Nothing to do
+            // Set the enable attribute to true
+            model.get(CommonAttributes.ENABLED.getName()).set(true);
         }
 
         @Override
@@ -420,7 +421,8 @@ final class HandlerOperations {
     public static LoggingOperations.LoggingUpdateOperationStepHandler DISABLE_HANDLER = new LoggingOperations.LoggingUpdateOperationStepHandler() {
         @Override
         public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            // Nothing to do
+            // Set the enable attribute to false
+            model.get(CommonAttributes.ENABLED.getName()).set(false);
         }
 
         @Override


### PR DESCRIPTION
The `enable` attribute should be set to `true` if the legacy `enable` operation is executed and `false` if the legacy `disable` operations is executed.
