### PR TITLE
Cli AS7-6824 and AS7-6512

### DIFF
--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -3,7 +3,7 @@
 <!--
    JBoss AS7 Command-line Interface configuration.
 -->
-<jboss-cli xmlns="urn:jboss:cli:1.1">
+<jboss-cli xmlns="urn:jboss:cli:1.2">
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_1_2.xsd
@@ -23,8 +23,8 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:jboss:cli:1.1"
-           targetNamespace="urn:jboss:cli:1.1"
+           xmlns="urn:jboss:cli:1.2"
+           targetNamespace="urn:jboss:cli:1.2"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
         >

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -328,6 +328,7 @@ class CliConfigImpl implements CliConfig {
             switch (readerNS) {
                 case CLI_1_0:
                 case CLI_1_1:
+                case CLI_1_2:
                     readCLIElement_1_0(reader, readerNS, config);
                     break;
                 default:

--- a/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
@@ -42,12 +42,14 @@ public enum Namespace {
 
     CLI_1_0("urn:jboss:cli:1.0"),
 
-    CLI_1_1("urn:jboss:cli:1.1");
+    CLI_1_1("urn:jboss:cli:1.1"),
+
+    CLI_1_2("urn:jboss:cli:1.2");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = CLI_1_1;
+    public static final Namespace CURRENT = CLI_1_2;
 
     private final String name;
 

--- a/cli/src/main/java/org/jboss/as/cli/parsing/EscapeCharacterState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/EscapeCharacterState.java
@@ -48,6 +48,13 @@ public final class EscapeCharacterState extends BaseParsingState {
 
     EscapeCharacterState() {
         super(ID);
+        setEnterHandler(new CharacterHandler(){
+            @Override
+            public void handle(ParsingContext ctx) throws CommandFormatException {
+                if(ctx.getLocation() + 1 < ctx.getInput().length() && ctx.getInput().charAt(ctx.getLocation() + 1) == '\\') {
+                    ctx.getCallbackHandler().character(ctx);
+                }
+            }});
     }
 
     @Override


### PR DESCRIPTION
This includes
- AS7-6824 jboss-as-cli_1_2.xsd targets 1.1 namespace;
- AS7-6512 For CLI entered values, escape character for backslash '\' is not the expected '\' but '\'.

Thanks,
Alexey
