### PR TITLE
[AS7-6722] Best attempt to process overridden directory properties in scripts

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -159,6 +159,36 @@ if exist "%JBOSS_HOME%\jboss-modules.jar" (
 
 rem Setup JBoss specific properties
 
+rem Setup directories, note directories with spaces do not work
+set "CONSOLIDATED_OPTS=%JAVA_OPTS% %SERVER_OPTS%"
+:DIRLOOP
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.base.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_BASE_DIR=%%~fi"
+  )
+)
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.config.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_CONFIG_DIR=%%~fi"
+  )
+)
+echo(%CONSOLIDATED_OPTS% | findstr /r /c:"^-Djboss.server.log.dir" > nul && (
+  for /f "tokens=1,2* delims==" %%a IN ("%CONSOLIDATED_OPTS%") DO (
+    for /f %%i IN ("%%b") DO set "JBOSS_LOG_DIR=%%~fi"
+  )
+)
+
+for /f "tokens=1* delims= " %%i IN ("%CONSOLIDATED_OPTS%") DO (
+  if %%i == "" (
+    goto ENDDIRLOOP
+  ) else (
+    set CONSOLIDATED_OPTS=%%j
+    GOTO DIRLOOP
+  )
+)
+
+:ENDDIRLOOP
+
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
   set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"


### PR DESCRIPTION
This is a best attempt to process overridden directories when being passed in the `standalone.conf` files or via the command line. This has no affect on how the values are used in the main Java entry points only how they are used in the scripts themselves.

One major note is none of them allow for spaces in the directory name. This looks like it has never worked that way. Note though this **only** affects directory overrides of:
- `jboss.server.base.dir`
- `jboss.server.config.dir`
- `jboss.server.log.dir`

Currently the issue seems to only be with the `jboss.server.config.dir` when attempting to find the `logging.properties` file at boot. On the initial boot this could affect the `jboss.server.log.dir` as well.

Just as a side note this could fix the issues with writing expressions to the `logging.properties` file where the `jboss.server.log.dir` wasn't being found.
