### PR TITLE
Remove release specific version qualifiers from README

### DIFF
--- a/build/javadoc/README.txt
+++ b/build/javadoc/README.txt
@@ -44,7 +44,7 @@ TattleTale duplicated classes report may help with this.
 
 7) When done, aggregated JavaDoc will be created in:
   target/apidocs
-  target/jboss-as-build-<version>.Final-SNAPSHOT-javadoc.jar
+  target/jboss-as-build-<version>-javadoc.jar
 
 8) Check that the final result contains all packages it should.
 


### PR DESCRIPTION
While checking for wrong -SNAPSHOT references in the 7.2.0.Final I noticed this readme file could be a more generic (removing the need to maintain this text - especially as it is wrong anyway).
