### PR TITLE
Revert "Retain version string in filename of jboss-seam-int"

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -91,7 +91,7 @@
 
     <target name="create-ext-content">
         <mkdir dir="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled"/>
-        <copy file="${org.jboss.seam.integration:jboss-seam-int-jbossas:jar}" todir="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled/"/>
+        <copy file="${org.jboss.seam.integration:jboss-seam-int-jbossas:jar}" tofile="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled/jboss-seam-int.jar"/>
 
         <!-- Copy the EJB specific schemas to the JBOSS_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-ejb:jar}" dest="${output.dir}/docs/schema/">


### PR DESCRIPTION
This reverts commit b036d103ed503b0099d3f62c1c50f954aef03137.
The jar name is hard-coded in the source, so this change would
break seam integration.
