### PR TITLE
Fix AS7-6714: Update to console 1.5.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <version.org.jdom>1.1.2</version.org.jdom>
         <version.org.jboss.arquillian.core>1.0.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.osgi>2.0.0.Alpha2</version.org.jboss.arquillian.osgi>
-        <version.org.jboss.as.console>1.5.1.Final</version.org.jboss.as.console>
+        <version.org.jboss.as.console>1.5.2.Final</version.org.jboss.as.console>
         <version.org.jboss.as.jbossweb-native>2.0.10.Final</version.org.jboss.as.jbossweb-native>
         <version.org.jboss.byteman>2.0.1</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.0.4.Final</version.org.jboss.classfilewriter>


### PR DESCRIPTION
Incorporates:
- AS7-6682: Reporting product version instead of release Version in console
- AS7-6676: Security attribute for JacORB Subsystem is missing setting options
- AS7-6550: Confusing behavior of form under the "Unmanaged" tab in deployment's Replace dialog
- AS7-6518: Section "Runtime Operations" should not be visible when empty
- AS7-6516: Wrong value of "runtime-name" property for unmanaged deployments
- AS7-6510: Unable to add Modules for security domains
- AS7-6505: "Add" button for http/ajp connector does not work if no server groups present
- AS7-6493: Unable to create JMS connection factory
- AS7-6283: Web Services Endpoints table in console is not paginated
- AS7-4331: Management operations for accessing transaction logs should be exposed in the web console
