### PR TITLE
[AS7-6736] Don't add the log4j library to the module.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -185,9 +185,7 @@
 
         <module-def name="javax.xml.stream.api"/>
 
-        <module-def name="org.apache.log4j">
-            <maven-resource group="log4j" artifact="log4j"/>
-        </module-def>
+        <module-def name="org.apache.log4j"/>
 
         <module-def name="org.jboss.as.controller">
             <maven-resource group="org.jboss.as" artifact="jboss-as-controller"/>


### PR DESCRIPTION
[AS7-6736] Don't add the log4j library to the module.
