### PR TITLE
[AS7-6651] Fix DiscoveryOptionsWriteAttributeHandler to use standard bas...

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerMessages.java
@@ -727,5 +727,5 @@ public interface HostControllerMessages {
     IllegalStateException cannotInstantiateDiscoveryOptionClass(String className, String message);
 
     @Message(id=16538, value="Invalid value for %s. Must only contain all of the existing discovery options")
-    String invalidDiscoveryOptionsOrdering(String name);
+    OperationFailedException invalidDiscoveryOptionsOrdering(String name);
 }


### PR DESCRIPTION
...e classes for everything except list content verification

Use standard AD validateAndSet for basic param validation. 
Use ReloadRequiredWriteAttributeHandler for dealing with reloadRequired/revertReloadRequired.
Implement the extra validation in finishModelStage.
