### PR TITLE
AS7-6561 EJB 3.2 support - Add support for @Stateful(passivationCapable=false)

### DIFF
--- a/build/src/main/resources/configuration/subsystems/ejb3.xml
+++ b/build/src/main/resources/configuration/subsystems/ejb3.xml
@@ -45,7 +45,7 @@
    </subsystem>
    <supplement name="default">
       <replacement placeholder="STATEFUL-BEAN">
-         <stateful default-access-timeout="5000" cache-ref="simple"/>
+         <stateful default-access-timeout="5000" cache-ref="simple" passivation-disabled-cache-ref="simple"/>
       </replacement>
    </supplement>
    <supplement name="full" includes="default">
@@ -61,7 +61,7 @@
    </supplement>
    <supplement name="ha">
       <replacement placeholder="STATEFUL-BEAN">
-         <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered"/>
+         <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered" passivation-disabled-cache-ref="simple"/>
       </replacement>
       <replacement placeholder="CLUSTERED-CACHE">
          <cache name="clustered" passivation-store-ref="infinispan" aliases="StatefulTreeCache"/>

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
@@ -117,6 +117,16 @@
         </xs:attribute>
         <xs:attribute name="cache-ref" type="xs:string"/>
         <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional"/>
+        <xs:attribute name="passivation-disabled-cache-ref" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    EJB 3.2 spec allows individual stateful EJBs to declare whether they want to disable passivation for those beans.
+                    The EJB3 subsystem as a result is expected to have a passivation disabled cache factory, which it can use as a default
+                    for such EJBs.
+                    This passivation-disabled-cache-ref attribute points to such a cache configuration in the EJB3 subsystem
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="singleton-beanType">

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -63,6 +63,7 @@ import org.jboss.as.ee.component.ComponentCreateServiceFactory;
 import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.ComponentInstance;
 import org.jboss.as.ee.component.ResourceInjectionTarget;
+import org.jboss.as.ejb3.cache.CacheFactory;
 import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
 import org.jboss.as.ejb3.component.EJBViewDescription;
@@ -2461,6 +2462,9 @@ public interface EjbMessages {
 
     @Message(id = 14582, value = "Timer service resource %s is not suitable for the target. Only a configuration with a single file-store and no other configured data-store is supported on target")
     String untransformableTimerService(PathAddress address);
+
+    @Message(id = 14583, value = "Stateful bean %s is disabled for passivation, but the cache factory %s has passivation enabled")
+    IllegalStateException requiresNonPassivatingCacheFactory(String ejbName, CacheFactory cacheFactory);
 
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/CacheFactoryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/CacheFactoryService.java
@@ -22,15 +22,15 @@
 
 package org.jboss.as.ejb3.cache;
 
-import java.io.Serializable;
-import java.util.Set;
-
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
+
+import java.io.Serializable;
+import java.util.Set;
 
 /**
  * @author Paul Ferraro
@@ -39,6 +39,7 @@ public abstract class CacheFactoryService<K extends Serializable, V extends Iden
 
     public static final ServiceName BASE_CACHE_SERVICE_NAME = ServiceName.JBOSS.append("ejb", "cache");
     public static final ServiceName DEFAULT_SFSB_CACHE_SERVICE_NAME = BASE_CACHE_SERVICE_NAME.append("sfsb-default");
+    public static final ServiceName DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE_SERVICE_NAME = BASE_CACHE_SERVICE_NAME.append("sfsb-default-passivation-disabled");
     public static final ServiceName DEFAULT_CLUSTERED_SFSB_CACHE_SERVICE_NAME = BASE_CACHE_SERVICE_NAME.append("clustered-sfsb-default");
 
     private static final ServiceName BASE_CACHE_FACTORY_SERVICE_NAME = BASE_CACHE_SERVICE_NAME.append("factory");

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentCreateServiceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentCreateServiceFactory.java
@@ -64,6 +64,10 @@ public class StatefulComponentCreateServiceFactory extends EJBComponentCreateSer
                 if (cache != null) {
                     return CacheFactoryService.getServiceName(cache.getName());
                 }
+                if (!service.isPassivationCapable()) {
+                    // use the default passivation disabled cache
+                    return CacheFactoryService.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE_SERVICE_NAME;
+                }
                 return (service.getClustering() == null) ? CacheFactoryService.DEFAULT_SFSB_CACHE_SERVICE_NAME : CacheFactoryService.DEFAULT_CLUSTERED_SFSB_CACHE_SERVICE_NAME;
             }
         });

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -82,6 +82,8 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
     private final Map<MethodIdentifier, StatefulRemoveMethod> removeMethods = new HashMap<MethodIdentifier, StatefulRemoveMethod>();
     private StatefulTimeoutInfo statefulTimeout;
     private CacheInfo cache;
+    // by default stateful beans are passivation capable, but beans can override it via annotation or deployment descriptor, starting EJB 3.2
+    private boolean passivationApplicable = true;
 
     /**
      * Map of init method, to the corresponding home create method on the home interface
@@ -390,6 +392,10 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
 
     @Override
     public boolean isPassivationApplicable() {
-        return true;
+        return this.passivationApplicable;
+    }
+
+    public void setPassivationApplicable(final boolean passivationApplicable) {
+        this.passivationApplicable = passivationApplicable;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
@@ -144,6 +144,12 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
                     break;
                 case STATEFUL:
                     sessionBeanDescription = new StatefulComponentDescription(beanName, beanClassName, ejbJarDescription, deploymentUnitServiceName, beanMetaData);
+                    // If passivation is disabled for the SFSB, either via annotation or via DD, then setup the component
+                    // description appropriately
+                    final boolean passivationCapableAnnotationValue = sessionBeanAnnotation.value("passivationCapable") == null ? true : sessionBeanAnnotation.value("passivationCapable").asBoolean();
+                    // TODO: Pass the DD value as first param for override
+                    final boolean passivationApplicable = override(null, passivationCapableAnnotationValue);
+                    ((StatefulComponentDescription) sessionBeanDescription).setPassivationApplicable(passivationApplicable);
                     break;
                 case SINGLETON:
                     sessionBeanDescription = new SingletonComponentDescription(beanName, beanClassName, ejbJarDescription, deploymentUnitServiceName, beanMetaData);
@@ -231,6 +237,7 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
                 break;
             case Stateful:
                 sessionBeanDescription = new StatefulComponentDescription(beanName, beanClassName, ejbJarDescription, deploymentUnit.getServiceName(), sessionBean);
+                // TODO: Handle passivation capable for stateful beans in EJB3.2
                 break;
             case Singleton:
                 sessionBeanDescription = new SingletonComponentDescription(beanName, beanClassName, ejbJarDescription, deploymentUnit.getServiceName(), sessionBean);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -22,6 +22,22 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.threads.Namespace;
+import org.jboss.as.threads.ThreadsParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -47,23 +63,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVICE;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.STRICT_MAX_BEAN_INSTANCE_POOL;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.THREAD_POOL;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
-
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.as.threads.Namespace;
-import org.jboss.as.threads.ThreadsParser;
-import org.jboss.dmr.ModelNode;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
  * @author Jaikiran Pai
@@ -338,7 +337,7 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>> 
         }
     }
 
-    private void parseStatefulBean(final XMLExtendedStreamReader reader, final List<ModelNode> operations, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+    protected void parseStatefulBean(final XMLExtendedStreamReader reader, final List<ModelNode> operations, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
         final int count = reader.getAttributeCount();
         final EnumSet<EJB3SubsystemXMLAttribute> missingRequiredAttributes = EnumSet.of(EJB3SubsystemXMLAttribute.DEFAULT_ACCESS_TIMEOUT, EJB3SubsystemXMLAttribute.CACHE_REF);
         for (int i = 0; i < count; i++) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
@@ -22,14 +22,13 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import java.util.EnumSet;
-import java.util.List;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
-
-import org.jboss.dmr.ModelNode;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
+import java.util.EnumSet;
+import java.util.List;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
@@ -77,6 +76,43 @@ public class EJB3Subsystem20Parser extends EJB3Subsystem14Parser {
         return EJB3SubsystemNamespace.EJB3_2_0;
     }
 
+    @Override
+    protected void parseStatefulBean(final XMLExtendedStreamReader reader, final List<ModelNode> operations, final ModelNode ejb3SubsystemAddOperation) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        final EnumSet<EJB3SubsystemXMLAttribute> missingRequiredAttributes = EnumSet.of(EJB3SubsystemXMLAttribute.DEFAULT_ACCESS_TIMEOUT, EJB3SubsystemXMLAttribute.CACHE_REF);
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final EJB3SubsystemXMLAttribute attribute = EJB3SubsystemXMLAttribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case DEFAULT_ACCESS_TIMEOUT: {
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
+                case CACHE_REF: {
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
+                case CLUSTERED_CACHE_REF: {
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
+                case PASSIVATION_DISABLED_CACHE_REF: {
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
+                default: {
+                    throw unexpectedAttribute(reader, i);
+                }
+            }
+            // found the mandatory attribute
+            missingRequiredAttributes.remove(attribute);
+        }
+        requireNoContent(reader);
+        if (!missingRequiredAttributes.isEmpty()) {
+            throw missingRequired(reader, missingRequiredAttributes);
+        }
+    }
 
     private void parseTimerService(final XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -22,20 +22,6 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
-
-import java.util.List;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-
 import org.jboss.as.clustering.registry.RegistryCollector;
 import org.jboss.as.clustering.registry.RegistryCollectorService;
 import org.jboss.as.connector.util.ConnectorServices;
@@ -139,6 +125,21 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.omg.PortableServer.POA;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+import java.util.List;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_RESOURCE_ADAPTER_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
 
 /**
  * Add operation handler for the EJB3 subsystem.
@@ -293,6 +294,10 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         if (model.hasDefined(DEFAULT_SFSB_CACHE)) {
             EJB3SubsystemDefaultCacheWriteHandler.SFSB_CACHE.updateCacheService(context, model, newControllers);
+        }
+
+        if (model.hasDefined(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)) {
+            EJB3SubsystemDefaultCacheWriteHandler.SFSB_PASSIVATION_DISABLED_CACHE.updateCacheService(context, model, newControllers);
         }
 
         EJB3SubsystemDefaultCacheWriteHandler.CLUSTERED_SFSB_CACHE.updateCacheService(context, model, newControllers);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDefaultCacheWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDefaultCacheWriteHandler.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import java.util.List;
-
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -39,6 +37,8 @@ import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.InjectedValue;
 
+import java.util.List;
+
 /**
  * @author Paul Ferraro
  */
@@ -49,6 +49,12 @@ public class EJB3SubsystemDefaultCacheWriteHandler extends AbstractWriteAttribut
                     null,
                     null,
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE);
+
+    public static final EJB3SubsystemDefaultCacheWriteHandler SFSB_PASSIVATION_DISABLED_CACHE =
+            new EJB3SubsystemDefaultCacheWriteHandler(CacheFactoryService.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE_SERVICE_NAME,
+                    null,
+                    null,
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE);
 
     public static final EJB3SubsystemDefaultCacheWriteHandler CLUSTERED_SFSB_CACHE =
             new EJB3SubsystemDefaultCacheWriteHandler(CacheFactoryService.DEFAULT_CLUSTERED_SFSB_CACHE_SERVICE_NAME,

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -47,6 +47,7 @@ public interface EJB3SubsystemModel {
     String DEFAULT_RESOURCE_ADAPTER_NAME = "default-resource-adapter-name";
     String DEFAULT_SFSB_CACHE = "default-sfsb-cache";
     String DEFAULT_CLUSTERED_SFSB_CACHE = "default-clustered-sfsb-cache";
+    String DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE = "default-sfsb-passivation-disabled-cache";
     String DEFAULT_SLSB_INSTANCE_POOL = "default-slsb-instance-pool";
     String INSTANCE_ACQUISITION_TIMEOUT = "timeout";
     String INSTANCE_ACQUISITION_TIMEOUT_UNIT = "timeout-unit";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -101,6 +101,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                     .build();
     static final SimpleAttributeDefinition DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, ModelType.STRING, true)
+                    .setXmlName(EJB3SubsystemXMLAttribute.PASSIVATION_DISABLED_CACHE_REF.getLocalName())
                     .setAllowExpression(true)
                     .build();
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
@@ -65,6 +65,7 @@ public enum EJB3SubsystemXMLAttribute {
 
     PASS_BY_VALUE("pass-by-value"),
     PASSIVATE_EVENTS_ON_REPLICATE("passivate-events-on-replicate"),
+    PASSIVATION_DISABLED_CACHE_REF("passivation-disabled-cache-ref"),
     PASSIVATION_STORE_REF("passivation-store-ref"),
     PATH("path"),
     POOL_NAME("pool-name"),

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -22,10 +22,6 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import java.util.List;
-
-import javax.xml.stream.XMLStreamException;
-
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.remoting.Attribute;
 import org.jboss.as.threads.ThreadsParser;
@@ -34,8 +30,26 @@ import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.*;
+import javax.xml.stream.XMLStreamException;
+import java.util.List;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ASYNC;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CHANNEL_CREATION_OPTIONS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_DISTINCT_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ENABLE_STATISTICS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.IIOP;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.IN_VM_REMOTE_INTERFACE_INVOCATION_PASS_BY_VALUE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVICE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.THREAD_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
 
 /**
  * The {@link XMLElementWriter} that handles the EJB subsystem. As we only write out the most recent version of
@@ -82,7 +96,8 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         // <stateful> element
         if (model.hasDefined(EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT)
                 || model.hasDefined(EJB3SubsystemModel.DEFAULT_SFSB_CACHE)
-                || model.hasDefined(EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE)) {
+                || model.hasDefined(EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE)
+                || model.hasDefined(EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)) {
             // <stateful>
             writer.writeStartElement(EJB3SubsystemXMLElement.STATEFUL.getLocalName());
             // write out the <stateful> element contents
@@ -341,6 +356,10 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         if (statefulBeanModel.hasDefined(DEFAULT_CLUSTERED_SFSB_CACHE)) {
             String cache = statefulBeanModel.get(DEFAULT_CLUSTERED_SFSB_CACHE).asString();
             writer.writeAttribute(EJB3SubsystemXMLAttribute.CLUSTERED_CACHE_REF.getLocalName(), cache);
+        }
+        if (statefulBeanModel.hasDefined(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)) {
+            final String cacheRef = statefulBeanModel.get(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE).asString();
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.PASSIVATION_DISABLED_CACHE_REF.getLocalName(), cacheRef);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -40,7 +40,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_DISTINCT_NA
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ENABLE_STATISTICS;
@@ -357,10 +356,7 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
             String cache = statefulBeanModel.get(DEFAULT_CLUSTERED_SFSB_CACHE).asString();
             writer.writeAttribute(EJB3SubsystemXMLAttribute.CLUSTERED_CACHE_REF.getLocalName(), cache);
         }
-        if (statefulBeanModel.hasDefined(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)) {
-            final String cacheRef = statefulBeanModel.get(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE).asString();
-            writer.writeAttribute(EJB3SubsystemXMLAttribute.PASSIVATION_DISABLED_CACHE_REF.getLocalName(), cacheRef);
-        }
+        EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.marshallAsAttribute(statefulBeanModel, writer);
     }
 
     private void writeDefaultSLSBPool(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -4,6 +4,7 @@ ejb3.enable-statistics=If set to true, enable the collection of invocation stati
 ejb3.remove=Removes the ejb3 subsystem.
 ejb3.lite=Specifies whether the ejb3 container need only provide the "LITE" profile of the specification. This value should only be false when using the "everything" distro.
 ejb3.default-clustered-sfsb-cache=Name of the default stateful bean cache, which will be applicable to all clustered stateful EJBs, unless overridden at the deployment or bean level
+ejb3.default-sfsb-passivation-disabled-cache=Name of the default stateful bean cache, which will be applicable to all stateful EJBs which have passivation disabled. Each deployment or EJB can optionally override this cache name.
 ejb3.default-mdb-instance-pool=Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level
 ejb3.default-entity-bean-instance-pool=Name of the default entity bean instance pool, which will be applicable to all entity beans, unless overridden at the deployment or bean level
 ejb3.default-entity-bean-optimistic-locking=If set to true entity beans will use optimistic locking by default

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -45,6 +45,9 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.List;
+
 /**
  * @author Emanuel Muckenhuber
  */
@@ -87,8 +90,8 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
                 .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + controllerVersion.getMavenGavVersion())
                 .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + controllerVersion.getMavenGavVersion())
                 .skipReverseControllerCheck()
-                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, mainSubsystemName)))
-                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, mainSubsystemName), PathElement.pathElement("strict-max-bean-instance-pool")));
+                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName())))
+                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement("strict-max-bean-instance-pool")));
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
@@ -174,7 +177,8 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
                                 EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS,
                                 EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN)
                                 .addConfig(new FailedOperationTransformationConfig.RejectExpressionsConfig(EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS))
-                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN)).build())
+                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN))
+                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)).build())
                 .addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL)),
                         keepaliveOnly)
                 .addFailedAttribute(subsystemAddress.append(StrictMaxPoolResourceDefinition.INSTANCE.getPathElement()),
@@ -194,6 +198,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
 
     private FailedOperationTransformationConfig getFileStorePathConfig() {
         return new FailedOperationTransformationConfig()
+                .addFailedAttribute(PathAddress.pathAddress(EJB3Extension.SUBSYSTEM_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE))
                 .addFailedAttribute(PathAddress.pathAddress(EJB3Extension.SUBSYSTEM_PATH, EJB3SubsystemModel.TIMER_SERVICE_PATH,
                         PathElement.pathElement(EJB3SubsystemModel.FILE_DATA_STORE, "file-data-store")),
                         new FailedOperationTransformationConfig.RejectExpressionsConfig(FileDataStoreResourceDefinition.PATH));

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
@@ -3,7 +3,7 @@
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
         </stateless>
-        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="file" clustered-cache-ref="cluster"/>
+        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="file" clustered-cache-ref="cluster" passivation-disabled-cache-ref="simple"/>
         <singleton default-access-timeout="${prop.default-access-timeout:5000}"/>
     </session-bean>
     <entity-bean>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationDisabledBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationDisabledBean.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import javax.ejb.PostActivate;
+import javax.ejb.PrePassivate;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful(passivationCapable = false)
+public class PassivationDisabledBean {
+
+    private boolean prePrePassivateInvoked;
+    private boolean postActivateInvoked;
+
+    @PrePassivate
+    private void beforePassivate() {
+        this.prePrePassivateInvoked = true;
+    }
+
+    @PostActivate
+    private void afterActivate() {
+        this.postActivateInvoked = true;
+    }
+
+    public void doNothing() {
+
+    }
+
+    public boolean wasPassivated() {
+        return this.prePrePassivateInvoked;
+    }
+
+    public boolean wasActivated() {
+        return this.postActivateInvoked;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationEnabledBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationEnabledBean.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import org.jboss.ejb3.annotation.Cache;
+
+import javax.ejb.PostActivate;
+import javax.ejb.PrePassivate;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful(passivationCapable = true)
+public class PassivationEnabledBean {
+
+    private boolean prePrePassivateInvoked;
+    private boolean postActivateInvoked;
+
+    @PrePassivate
+    private void beforePassivate() {
+        this.prePrePassivateInvoked = true;
+    }
+
+    @PostActivate
+    private void afterActivate() {
+        this.postActivateInvoked = true;
+    }
+
+    public void doNothing() {
+
+    }
+
+    public boolean wasPassivated() {
+        return this.prePrePassivateInvoked;
+    }
+
+    public boolean wasActivated() {
+        return this.postActivateInvoked;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCaseSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCaseSetup.java
@@ -22,10 +22,13 @@
 
 package org.jboss.as.test.integration.ejb.stateful.passivation;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
@@ -38,10 +41,12 @@ import org.junit.Assert;
  *
  * @author Stuart Douglas, Ondrej Chaloupka
  */
-public class PassivationSucceedsUnitTestCaseSetup implements ServerSetupTask {
-    private static final Logger log = Logger.getLogger(PassivationSucceedsUnitTestCaseSetup.class);
+public class PassivationTestCaseSetup implements ServerSetupTask {
+    private static final Logger log = Logger.getLogger(PassivationTestCaseSetup.class);
 
-    private static ModelNode getAddress() {
+    private String previousDefaultSFSBCache;
+
+    private static ModelNode getFilePassivationStoreAddress() {
         ModelNode address = new ModelNode();
         address.add("subsystem", "ejb3");
         address.add("file-passivation-store", "file");
@@ -51,10 +56,15 @@ public class PassivationSucceedsUnitTestCaseSetup implements ServerSetupTask {
     
     @Override
     public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
-        ModelNode address = getAddress();
+        this.previousDefaultSFSBCache = this.getDefaultSFSBCache(managementClient);
+        log.info("Default SFSB cache is " + previousDefaultSFSBCache);
+        // change the default sfsb cache to a passivating one
+        this.changeDefaultSFSBCache(managementClient, "passivating");
+        // update the file passivation store attributes
+        ModelNode filePassivationStoreAddress = getFilePassivationStoreAddress();
         ModelNode operation = new ModelNode();
         operation.get(OP).set("write-attribute");
-        operation.get(OP_ADDR).set(address);
+        operation.get(OP_ADDR).set(filePassivationStoreAddress);
         operation.get("name").set("max-size");
         operation.get("value").set(1);
         ModelNode result = managementClient.getControllerClient().execute(operation);
@@ -62,7 +72,7 @@ public class PassivationSucceedsUnitTestCaseSetup implements ServerSetupTask {
         Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
         operation = new ModelNode();
         operation.get(OP).set("write-attribute");
-        operation.get(OP_ADDR).set(address);
+        operation.get(OP_ADDR).set(filePassivationStoreAddress);
         operation.get("name").set("idle-timeout");
         operation.get("value").set(1);
         result = managementClient.getControllerClient().execute(operation);
@@ -73,7 +83,12 @@ public class PassivationSucceedsUnitTestCaseSetup implements ServerSetupTask {
 
     @Override
     public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
-        ModelNode address = getAddress();
+        if (this.previousDefaultSFSBCache != null) {
+            // reset back to the original one
+            this.changeDefaultSFSBCache(managementClient, this.previousDefaultSFSBCache);
+        }
+        // reset the file passivation store attributes
+        ModelNode address = getFilePassivationStoreAddress();
         ModelNode operation = new ModelNode();
         operation.get(OP).set("undefine-attribute");
         operation.get(OP_ADDR).set(address);
@@ -85,5 +100,29 @@ public class PassivationSucceedsUnitTestCaseSetup implements ServerSetupTask {
         operation.get("name").set("idle-timeout");
         ModelNode result = managementClient.getControllerClient().execute(operation);
         Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private String getDefaultSFSBCache(final ManagementClient managementClient) throws Exception {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "ejb3");
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set("read-attribute");
+        operation.get(OP_ADDR).set(address);
+        operation.get(NAME).set("default-sfsb-cache");
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        return result.get(RESULT).asString();
+    }
+
+    private void changeDefaultSFSBCache(final ManagementClient managementClient, final String cacheName) throws Exception {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "ejb3");
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set("write-attribute");
+        operation.get(OP_ADDR).set(address);
+        operation.get(NAME).set("default-sfsb-cache");
+        operation.get(VALUE).set(cacheName);
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals("Failed to change default SFSB cache to: " + cacheName, SUCCESS, result.get(OUTCOME).asString());
+        log.info("Changed default SFSB cache to " + cacheName);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ejb2/PassivationSucceedsEJB2TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ejb2/PassivationSucceedsEJB2TestCase.java
@@ -28,7 +28,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.integration.ejb.stateful.passivation.PassivationSucceedsUnitTestCaseSetup;
+import org.jboss.as.test.integration.ejb.stateful.passivation.PassivationTestCaseSetup;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -40,12 +40,12 @@ import org.junit.runner.RunWith;
 
 /**
  * Tests that passivation succeeds for ejb2 beans.
- * @see org.jboss.as.test.integration.ejb.stateful.passivation.PassivationSucceedsUnitTestCase
+ * @see org.jboss.as.test.integration.ejb.stateful.passivation.PassivationTestCase
  *
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
-@ServerSetup(PassivationSucceedsUnitTestCaseSetup.class)
+@ServerSetup(PassivationTestCaseSetup.class)
 public class PassivationSucceedsEJB2TestCase {
     private static final Logger log = Logger.getLogger(PassivationSucceedsEJB2TestCase.class);
     private static String jndi;
@@ -61,7 +61,7 @@ public class PassivationSucceedsEJB2TestCase {
     public static Archive<?> deploy() throws Exception {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "passivation-ejb2-test.jar");
         jar.addPackage(PassivationSucceedsEJB2TestCase.class.getPackage());
-        jar.addClasses(PassivationSucceedsUnitTestCaseSetup.class);
+        jar.addClasses(PassivationTestCaseSetup.class);
         jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"),
                 "MANIFEST.MF");
         log.info(jar.toString(true));


### PR DESCRIPTION
The EJB 3.2 spec introduces a way to disable passivation of stateful beans. User applications can use @Stateful(passivationCapable=false) to disable passivation for the bean. There's a ejb-jar.xml deployment descriptor equivalent too.

The commits here introduces support for disabling the passivation using the annotation approach. New tests have been added to make sure this is functional.

There are couple of TODOs in this PR for adding support for the deployment descriptor based approach. A subsequent PR which depends on a jboss-metadata release will add support for that. This PR is ready for review and merge in the meantime.
