### PR TITLE
[AS7-6646] Cut dependency of client side libs on security-util

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
@@ -34,7 +34,6 @@
 
     <dependencies>
         <module name="org.jboss.as.protocol"/>
-        <module name="org.jboss.as.security-util"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
@@ -34,7 +34,6 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.xml.stream.api"/>
-        <module name="org.jboss.as.security-util"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river" services="import"/>

--- a/controller-client/pom.xml
+++ b/controller-client/pom.xml
@@ -58,10 +58,6 @@
             <artifactId>jboss-as-protocol</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-security-util</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-dmr</artifactId>
         </dependency>

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -23,7 +23,6 @@
 package org.jboss.as.controller.client.impl;
 
 import org.jboss.as.controller.client.ModelControllerClientConfiguration;
-import org.jboss.as.util.security.ReadPropertyAction;
 import org.jboss.threads.JBossThreadFactory;
 
 import javax.net.ssl.SSLContext;
@@ -31,6 +30,7 @@ import javax.security.auth.callback.CallbackHandler;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -171,6 +171,11 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     }
 
     private static String getStringProperty(final String name) {
-        return getSecurityManager() == null ? getProperty(name) : doPrivileged(new ReadPropertyAction(name));
+        return getSecurityManager() == null ? getProperty(name) : doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return getProperty(name);
+            }
+        });
     }
 }

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -42,10 +42,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.as</groupId>
-            <artifactId>jboss-as-security-util</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/protocol/src/main/java/org/jboss/as/protocol/SecurityActions.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/SecurityActions.java
@@ -22,11 +22,11 @@
 
 package org.jboss.as.protocol;
 
-import org.jboss.as.util.security.ReadPropertyAction;
-
 import static java.lang.System.getProperty;
 import static java.lang.System.getSecurityManager;
 import static java.security.AccessController.doPrivileged;
+
+import java.security.PrivilegedAction;
 
 /**
  * Security actions to access system environment information.  No methods in
@@ -40,6 +40,11 @@ final class SecurityActions {
     }
 
     static String getSystemProperty(final String key) {
-        return getSecurityManager() == null ? getProperty(key) : doPrivileged(new ReadPropertyAction(key));
+        return getSecurityManager() == null ? getProperty(key) : doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return getProperty(key);
+            }
+        });
     }
 }


### PR DESCRIPTION
The protocol and controller-client modules produce client side binaries. This commit cuts the recently added dependency on the security-util module, which was added to support 2 uses total of ReadPropertyAction. Not worth it to add a classpath dependency to clients for such a minor benefit.
