### PR TITLE
[AS7-6777] Missing Resource Adaptor dependency

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
@@ -328,6 +328,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                     .addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class,
                             activator.getCcmInjector()).addDependency(NamingService.SERVICE_NAME)
                     .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                    .addDependency(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"))
                     .setInitialMode(ServiceController.Mode.ACTIVE).install();
 
             createJNDIAliases(jndiName, jndiAliases, controller);


### PR DESCRIPTION
The RA Activator service created by a pooled connection-factory
service requires an explicit dependency to the default bootstrap
context service to ensure it is properly started.
