### PR TITLE
[AS7-6840] HornetQ backup can not failover after failback

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSService.java
@@ -43,7 +43,8 @@ import org.jboss.msc.value.InjectedValue;
 
 import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
-import static org.jboss.msc.service.ServiceController.Mode.REMOVE;
+import static org.jboss.msc.service.ServiceController.Mode.ACTIVE;
+import static org.jboss.msc.service.ServiceController.Mode.PASSIVE;
 
 /**
  * The {@code JMSServerManager} service.
@@ -76,7 +77,7 @@ public class JMSService implements Service<JMSServerManager> {
                     .setInitialMode(Mode.ACTIVE);
 
             hornetQServer.getValue().registerActivateCallback(new ActivateCallback() {
-                public ServiceController<Void> hornetqActivationController;
+                private volatile ServiceController<Void> hornetqActivationController;
 
                 public void preActivate() {
                 }
@@ -85,13 +86,21 @@ public class JMSService implements Service<JMSServerManager> {
                     // FIXME - this check is a work-around for AS7-3658
                     hornetQServer.getValue().getRemotingService().allowInvmSecurityOverride(new HornetQPrincipal(HornetQDefaultCredentials.getUsername(), HornetQDefaultCredentials.getPassword()));
                     // HornetQ only provides a callback to be notified when HornetQ core server is activated.
-                    // but the JMS service start must not be completed until the JMSServerManager wrappee is indeed started (and has deployed the JMS resources, etc.)
-                    hornetqActivationController = hornetqActivationService.install();
+                    // but the JMS service start must not be completed until the JMSServerManager wrappee is indeed started (and has deployed the JMS resources, etc.).
+                    // It is possible that the activation service has already been installed but becomes passive when a backup server has failed over (-> ACTIVE) and failed back (-> PASSIVE)
+                    if (hornetqActivationController == null) {
+                        hornetqActivationController = hornetqActivationService.install();
+                    } else {
+                        hornetqActivationController.setMode(ACTIVE);
+                    }
                 }
 
                 public void deActivate() {
-                    if (hornetqActivationController != null) {
-                        hornetqActivationController.setMode(REMOVE);
+                    // passivate the activation service only if the HornetQ server is deactivated when it fails back
+                    // and *not* during AS7 service container shutdown (AS7-6840)
+                    if (hornetqActivationController != null &&
+                            !hornetqActivationController.getServiceContainer().isShutdown()) {
+                        hornetqActivationController.setMode(PASSIVE);
                     }
                 }
             });


### PR DESCRIPTION
Make sure that when HornetQ backup server fails back, the activation
service becomes PASSIVE (unless AS7 is shutting down) so that it can
becomes ACTIVE again when the hornetq server failed over again instead
of trying to install again the activation service
