### PR TITLE
Fix AS7-6863

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/Common.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/Common.java
@@ -69,7 +69,7 @@ public class Common {
                 byte[] bytes = bout.toByteArray();
 
                 exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, APPLICATION_DMR_ENCODED+ ";" + UTF_8);
-                exchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, String.valueOf(bytes));
+                exchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, String.valueOf(bytes.length));
                 exchange.setResponseCode(500);
 
                 exchange.getResponseSender().send(new String(bytes), IoCallback.END_EXCHANGE);

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiHandler.java
@@ -109,7 +109,7 @@ class DomainApiHandler implements HttpHandler {
             dmr = get ? convertGetRequest(exchange) : convertPostRequest(exchange, encode);
         } catch (Exception e) {
             ROOT_LOGGER.debugf("Unable to construct ModelNode '%s'", e.getMessage());
-            Common.sendError(exchange, get, e.getLocalizedMessage());
+            Common.sendError(exchange, get, false, e.getLocalizedMessage());
             return;
         }
 
@@ -117,12 +117,12 @@ class DomainApiHandler implements HttpHandler {
             response = modelController.execute(new OperationBuilder(dmr).build());
         } catch (Throwable t) {
             ROOT_LOGGER.modelRequestError(t);
-            Common.sendError(exchange, get, t.getLocalizedMessage());
+            Common.sendError(exchange, get, encode, t.getLocalizedMessage());
             return;
         }
 
         if (response.hasDefined(OUTCOME) && FAILED.equals(response.get(OUTCOME).asString())) {
-            Common.sendError(exchange, get, response.get(FAILURE_DESCRIPTION).asString());
+            Common.sendError(exchange, get, encode, response.get(FAILURE_DESCRIPTION).asString());
             return;
         }
 

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiUploadHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiUploadHandler.java
@@ -75,13 +75,13 @@ class DomainApiUploadHandler implements HttpHandler {
                     operation.addInputStream(in);
                     response = modelController.execute(operation.build());
                     if (!response.get(OUTCOME).asString().equals(SUCCESS)){
-                        Common.sendError(exchange, false, response.get(FAILURE_DESCRIPTION).asString());
+                        Common.sendError(exchange, false, false, response.get(FAILURE_DESCRIPTION).asString());
                         return;
                     }
                 } catch (Throwable t) {
                     // TODO Consider draining input stream
                     ROOT_LOGGER.uploadError(t);
-                    Common.sendError(exchange, false, t.getLocalizedMessage());
+                    Common.sendError(exchange, false, false, t.getLocalizedMessage());
                     return;
                 } finally {
                     IoUtils.safeClose(in);
@@ -92,7 +92,7 @@ class DomainApiUploadHandler implements HttpHandler {
                 return; //Ignore later files
             }
         }
-        Common.sendError(exchange, false, "No file found"); //TODO i18n
+        Common.sendError(exchange, false, false, "No file found"); //TODO i18n
     }
 
     static void writeResponse(HttpServerExchange exchange, ModelNode response, String contentType) {


### PR DESCRIPTION
The DMR Handler needs to return an encoded response matching the accept headers the client did send. Otherwise the error processing breaks on the client side if "application/dmr-encoded" requests get mixed "text/plain" responses.
