### PR TITLE
AS7-6561 Add EJB 3.2 support for passivation disabling via ejb-jar.xml

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
@@ -22,13 +22,6 @@
 
 package org.jboss.as.ejb3.deployment.processors;
 
-import java.lang.reflect.Modifier;
-import java.util.List;
-
-import javax.ejb.Singleton;
-import javax.ejb.Stateful;
-import javax.ejb.Stateless;
-
 import org.jboss.as.ee.metadata.MetadataCompleteMarker;
 import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.EjbMessages;
@@ -49,9 +42,16 @@ import org.jboss.jandex.DotName;
 import org.jboss.metadata.ejb.spec.EjbType;
 import org.jboss.metadata.ejb.spec.EnterpriseBeanMetaData;
 import org.jboss.metadata.ejb.spec.GenericBeanMetaData;
+import org.jboss.metadata.ejb.spec.SessionBean32MetaData;
 import org.jboss.metadata.ejb.spec.SessionBeanMetaData;
 import org.jboss.metadata.ejb.spec.SessionType;
 import org.jboss.msc.service.ServiceName;
+
+import javax.ejb.Singleton;
+import javax.ejb.Stateful;
+import javax.ejb.Stateless;
+import java.lang.reflect.Modifier;
+import java.util.List;
 
 import static org.jboss.as.ejb3.deployment.processors.AbstractDeploymentUnitProcessor.getEjbJarDescription;
 
@@ -147,8 +147,13 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
                     // If passivation is disabled for the SFSB, either via annotation or via DD, then setup the component
                     // description appropriately
                     final boolean passivationCapableAnnotationValue = sessionBeanAnnotation.value("passivationCapable") == null ? true : sessionBeanAnnotation.value("passivationCapable").asBoolean();
-                    // TODO: Pass the DD value as first param for override
-                    final boolean passivationApplicable = override(null, passivationCapableAnnotationValue);
+                    final Boolean passivationCapableDeploymentDescriptorValue;
+                    if ((beanMetaData instanceof SessionBean32MetaData)) {
+                        passivationCapableDeploymentDescriptorValue = ((SessionBean32MetaData) beanMetaData).isPassivationCapable();
+                    } else {
+                        passivationCapableDeploymentDescriptorValue = null;
+                    }
+                    final boolean passivationApplicable = override(passivationCapableDeploymentDescriptorValue, passivationCapableAnnotationValue);
                     ((StatefulComponentDescription) sessionBeanDescription).setPassivationApplicable(passivationApplicable);
                     break;
                 case SINGLETON:
@@ -237,7 +242,9 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
                 break;
             case Stateful:
                 sessionBeanDescription = new StatefulComponentDescription(beanName, beanClassName, ejbJarDescription, deploymentUnit.getServiceName(), sessionBean);
-                // TODO: Handle passivation capable for stateful beans in EJB3.2
+                if (sessionBean instanceof SessionBean32MetaData && ((SessionBean32MetaData) sessionBean).isPassivationCapable() != null) {
+                    ((StatefulComponentDescription) sessionBeanDescription).setPassivationApplicable(((SessionBean32MetaData) sessionBean).isPassivationCapable());
+                }
                 break;
             case Singleton:
                 sessionBeanDescription = new SingletonComponentDescription(beanName, beanClassName, ejbJarDescription, deploymentUnit.getServiceName(), sessionBean);

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>1.4.1.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.0.1.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.3.16.GA</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.metadata>8.0.0.Alpha1</version.org.jboss.metadata>
+        <version.org.jboss.metadata>8.0.0.Alpha2</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.2.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.2.0.CR2</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.1.1.Final</version.org.jboss.msc.jboss-msc>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/DDBasedSFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/DDBasedSFSB.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import javax.ejb.PostActivate;
+import javax.ejb.PrePassivate;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful
+public class DDBasedSFSB {
+
+    private boolean prePrePassivateInvoked;
+    private boolean postActivateInvoked;
+
+    @PrePassivate
+    private void beforePassivate() {
+        this.prePrePassivateInvoked = true;
+    }
+
+    @PostActivate
+    private void afterActivate() {
+        this.postActivateInvoked = true;
+    }
+
+    public void doNothing() {
+
+    }
+
+    public boolean wasPassivated() {
+        return this.prePrePassivateInvoked;
+    }
+
+    public boolean wasActivated() {
+        return this.postActivateInvoked;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ejb-jar.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+      	  http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd"
+         version="3.2">
+    <enterprise-beans>
+        <session>
+            <ejb-name>passivation-disabled-bean</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ejb.stateful.passivation.DDBasedSFSB</ejb-class>
+            <passivation-capable>false</passivation-capable>
+        </session>
+        <session>
+            <ejb-name>passivation-enabled-bean</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ejb.stateful.passivation.DDBasedSFSB</ejb-class>
+            <passivation-capable>true</passivation-capable>
+        </session>
+
+        <!-- override passivation-capable for the bean -->
+        <session>
+            <ejb-name>passivation-override-bean</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ejb.stateful.passivation.PassivationEnabledBean</ejb-class>
+            <passivation-capable>false</passivation-capable>
+        </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
https://issues.jboss.org/browse/AS7-6561

The commit here completes the pending TODO item for processing the passivation-capable configuration in ejb-jar.xml of EJB 3.2 applications. With this change, the user applications can now either use annotation or ejb-jar.xml to disable passivation for stateful beans of their choice.
