### PR TITLE
Add object factory that just returns a new initial context

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/ExternalContextObjectFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/ExternalContextObjectFactory.java
@@ -1,0 +1,20 @@
+package org.jboss.as.naming;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.Name;
+import javax.naming.spi.ObjectFactory;
+
+/**
+ * object factory that creates a new initial context with the supplied properties
+ *
+ * @author Stuart Douglas
+ */
+public class ExternalContextObjectFactory implements ObjectFactory {
+    @Override
+    public Object getObjectInstance(final Object obj, final Name name, final Context nameCtx, final Hashtable<?, ?> environment) throws Exception {
+        return new InitialContext((Hashtable)environment);
+    }
+}


### PR DESCRIPTION
This factory can then be used to bind new initial contexts from the naming subsystem, allowing similar functionality to the old ExternalContextMBean. There will be a seperate commit a bit later that will expose this functionality directly in the naming subsystem config.
