### PR TITLE
Update PathManagerService.java

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathManagerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathManagerService.java
@@ -88,7 +88,7 @@ public abstract class PathManagerService implements PathManager, Service<PathMan
             synchronized (pathEntries) {
                 pathEntry = pathEntries.get(relativeTo);
                 if (pathEntry == null) {
-                    throw MESSAGES.pathEntryNotFound(path);
+                    throw MESSAGES.pathEntryNotFound(relativeTo);
                 }
                 return RelativePathService.doResolve(pathEntry.resolvePath(), path);
             }


### PR DESCRIPTION
It seems to me that this error would be more clear if it stated the relativeTo that was not found (rather than the path itself).
