### PR TITLE
Fix default permission of distributed tmp/auth directory.

### DIFF
--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -18,7 +18,7 @@
             <excludes>
                 <exclude>**/*.sh</exclude>
                 <exclude>jboss-*/domain/tmp/auth</exclude>
-                <exclude>jboss-*/domain/tmp/auth</exclude>
+                <exclude>jboss-*/standalone/tmp/auth</exclude>
                 <exclude>**/*-users.properties</exclude>
             </excludes>
         </fileSet>
@@ -43,7 +43,7 @@
             <outputDirectory/>
             <includes>
                 <include>jboss-*/domain/tmp/auth</include>
-                <include>jboss-*/standalone//tmp/auth</include>
+                <include>jboss-*/standalone/tmp/auth</include>
             </includes>
             <directoryMode>0700</directoryMode>
         </fileSet>


### PR DESCRIPTION
The build scripts produce distribution artifacts with wrong permission for auth dir:

```
drwxr-xr-x 0/0               0 2013-04-06 21:54 jboss-as-8.0.0.Alpha1-SNAPSHOT/standalone/tmp/auth/
drwx------ 0/0               0 2013-04-06 21:54 jboss-as-8.0.0.Alpha1-SNAPSHOT/domain/tmp/auth/
```

Unfortunatelly also present in 7.2.0 and most likely EAP 6.1

```
drwxr-xr-x 0/0               0 2013-04-06 20:08 jboss-as-7.2.0.Final/standalone/tmp/auth/
drwx------ 0/0               0 2013-04-06 20:08 jboss-as-7.2.0.Final/domain/tmp/auth/
```
