### PR TITLE
Use JDK tools.jar matching source version (1.7 for AS8).

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -86,7 +86,7 @@
             <groupId>com.sun</groupId>
             <artifactId>tools</artifactId>
             <scope>system</scope>
-            <version>1.6</version>
+            <version>${maven.compiler.source}</version>
             <systemPath>${com.sun.tools.path}</systemPath>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1399,7 +1399,7 @@
                 <groupId>com.sun</groupId>
                 <artifactId>tools</artifactId>
                 <scope>system</scope>
-                <version>1.6</version>
+                <version>${maven.compiler.source}</version>
                 <systemPath>${com.sun.tools.path}</systemPath>
             </dependency>
 

--- a/process-controller/pom.xml
+++ b/process-controller/pom.xml
@@ -111,7 +111,7 @@
                     <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                     <scope>system</scope>
-                    <version>1.6</version>
+                    <version>${maven.compiler.source}</version>
                     <systemPath>${com.sun.tools.path}</systemPath>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
com.sun:tools.jar is hardcoded to be 1.6, which leads to "boot classpath needs to match -source 1.6" warnings. With using the maven.compiler.source version (which is also used by the java version enforcer) the tools.jar should match the rest of the compile world.

Discussion: https://community.jboss.org/message/807105#807105
