### PR TITLE
[AS7-6713] Some filter attributes require special validators

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/ObjectTypeValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/ObjectTypeValidator.java
@@ -25,10 +25,8 @@ package org.jboss.as.controller.operations.validation;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -45,7 +43,7 @@ public class ObjectTypeValidator extends ModelTypeValidator implements AllowedVa
     private final List<ModelNode> nodeValues;
 
     public ObjectTypeValidator(final boolean nullable, final AttributeDefinition... attributes) {
-        super(nullable, true, false, ModelType.OBJECT, findModelTypes(attributes));
+        super(nullable, true, false, ModelType.OBJECT);
         allowedValues = new HashMap<String, AttributeDefinition>(attributes.length);
         nodeValues = new ArrayList<ModelNode>(attributes.length);
         for (AttributeDefinition attribute : attributes) {
@@ -71,14 +69,5 @@ public class ObjectTypeValidator extends ModelTypeValidator implements AllowedVa
     @Override
     public List<ModelNode> getAllowedValues() {
         return nodeValues;
-    }
-
-    private static ModelType[] findModelTypes(final AttributeDefinition... attributes) {
-        final Set<ModelType> result = new HashSet<ModelType>();
-        for (AttributeDefinition attr : attributes) {
-            if (attr.getType() != ModelType.OBJECT)
-                result.add(attr.getType());
-        }
-        return result.toArray(new ModelType[result.size()]);
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/Filters.java
+++ b/logging/src/main/java/org/jboss/as/logging/Filters.java
@@ -126,7 +126,12 @@ class Filters {
             return String.format("%s(%s)", NOT, filterToFilterSpec(value.get(CommonAttributes.NOT.getName())));
         } else if (value.hasDefined(CommonAttributes.REPLACE.getName())) {
             final ModelNode replace = value.get(CommonAttributes.REPLACE.getName());
-            final boolean replaceAll = replace.get(CommonAttributes.REPLACE_ALL.getName()).asBoolean();
+            final boolean replaceAll;
+            if (replace.hasDefined(CommonAttributes.REPLACE_ALL.getName())) {
+                replaceAll = replace.get(CommonAttributes.REPLACE_ALL.getName()).asBoolean();
+            } else {
+                replaceAll = CommonAttributes.REPLACE_ALL.getDefaultValue().asBoolean();
+            }
             final StringBuilder result = new StringBuilder();
             if (replaceAll) {
                 result.append(SUBSTITUTE_ALL);

--- a/logging/src/test/java/org/jboss/as/logging/FilterConversionTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/FilterConversionTestCase.java
@@ -26,12 +26,10 @@ import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.Level;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
Some filter attributes require special validators.

Also the `ObjectTypeValidator` should only allow `ModelType.OBJECT` for it's value type.
