### PR TITLE
[AS7-6828] add empty messaging subsystem using CLI

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -539,18 +539,10 @@ public interface MessagingMessages {
     String hqServerInBackupMode(PathAddress address);
 
     /**
-     * Create a failure description message indicating that the there are no connectors defined.
+     * Create a failure description message indicating that the given broadcast-group's connector reference is not present in the listed connectors.
      *
      * @return an {@link OperationFailedException} for the error.
      */
-    @Message(id = 11679, value = "No connectors definition present.")
-    OperationFailedException noConnectors();
-
-    /**
-     * Create a failure description message indicating that the there are no connectors defined.
-     *
-     * @return an {@link OperationFailedException} for the error.
-     */
-    @Message(id = 11680, value = "The broadcast group '%s' defines reference to nonexistent connector '%s'. Available connectors '%s'.")
+    @Message(id = 11679, value = "The broadcast group '%s' defines reference to nonexistent connector '%s'. Available connectors '%s'.")
     OperationFailedException wrongConnectorRefInBroadCastGroup(final String bgName, final String connectorRef, final Collection<String> presentConnectors);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
@@ -164,9 +164,6 @@ class TransportConfigOperationHandlers {
                 connectors.put(connectorName, new TransportConfiguration(InVMConnectorFactory.class.getName(), parameters, connectorName));
             }
         }
-        if(connectors.size() == 0){
-            throw MESSAGES.noConnectors();
-        }
         configuration.setConnectorConfigurations(connectors);
     }
 


### PR DESCRIPTION
do not fail if there are no connectors defined when a hornetq-server
is started. It is a legitimate case
