### PR TITLE
DomainTestSuite - added support for execution on mix of multiple JVMs.

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
@@ -138,6 +138,10 @@ public class DomainLifecycleUtil {
             String javaHome = configuration.getJavaHome();
             String java = (javaHome != null) ? javaHome + File.separatorChar + "bin" + File.separatorChar + "java" : "java";
 
+            String controllerJavaHome = configuration.getControllerJavaHome();
+            String controllerJava = (controllerJavaHome != null) ?
+                    controllerJavaHome + File.separatorChar + "bin" + File.separatorChar + "java" : "java";
+
             File domainDir = configuration.getDomainDirectory() != null ? new File(configuration.getDomainDirectory()) : new File(new File(jbossHomeDir), "domain");
             String domainPath = domainDir.getAbsolutePath();
 
@@ -169,7 +173,7 @@ public class DomainLifecycleUtil {
             fos.close();
 
             List<String> cmd = new ArrayList<String>();
-            cmd.add(java);
+            cmd.add(controllerJava);
             cmd.addAll(additionalJavaOpts);
             TestSuiteEnvironment.getIpv6Args(cmd);
             cmd.add("-Djboss.home.dir=" + jbossHomeDir);
@@ -183,7 +187,7 @@ public class DomainLifecycleUtil {
             cmd.add("-jboss-home");
             cmd.add(jbossHomeDir);
             cmd.add("-jvm");
-            cmd.add(java);
+            cmd.add(controllerJava);
             cmd.add("--");
             cmd.add("-Dorg.jboss.boot.log.file=" + domainPath + "/log/host-controller.log");
             cmd.add("-Dlogging.configuration=file:" + jbossHomeDir + "/domain/configuration/logging.properties");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -62,6 +62,10 @@ public class DomainTestSupport {
     public static final String slaveAddress = System.getProperty("jboss.test.host.slave.address", "127.0.0.1");
     public static final long domainBootTimeout = Long.valueOf(System.getProperty("jboss.test.domain.boot.timeout", "60000"));
     public static final long domainShutdownTimeout = Long.valueOf(System.getProperty("jboss.test.domain.shutdown.timeout", "20000"));
+    public static final String masterJvmHome = System.getProperty("jboss.test.host.master.jvmhome");
+    public static final String slaveJvmHome = System.getProperty("jboss.test.host.slave.jvmhome");
+    public static final String masterControllerJvmHome = System.getProperty("jboss.test.host.master.controller.jvmhome");
+    public static final String slaveControllerJvmHome = System.getProperty("jboss.test.host.slave.controller.jvmhome");
 
     static {
         DEFAULT_CONFIG = DomainTestSupport.Configuration.create("domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml", JBossAsManagedConfigurationParameters.STANDARD, JBossAsManagedConfigurationParameters.STANDARD);
@@ -106,7 +110,8 @@ public class DomainTestSupport {
         // TODO this should not be necessary
         new File(masterDir, "configuration").mkdirs();
         masterConfig.setDomainDirectory(masterDir.getAbsolutePath());
-
+        if (masterJvmHome != null) masterConfig.setJavaHome(masterJvmHome);
+        if (masterControllerJvmHome != null) masterConfig.setControllerJavaHome(masterControllerJvmHome);
         return masterConfig;
     }
 
@@ -131,7 +136,8 @@ public class DomainTestSupport {
         new File(slaveDir, "configuration").mkdirs();
         slaveConfig.setDomainDirectory(slaveDir.getAbsolutePath());
         System.out.println(slaveConfig.getDomainDirectory());
-
+        if (slaveJvmHome != null) slaveConfig.setJavaHome(slaveJvmHome);
+        if (slaveControllerJvmHome != null) slaveConfig.setControllerJavaHome(slaveControllerJvmHome);
         return slaveConfig;
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
@@ -31,6 +31,8 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
 
     private String javaHome = System.getenv("JAVA_HOME");
 
+    private String controllerJavaHome = System.getenv("JAVA_HOME");
+
     private String modulePath = System.getProperty("module.path");
 
     private String javaVmArguments = "-Xmx512m -XX:MaxPermSize=128m";
@@ -72,6 +74,9 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
         if (javaHome != null) {
             Validate.configurationDirectoryExists(javaHome, "javaHome must exist");
         }
+        if (controllerJavaHome != null) {
+            Validate.configurationDirectoryExists(javaHome, "controllerJavaHome must exist");
+        }
     }
 
     /**
@@ -102,6 +107,19 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
         this.javaHome = javaHome;
     }
 
+    /**
+     * @return the controllerJavaHome
+     */
+    public String getControllerJavaHome() {
+        return controllerJavaHome;
+    }
+
+    /**
+     * @param javaHome the javaHome to set
+     */
+    public void setControllerJavaHome(String controllerJavaHome) {
+        this.controllerJavaHome = controllerJavaHome;
+    }
     /**
      * @return the javaVmArguments
      */


### PR DESCRIPTION
Added ability to execute DomainTestSuite on a mix of various JVMs via jboss.test.host.master.jvmhome, jboss.test.host.master.controller.jvmhome, jboss.test.host.slave.jvmhome and jboss.test.host.slave.controller.jvmhome.
