### PR TITLE
upgrade metadata to 8.0.0.Alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>1.4.1.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.0.1.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.3.16.GA</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.metadata>7.0.8.Final</version.org.jboss.metadata>
+        <version.org.jboss.metadata>8.0.0.Alpha1</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.2.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.2.0.CR2</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.1.1.Final</version.org.jboss.msc.jboss-msc>
@@ -439,7 +439,6 @@
                                             <exclude>org.jboss.interceptor:jboss-interceptor-api</exclude>
                                             <exclude>org.jboss.javaee:jboss-javaee</exclude>
                                             <exclude>org.jboss.javaee:jboss-ejb-api</exclude>
-                                            <exclude>org.jboss.javaee:jboss-ejb-api_3.1</exclude>
                                             <exclude>org.jboss.javaee:jboss-jacc-api</exclude>
                                             <exclude>org.jboss.javaee:jboss-jad-api</exclude>
                                             <exclude>org.jboss.javaee:jboss-jaspi-api</exclude>


### PR DESCRIPTION
Should help get rid of problems with old transitive dependencies 
