### PR TITLE
AS7-6862 Deprecate usage of EJBUtilities

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -21,27 +21,6 @@
  */
 package org.jboss.as.ejb3.component;
 
-import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.Principal;
-import java.security.PrivilegedAction;
-import java.util.Collections;
-import java.util.Map;
-
-import javax.ejb.EJBHome;
-import javax.ejb.EJBLocalHome;
-import javax.ejb.TimerService;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagementType;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentView;
@@ -64,6 +43,26 @@ import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+
+import javax.ejb.EJBHome;
+import javax.ejb.EJBLocalHome;
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagementType;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
@@ -100,6 +99,10 @@ public abstract class EJBComponent extends BasicComponent {
 
     private final InvocationMetrics invocationMetrics = new InvocationMetrics();
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
+    private final TransactionManager transactionManager;
+    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
+    private final UserTransaction userTransaction;
+    private final ServerSecurityManager serverSecurityManager;
 
     /**
      * Construct a new instance.
@@ -113,7 +116,6 @@ public abstract class EJBComponent extends BasicComponent {
         this.applicationExceptions = Collections.unmodifiableMap(ejbComponentCreateService.getApplicationExceptions().getApplicationExceptions());
 
         this.utilities = ejbComponentCreateService.getEJBUtilities();
-
         final Map<MethodTransactionAttributeKey, TransactionAttributeType> txAttrs = ejbComponentCreateService.getTxAttrs();
         if (txAttrs == null || txAttrs.isEmpty()) {
             this.txAttrs = Collections.emptyMap();
@@ -145,6 +147,10 @@ public abstract class EJBComponent extends BasicComponent {
         this.ejbRemoteTransactionsRepository = ejbComponentCreateService.getEJBRemoteTransactionsRepository();
         this.timeoutInterceptors = Collections.unmodifiableMap(ejbComponentCreateService.getTimeoutInterceptors());
         this.shutDownInterceptorFactory = ejbComponentCreateService.getShutDownInterceptorFactory();
+        this.transactionManager = ejbComponentCreateService.getTransactionManager();
+        this.transactionSynchronizationRegistry = ejbComponentCreateService.getTransactionSynchronizationRegistry();
+        this.userTransaction = ejbComponentCreateService.getUserTransaction();
+        this.serverSecurityManager = ejbComponentCreateService.getServerSecurityManager();
     }
 
     protected <T> T createViewInstanceProxy(final Class<T> viewInterface, final Map<Object, Object> contextData) {
@@ -233,7 +239,7 @@ public abstract class EJBComponent extends BasicComponent {
     }
 
     public Principal getCallerPrincipal() {
-        return utilities.getSecurityManager().getCallerPrincipal();
+        return this.serverSecurityManager.getCallerPrincipal();
     }
 
     protected TransactionAttributeType getCurrentTransactionAttribute() {
@@ -313,7 +319,7 @@ public abstract class EJBComponent extends BasicComponent {
     }
 
     public ServerSecurityManager getSecurityManager() {
-        return utilities.getSecurityManager();
+        return this.serverSecurityManager;
     }
 
     public TimerService getTimerService() throws IllegalStateException {
@@ -325,22 +331,22 @@ public abstract class EJBComponent extends BasicComponent {
     }
 
     public TransactionAttributeType getTransactionAttributeType(final MethodIntf methodIntf, final MethodIdentifier method) {
-            TransactionAttributeType txAttr = txAttrs.get(new MethodTransactionAttributeKey(methodIntf, method));
-            //fall back to type bean if not found
-            if (txAttr == null && methodIntf != MethodIntf.BEAN) {
-                txAttr = txAttrs.get(new MethodTransactionAttributeKey(MethodIntf.BEAN,method));
-            }
-            if (txAttr == null)
-                return TransactionAttributeType.REQUIRED;
-            return txAttr;
+        TransactionAttributeType txAttr = txAttrs.get(new MethodTransactionAttributeKey(methodIntf, method));
+        //fall back to type bean if not found
+        if (txAttr == null && methodIntf != MethodIntf.BEAN) {
+            txAttr = txAttrs.get(new MethodTransactionAttributeKey(MethodIntf.BEAN, method));
         }
+        if (txAttr == null)
+            return TransactionAttributeType.REQUIRED;
+        return txAttr;
+    }
 
     public TransactionManager getTransactionManager() {
-        return utilities.getTransactionManager();
+        return this.transactionManager;
     }
 
     public TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
-        return utilities.getTransactionSynchronizationRegistry();
+        return this.transactionSynchronizationRegistry;
     }
 
     public int getTransactionTimeout(final MethodIntf methodIntf, final Method method) {
@@ -349,7 +355,7 @@ public abstract class EJBComponent extends BasicComponent {
 
     public int getTransactionTimeout(final MethodIntf methodIntf, final MethodIdentifier method) {
         Integer txTimeout = txTimeouts.get(new MethodTransactionAttributeKey(methodIntf, method));
-        if(txTimeout == null && methodIntf != MethodIntf.BEAN) {
+        if (txTimeout == null && methodIntf != MethodIntf.BEAN) {
             txTimeout = txTimeouts.get(new MethodTransactionAttributeKey(MethodIntf.BEAN, method));
         }
         if (txTimeout == null)
@@ -359,7 +365,7 @@ public abstract class EJBComponent extends BasicComponent {
     }
 
     public UserTransaction getUserTransaction() throws IllegalStateException {
-        return utilities.getUserTransaction();
+        return this.userTransaction;
     }
 
     public boolean isBeanManagedTransaction() {
@@ -367,7 +373,7 @@ public abstract class EJBComponent extends BasicComponent {
     }
 
     public boolean isCallerInRole(final String roleName) throws IllegalStateException {
-        return utilities.getSecurityManager().isCallerInRole(securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
+        return this.serverSecurityManager.isCallerInRole(securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
     }
 
     public boolean isStatisticsEnabled() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -22,18 +22,7 @@
 
 package org.jboss.as.ejb3.component;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ejb.TimerService;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagementType;
-
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponentCreateService;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ee.component.ViewConfiguration;
@@ -51,6 +40,20 @@ import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
+
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagementType;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Jaikiran Pai
@@ -89,6 +92,11 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
 
     private final InjectedValue<EJBRemoteTransactionsRepository> ejbRemoteTransactionsRepository = new InjectedValue<EJBRemoteTransactionsRepository>();
+    private final InjectedValue<TransactionManager> transactionManagerInjectedValue = new InjectedValue<>();
+    private final InjectedValue<UserTransaction> userTransactionInjectedValue = new InjectedValue<>();
+    private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
+    private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();
+
 
     /**
      * Construct a new instance.
@@ -120,8 +128,8 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
             for (Method method : componentConfiguration.getDefinedComponentMethods()) {
                 if ((ejbComponentDescription.getTimeoutMethod() != null && ejbComponentDescription.getTimeoutMethod().equals(method)) ||
                         ejbComponentDescription.getScheduleMethods().containsKey(method)) {
-                        final InterceptorFactory interceptorFactory = Interceptors.getChainedInterceptorFactory(componentConfiguration.getAroundTimeoutInterceptors(method));
-                        timeoutInterceptors.put(method, interceptorFactory);
+                    final InterceptorFactory interceptorFactory = Interceptors.getChainedInterceptorFactory(componentConfiguration.getAroundTimeoutInterceptors(method));
+                    timeoutInterceptors.put(method, interceptorFactory);
                 }
             }
             this.timeoutInterceptors = timeoutInterceptors;
@@ -181,10 +189,10 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     @Override
     protected boolean requiresInterceptors(final Method method, final ComponentConfiguration componentConfiguration) {
-        if(super.requiresInterceptors(method, componentConfiguration)) {
+        if (super.requiresInterceptors(method, componentConfiguration)) {
             return true;
         }
-        final EJBComponentDescription ejbComponentDescription = (EJBComponentDescription)componentConfiguration.getComponentDescription();
+        final EJBComponentDescription ejbComponentDescription = (EJBComponentDescription) componentConfiguration.getComponentDescription();
         if ((ejbComponentDescription.getTimeoutMethod() != null && ejbComponentDescription.getTimeoutMethod().equals(method)) ||
                 ejbComponentDescription.getScheduleMethods().containsKey(method)) {
             return true;
@@ -200,6 +208,11 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         }
     }
 
+    /**
+     * @return
+     * @deprecated {@link EJBUtilities} is deprecated post 7.2.0.Final version.
+     */
+    @Deprecated
     protected EJBUtilities getEJBUtilities() {
         // constructs
         final DeploymentUnit deploymentUnit = getDeploymentUnitInjector().getValue();
@@ -305,4 +318,37 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         // remote tx repo is applicable only for remote views, hence the optionalValue
         return this.ejbRemoteTransactionsRepository.getOptionalValue();
     }
+
+    Injector<TransactionManager> getTransactionManagerInjector() {
+        return this.transactionManagerInjectedValue;
+    }
+
+    TransactionManager getTransactionManager() {
+        return this.transactionManagerInjectedValue.getValue();
+    }
+
+    Injector<UserTransaction> getUserTransactionInjector() {
+        return this.userTransactionInjectedValue;
+    }
+
+    UserTransaction getUserTransaction() {
+        return this.userTransactionInjectedValue.getValue();
+    }
+
+    Injector<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistryInjector() {
+        return transactionSynchronizationRegistryValue;
+    }
+
+    TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
+        return transactionSynchronizationRegistryValue.getOptionalValue();
+    }
+
+    ServerSecurityManager getServerSecurityManager() {
+        return this.serverSecurityManagerInjectedValue.getValue();
+    }
+
+    Injector<ServerSecurityManager> getServerSecurityManagerInjector() {
+        return this.serverSecurityManagerInjectedValue;
+    }
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.component;
 
 
+import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.BindingConfiguration;
 import org.jboss.as.ee.component.Component;
@@ -63,10 +64,12 @@ import org.jboss.as.ejb3.security.SecurityContextInterceptorFactory;
 import org.jboss.as.ejb3.timerservice.AutoTimer;
 import org.jboss.as.ejb3.timerservice.NonFunctionalTimerService;
 import org.jboss.as.security.service.SecurityDomainService;
+import org.jboss.as.security.service.SimpleSecurityManagerService;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.SetupAction;
+import org.jboss.as.txn.service.TxnServices;
 import org.jboss.invocation.ContextClassLoaderInterceptor;
 import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.invocation.Interceptor;
@@ -83,6 +86,9 @@ import javax.ejb.EJBLocalObject;
 import javax.ejb.TimerService;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagementType;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
 import java.lang.reflect.Method;
 import java.rmi.Remote;
 import java.util.ArrayList;
@@ -328,6 +334,12 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                 configuration.addComponentInterceptor(ExecutionTimeInterceptor.FACTORY, InterceptorOrder.Component.EJB_EXECUTION_TIME_INTERCEPTOR, true);
             }
         });
+
+        // setup dependencies on the transaction manager services
+        addTransactionManagerDependencies();
+
+        // setup dependency on ServerSecurityManager
+        addServerSecurityManagerDependency();
     }
 
 
@@ -502,6 +514,46 @@ public abstract class EJBComponentDescription extends ComponentDescription {
         });
     }
 
+    /**
+     * Sets up a {@link ComponentConfigurator} which then sets up the relevant dependencies on the transaction manager services for the {@link EJBComponentCreateService}
+     */
+    protected void addTransactionManagerDependencies() {
+        this.getConfigurators().add(new ComponentConfigurator() {
+            @Override
+            public void configure(final DeploymentPhaseContext context, final ComponentDescription description, final ComponentConfiguration componentConfiguration) throws DeploymentUnitProcessingException {
+                componentConfiguration.getCreateDependencies().add(new DependencyConfigurator<EJBComponentCreateService>() {
+                    @Override
+                    public void configureDependency(final ServiceBuilder<?> serviceBuilder, final EJBComponentCreateService ejbComponentCreateService) throws DeploymentUnitProcessingException {
+                        // add dependency on transaction manager
+                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, ejbComponentCreateService.getTransactionManagerInjector());
+                        // add dependency on UserTransaction
+                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION, UserTransaction.class, ejbComponentCreateService.getUserTransactionInjector());
+                        // add dependency on TransactionSynchronizationRegistry
+                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, ejbComponentCreateService.getTransactionSynchronizationRegistryInjector());
+                    }
+                });
+
+            }
+        });
+    }
+
+    /**
+     * Sets up a {@link ComponentConfigurator} which then sets up the dependency on the ServerSecurityManager service for the {@link EJBComponentCreateService}
+     */
+    protected void addServerSecurityManagerDependency() {
+        getConfigurators().add(new ComponentConfigurator() {
+            @Override
+            public void configure(final DeploymentPhaseContext context, final ComponentDescription description, final ComponentConfiguration componentConfiguration) throws DeploymentUnitProcessingException {
+                componentConfiguration.getCreateDependencies().add(new DependencyConfigurator<EJBComponentCreateService>() {
+                    @Override
+                    public void configureDependency(final ServiceBuilder<?> serviceBuilder, final EJBComponentCreateService ejbComponentCreateService) throws DeploymentUnitProcessingException {
+                        serviceBuilder.addDependency(SimpleSecurityManagerService.SERVICE_NAME, ServerSecurityManager.class, ejbComponentCreateService.getServerSecurityManagerInjector());
+                    }
+                });
+            }
+        });
+    }
+
     protected void setupSecurityInterceptors(final ViewDescription view) {
         // setup security interceptor for the component
         view.getConfigurators().add(new EJBSecurityViewConfigurator());
@@ -596,6 +648,7 @@ public abstract class EJBComponentDescription extends ComponentDescription {
      * Returns the security domain that is applicable for this bean. In the absence of any explicit
      * configuration of a security domain for this bean, this method returns the default security domain
      * (if any) that's configured for all beans in the EJB3 subsystem
+     *
      * @return
      */
     public String getSecurityDomain() {
@@ -609,6 +662,7 @@ public abstract class EJBComponentDescription extends ComponentDescription {
      * Returns true if this bean has been explicitly configured with a security domain via the
      * {@link org.jboss.ejb3.annotation.SecurityDomain} annotation or via the jboss-ejb3.xml deployment descriptor.
      * Else returns false.
+     *
      * @return
      */
     public boolean isExplicitSecurityDomainConfigured() {
@@ -912,10 +966,10 @@ public abstract class EJBComponentDescription extends ComponentDescription {
 
     public Set<MethodIdentifier> getTimerMethods() {
         final Set<MethodIdentifier> methods = new HashSet<MethodIdentifier>();
-        if(timeoutMethod != null) {
+        if (timeoutMethod != null) {
             methods.add(MethodIdentifier.getIdentifierForMethod(timeoutMethod));
         }
-        for(Method method : scheduleMethods.keySet()) {
+        for (Method method : scheduleMethods.keySet()) {
             methods.add(MethodIdentifier.getIdentifierForMethod(method));
         }
         return methods;
@@ -923,7 +977,6 @@ public abstract class EJBComponentDescription extends ComponentDescription {
 
     /**
      * Returns a combined map of class and method level container interceptors
-     *
      */
     public Set<InterceptorDescription> getAllContainerInterceptors() {
         if (this.allContainerInterceptors == null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -21,19 +21,6 @@
  */
 package org.jboss.as.ejb3.component;
 
-import java.beans.IntrospectionException;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
-import javax.resource.ResourceException;
-import javax.resource.spi.ActivationSpec;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
@@ -51,6 +38,18 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.util.propertyeditor.PropertyEditors;
 
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+import java.beans.IntrospectionException;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
 import static org.jboss.as.ejb3.EjbLogger.EJB3_LOGGER;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 
@@ -59,7 +58,9 @@ import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
  *
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  * @author Jaikiran Pai
+ * @deprecated Deprecated post 7.2.x version. Services/Components which depended on this service for getting access to various other services are expected to directly depend on the relevant services themselves.
  */
+@Deprecated
 public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
 
 


### PR DESCRIPTION
The commit here deprecates the usage of EJBUtilities and instead sets up relevant dependencies on appropriate services for the EJB components.
