### PR TITLE
Fix for EJBCLIENT-73 

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/JBossEJBClientXmlConfiguration.java
@@ -61,9 +61,9 @@ public class JBossEJBClientXmlConfiguration implements EJBClientConfiguration {
 
     @Override
     public CallbackHandler getCallbackHandler() {
-        // The appropriate callback handler will either be available on the remote-outbound-connection
-        // reference or in the cluster configuration of this client context
-        return null;
+        // The appropriate callback handler will be overridden on the remote-outbound-connection
+        // reference or in the cluster configuration of this client context. We just return the default callbackhandler here.
+        return new AnonymousCallbackHandler();
     }
 
     @Override


### PR DESCRIPTION
The commit here prevents the possibility of a NPE as reported in https://issues.jboss.org/browse/EJBCLIENT-73 by returning the default callbackhandler.
