### PR TITLE
[AS7-6730] Instead of relying on a ThreadLocal to access the connection wrap it in a Credential

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/security/ServerSecurityManager.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/ServerSecurityManager.java
@@ -38,8 +38,11 @@ import javax.security.auth.Subject;
  */
 public interface ServerSecurityManager {
 
-    void push(final String securityDomain, final String runAs, final String runAsPrincipal, final Set<String> extraRoles);
+    void push(final String securityDomain);
     void push(final String securityDomain, String userName, char[] password, final Subject subject);
+
+    void authenticate();
+    void authenticate(final String runAs, final String runAsPrincipal, final Set<String> extraRoles);
 
     void pop();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/JaasCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/JaasCallbackHandler.java
@@ -155,6 +155,7 @@ public class JaasCallbackHandler implements Service<CallbackHandlerService>, Cal
         if ((securityManager = securityManagerValue.getOptionalValue()) != null) {
             try {
                 securityManager.push(name, userName, password, subject);
+                securityManager.authenticate();
                 verifyPasswordCallback.setVerified(true);
                 subject.getPrivateCredentials().add(new PasswordCredential(userName, password));
                 if (subjectCallback != null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -308,7 +308,7 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                     configuration.addTimeoutViewInterceptor(configuration.getNamespaceContextInterceptorFactory(), InterceptorOrder.View.JNDI_NAMESPACE_INTERCEPTOR);
                     configuration.addTimeoutViewInterceptor(CurrentInvocationContextInterceptor.FACTORY, InterceptorOrder.View.INVOCATION_CONTEXT_INTERCEPTOR);
                     if (isSecurityEnabled()) {
-                        configuration.addTimeoutViewInterceptor(new SecurityContextInterceptorFactory(), InterceptorOrder.View.SECURITY_CONTEXT);
+                        configuration.addTimeoutViewInterceptor(new SecurityContextInterceptorFactory(true), InterceptorOrder.View.SECURITY_CONTEXT);
                     }
                     for (final Method method : configuration.getClassIndex().getClassMethods()) {
                         configuration.addTimeoutViewInterceptor(method, new ImmediateInterceptorFactory(new ComponentDispatcherInterceptor(method)), InterceptorOrder.View.COMPONENT_DISPATCHER);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -114,10 +114,11 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
             }
         }
 
+        final boolean securityRequired = beanHasMethodLevelSecurityMetadata || this.hasSecurityMetaData(ejbComponentDescription);
+        // setup the security context interceptor
+        viewConfiguration.addViewInterceptor(new SecurityContextInterceptorFactory(securityRequired), InterceptorOrder.View.SECURITY_CONTEXT);
         // now add the security interceptor if the bean has *any* security metadata applicable
-        if (beanHasMethodLevelSecurityMetadata || this.hasSecurityMetaData(ejbComponentDescription)) {
-            // setup the security context interceptor
-            viewConfiguration.addViewInterceptor(new SecurityContextInterceptorFactory(), InterceptorOrder.View.SECURITY_CONTEXT);
+        if (securityRequired) {
             // also check the missing-method-permissions-deny-access configuration and add the authorization interceptor
             // to methods which don't have explicit method permissions.
             // (@see http://anil-identity.blogspot.in/2010/02/tip-interpretation-of-missing-ejb.html for details)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptor.java
@@ -46,8 +46,11 @@ public class SecurityContextInterceptor implements Interceptor {
             @Override
             public Void run() {
                 try {
-                    holder.securityManager.push(holder.securityDomain, holder.runAs, holder.runAsPrincipal, holder.extraRoles);
-                    if(holder.principalVsRolesMap != null){
+                    holder.securityManager.push(holder.securityDomain);
+                    if (holder.skipAuthentication == false) {
+                        holder.securityManager.authenticate(holder.runAs, holder.runAsPrincipal, holder.extraRoles);
+                    }
+                    if (holder.principalVsRolesMap != null) {
                         SecurityRolesAssociation.setSecurityRoles(holder.principalVsRolesMap);
                     }
                 } catch (SecurityException e) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
@@ -40,6 +40,14 @@ import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
  */
 public class SecurityContextInterceptorFactory extends ComponentInterceptorFactory {
 
+    private static final String DEFAULT_DOMAIN = "other";
+
+    private final boolean securityRequired;
+
+    public SecurityContextInterceptorFactory(final boolean securityRequired) {
+        this.securityRequired = securityRequired;
+    }
+
     @Override
     protected Interceptor create(final Component component, final InterceptorFactoryContext context) {
         if (component instanceof EJBComponent == false) {
@@ -48,9 +56,9 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
         final EJBComponent ejbComponent = (EJBComponent) component;
         final ServerSecurityManager securityManager = ejbComponent.getSecurityManager();
         final EJBSecurityMetaData securityMetaData = ejbComponent.getSecurityMetaData();
-        final String securityDomain = securityMetaData.getSecurityDomain();
+        String securityDomain =  securityMetaData.getSecurityDomain();
         if (securityDomain == null) {
-            throw MESSAGES.invalidSecurityForDomainSet(ejbComponent.getComponentName());
+            securityDomain = DEFAULT_DOMAIN;
         }
         if (ROOT_LOGGER.isTraceEnabled()) {
             ROOT_LOGGER.trace("Using security domain: " + securityDomain + " for EJB " + ejbComponent.getComponentName());
@@ -69,7 +77,8 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
         SecurityContextInterceptorHolder holder = new SecurityContextInterceptorHolder();
         holder.setSecurityManager(securityManager).setSecurityDomain(securityDomain)
         .setRunAs(runAs).setRunAsPrincipal(runAsPrincipal)
-        .setExtraRoles(extraRoles).setPrincipalVsRolesMap(principalVsRolesMap);
+        .setExtraRoles(extraRoles).setPrincipalVsRolesMap(principalVsRolesMap)
+        .setSkipAuthentication(securityRequired == false);
 
         return new SecurityContextInterceptor(holder);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorHolder.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorHolder.java
@@ -36,6 +36,7 @@ class SecurityContextInterceptorHolder {
     String securityDomain, runAs, runAsPrincipal;
     Set<String> extraRoles;
     Map<String, Set<String>> principalVsRolesMap;
+    boolean skipAuthentication;
 
     public SecurityContextInterceptorHolder() {
     }
@@ -68,5 +69,11 @@ class SecurityContextInterceptorHolder {
     public SecurityContextInterceptorHolder setPrincipalVsRolesMap(Map<String, Set<String>> pr) {
         this.principalVsRolesMap = pr;
         return this;
+    }
+
+    public SecurityContextInterceptorHolder setSkipAuthentication(boolean skipAuthentication) {
+        this.skipAuthentication = skipAuthentication;
+        return this;
+
     }
 }

--- a/security/src/main/java/org/jboss/as/security/SecurityMessages.java
+++ b/security/src/main/java/org/jboss/as/security/SecurityMessages.java
@@ -288,4 +288,11 @@ public interface SecurityMessages {
     @Message(id = 13328, value = "No authentication cache for security domain '%s' available")
     OperationFailedException noAuthenticationCacheAvailable(String securityDomain);
 
+    /**
+     * Create an IllegalStateFoundException to indicate no UserPrincipal was found on the underlying connection.
+     * @return the exception
+     */
+    @Message(id= 13329, value = "No UserPrincipalFound constructing RemotingConnectionPrincipal.")
+    IllegalStateException noUserPrincipalFound();
+
 }

--- a/security/src/main/java/org/jboss/as/security/remoting/RemotingConnectionCredential.java
+++ b/security/src/main/java/org/jboss/as/security/remoting/RemotingConnectionCredential.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security.remoting;
+
+import javax.security.auth.Subject;
+
+import org.jboss.as.controller.security.SubjectUserInfo;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.security.UserInfo;
+
+/**
+ * A Credential wrapping a Remoting {@link Connection}.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class RemotingConnectionCredential {
+
+    private final Connection connection;
+    private final Subject subject;
+
+    public RemotingConnectionCredential(final Connection connection) {
+        this.connection = connection;
+        Subject subject = null;
+        UserInfo userInfo = connection.getUserInfo();
+        if (userInfo instanceof SubjectUserInfo) {
+            subject = ((SubjectUserInfo) userInfo).getSubject();
+        }
+        this.subject = subject;
+    }
+
+    Connection getConnection() {
+        return connection;
+    }
+
+    public Subject getSubject() {
+        return subject;
+    }
+
+    @Override
+    public int hashCode() {
+        return connection.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof RemotingConnectionCredential ? equals((RemotingConnectionCredential) obj) : false;
+    }
+
+    public boolean equals(RemotingConnectionCredential obj) {
+        return connection.equals(obj.connection);
+    }
+}

--- a/security/src/main/java/org/jboss/as/security/remoting/RemotingConnectionPrincipal.java
+++ b/security/src/main/java/org/jboss/as/security/remoting/RemotingConnectionPrincipal.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security.remoting;
+
+import static org.jboss.as.security.SecurityMessages.MESSAGES;
+import java.security.Principal;
+import java.util.Collection;
+
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.security.UserPrincipal;
+
+/**
+ * A {@link Principal} implementation to wrap a Remoting {@link Connection} and represent the identity authenticated against that Connection.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class RemotingConnectionPrincipal implements Principal {
+
+    private final Connection connection;
+    private final String name;
+    private final int hashCode;
+
+    public RemotingConnectionPrincipal(final Connection connection) {
+        this.connection = connection;
+        Collection<Principal> principals = connection.getPrincipals();
+        String userName = null;
+        for (Principal current : principals) {
+            if (current instanceof UserPrincipal) {
+                userName = current.getName();
+                break;
+            }
+        }
+        if (userName == null) {
+            throw MESSAGES.noUserPrincipalFound();
+        }
+        name = userName;
+        hashCode = connection.hashCode() * name.hashCode();
+
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof RemotingConnectionPrincipal ? equals((RemotingConnectionPrincipal)obj) : false;
+    }
+
+    public boolean equals(RemotingConnectionPrincipal obj) {
+        return this.connection.equals(obj.connection);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+}

--- a/security/src/main/java/org/jboss/as/security/service/ThreadLocalStack.java
+++ b/security/src/main/java/org/jboss/as/security/service/ThreadLocalStack.java
@@ -50,7 +50,7 @@ class ThreadLocalStack<T> {
         return rtn;
     }
 
-    public T get() {
+    public T peek() {
         LinkedList<T> list = stack.get();
         if (list == null) {
             return null;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EJBUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EJBUtil.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.security;
+
+import java.net.UnknownHostException;
+import java.util.Hashtable;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Utility class for looking up EJBs. It contains also some common constants for this test.
+ *
+ * @author Josef Cacek
+ */
+class EJBUtil {
+
+    protected static final String APPLICATION_NAME = "ejb-remote-security-test";
+
+    protected static final String CONNECTION_USERNAME = "guest";
+    protected static final String CONNECTION_PASSWORD = "guest";
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     * Lookup for remote EJBs.
+     *
+     * @param beanImplClass
+     * @param remoteInterface
+     * @return
+     * @throws NamingException
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface) throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        //        jndiProperties.put("jboss.naming.client.ejb.context", "true");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (T) context.lookup("ejb:/" + APPLICATION_NAME + "/" + beanImplClass.getSimpleName() + "!"
+                + remoteInterface.getName());
+    }
+
+    /**
+     * Creates {@link Properties} for the EJB client configuration.
+     *
+     * <pre>
+     * remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+     *
+     * remote.connections=default
+     *
+     * remote.connection.default.host=localhost
+     * remote.connection.default.port = 4447
+     * remote.connection.default.username=guest
+     * remote.connection.default.password=guest
+     *
+     * remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+     * </pre>
+     *
+     * @param hostName
+     * @return
+     * @throws UnknownHostException
+     */
+    public static Properties createEjbClientConfiguration(String hostName) throws UnknownHostException {
+        final Properties pr = new Properties();
+        pr.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        pr.put("remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS", "JBOSS_LOCAL_USER");
+        pr.put("remote.connections", "default");
+        pr.put("remote.connection.default.host", hostName);
+        pr.put("remote.connection.default.port", "4447");
+        pr.put("remote.connection.default.username", CONNECTION_USERNAME);
+        pr.put("remote.connection.default.password", CONNECTION_PASSWORD);
+        return pr;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EntryBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/EntryBean.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.security;
+
+import org.jboss.as.test.shared.integration.ejb.security.Util;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.EJBContext;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+/**
+ * An unsecured EJB used to test switching the identity before calling a secured EJB.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@Remote(IntermediateAccess.class)
+public class EntryBean implements IntermediateAccess {
+
+    @Resource
+    private EJBContext context;
+
+    @EJB
+    private SecurityInformation ejb;
+
+    @Override
+    public String getPrincipalName() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    @Override
+    public String getPrincipalName(String username, String password) {
+        try {
+            LoginContext lc = null;
+            try {
+                if (username != null && password != null) {
+                    lc = Util.getCLMLoginContext(username, password);
+                    lc.login();
+                }
+                return ejb.getPrincipalName();
+            } finally {
+                if (lc != null) {
+                    lc.logout();
+                }
+            }
+        } catch (LoginException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/IntermediateAccess.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/IntermediateAccess.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.security;
+
+/**
+ * An extension to {@link SecurityInformation} that allows a username and password to be specified for calling a subsequent
+ * bean.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface IntermediateAccess extends SecurityInformation {
+
+    String getPrincipalName(final String userName, final String password);
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.security;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A test case to test an unsecured EJB setting the username and password before the call reaches a secured EJB.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RemoteIdentityTestCase {
+
+    @ArquillianResource
+    private ManagementClient mgmtClient;
+
+    /**
+     * Creates a deployment application for this test.
+     *
+     * @return
+     * @throws IOException
+     */
+    @Deployment
+    public static JavaArchive createDeployment() throws IOException {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EJBUtil.APPLICATION_NAME + ".jar");
+        jar.addClasses(SecurityInformation.class, IntermediateAccess.class, EntryBean.class, SecuredBean.class, Util.class);
+        return jar;
+    }
+
+    @Test
+    public void testDirect() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
+        final SecurityInformation targetBean = EJBUtil.lookupEJB(SecuredBean.class, SecurityInformation.class);
+
+        assertEquals("guest", targetBean.getPrincipalName());
+    }
+
+    @Test
+    public void testUnsecured() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
+        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
+
+        assertEquals("anonymous", targetBean.getPrincipalName());
+    }
+
+    @Test
+    public void testSwitched() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
+        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
+
+        assertEquals("user1", targetBean.getPrincipalName("user1", "password1"));
+    }
+
+    @Test
+    public void testNotSwitched() throws Exception {
+        final Properties ejbClientConfiguration = EJBUtil.createEjbClientConfiguration(Utils.getHost(mgmtClient));
+        EJBClientConfiguration cc = new PropertiesBasedEJBClientConfiguration(ejbClientConfiguration);
+        final ContextSelector<EJBClientContext> selector = new ConfigBasedEJBClientContextSelector(cc);
+        EJBClientContext.setSelector(selector);
+
+        final IntermediateAccess targetBean = EJBUtil.lookupEJB(EntryBean.class, IntermediateAccess.class);
+
+        assertEquals("guest", targetBean.getPrincipalName(null, null));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/SecuredBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/SecuredBean.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.security;
+
+import javax.annotation.Resource;
+import javax.annotation.security.PermitAll;
+import javax.ejb.EJBContext;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Simple EJB to return information about the current Principal.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@Remote(SecurityInformation.class)
+@SecurityDomain("other")
+@PermitAll
+public class SecuredBean implements SecurityInformation {
+
+    @Resource
+    private EJBContext context;
+
+    @Override
+    public String getPrincipalName() {
+        return context.getCallerPrincipal().getName();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/SecurityInformation.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/SecurityInformation.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.security;
+
+/**
+ * Interface to session beans to obtain information about the current identity of the caller.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface SecurityInformation {
+
+    String getPrincipalName();
+
+}


### PR DESCRIPTION
Also, the Connection is now wrapped regardless of if security is actually enabled - if security is not enabled then it is still available when the call reaches the first secured EJB.

In the meantime this also allows other beans to replace the Principal and Credential should it be required.
