### PR TITLE
Fix for AS7-6770 

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
@@ -22,13 +22,11 @@
 
 package org.jboss.as.txn.service;
 
-import static org.jboss.as.txn.TransactionMessages.MESSAGES;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
+import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
+import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.tools.osb.mbean.ObjStoreBrowser;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.orbportability.internal.utils.PostInitLoader;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -37,19 +35,14 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.tm.JBossXATerminator;
-import org.jboss.tm.LastResource;
 import org.jboss.tm.usertx.UserTransactionRegistry;
 import org.jboss.tm.usertx.client.ServerVMClientUserTransaction;
 import org.omg.CORBA.ORB;
 
-import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
-import com.arjuna.ats.arjuna.common.arjPropertyManager;
-import com.arjuna.ats.arjuna.tools.osb.mbean.ObjStoreBrowser;
-import com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter;
-import com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter;
-import com.arjuna.ats.jta.common.JTAEnvironmentBean;
-import com.arjuna.ats.jta.common.jtaPropertyManager;
-import com.arjuna.orbportability.internal.utils.PostInitLoader;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.jboss.as.txn.TransactionMessages.MESSAGES;
 
 /**
  * A service for the proprietary Arjuna {@link com.arjuna.ats.jbossatx.jta.TransactionManagerService}
@@ -65,6 +58,7 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
     private final InjectedValue<JBossXATerminator> xaTerminatorInjector = new InjectedValue<JBossXATerminator>();
     private final InjectedValue<ORB> orbInjector = new InjectedValue<ORB>();
     private final InjectedValue<UserTransactionRegistry> userTransactionRegistry = new InjectedValue<UserTransactionRegistry>();
+    private final InjectedValue<JTAEnvironmentBean> jtaEnvironmentBean = new InjectedValue<>();
 
 
     private com.arjuna.ats.jbossatx.jta.TransactionManagerService value;
@@ -77,7 +71,7 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
     private final String nodeIdentifier;
 
     public ArjunaTransactionManagerService(final boolean coordinatorEnableStatistics, final int coordinatorDefaultTimeout,
-                                    final boolean transactionStatusManagerEnable, final boolean jts, final String nodeIdentifier) {
+                                           final boolean transactionStatusManagerEnable, final boolean jts, final String nodeIdentifier) {
         this.coordinatorEnableStatistics = coordinatorEnableStatistics;
         this.coordinatorDefaultTimeout = coordinatorDefaultTimeout;
         this.transactionStatusManagerEnable = transactionStatusManagerEnable;
@@ -87,12 +81,6 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
-
-        final JTAEnvironmentBean jtaEnvironmentBean = jtaPropertyManager.getJTAEnvironmentBean();
-        jtaEnvironmentBean.setLastResourceOptimisationInterfaceClassName(LastResource.class.getName());
-        jtaEnvironmentBean.setXaRecoveryNodes(Collections.singletonList(nodeIdentifier));
-        jtaEnvironmentBean.setXaResourceOrphanFilterClassNames(Arrays.asList(JTATransactionLogXAResourceOrphanFilter.class.getName(), JTANodeNameXAResourceOrphanFilter.class.getName()));
-        jtaEnvironmentBean.setXAResourceRecordWrappingPlugin(new com.arjuna.ats.internal.jbossatx.jta.XAResourceRecordWrappingPluginImpl());
 
         final CoordinatorEnvironmentBean coordinatorEnvironmentBean = arjPropertyManager.getCoordinatorEnvironmentBean();
         coordinatorEnvironmentBean.setEnableStatistics(coordinatorEnableStatistics);
@@ -108,13 +96,13 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
 
         if (!jts) {
             // No IIOP, stick with JTA mode.
-            jtaEnvironmentBean.setTransactionManagerClassName(com.arjuna.ats.jbossatx.jta.TransactionManagerDelegate.class.getName());
-            jtaEnvironmentBean.setTransactionSynchronizationRegistryClassName(com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple.class.getName());
+            jtaEnvironmentBean.getValue().setTransactionManagerClassName(com.arjuna.ats.jbossatx.jta.TransactionManagerDelegate.class.getName());
+            jtaEnvironmentBean.getValue().setTransactionSynchronizationRegistryClassName(com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple.class.getName());
 
             final com.arjuna.ats.jbossatx.jta.TransactionManagerService service = new com.arjuna.ats.jbossatx.jta.TransactionManagerService();
             final ServerVMClientUserTransaction userTransaction = new ServerVMClientUserTransaction(service.getTransactionManager());
             userTransactionRegistry.getValue().addProvider(userTransaction);
-            jtaEnvironmentBean.setUserTransaction(userTransaction);
+            jtaEnvironmentBean.getValue().setUserTransaction(userTransaction);
             service.setJbossXATerminator(xaTerminatorInjector.getValue());
             service.setTransactionSynchronizationRegistry(new com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionSynchronizationRegistryImple());
 
@@ -130,12 +118,12 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
             new PostInitLoader(PostInitLoader.generateORBPropertyName("com.arjuna.orbportability.orb"), orb);
 
             // IIOP is enabled, so fire up JTS mode.
-            jtaEnvironmentBean.setTransactionManagerClassName(com.arjuna.ats.jbossatx.jts.TransactionManagerDelegate.class.getName());
-            jtaEnvironmentBean.setTransactionSynchronizationRegistryClassName(com.arjuna.ats.internal.jta.transaction.jts.TransactionSynchronizationRegistryImple.class.getName());
+            jtaEnvironmentBean.getValue().setTransactionManagerClassName(com.arjuna.ats.jbossatx.jts.TransactionManagerDelegate.class.getName());
+            jtaEnvironmentBean.getValue().setTransactionSynchronizationRegistryClassName(com.arjuna.ats.internal.jta.transaction.jts.TransactionSynchronizationRegistryImple.class.getName());
 
             final com.arjuna.ats.jbossatx.jts.TransactionManagerService service = new com.arjuna.ats.jbossatx.jts.TransactionManagerService();
             final ServerVMClientUserTransaction userTransaction = new ServerVMClientUserTransaction(service.getTransactionManager());
-            jtaEnvironmentBean.setUserTransaction(userTransaction);
+            jtaEnvironmentBean.getValue().setUserTransaction(userTransaction);
             userTransactionRegistry.getValue().addProvider(userTransaction);
             service.setJbossXATerminator(xaTerminatorInjector.getValue());
             service.setTransactionSynchronizationRegistry(new com.arjuna.ats.internal.jta.transaction.jts.TransactionSynchronizationRegistryImple());
@@ -187,5 +175,9 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
 
     public InjectedValue<UserTransactionRegistry> getUserTransactionRegistry() {
         return userTransactionRegistry;
+    }
+
+    public Injector<JTAEnvironmentBean> getJTAEnvironmentBeanInjector() {
+        return this.jtaEnvironmentBean;
     }
 }

--- a/transactions/src/main/java/org/jboss/as/txn/service/JTAEnvironmentBeanService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/JTAEnvironmentBeanService.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.service;
+
+import com.arjuna.ats.internal.jta.recovery.arjunacore.JTANodeNameXAResourceOrphanFilter;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.JTATransactionLogXAResourceOrphanFilter;
+import com.arjuna.ats.internal.jta.recovery.arjunacore.SubordinateJTAXAResourceOrphanFilter;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.tm.LastResource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+/**
+ * Sets up the {@link JTAEnvironmentBean}
+ *
+ * @author Jaikiran Pai
+ */
+public class JTAEnvironmentBeanService implements Service<JTAEnvironmentBean> {
+
+    private final String nodeIdentifier;
+    private final boolean jts;
+
+    public JTAEnvironmentBeanService(final String nodeIdentifier, final boolean jts) {
+        this.nodeIdentifier = nodeIdentifier;
+        this.jts = jts;
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        final JTAEnvironmentBean jtaEnvironmentBean = jtaPropertyManager.getJTAEnvironmentBean();
+        jtaEnvironmentBean.setLastResourceOptimisationInterfaceClassName(LastResource.class.getName());
+        // recovery nodes
+        jtaEnvironmentBean.setXaRecoveryNodes(Collections.singletonList(nodeIdentifier));
+        // setup the XA orphan filters
+        jtaEnvironmentBean.setXaResourceOrphanFilterClassNames(Arrays.asList(JTATransactionLogXAResourceOrphanFilter.class.getName(), JTANodeNameXAResourceOrphanFilter.class.getName(), SubordinateJTAXAResourceOrphanFilter.class.getName()));
+        jtaEnvironmentBean.setXAResourceRecordWrappingPlugin(new com.arjuna.ats.internal.jbossatx.jta.XAResourceRecordWrappingPluginImpl());
+
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        final JTAEnvironmentBean jtaEnvironmentBean = jtaPropertyManager.getJTAEnvironmentBean();
+        // reset the XA orphan filters
+        jtaEnvironmentBean.setXaResourceOrphanFilterClassNames(null);
+        // reset the recovery nodes
+        jtaEnvironmentBean.setXaRecoveryNodes(null);
+        // reset the record wrapper plugin
+        jtaEnvironmentBean.setXAResourceRecordWrappingPlugin(null);
+        jtaEnvironmentBean.setLastResourceOptimisationInterfaceClassName(null);
+
+    }
+
+    @Override
+    public JTAEnvironmentBean getValue() throws IllegalStateException, IllegalArgumentException {
+        return jtaPropertyManager.getJTAEnvironmentBean();
+    }
+}

--- a/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
@@ -54,6 +54,8 @@ public final class TxnServices {
 
     public static final ServiceName JBOSS_TXN_SYNCHRONIZATION_REGISTRY = JBOSS_TXN.append("TransactionSynchronizationRegistry");
 
+    public static final ServiceName JBOSS_TXN_JTA_ENVIRONMENT = JBOSS_TXN.append("JTAEnvironment");
+
     public static <T> T notNull(T value) {
         if (value == null) throw MESSAGES.serviceNotStarted();
         return value;

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -24,6 +24,7 @@ package org.jboss.as.txn.subsystem;
 
 import com.arjuna.ats.internal.arjuna.utils.UuidProcessId;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jts.common.jtsPropertyManager;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -50,11 +51,12 @@ import org.jboss.as.txn.service.ArjunaObjectStoreEnvironmentService;
 import org.jboss.as.txn.service.ArjunaRecoveryManagerService;
 import org.jboss.as.txn.service.ArjunaTransactionManagerService;
 import org.jboss.as.txn.service.CoreEnvironmentService;
+import org.jboss.as.txn.service.JTAEnvironmentBeanService;
 import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.as.txn.service.TxnServices;
-import org.jboss.as.txn.service.UserTransactionBindingService;
 import org.jboss.as.txn.service.UserTransactionAccessControlService;
+import org.jboss.as.txn.service.UserTransactionBindingService;
 import org.jboss.as.txn.service.UserTransactionRegistryService;
 import org.jboss.as.txn.service.UserTransactionService;
 import org.jboss.as.txn.service.XATerminatorService;
@@ -73,7 +75,6 @@ import org.omg.CORBA.ORB;
 
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
-
 import java.util.List;
 
 import static org.jboss.as.txn.TransactionLogger.ROOT_LOGGER;
@@ -260,9 +261,9 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final UserTransactionBindingService userTransactionBindingService = new UserTransactionBindingService("UserTransaction");
         final ServiceBuilder<ManagedReferenceFactory> utBuilder = context.getServiceTarget().addService(ContextNames.JBOSS_CONTEXT_SERVICE_NAME.append("UserTransaction"), userTransactionBindingService);
         utBuilder.addDependency(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, userTransactionBindingService.getNamingStoreInjector())
-            .addDependency(UserTransactionAccessControlService.SERVICE_NAME, UserTransactionAccessControlService.class,userTransactionBindingService.getUserTransactionAccessControlServiceInjector())
-            .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class,
-                    new ManagedReferenceInjector<UserTransaction>(userTransactionBindingService.getManagedObjectInjector()));
+                .addDependency(UserTransactionAccessControlService.SERVICE_NAME, UserTransactionAccessControlService.class, userTransactionBindingService.getUserTransactionAccessControlServiceInjector())
+                .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class,
+                        new ManagedReferenceInjector<UserTransaction>(userTransactionBindingService.getManagedObjectInjector()));
         utBuilder.addListener(verificationHandler);
         controllers.add(utBuilder.install());
 
@@ -273,10 +274,10 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
                                             ServiceVerificationHandler verificationHandler,
                                             List<ServiceController<?>> controllers) throws OperationFailedException {
         boolean useHornetqJournalStore = model.hasDefined(USEHORNETQSTORE) && model.get(USEHORNETQSTORE).asBoolean();
-        final String objectStorePathRef =TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO.resolveModelAttribute(context, model).asString();
+        final String objectStorePathRef = TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO.resolveModelAttribute(context, model).asString();
         final String objectStorePath = TransactionSubsystemRootResourceDefinition.OBJECT_STORE_PATH.resolveModelAttribute(context, model).asString();
 
-        final boolean useJdbcStore =  model.hasDefined(USE_JDBC_STORE) && model.get(USE_JDBC_STORE).asBoolean();
+        final boolean useJdbcStore = model.hasDefined(USE_JDBC_STORE) && model.get(USE_JDBC_STORE).asBoolean();
         final String dataSourceJndiName = TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE.resolveModelAttribute(context, model).asString();
 
         ArjunaObjectStoreEnvironmentService.JdbcStoreConfigBulder confiBuilder = new ArjunaObjectStoreEnvironmentService.JdbcStoreConfigBulder();
@@ -372,8 +373,10 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         final ArjunaRecoveryManagerService recoveryManagerService = new ArjunaRecoveryManagerService(recoveryListener, jts);
         final ServiceBuilder<RecoveryManagerService> recoveryManagerServiceServiceBuilder = context.getServiceTarget().addService(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, recoveryManagerService);
+        // add dependency on JTA environment bean
+        recoveryManagerServiceServiceBuilder.addDependency(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT);
 
-        if(jts) {
+        if (jts) {
             recoveryManagerServiceServiceBuilder.addDependency(ServiceName.JBOSS.append("jacorb", "orb-service"), ORB.class, recoveryManagerService.getOrbInjector());
         }
 
@@ -398,9 +401,17 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         final String nodeIdentifier = TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER.resolveModelAttribute(context, coordEnvModel).asString();
 
+        // install JTA environment bean service
+        final JTAEnvironmentBeanService jtaEnvironmentBeanService = new JTAEnvironmentBeanService(nodeIdentifier, jts);
+        final ServiceController jtaEnvironmentServiceController = context.getServiceTarget().addService(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, jtaEnvironmentBeanService)
+                .setInitialMode(Mode.ACTIVE)
+                .install();
+        controllers.add(jtaEnvironmentServiceController);
 
         final ArjunaTransactionManagerService transactionManagerService = new ArjunaTransactionManagerService(coordinatorEnableStatistics, coordinatorDefaultTimeout, transactionStatusManagerEnable, jts, nodeIdentifier);
         final ServiceBuilder<com.arjuna.ats.jbossatx.jta.TransactionManagerService> transactionManagerServiceServiceBuilder = context.getServiceTarget().addService(TxnServices.JBOSS_TXN_ARJUNA_TRANSACTION_MANAGER, transactionManagerService);
+        // add dependency on JTA environment bean service
+        transactionManagerServiceServiceBuilder.addDependency(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, JTAEnvironmentBean.class, transactionManagerService.getJTAEnvironmentBeanInjector());
 
         //if jts is enabled we need the ORB
         if (jts) {


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/AS7-6770 where the JTAEnvironmentBean setup wasn't done in a service which resulted in other services like the recovery manager service and transaction manager service couldn't "depend" on the state of the JTAEnvironmentBean.
