### PR TITLE
Upgrade to 1.0.6.Final of remote-naming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.osgi.repository>3.0.0.CR1</version.org.jboss.osgi.repository>
         <version.org.jboss.osgi.spi>4.0.0.Alpha2</version.org.jboss.osgi.spi>
         <version.org.jboss.osgi.vfs>2.0.0.Alpha3</version.org.jboss.osgi.vfs>
-        <version.org.jboss.remote-naming>1.0.5.Final</version.org.jboss.remote-naming>
+        <version.org.jboss.remote-naming>1.0.6.Final</version.org.jboss.remote-naming>
         <version.org.jboss.remoting3>3.2.15.GA</version.org.jboss.remoting3>
         <version.org.jboss.remotingjmx.remoting-jmx>1.1.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.resteasy>3.0-beta-3</version.org.jboss.resteasy>


### PR DESCRIPTION
The commit here upgrades remote-naming to 1.0.6.Final to bring in certain fixes that were done in that version, especially the one required for https://issues.jboss.org/browse/JBEAP-4
