### PR TITLE
Ignore HornetQ backup activation test

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
@@ -51,6 +51,7 @@ import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -94,6 +95,7 @@ public class HornetQBackupActivationTestCase {
         backupClient = null;
     }
 
+    @Ignore
     @Test
     public void testBackupActivation() throws Exception {
         checkHornetQServerStartedAndActiveAttributes(liveClient, true, true);


### PR DESCRIPTION
the test fails frequently on our CI.
Ignore it until I modify it to make sure it passes as expected
