### PR TITLE
[AS7-6822] Swap the result of the check for the debug option in the JAVA_OPT in the bat file

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -31,7 +31,7 @@ if "%OS%" == "Windows_NT" (
 
 rem Read command-line args.
 :READ-ARGS
-if "%1" == "" ( 
+if "%1" == "" (
    goto MAIN
 ) else if "%1" == "--debug" (
    goto READ-DEBUG-PORT
@@ -96,9 +96,9 @@ rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
    echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
   if errorlevel == 1 (
-     echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
-  ) else (
      set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
+  ) else (
+     echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
   )
 )
 


### PR DESCRIPTION
The check in the Windows batch script improperly checked the `errorlevel` value of the `findstr`. Kept the check for the same value to keep it consistent with the rest of the script, but swapped the resulting actions.
