### PR TITLE
[AS7-6699] HornetQ backup mode

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractHornetQComponentControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractHornetQComponentControlHandler.java
@@ -76,19 +76,30 @@ public abstract class AbstractHornetQComponentControlHandler<T extends HornetQCo
 
         final String operationName = operation.require(OP).asString();
 
-        HornetQComponentControl control = null;
-        boolean appliedToRuntime = false;
-        Object handback = null;
         if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
+            if (HornetQActivationService.ignoreOperationIfServerNotActive(context, operation)) {
+                return;
+            }
             readAttributeValidator.validate(operation);
             final String name = operation.require(NAME).asString();
             if (STARTED.getName().equals(name)) {
-                control = getHornetQComponentControl(context, operation, false);
+                HornetQComponentControl control = getHornetQComponentControl(context, operation, false);
                 context.getResult().set(control.isStarted());
             } else {
                 handleReadAttribute(name, context, operation);
             }
-        } else if (START.equals(operationName)) {
+            context.stepCompleted();
+            return;
+        }
+
+        if (HornetQActivationService.rollbackOperationIfServerNotActive(context, operation)) {
+            return;
+        }
+
+        HornetQComponentControl control = null;
+        boolean appliedToRuntime = false;
+        Object handback = null;
+        if (START.equals(operationName)) {
             control = getHornetQComponentControl(context, operation, true);
             try {
                 control.start();

--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractQueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractQueueControlHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging;
 
 import static org.jboss.as.messaging.CommonAttributes.FILTER;
+import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
 import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
@@ -279,6 +280,10 @@ public abstract class AbstractQueueControlHandler<T> extends AbstractRuntimeOnly
 
     @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        if (rollbackOperationIfServerNotActive(context, operation)) {
+            return;
+        }
 
         final String operationName = operation.require(ModelDescriptionConstants.OP).asString();
         final String queueName = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
@@ -30,6 +30,8 @@ import static org.jboss.as.messaging.CommonAttributes.NUMBER_OF_BYTES_PER_PAGE;
 import static org.jboss.as.messaging.CommonAttributes.NUMBER_OF_PAGES;
 import static org.jboss.as.messaging.CommonAttributes.QUEUE_NAMES;
 import static org.jboss.as.messaging.CommonAttributes.ROLES_ATTR_NAME;
+import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
+import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
 import static org.jboss.as.messaging.ManagementUtil.reportListOfString;
 import static org.jboss.as.messaging.ManagementUtil.reportRoles;
 import static org.jboss.as.messaging.ManagementUtil.reportRolesAsJSON;
@@ -62,6 +64,10 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
     @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
 
+        if (rollbackOperationIfServerNotActive(context, operation)) {
+            return;
+        }
+
         final String operationName = operation.require(OP).asString();
         if (READ_ATTRIBUTE_OPERATION.equals(operationName)) {
             handleReadAttribute(context, operation);
@@ -71,6 +77,11 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
     }
 
     private void handleReadAttribute(OperationContext context, ModelNode operation) {
+
+        if (ignoreOperationIfServerNotActive(context, operation)) {
+            return;
+        }
+
         final AddressControl addressControl = getAddressControl(context, operation);
         if (addressControl == null) {
             ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingAdd.java
@@ -24,6 +24,7 @@ package org.jboss.as.messaging;
 
 import static org.jboss.as.messaging.CommonAttributes.DEAD_LETTER_ADDRESS;
 import static org.jboss.as.messaging.CommonAttributes.EXPIRY_ADDRESS;
+import static org.jboss.as.messaging.HornetQActivationService.getHornetQServer;
 
 import java.util.List;
 
@@ -42,7 +43,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * {@code OperationStepHandler} adding a new address setting.
@@ -64,7 +64,7 @@ class AddressSettingAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model,
                                   final ServiceVerificationHandler verificationHandler,
                                   final List<ServiceController<?>> newControllers) throws OperationFailedException {
-        final HornetQServer server = getServer(context, operation);
+        final HornetQServer server = getHornetQServer(context, operation);
         if(server != null) {
             final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
             final AddressSettings settings = createSettings(context, model);
@@ -103,12 +103,4 @@ class AddressSettingAdd extends AbstractAddStepHandler {
         return SimpleString.toSimpleString(node.getType() != ModelType.UNDEFINED ? node.asString() : defVal);
     }
 
-    static HornetQServer getServer(final OperationContext context, ModelNode operation) {
-        final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
-        final ServiceController<?> controller = context.getServiceRegistry(true).getService(hqServiceName);
-        if(controller != null) {
-            return HornetQServer.class.cast(controller.getValue());
-        }
-        return null;
-    }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsWriteHandler.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.messaging.HornetQActivationService.getHornetQServer;
+
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.settings.HierarchicalRepository;
 import org.hornetq.core.settings.impl.AddressSettings;
@@ -48,7 +50,7 @@ class AddressSettingsWriteHandler extends AbstractWriteAttributeHandler<AddressS
     protected boolean applyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue,
                                            final ModelNode currentValue, final HandbackHolder<RevertHandback> handbackHolder) throws OperationFailedException {
         final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
-        final HornetQServer server = AddressSettingAdd.getServer(context, operation);
+        final HornetQServer server = getHornetQServer(context, operation);
         if(server != null) {
             final ModelNode model = resource.getModel();
             final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQActivationService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQActivationService.java
@@ -1,0 +1,113 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.PathAddress.pathAddress;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.hornetq.core.server.HornetQServer;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * A service that can be dependent on to ensure the HornetQ server is active.
+ *
+ * HornetQ server can be passive when they are configured as backup and wait for a live node to fail.
+ * In this passive state, the server does not accept connections or create resources.
+ *
+ * This service must be used by any service depending on a HornetQ server being active.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class HornetQActivationService implements Service<Void> {
+
+    public static ServiceName getHornetQActivationServiceName(ServiceName hqServerName) {
+        return hqServerName.append("activation");
+    }
+
+    public static boolean isHornetQServerActive(OperationContext context, ModelNode operation) {
+        PathAddress address = pathAddress(operation.get(OP_ADDR));
+        return isHornetQServerActive(context.getServiceRegistry(false), MessagingServices.getHornetQServiceName(address));
+    }
+
+    public static boolean isHornetQServerActive(ServiceRegistry serviceRegistry, ServiceName hqServiceName) {
+        ServiceController<?> service = serviceRegistry.getService(hqServiceName);
+        if (service != null) {
+            HornetQServer server = HornetQServer.class.cast(service.getValue());
+            if (server.isStarted() && server.isActive()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean rollbackOperationIfServerNotActive(OperationContext context, ModelNode operation) {
+        if (isHornetQServerActive(context, operation)) {
+            return false;
+        }
+        context.getFailureDescription().set(MessagingMessages.MESSAGES.hqServerInBackupMode(pathAddress(operation.require(OP_ADDR))));
+        context.setRollbackOnly();
+        context.stepCompleted();
+        return true;
+    }
+
+    public static boolean ignoreOperationIfServerNotActive(OperationContext context, ModelNode operation) {
+        if (isHornetQServerActive(context, operation)) {
+            return false;
+        }
+        // undefined result
+        context.getResult();
+        context.stepCompleted();
+        return true;
+    }
+
+    static HornetQServer getHornetQServer(final OperationContext context, ModelNode operation) {
+        final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(pathAddress(operation.get(OP_ADDR)));
+        final ServiceController<?> controller = context.getServiceRegistry(false).getService(hqServiceName);
+        if(controller != null) {
+            return HornetQServer.class.cast(controller.getValue());
+        }
+        return null;
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    @Override
+    public Void getValue() throws IllegalStateException, IllegalArgumentException {
+        return null;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
@@ -119,7 +119,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathManagerService;
-import org.jboss.as.messaging.HornetQService.PathConfig;
 import org.jboss.as.messaging.jms.JMSService;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
@@ -228,9 +227,7 @@ class HornetQServerAdd implements OperationStepHandler {
 
                 // Create the HornetQ Service
                 final HornetQService hqService = new HornetQService(
-                        new PathConfig(bindingsPath, bindingsRelativeToPath, journalPath, journalRelativeToPath, largeMessagePath, largeMessageRelativeToPath, pagingPath, pagingRelativeToPath));
-
-                hqService.setConfiguration(configuration);
+                        configuration, new HornetQService.PathConfig(bindingsPath, bindingsRelativeToPath, journalPath, journalRelativeToPath, largeMessagePath, largeMessageRelativeToPath, pagingPath, pagingRelativeToPath));
 
                 // Add the HornetQ Service
                 ServiceName hqServiceName = MessagingServices.getHornetQServiceName(serverName);

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.messaging;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.messaging.CommonAttributes.CLUSTERED;
+import static org.jboss.as.messaging.HornetQActivationService.isHornetQServerActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.Set;
@@ -97,6 +98,9 @@ public class HornetQServerControlWriteHandler extends AbstractWriteAttributeHand
                 // No, don't barf; just let the update apply to the model and put the server in a reload-required state
                 return true;
             } else {
+                if (!isHornetQServerActive(context, operation)) {
+                    return false;
+                }
                 applyOperationToHornetQService(context, operation, attributeName, hqService);
                 return false;
             }

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -83,8 +83,6 @@ class HornetQService implements Service<HornetQServer> {
      */
     private static final String SOCKET_REF = RemoteTransportDefinition.SOCKET_BINDING.getName();
 
-    private Configuration configuration;
-
     private HornetQServer server;
     private Map<String, SocketBinding> socketBindings = new HashMap<String, SocketBinding>();
     private Map<String, OutboundSocketBinding> outboundSocketBindings = new HashMap<String, OutboundSocketBinding>();
@@ -93,6 +91,7 @@ class HornetQService implements Service<HornetQServer> {
     private final InjectedValue<MBeanServer> mbeanServer = new InjectedValue<MBeanServer>();
     private final InjectedValue<SecurityDomainContext> securityDomainContextValue = new InjectedValue<SecurityDomainContext>();
     private final PathConfig pathConfig;
+    private final Configuration configuration;
     // mapping between the {broacast|discovery}-groups and the *names* of the JGroups channel they use
     private final Map<String, String> jgroupsChannels = new HashMap<String, String>();
     // mapping between the {broacast|discovery}-groups and the JGroups channel factory for the *stack* they use
@@ -101,7 +100,8 @@ class HornetQService implements Service<HornetQServer> {
     // broadcast-group and discovery-groups configured with JGroups must share the same channel
     private final Map<String, JChannel> channels = new HashMap<String, JChannel>();
 
-    public HornetQService(PathConfig pathConfig) {
+    public HornetQService(Configuration configuration, PathConfig pathConfig) {
+        this.configuration = configuration;
         this.pathConfig = pathConfig;
     }
 
@@ -266,18 +266,12 @@ class HornetQService implements Service<HornetQServer> {
             // security
             HornetQSecurityManagerAS7 hornetQSecurityManagerAS7 = new HornetQSecurityManagerAS7(securityDomainContextValue.getValue());
 
-            // Now start the server
+            // Now create the server
             server = new HornetQServerImpl(configuration, mbeanServer.getOptionalValue(), hornetQSecurityManagerAS7);
             if (HornetQDefaultConfiguration.DEFAULT_CLUSTER_PASSWORD.equals(server.getConfiguration().getClusterPassword())) {
                 server.getConfiguration().setClusterPassword(java.util.UUID.randomUUID().toString());
             }
-
-            // FIXME started by the JMSService
-            // HornetQ expects the TCCL to be set to something that can find the
-            // log factory class.
-            // ClassLoader loader = getClass().getClassLoader();
-            // SecurityActions.setContextClassLoader(loader);
-            // server.start();
+            // the server is not started here but by the JMSService to ensure correct dependencies of JMS-related resources.
         } catch (Exception e) {
             throw MESSAGES.failedToStartService(e);
         } finally {
@@ -287,10 +281,7 @@ class HornetQService implements Service<HornetQServer> {
 
     public synchronized void stop(final StopContext context) {
         try {
-            if (server != null) {
-                // FIXME stopped by the JMSService
-                // server.stop();
-            }
+            // server is stopped by the JMSService
             pathConfig.closeCallbacks(pathManager.getValue());
         } catch (Exception e) {
             throw MESSAGES.failedToShutdownServer(e, "HornetQ");
@@ -303,14 +294,6 @@ class HornetQService implements Service<HornetQServer> {
             throw new IllegalStateException();
         }
         return server;
-    }
-
-    public Configuration getConfiguration() {
-        return configuration;
-    }
-
-    public void setConfiguration(Configuration hqConfig) {
-        this.configuration = hqConfig;
     }
 
     public Injector<SecurityDomainContext> getSecurityDomainContextInjector() {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -534,4 +534,7 @@ public interface MessagingMessages {
 
     @Message(id = 11677, value = "Can not change the clustered attribute to false: The hornetq-server resource at %s has cluster-connection children resources and will remain clustered.")
     String canNotChangeClusteredAttribute(PathAddress address);
+
+    @Message(id = 11678, value = "Resource at the address %s can not be managed, the hornetq-server is in backup mode")
+    String hqServerInBackupMode(PathAddress address);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueAdd.java
@@ -77,9 +77,10 @@ public class QueueAdd extends AbstractAddStepHandler {
             final QueueService service = new QueueService(queueConfiguration, false);
             final ServiceName queueServiceName = MessagingServices.getQueueBaseServiceName(hqServiceName).append(queueName);
             newControllers.add(context.getServiceTarget().addService(queueServiceName, service)
+                    .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
                     .addDependency(hqServiceName, HornetQServer.class, service.getHornetQService())
                     .addListener(verificationHandler)
-                    .setInitialMode(Mode.ACTIVE)
+                    .setInitialMode(Mode.PASSIVE)
                     .install());
 
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
@@ -31,6 +31,7 @@ import static org.jboss.as.messaging.CommonAttributes.MESSAGE_COUNT;
 import static org.jboss.as.messaging.CommonAttributes.PAUSED;
 import static org.jboss.as.messaging.CommonAttributes.SCHEDULED_COUNT;
 import static org.jboss.as.messaging.CommonAttributes.TEMPORARY;
+import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 import static org.jboss.as.messaging.QueueDefinition.ADDRESS;
 import static org.jboss.as.messaging.QueueDefinition.DEAD_LETTER_ADDRESS;
@@ -79,6 +80,10 @@ public class QueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
 
     @Override
     public void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if(ignoreOperationIfServerNotActive(context, operation)) {
+            return;
+        }
+
         validator.validate(operation);
         final String attributeName = operation.require(ModelDescriptionConstants.NAME).asString();
 

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueService.java
@@ -57,8 +57,8 @@ class QueueService implements Service<Void> {
     @Override
     public synchronized void start(StartContext context) throws StartException {
         try {
-            final HornetQServer hornetQService = this.hornetQService.getValue();
-            hornetQService.deployQueue(new SimpleString(queueConfiguration.getAddress()), new SimpleString(queueConfiguration.getName()),
+            final HornetQServer hornetQServer = this.hornetQService.getValue();
+            hornetQServer.deployQueue(new SimpleString(queueConfiguration.getAddress()), new SimpleString(queueConfiguration.getName()),
                     SimpleString.toSimpleString(queueConfiguration.getFilterString()), queueConfiguration.isDurable(),
                     temporary);
         } catch (Exception e) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/AbstractAddJndiHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/AbstractAddJndiHandler.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.messaging.jms;
 
+import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.core.server.HornetQServer;
@@ -70,6 +71,10 @@ public abstract class AbstractAddJndiHandler implements OperationStepHandler {
 
 
         if (context.isNormalServer()) {
+            if (rollbackOperationIfServerNotActive(context, operation)) {
+                return;
+            }
+
             context.addStep(new OperationStepHandler() {
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAdd.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.messaging.AlternativeAttributeCheckHandler;
+import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Common;
 import org.jboss.dmr.ModelNode;
@@ -83,9 +84,10 @@ public class ConnectionFactoryAdd extends AbstractAddStepHandler {
         final ConnectionFactoryService service = new ConnectionFactoryService(configuration);
         final ServiceName serviceName = JMSServices.getConnectionFactoryBaseServiceName(hqServiceName).append(name);
         ServiceBuilder<?> serviceBuilder = context.getServiceTarget().addService(serviceName, service)
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(hqServiceName), JMSServerManager.class, service.getJmsServer())
                 .addListener(verificationHandler)
-                .setInitialMode(Mode.ACTIVE);
+                .setInitialMode(Mode.PASSIVE);
         org.jboss.as.server.Services.addServerExecutorDependency(serviceBuilder, service.getExecutorInjector(), false);
         newControllers.add(serviceBuilder.install());
     }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryReadAttributeHandler.java
@@ -24,6 +24,7 @@ package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.messaging.CommonAttributes.HA;
 import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
 import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
@@ -64,6 +65,10 @@ public class ConnectionFactoryReadAttributeHandler extends AbstractRuntimeOnlyHa
 
     @Override
     public void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        if (ignoreOperationIfServerNotActive(context, operation)) {
+            return;
+        }
 
         validator.validate(operation);
         final String attributeName = operation.require(ModelDescriptionConstants.NAME).asString();

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryWriteAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryWriteAttributeHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.OperationContext.Stage.MODEL;
+import static org.jboss.as.messaging.HornetQActivationService.isHornetQServerActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.api.core.management.ResourceNames;
@@ -88,6 +89,9 @@ public class ConnectionFactoryWriteAttributeHandler extends AbstractWriteAttribu
             // No, don't barf; just let the update apply to the model and put the server in a reload-required state
             return true;
         } else {
+            if (!isHornetQServerActive(context, operation)) {
+                return false;
+            }
             // Actually apply the update
             applyOperationToHornetQService(context, getName(operation), attributeName, newValue, hqService);
             return false;

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueAdd.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
@@ -83,8 +84,9 @@ public class JMSQueueAdd extends AbstractAddStepHandler {
 
         final ServiceName serviceName = JMSServices.getJmsQueueBaseServiceName(hqServiceName).append(name);
         final ServiceBuilder<Void> serviceBuilder = serviceTarget.addService(serviceName, service)
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(hqServiceName), JMSServerManager.class, service.getJmsServer())
-                .setInitialMode(Mode.ACTIVE);
+                .setInitialMode(Mode.PASSIVE);
         org.jboss.as.server.Services.addServerExecutorDependency(serviceBuilder, service.getExecutorInjector(), false);
         if (verificationHandler != null) {
             serviceBuilder.addListener(verificationHandler);

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
@@ -24,6 +24,7 @@ package org.jboss.as.messaging.jms;
 
 
 import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.api.core.management.ResourceNames;
@@ -61,6 +62,10 @@ public class JMSQueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
 
     @Override
     public void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        if (ignoreOperationIfServerNotActive(context, operation)) {
+            return;
+        }
 
         validator.validate(operation);
         final String attributeName = operation.require(ModelDescriptionConstants.NAME).asString();

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServerControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServerControlHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
 import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
@@ -90,6 +91,10 @@ public class JMSServerControlHandler extends AbstractRuntimeOnlyHandler {
 
     @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        if (rollbackOperationIfServerNotActive(context, operation)) {
+            return;
+        }
 
         final String operationName = operation.require(OP).asString();
         final JMSServerControl serverControl = getServerControl(context, operation);

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAdd.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
@@ -73,8 +74,9 @@ public class JMSTopicAdd extends AbstractAddStepHandler {
         final ServiceName serviceName = JMSServices.getJmsTopicBaseServiceName(hqServiceName).append(name);
 
         final ServiceBuilder<Void> serviceBuilder = serviceTarget.addService(serviceName, service)
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(hqServiceName), JMSServerManager.class, service.getJmsServer())
-                .setInitialMode(Mode.ACTIVE);
+                .setInitialMode(Mode.PASSIVE);
         org.jboss.as.server.Services.addServerExecutorDependency(serviceBuilder, service.getExecutorInjector(), false);
         if(verificationHandler != null) {
             serviceBuilder.addListener(verificationHandler);

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicControlHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.messaging.jms;
 import static org.jboss.as.messaging.CommonAttributes.CLIENT_ID;
 import static org.jboss.as.messaging.CommonAttributes.FILTER;
 import static org.jboss.as.messaging.CommonAttributes.QUEUE_NAME;
+import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
 import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
@@ -74,6 +75,9 @@ public class JMSTopicControlHandler extends AbstractRuntimeOnlyHandler {
 
     @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if (rollbackOperationIfServerNotActive(context, operation)) {
+            return;
+        }
 
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicReadAttributeHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
 import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 import static org.jboss.as.messaging.jms.JMSTopicDefinition.DURABLE_MESSAGE_COUNT;
@@ -66,6 +67,10 @@ public class JMSTopicReadAttributeHandler extends AbstractRuntimeOnlyHandler {
 
     @Override
     public void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        if (ignoreOperationIfServerNotActive(context, operation)) {
+            return;
+        }
 
         validator.validate(operation);
         final String attributeName = operation.require(ModelDescriptionConstants.NAME).asString();

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
@@ -47,6 +47,7 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.messaging.AlternativeAttributeCheckHandler;
 import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.as.messaging.MessagingDescriptions;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Common;
@@ -135,11 +136,11 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler implement
                 .addService(hornetQResourceAdapterService, resourceAdapterService)
                 .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, resourceAdapterService.getTransactionManager())
                 .addDependency(hqServiceName, HornetQServer.class, resourceAdapterService.getHornetQService())
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(hqServiceName))
+                .setInitialMode(Mode.PASSIVE)
                 .addListener(verificationHandler);
-
-
-        newControllers.add(serviceBuilder.setInitialMode(Mode.ACTIVE).install());
+        newControllers.add(serviceBuilder.install());
     }
 
     static List<String> getConnectors(final ModelNode model) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
@@ -91,14 +91,14 @@ class JMSBridgeService implements Service<JMSBridge> {
         if (moduleName == null) {
             bridge.start();
         } else {
-            ClassLoader cl = SecurityActions.getContextClassLoader();
+            ClassLoader oldTccl= SecurityActions.getContextClassLoader();
             try {
                 ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
                 Module module = Module.getCallerModuleLoader().loadModule(moduleID);
-                SecurityActions.setContextClassLoader(module.getClassLoader());
+                SecurityActions.setThreadContextClassLoader(module.getClassLoader());
                 bridge.start();
             } finally {
-                SecurityActions.setContextClassLoader(cl);
+                SecurityActions.setThreadContextClassLoader(oldTccl);
             }
         }
         MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -4,6 +4,7 @@ messaging.remove=Operation removing the messaging subsystem
 messaging.hornetq-server=HornetQ servers provided by the messaging subsystem
 
 hornetq-server=A HornetQ server instance.
+hornetq-server.active=Whether the server is active (and accepting connections) or passive (in backup mode, waiting for failover).
 hornetq-server.add=Operation adding a HornetQ server.
 hornetq-server.remove=Operation removing a HornetQ server.
 hornetq-server.name=Not used.

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -49,7 +49,36 @@
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
-        
+
+        <container qualifier="jbossas-messaging-live" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-messaging-failover</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-messaging-failover -Djboss.node.name=default-jbossas-messaging-failover</property>
+                <property name="serverConfig">standalone-full.xml</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9999}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="jbossas-messaging-backup" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-messaging-failover</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.socket.binding.port-offset=100 -Djboss.inst=${basedir}/target/jbossas-messaging-failover -Djboss.node.name=default-jbossas-messaging-failover</property>
+                <property name="serverConfig">standalone-full-backup.xml</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:10099}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8987} ${as.managementPort:10099}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
@@ -1,0 +1,302 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.messaging;
+
+import static java.util.UUID.randomUUID;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.fail;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.Authentication;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat, inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class HornetQBackupActivationTestCase {
+
+    // maximum time for HornetQ activation to detect node failover/failback
+    private static int ACTIVATION_TIMEOUT = 10000;
+
+    public static final String LIVE_SERVER = "jbossas-messaging-live";
+    public static final String BACKUP_SERVER = "jbossas-messaging-backup";
+
+    @ArquillianResource
+    private static ContainerController container;
+
+    private ModelControllerClient liveClient;
+
+    private ModelControllerClient backupClient;
+
+    @Before
+    public void initServer() throws Exception {
+        container.start(LIVE_SERVER);
+        container.start(BACKUP_SERVER);
+        liveClient = TestSuiteEnvironment.getModelControllerClient();
+        backupClient = ModelControllerClient.Factory.create(InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                TestSuiteEnvironment.getServerPort() + 100,
+                Authentication.getCallbackHandler());
+    }
+
+    @After
+    public void closeServer() throws Exception {
+        if (container.isStarted(BACKUP_SERVER)) {
+            container.stop(BACKUP_SERVER);
+        }
+        if (container.isStarted(LIVE_SERVER)) {
+            container.stop(LIVE_SERVER);
+        }
+        liveClient = null;
+        backupClient = null;
+    }
+
+    @Test
+    public void testBackupActivation() throws Exception {
+        checkHornetQServerStartedAndActiveAttributes(liveClient, true, true);
+        checkHornetQServerStartedAndActiveAttributes(backupClient, true, false);
+
+        final String queueName = randomUUID().toString();
+        addQueue(backupClient, queueName);
+        final String jmsQueueName = randomUUID().toString();
+        addJMSQueue(backupClient, jmsQueueName);
+        final String jmsTopicName = randomUUID().toString();
+        addJMSTopic(backupClient, jmsTopicName);
+
+        checkQueue(backupClient, queueName, false);
+        checkJMSQueue(backupClient, jmsQueueName, false);
+        checkJMSTopic(backupClient, jmsTopicName, false);
+        checkConnectionFactory(backupClient, false);
+
+        // shutdown live server
+        container.stop(LIVE_SERVER);
+        // let some time for the backup to detect the failure
+        waitForHornetQServerActivation(backupClient, true, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
+
+        checkHornetQServerStartedAndActiveAttributes(backupClient, true, true);
+        checkQueue(backupClient, queueName, true);
+        checkJMSQueue(backupClient, jmsQueueName, true);
+        checkJMSTopic(backupClient, jmsTopicName, true);
+        checkConnectionFactory(backupClient, true);
+
+        // restart the live server
+        container.start(LIVE_SERVER);
+        // let some time for the backup to detect the live node and failback
+        waitForHornetQServerActivation(liveClient, true, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
+        checkHornetQServerStartedAndActiveAttributes(liveClient, true, true);
+
+        // let some time for the backup to detect the live node and failback
+        waitForHornetQServerActivation(backupClient, false, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
+        // backup server has been restarted in passive mode
+        checkHornetQServerStartedAndActiveAttributes(backupClient, true, false);
+
+        checkQueue(backupClient, queueName, false);
+        checkJMSQueue(backupClient, jmsQueueName, false);
+        checkJMSTopic(backupClient, jmsTopicName, false);
+        checkConnectionFactory(backupClient, false);
+    }
+
+    private static void waitForHornetQServerActivation(ModelControllerClient client, boolean expectedActive, int timeout) throws IOException {
+        long start = System.currentTimeMillis();
+        long now;
+        do {
+            ModelNode operation = new ModelNode();
+            operation.get(OP_ADDR).add("subsystem", "messaging");
+            operation.get(OP_ADDR).add("hornetq-server", "default");
+            operation.get(OP).set(READ_RESOURCE_OPERATION);
+            operation.get(INCLUDE_RUNTIME).set(true);
+            ModelNode result = execute(client, operation);
+            boolean started = result.get(RESULT, "started").asBoolean();
+            boolean active = result.get(RESULT, "active").asBoolean();
+            if (started && expectedActive == active) {
+                return;
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+            now = System.currentTimeMillis();
+        } while (now - start < timeout);
+
+        fail("Server did not become active in the imparted time.");
+
+    }
+
+    private static void addQueue(ModelControllerClient client, String queueName) throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).add("subsystem", "messaging");
+        operation.get(OP_ADDR).add("hornetq-server", "default");
+        operation.get(OP_ADDR).add("queue", queueName);
+        operation.get(OP).set(ADD);
+        operation.get("queue-address").set(queueName);
+        execute(client, operation);
+    }
+
+    private static void addJMSQueue(ModelControllerClient client, String jmsQueueName) throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).add("subsystem", "messaging");
+        operation.get(OP_ADDR).add("hornetq-server", "default");
+        operation.get(OP_ADDR).add("jms-queue", jmsQueueName);
+        operation.get(OP).set(ADD);
+        operation.get("entries").setEmptyList();
+        operation.get("entries").add("java:jboss/exported/jms/" + jmsQueueName);
+        execute(client, operation);
+    }
+
+    private static void addJMSTopic(ModelControllerClient client, String jmsTopicName) throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).add("subsystem", "messaging");
+        operation.get(OP_ADDR).add("hornetq-server", "default");
+        operation.get(OP_ADDR).add("jms-topic", jmsTopicName);
+        operation.get(OP).set(ADD);
+        operation.get("entries").setEmptyList();
+        operation.get("entries").add("java:jboss/exported/jms/" + jmsTopicName);
+        execute(client, operation);
+    }
+
+    private static void checkConnectionFactory(ModelControllerClient client, boolean active) throws Exception {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).add("subsystem", "messaging");
+        operation.get(OP_ADDR).add("hornetq-server", "default");
+        operation.get(OP_ADDR).add("connection-factory", "RemoteConnectionFactory");
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        ModelNode result = execute(client, operation);
+        // initial-message-packet-size is a runtime attribute. if the server is passive, it returns undefined
+        assertEquals(result.toJSONString(true), active, result.get(RESULT, "initial-message-packet-size").isDefined());
+
+        // runtime operation
+        operation.get(OP).set("add-jndi");
+        operation.get("jndi-binding").set("java:jboss/exported/jms/" + randomUUID().toString());
+        if (active) {
+            execute(client, operation);
+        } else {
+            executeWithFailure(client, operation);
+        }
+    }
+
+    private static void checkQueue(ModelControllerClient client, String queueName, boolean active) throws Exception {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "messaging");
+        address.add("hornetq-server", "default");
+        address.add("queue", queueName);
+        checkQueue0(client, address, "id", active);
+    }
+
+    private static void checkJMSQueue(ModelControllerClient client, String jmsQueueName, boolean active) throws Exception {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "messaging");
+        address.add("hornetq-server", "default");
+        address.add("jms-queue", jmsQueueName);
+        checkQueue0(client, address, "queue-address", active);
+    }
+
+    private static void checkQueue0(ModelControllerClient client, ModelNode address, String runtimeAttributeName, boolean active) throws Exception {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).set(address);
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        ModelNode result = execute(client, operation);
+        assertEquals(result.toJSONString(true), active, result.get(RESULT, runtimeAttributeName).isDefined());
+
+        // runtime operation
+        operation.get(OP).set("list-messages");
+        if (active) {
+            execute(client, operation);
+        } else {
+            executeWithFailure(client, operation);
+        }
+    }
+
+    private static void checkJMSTopic(ModelControllerClient client, String jmsTopicName, boolean active) throws Exception {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).add("subsystem", "messaging");
+        operation.get(OP_ADDR).add("hornetq-server", "default");
+        operation.get(OP_ADDR).add("jms-topic", jmsTopicName);
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        ModelNode result = execute(client, operation);
+        assertEquals(result.toJSONString(true), active, result.get(RESULT, "topic-address").isDefined());
+
+        // runtime operation
+        operation.get(OP).set("list-all-subscriptions");
+        if (active) {
+            execute(client, operation);
+        } else {
+            executeWithFailure(client, operation);
+        }
+    }
+
+    public static void checkHornetQServerStartedAndActiveAttributes(ModelControllerClient client, boolean expectedStarted, boolean  expectedActive) throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).add("subsystem", "messaging");
+        operation.get(OP_ADDR).add("hornetq-server", "default");
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        ModelNode result = execute(client, operation);
+        assertEquals(expectedStarted, result.get(RESULT, "started").asBoolean());
+        assertEquals(expectedActive, result.get(RESULT, "active").asBoolean());
+    }
+
+    private static ModelNode execute(ModelControllerClient client, ModelNode operation) throws IOException {
+        ModelNode result = client.execute(operation);
+        System.out.println(operation.toJSONString(false) + "\n=>\n" + result.toJSONString(false));
+        assertEquals(result.toJSONString(true), SUCCESS, result.get(OUTCOME).asString());
+        return result;
+    }
+
+    private static void executeWithFailure(ModelControllerClient client, ModelNode operation) throws IOException {
+        ModelNode result = client.execute(operation);
+        System.out.println(operation.toJSONString(false) + "\n=>\n" + result.toJSONString(false));
+        assertEquals(result.toJSONString(true), FAILED, result.get(OUTCOME).asString());
+        assertTrue(result.toJSONString(true), result.get(FAILURE_DESCRIPTION).asString().contains("JBAS011678"));
+        assertFalse(result.has(RESULT));
+    }
+
+}

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -471,5 +471,44 @@
         </sequential>
     </macrodef>
 
+    <macrodef name="ts.config-as.add-messaging-failover" description="Make default hornetq-server fails over on shutdown">
+
+        <attribute name="name" default="jbossas"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <sequential>
+            <echo message="Make default hornetq-server fails over on shutdown"/>
+            <copy file="@{output.dir}/@{name}/@{config.dir.name}/standalone-full.xml"
+                  tofile="@{output.dir}/@{name}/@{config.dir.name}/standalone-full-backup.xml" />
+
+            <!-- Process *.xml to *.xml.mod. -->
+            <xslt destdir="@{output.dir}/@{name}-tmp/@{config.dir.name}"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/addMessagingFailoverOnShutdown.xsl"
+                  extension=".xml.mod"
+                  useImplicitFileset="false">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+                    <include name="**/standalone-full.xml"/>
+                </fileset>
+            </xslt>
+            <xslt destdir="@{output.dir}/@{name}-tmp/@{config.dir.name}"
+                  style="${jbossas.ts.integ.dir}/src/test/xslt/addMessagingBackup.xsl"
+                  extension=".xml.mod"
+                  useImplicitFileset="false">
+                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
+                    <include name="**/standalone-full-backup.xml"/>
+                </fileset>
+            </xslt>
+
+            <!-- Move processed files back. -->
+            <move todir="@{output.dir}/@{name}/@{config.dir.name}">
+                <fileset dir="@{output.dir}/@{name}-tmp/@{config.dir.name}">
+                    <include name="**/standalone-full.xml.mod"/>
+                    <include name="**/standalone-full-backup.xml.mod"/>
+                </fileset>
+                <mapper type="glob" from="*.mod" to="*"/>
+            </move>
+        </sequential>
+    </macrodef>
 
 </project>

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -53,6 +53,15 @@
             mcast="${mcast}"
         />
         <ts.config-as.add-port-offset name="jbossas-with-remote-outbound-connection" offset="100" nativePort="9999" httpPort="9990"/>
+
+        <echo message="Copying and configuring instance jbossas-messaging-failover"/>
+        <copy todir="target/jbossas-messaging-failover">
+            <fileset dir="target/jbossas"/>
+        </copy>
+        <copy todir="target/jbossas-messaging-failover/modules">
+            <fileset dir="${jboss.dist}/modules"/>
+        </copy>
+        <ts.config-as.add-messaging-failover name="jbossas-messaging-failover"/>
     </target>
 
 </project>

--- a/testsuite/integration/src/test/xslt/addMessagingBackup.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingBackup.xsl
@@ -1,0 +1,19 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:messaging="urn:jboss:domain:messaging:1.3">
+
+<xsl:output method="xml" indent="yes"/>
+    <xsl:template match="//messaging:subsystem/messaging:hornetq-server">
+        <xsl:copy>
+            <xsl:element name="backup">true</xsl:element>
+            <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
@@ -1,0 +1,19 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:messaging="urn:jboss:domain:messaging:1.3">
+
+<xsl:output method="xml" indent="yes"/>
+    <xsl:template match="//messaging:subsystem/messaging:hornetq-server">
+        <xsl:copy>
+            <xsl:element name="failover-on-shutdown">true</xsl:element>
+            <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
When HornetQ is configured to be a backup, it will start and remain
passive (its resources are not deployed, it does not accept any
connections, etc.)

For AS7 hornetq-server's children resources, that means that:
- read-attribute on runtime attributes is a no-op (returns undefined)
- execute an operation on a queue will throw an exception warning the
  user that HornetQ is in backup mode
- add active runtime r/o attribute to hornetq-server

For AS7 services, there are some substantial changes too.
HornetQService default does _not_ start the HornetQ server. This is done
by JMSService. This means that any service must not depend on
HornetQService but JMSService to make sure that the server is
effectively started.
JMSService is started asynchronously and the server start is completed
when:
- the HornetQ server has been activated (immediately when it is a live
  node, or after failover if it is a backup)
- and the JMSServerManager is started (and can deploy JMS resources)

It is important for other services depending on messaging services
(queue, jms-queue, topic, connection-factory &
pooled-connection-factory) that these services must NOT be started
until a backup hornetq-server fails over.
