### PR TITLE
Upgrade to Apache CXF 2.7.4 + fixes to OOME in RemoteDeployer

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -44,6 +44,7 @@
         <module name="com.sun.xml.bind" services="import"/>
         <module name="org.apache.neethi" />
         <module name="org.apache.ws.xmlschema" />
+        <module name="org.codehaus.woodstox" />
         <module name="org.springframework.spring" optional="true" />
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <version.log4j>1.2.16</version.log4j>
         <version.net.jcip>1.0</version.net.jcip>
         <version.org.apache.ant>1.8.2</version.org.apache.ant>
-        <version.org.apache.cxf>2.7.3</version.org.apache.cxf>
+        <version.org.apache.cxf>2.7.4</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>2.6.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.felix.configadmin>1.2.8</version.org.apache.felix.configadmin>
         <version.org.apache.felix.log>1.0.0</version.org.apache.felix.log>
@@ -130,9 +130,9 @@
         <version.org.apache.myfaces.core>2.1.8</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.0.2</version.org.apache.neethi>
         <version.org.apache.openjpa>2.1.1</version.org.apache.openjpa>
-        <version.org.apache.santuario>1.5.3</version.org.apache.santuario>
+        <version.org.apache.santuario>1.5.4</version.org.apache.santuario>
         <version.org.apache.velocity>1.7</version.org.apache.velocity>
-        <version.org.apache.ws.security>1.6.9.jbossorg-1</version.org.apache.ws.security>
+        <version.org.apache.ws.security>1.6.10</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.0.2</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-1</version.org.apache.xalan>
         <version.org.apache.xerces>2.9.1-jbossas-2</version.org.apache.xerces>
@@ -140,7 +140,7 @@
         <version.org.codehaus.jettison>1.3.1</version.org.codehaus.jettison>
         <version.org.codehaus.plexus.plexus-utils>3.0.9</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>3.1.1</version.org.codehaus.woodstox.stax2-api>
-        <version.org.codehaus.woodstox.woodstox-core-asl>4.1.1</version.org.codehaus.woodstox.woodstox-core-asl>
+        <version.org.codehaus.woodstox.woodstox-core-asl>4.2.0</version.org.codehaus.woodstox.woodstox-core-asl>
         <version.org.eclipse.jdt.core.compiler.ecj>3.7.2</version.org.eclipse.jdt.core.compiler.ecj>
         <version.org.hibernate>4.2.0.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.1.Final</version.org.hibernate.commons.annotations>
@@ -262,7 +262,7 @@
         <version.sun.jaxb>2.2.5.jboss-1</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>
         <version.rhino.js>1.7R2</version.rhino.js>
-        <version.wsdl4j>1.6.2</version.wsdl4j>
+        <version.wsdl4j>1.6.3</version.wsdl4j>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <version.xom>1.2.5</version.xom>
 

--- a/webservices/tests-integration/src/main/java/org/jboss/as/webservices/deployer/RemoteDeployer.java
+++ b/webservices/tests-integration/src/main/java/org/jboss/as/webservices/deployer/RemoteDeployer.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.client.helpers.standalone.DeploymentPlanBuilder;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentActionResult;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentPlanResult;
+import org.jboss.as.controller.client.helpers.standalone.impl.ModelControllerClientServerDeploymentManager;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.security.Constants;
 import org.jboss.dmr.ModelNode;
@@ -387,6 +388,6 @@ public final class RemoteDeployer implements Deployer {
     }
 
     private static ServerDeploymentManager newDeploymentManager() throws Exception {
-        return ServerDeploymentManager.Factory.create(newModelControllerClient());
+        return new ModelControllerClientServerDeploymentManager(newModelControllerClient(), true);
     }
 }

--- a/webservices/tests-integration/src/main/java/org/jboss/as/webservices/deployer/RemoteDeployer.java
+++ b/webservices/tests-integration/src/main/java/org/jboss/as/webservices/deployer/RemoteDeployer.java
@@ -49,7 +49,6 @@ import org.jboss.as.controller.client.helpers.standalone.DeploymentPlanBuilder;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentActionResult;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentPlanResult;
-import org.jboss.as.controller.client.helpers.standalone.impl.ModelControllerClientServerDeploymentManager;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.security.Constants;
 import org.jboss.dmr.ModelNode;
@@ -126,12 +125,13 @@ public final class RemoteDeployer implements Deployer {
             } else {
                 archiveCounters.put(k, 1);
             }
-            final ServerDeploymentManager deploymentManager = newDeploymentManager();
+            final ModelControllerClient client = newModelControllerClient();
+            final ServerDeploymentManager deploymentManager = newDeploymentManager(client);
             final DeploymentPlanBuilder builder = deploymentManager.newDeploymentPlan().add(archiveURL).andDeploy();
             final DeploymentPlan plan = builder.build();
             final DeploymentAction deployAction = builder.getLastAction();
             final String uniqueId = deployAction.getDeploymentUnitUniqueName();
-            executeDeploymentPlan(plan, deployAction, deploymentManager);
+            executeDeploymentPlan(plan, deployAction, client, deploymentManager);
             url2Id.put(archiveURL, uniqueId);
         }
     }
@@ -152,14 +152,15 @@ public final class RemoteDeployer implements Deployer {
                 LOGGER.warn("Trying to undeploy archive " + archiveURL + " which is not currently deployed!");
                 return;
             }
-            final ServerDeploymentManager deploymentManager = newDeploymentManager();
+            final ModelControllerClient client = newModelControllerClient();
+            final ServerDeploymentManager deploymentManager = newDeploymentManager(client);
             final DeploymentPlanBuilder builder = deploymentManager.newDeploymentPlan();
             final String uniqueName = url2Id.get(archiveURL);
             if (uniqueName != null) {
                 final DeploymentPlan plan = builder.undeploy(uniqueName).remove(uniqueName).build();
                 final DeploymentAction deployAction = builder.getLastAction();
                 try {
-                    executeDeploymentPlan(plan, deployAction, deploymentManager);
+                    executeDeploymentPlan(plan, deployAction, client, deploymentManager);
                 } finally {
                     url2Id.remove(archiveURL);
                 }
@@ -168,7 +169,7 @@ public final class RemoteDeployer implements Deployer {
     }
 
     private void executeDeploymentPlan(final DeploymentPlan plan, final DeploymentAction deployAction,
-            final ServerDeploymentManager deploymentManager) throws Exception {
+            final ModelControllerClient client, final ServerDeploymentManager deploymentManager) throws Exception {
         try {
             final ServerDeploymentPlanResult planResult = deploymentManager.execute(plan).get();
 
@@ -184,6 +185,7 @@ public final class RemoteDeployer implements Deployer {
             LOGGER.fatal(e.getMessage(), e);
             throw e;
         } finally {
+            client.close();
             deploymentManager.close();
         }
     }
@@ -387,7 +389,7 @@ public final class RemoteDeployer implements Deployer {
         return ModelControllerClient.Factory.create(address.getHostAddress(), port, callbackHandler, null, TIMEOUT);
     }
 
-    private static ServerDeploymentManager newDeploymentManager() throws Exception {
-        return new ModelControllerClientServerDeploymentManager(newModelControllerClient(), true);
+    private static ServerDeploymentManager newDeploymentManager(ModelControllerClient client) throws Exception {
+        return ServerDeploymentManager.Factory.create(client);
     }
 }


### PR DESCRIPTION
- Make sure the ModelControllerClient is properly closed to avoid OOME in RemoteDeployer
- Upgrade to CXF 2.7.4, Woodstox 4.2.0, WSDL4J 1.6.3, WSS4J 1.6.10, Santuario 1.5.4
