### PR TITLE
[WFLY-206] JMS access over HTTP

### DIFF
--- a/build/src/main/resources/configuration/examples/subsystems/messaging-hornetq-colocated.xml
+++ b/build/src/main/resources/configuration/examples/subsystems/messaging-hornetq-colocated.xml
@@ -3,7 +3,7 @@
 <config>
    <!-- This is very different from the normal messaging setup, do duplicating the config is easier -->
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.4">
        <hornetq-server>
            <persistence-enabled>true</persistence-enabled>
            <shared-store>true</shared-store>

--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.messaging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+   <subsystem xmlns="urn:jboss:domain:messaging:1.4">
        <hornetq-server>
            <?CLUSTERED?>
            <persistence-enabled>true</persistence-enabled>
@@ -14,6 +14,7 @@
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                    <param key="batch-delay" value="50"/>
                </netty-connector>
+               <servlet-connector name="servlet" socket-binding="http" host="default-host" />
                <in-vm-connector name="in-vm" server-id="0"/>
            </connectors>
 
@@ -63,6 +64,14 @@
                        <!-- Global JNDI entry used to provide a default JMS Connection factory to EE application -->
                        <entry name="java:jboss/DefaultJMSConnectionFactory"/>
                        <entry name="java:/ConnectionFactory"/>
+                   </entries>
+               </connection-factory>
+               <connection-factory name="ServletConnectionFactory">
+                   <connectors>
+                       <connector-ref connector-name="servlet"/>
+                   </connectors>
+                   <entries>
+                       <entry name="java:jboss/exported/jms/ServletConnectionFactory"/>
                    </entries>
                </connection-factory>
                <connection-factory name="RemoteConnectionFactory">

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_4.xsd
@@ -1,0 +1,1143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:messaging:1.4"
+           targetNamespace="urn:jboss:domain:messaging:1.4"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.4">
+
+    <!-- The messaging subsystem root element -->
+    <xs:element name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the messaging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="hornetq-server" type="hornetq-serverType" />
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="hornetq-serverType">
+      <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+                The configuration of an individual HornetQ Server.
+            ]]>
+          </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+          <xs:element maxOccurs="1" minOccurs="0" name="clustered" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated. A HornetQ server is clustered if it has at least one cluster-connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <!-- no file system deployment in AS
+          <xs:element maxOccurs="1" minOccurs="0" type="file-deployment-enabled"/>
+           -->
+          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean" />
+          <!--  TODO use thread subsystem?  -->
+          <xs:element maxOccurs="1" minOccurs="0" name="scheduled-thread-pool-max-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                     Maximum number of threads to use for the scheduled thread pool
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="thread-pool-max-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Maximum number of threads to use for the thread pool
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string" />
+          <!-- no logging configuration for AS needed
+          <xs:element maxOccurs="1" minOccurs="0" name="log-delegate-factory-class-name" type="xs:string" />
+           -->
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-incoming-interceptors" type="remoting-interceptorsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-outgoing-interceptors" type="remoting-interceptorsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="live-connector-ref" type="live-connectorType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="perf-blast-pages" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="check-for-live-server" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="backup-group-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="replication-clustername" type="xs:string" />
+
+          <xs:element maxOccurs="1" minOccurs="0" name="paging-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="bindings-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="large-messages-directory" type="directoryType" />
+
+          <xs:element maxOccurs="1" minOccurs="0" name="connectors">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-connector" type="netty-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="servlet-connector" type="servlet-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-connector" type="inVM-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector" type="connectorType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="acceptors">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-acceptor" type="netty-acceptorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-acceptor" type="inVM-acceptorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="acceptor" type="acceptorType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="broadcast-groups">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="broadcast-group" type="broadcast-groupType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="discovery-groups">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="discovery-group" type="discovery-groupType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="diverts">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="divert" type="divertType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="core-queues" type="queuesType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="bridges">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="bridge" type="bridgeType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-connections">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="cluster-connection" type="clusterConnectionType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="grouping-handler" type="groupingHandlerType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-settings" type="security-settingsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="address-settings" type="address-settingsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connector-services">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-service" type="connectorServiceType"/>
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jms-connection-factories">
+              <xs:complexType>
+                  <xs:sequence>
+                  <xs:element name="connection-factory" maxOccurs="unbounded" minOccurs="0" type="connection-factoryType" />
+                  <xs:element name="pooled-connection-factory" maxOccurs="unbounded" minOccurs="0" type="pooled-connection-factoryType" />
+                </xs:sequence>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jms-destinations">
+              <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="jms-queue" maxOccurs="unbounded" minOccurs="0" type="jmsQueueType" />
+                    <xs:element name="jms-topic" maxOccurs="unbounded" minOccurs="0" type="jmsTopicType" />
+                </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+        <xs:annotation>
+            <xs:documentation>
+                The name to use for this HornetQ Server. Must be unique across all "hornetq-server" elements
+                in the subsystem. So, this attribute is optional with a default value, but if more than
+                one "hornetq-server" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="local-bind-address" type="xs:string"/>
+    <xs:element name="local-bind-port" type="xs:int"/>
+    <xs:element name="group-address" type="xs:string"/>
+    <xs:element name="group-port" type="xs:int"/>
+    <xs:element name="broadcast-period" type="xs:long"/>
+    <xs:element name="initial-wait-timeout" type="xs:int"/>
+
+    <xs:complexType name="broadcast-groupType">
+       <xs:sequence>
+           <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-stack" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name of a stack defined in the org.jboss.as.clustering.jgroups subsystem.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string" />
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+           </xs:choice>
+           <xs:element maxOccurs="1" minOccurs="0" ref="broadcast-period" />
+           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-groupType">
+        <xs:sequence>
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-stack" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name of a stack defined in the org.jboss.as.clustering.jgroups subsystem.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string" />
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+            </xs:choice>
+            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int" />
+            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Deprecated. Use remoting-incoming-interceptors instead.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-incoming-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Remoting incoming interceptors must be placed into a JBoss module and added as a dependency to org.jboss.as.messaging:main module.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-outgoing-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Remoting outgoing interceptors must be placed into a JBoss module and added as a dependency to org.jboss.as.messaging:main module.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+       <xs:attribute name="key" type="xs:string" use="required"/>
+       <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="servlet-connectorType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+              The Servlet connector type.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-connectorType">
+                <xs:attribute name="host" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                This attribute references the web host that will deploy a Servlet used to provide HornetQ protocol over HTTP.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="socket-binding" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                This attribute references the socket-binding used by the web host. Its host and port will be used to configure the connector
+                                with the Servlet URL to access teh Servlet endpoint to tunnel the HornetQ protocol over HTTP.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="netty-connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The netty connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="inVM-connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The inVM connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:attribute name="server-id" type="xs:int" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Generic connector type, with optional socket-binding depending on whether
+              the implementation requires a Host/Port parameter.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+             </xs:sequence>
+             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-connectorType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="netty-acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The netty acceptor type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="inVM-acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The inVM connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:attribute name="server-id" type="xs:int" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Generic acceptor type, with optional socket-binding depending on whether
+              the implementation requires a Host/Port parameter.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+             </xs:sequence>
+             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-acceptorType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="bridgeType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long"  />
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-server-shutdown" type="xs:boolean">
+             <xs:annotation>
+                <xs:documentation>
+                   Deprecated. the failover-on-server-shutdown attribute is no longer taken into account when configuring a connector-ref.
+                </xs:documentation>
+             </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string" />
+          <xs:choice>
+             <xs:element maxOccurs="1" minOccurs="1" name="static-connectors">
+                <xs:complexType>
+                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="1" name="connector-ref" type="xs:string"/>
+                   </xs:sequence>
+                </xs:complexType>
+             </xs:element>
+             <xs:element maxOccurs="1" minOccurs="1" name="discovery-group-ref" type="discovery-group-refType" />
+          </xs:choice>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="clusterConnectionType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="call-failover-timeout" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-attempts" type="xs:int" />
+          <xs:choice>
+             <xs:element maxOccurs="1" minOccurs="0" name="static-connectors">
+                <xs:complexType>
+                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string"/>
+                   </xs:sequence>
+                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional"/>
+                </xs:complexType>
+             </xs:element>
+             <xs:element maxOccurs="1" minOccurs="0" name="discovery-group-ref" type="discovery-group-refType" />
+          </xs:choice>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="divertType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="journalType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="ASYNCIO"/>
+          <xs:enumeration value="NIO"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="groupingHandlerType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="type" type="groupingHandlerTypeType"/>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string"/>
+          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int"/>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="groupingHandlerTypeType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="LOCAL"/>
+          <xs:enumeration value="REMOTE"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="security-settingsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="security-setting" type="security-settingType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="security-settingType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="permission">
+             <xs:complexType>
+                <xs:attribute name="type" type="security-permissionType" use="required"/>
+                <xs:attribute name="roles" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                List of roles that are granted the permission for the given type. The roles must be separated by spaces or commas.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+             </xs:complexType>
+          </xs:element>
+       </xs:sequence>
+       <xs:attribute name="match" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="address-settingsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="address-setting" type="address-settingType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="address-settingType">
+       <xs:all>
+          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean" />
+       </xs:all>
+       <xs:attribute name="match" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="queuesType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="queue" type="queueType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="queueType">
+       <xs:all>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required"/>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean" />
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="live-connectorType">
+       <xs:attribute name="connector-name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:simpleType name="addressFullMessagePolicyType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="DROP"/>
+          <xs:enumeration value="PAGE"/>
+          <xs:enumeration value="BLOCK"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="connectorServiceType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="directoryType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A directory location configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem pathname where the directory should be
+                located.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir" />
+        <xs:attribute name="path" type="xs:string" />
+    </xs:complexType>
+
+
+   <!-- using a xs:all does not allow to factorize connection-factoryType and pooled-connection-factoryType
+        in a common base type definition.
+        The elements/attributes common to both are copied/pasted...
+    -->
+   <xs:complexType name="connection-factoryType">
+      <xs:all>
+         <!-- start of JMS connection-factoryType specific elements          -->
+         <!-- ============================================================== -->
+         <xs:element name="factory-type" type="connectionFactoryType" minOccurs="0" maxOccurs="1"/>
+         <!-- ============================================================== -->
+         <!-- end of JMS connection-factoryType specific elements            -->
+
+         <!-- start of common elements                                       -->
+         <!--  ============================================================= -->
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="connector-ref" type="connector-refType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="entries" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1">
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                <xs:documentation>
+                   Deprecated. the failover-on-server-shutdown attribute is no longer taken into account when configuring a connector-ref.
+                </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <!-- ============================================================= -->
+         <!-- end of common elements                                        -->
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" />
+   </xs:complexType>
+
+   <xs:simpleType name="connectionFactoryType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="GENERIC"/>
+         <xs:enumeration value="QUEUE"/>
+         <xs:enumeration value="TOPIC"/>
+         <xs:enumeration value="XA_GENERIC"/>
+         <xs:enumeration value="XA_QUEUE"/>
+         <xs:enumeration value="XA_TOPIC"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="pooled-connection-factoryType">
+      <xs:all>
+         <!-- start of JMS pooled-connection-factoryType specific elements   -->
+         <!-- ============================================================== -->
+         <xs:element name="inbound-config" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="initial-message-packet-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="initial-connect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <!-- ============================================================== -->
+         <!-- end of JMS pooled-connection-factoryType specific elements     -->
+
+         <!-- start of common elements                                       -->
+         <!--  ============================================================= -->
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="connector-ref" type="connector-refType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="entries" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1">
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                <xs:documentation>
+                   Deprecated. the failover-on-server-shutdown attribute is no longer taken into account when configuring a connector-ref.
+                </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <!-- ============================================================= -->
+         <!-- end of common elements                                        -->
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" />
+   </xs:complexType>
+
+
+   <xs:complexType name="connector-refType">
+      <xs:attribute name="connector-name" type="xs:string" use="required" />
+      <xs:attribute name="backup-connector-name" type="xs:string" use="optional">
+          <xs:annotation>
+              <xs:documentation>
+                  Deprecated. the backup-connector-name attribute is no longer taken into account when configuring a connector-ref.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="entryType">
+      <xs:attribute name="name" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:complexType name="discovery-group-refType">
+      <xs:attribute name="discovery-group-name" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:complexType name="jmsQueueType">
+      <xs:sequence>
+         <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
+         <xs:element name="selector" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:attribute name="string" type="xs:string" use="required" />
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:complexType name="jmsTopicType">
+      <xs:sequence>
+         <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required" />
+   </xs:complexType>
+
+    <xs:complexType name="transactionType">
+        <xs:attribute name="mode" use="required" type="modeType"/>
+    </xs:complexType>
+
+    <xs:simpleType name="modeType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="xa">
+                <xs:annotation>
+                    <xs:documentation></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="local">
+                <xs:annotation>
+                    <xs:documentation></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation></xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+   <xs:complexType name="jms-bridgeType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge.
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType" />
+         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int" />
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long" />
+
+         <xs:element maxOccurs="1" minOccurs="0" name="selector" type="selectorType" />
+         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string" />
+         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string" />
+         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean" />
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+         <xs:annotation>
+            <xs:documentation>
+               The name to use for this JMS bridge. Must be unique across all "jms-bridge" elements
+               in the subsystem. So, this attribute is optional with a default value, but if more than
+               one "jms-bridge" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="module" type="xs:string" use="optional">
+         <xs:annotation>
+            <xs:documentation>
+               The name of the module that contains resources required to lookup source or target JMS resources from another messaging broker than AS7.
+               This does not need to be specified if the bridge uses AS7 instances for both source and target.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="jms-bridgeResourceType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge resource which serves either of the source (from which the messages are consumed)
+               or the destination (to which messages are produced).
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="connection-factory">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the connection factory.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the destination.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The name of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The password of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="context" type="contextType" />
+      </xs:all>
+   </xs:complexType>
+
+   <xs:complexType name="selectorType">
+      <xs:attribute name="string" type="xs:string" use="required" />
+   </xs:complexType>
+
+   <xs:simpleType name="quality-of-serviceType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="AT_MOST_ONCE"/>
+         <xs:enumeration value="DUPLICATES_OK"/>
+         <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="security-permissionType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="send"/>
+         <xs:enumeration value="consume"/>
+         <xs:enumeration value="createDurableQueue"/>
+         <xs:enumeration value="deleteDurableQueue"/>
+         <xs:enumeration value="createNonDurableQueue"/>
+         <xs:enumeration value="deleteNonDurableQueue"/>
+         <xs:enumeration value="manage"/>
+         <xs:enumeration value="createTempQueue">
+             <xs:annotation>
+                 <xs:documentation>
+                     Deprecated. use createNonDurableQueue instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="deleteTempQueue">
+             <xs:annotation>
+                 <xs:documentation>
+                     Deprecated. use deleteNonDurableQueue instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="contextType">
+      <xs:annotation>
+         <xs:documentation>
+             The properties set on the JNDI Context used to lookup the JMS bridge resources.
+             In the absence of a context element, the JMS bridge will lookup resources locally on its own AS7 instance.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="paramType" />
+      </xs:sequence>
+   </xs:complexType>
+</xs:schema>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -47,6 +47,8 @@
         <module name="org.jboss.as.network"/>
         <module name="org.wildfly.security.manager"/>
         <module name="org.jboss.as.server"/>
+        <!-- web-common is required only if servlet-connector are used -->
+        <module name="org.jboss.as.web-common" optional="true"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -132,6 +132,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-web-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
             <artifactId>ironjacamar-common-api</artifactId>
         </dependency>

--- a/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
@@ -41,6 +41,7 @@ public enum Attribute {
    BACKUP_CONNECTOR_NAME("backup-connector-name"),
    CONNECTOR_NAME(CommonAttributes.CONNECTOR_NAME),
    KEY(CommonAttributes.KEY),
+   HOST(ServletConnectorDefinition.HOST.getName()),
    MATCH(CommonAttributes.MATCH),
    NAME(CommonAttributes.NAME),
    PATH(ModelDescriptionConstants.PATH),

--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -760,6 +760,8 @@ public interface CommonAttributes {
     String ENTRY = "entry";
     String FILE_DEPLOYMENT_ENABLED = "file-deployment-enabled";
     String GROUPING_HANDLER = "grouping-handler";
+    String SERVLET_CONNECTOR = "servlet-connector";
+    String HOST = "host";
     String ID = "id";
     String IN_VM_ACCEPTOR = "in-vm-acceptor";
     String IN_VM_CONNECTOR = "in-vm-connector";
@@ -808,6 +810,7 @@ public interface CommonAttributes {
     String SECURITY_ROLE = "security-role";
     String SECURITY_SETTING = "security-setting";
     String SECURITY_SETTINGS = "security-settings";
+    String SERVLET_PATH = "servlet-path";
     String HORNETQ_SERVER = "hornetq-server";
     String STARTED = "started";
     String STATIC_CONNECTORS = "static-connectors";
@@ -816,6 +819,8 @@ public interface CommonAttributes {
     String SUBSYSTEM = "subsystem";
     String TOPIC_ADDRESS = "topic-address";
     String TYPE_ATTR_NAME = "type";
+    String USE_INVM = "use-invm";
+    String USE_SERVLET = "use-servlet";
     String VERSION = "version";
     String XA = "xa";
     String XA_TX = "XATransaction";

--- a/messaging/src/main/java/org/jboss/as/messaging/Element.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Element.java
@@ -88,6 +88,7 @@ public enum Element {
    GROUP_PORT(CommonAttributes.GROUP_PORT),
    GROUPING_HANDLER(CommonAttributes.GROUPING_HANDLER),
    HORNETQ_SERVER(CommonAttributes.HORNETQ_SERVER),
+   SERVLET_CONNECTOR(CommonAttributes.SERVLET_CONNECTOR),
    ID_CACHE_SIZE(CommonAttributes.ID_CACHE_SIZE),
    INITIAL_WAIT_TIMEOUT(DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT),
    IN_VM_ACCEPTOR(CommonAttributes.IN_VM_ACCEPTOR),

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.messaging.Attribute.HOST;
+import static org.jboss.as.messaging.Attribute.SOCKET_BINDING;
+import static org.jboss.as.messaging.CommonAttributes.CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.SERVLET_CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.IN_VM_CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.REMOTE_CONNECTOR;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+/**
+ * Messaging subsystem 1.4 XML parser.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a>
+ *
+ */
+public class Messaging14SubsystemParser extends Messaging13SubsystemParser {
+
+    private static final Messaging14SubsystemParser INSTANCE = new Messaging14SubsystemParser();
+
+    public static MessagingSubsystemParser getInstance() {
+        return INSTANCE;
+    }
+
+    protected Messaging14SubsystemParser() {
+    }
+
+    void processConnectors(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {
+        while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            String name = null;
+            String socketBinding = null;
+            String serverId = null;
+            String host = null;
+
+            int count = reader.getAttributeCount();
+            for (int i = 0; i < count; i++) {
+                final String attrValue = reader.getAttributeValue(i);
+                final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+                switch (attribute) {
+                    case NAME: {
+                        name = attrValue;
+                        break;
+                    }
+                    case SOCKET_BINDING: {
+                        socketBinding = attrValue;
+                        break;
+                    }
+                    case SERVER_ID: {
+                        serverId = attrValue;
+                        break;
+                    }
+                    case HOST: {
+                        host = attrValue;
+                        break;
+                    }
+                    default: {
+                        throw ParseUtils.unexpectedAttribute(reader, i);
+                    }
+                }
+            }
+            if(name == null) {
+                throw missingRequired(reader, Collections.singleton(Attribute.NAME));
+            }
+
+            final ModelNode connectorAddress = address.clone();
+            final ModelNode operation = new ModelNode();
+            operation.get(OP).set(ADD);
+
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case CONNECTOR: {
+                    connectorAddress.add(CONNECTOR, name);
+                    if (socketBinding != null) {
+                        operation.get(RemoteTransportDefinition.SOCKET_BINDING.getName()).set(socketBinding);
+                    }
+                    parseTransportConfiguration(reader, operation, true);
+                    break;
+                } case NETTY_CONNECTOR: {
+                    connectorAddress.add(REMOTE_CONNECTOR, name);
+                    if (socketBinding == null) {
+                        throw missingRequired(reader, Collections.singleton(Attribute.SOCKET_BINDING));
+                    }
+                    operation.get(RemoteTransportDefinition.SOCKET_BINDING.getName()).set(socketBinding);
+                    parseTransportConfiguration(reader, operation, false);
+                    break;
+                } case SERVLET_CONNECTOR: {
+                    if (socketBinding == null) {
+                        throw missingRequired(reader, Collections.singleton(SOCKET_BINDING));
+                    }
+                    if (host == null) {
+                        throw missingRequired(reader, Collections.singleton(HOST));
+                    }
+                    connectorAddress.add(SERVLET_CONNECTOR, name);
+                    ServletConnectorDefinition.SOCKET_BINDING.parseAndSetParameter(socketBinding, operation, reader);
+                    ServletConnectorDefinition.HOST.parseAndSetParameter(host, operation, reader);
+                    parseTransportConfiguration(reader, operation, false);
+                    break;
+                } case IN_VM_CONNECTOR: {
+                    connectorAddress.add(IN_VM_CONNECTOR, name);
+                    if (serverId != null) {
+                        InVMTransportDefinition.SERVER_ID.parseAndSetParameter(serverId, operation, reader);
+                    }
+                    parseTransportConfiguration(reader, operation, false);
+                    break;
+                } default: {
+                    throw ParseUtils.unexpectedElement(reader);
+                }
+            }
+
+            operation.get(OP_ADDR).set(connectorAddress);
+            updates.add(operation);
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -28,6 +28,7 @@ import static org.jboss.as.messaging.Namespace.MESSAGING_1_0;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_1;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_2;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_3;
+import static org.jboss.as.messaging.Namespace.MESSAGING_1_4;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
@@ -52,6 +53,13 @@ import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
  * Domain extension that integrates HornetQ.
  *
  * <dl>
+ *   <dt>AS 8.0.0</dt>
+ *   <dd>
+ *     <ul>
+ *       <li>XML namespace: urn:jboss:domain:messaging:1.4
+ *       <li>Management model: 2.0.0
+ *     </ul>
+ *   </dd>
  *   <dt>AS 7.2.0</dt>
  *   <dd>
  *     <ul>
@@ -80,10 +88,11 @@ public class MessagingExtension implements Extension {
 
     static final String RESOURCE_NAME = MessagingExtension.class.getPackage().getName() + ".LocalDescriptions";
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 2;
-    private static final int MANAGEMENT_API_MICRO_VERSION = 1;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 2;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 0;
+    private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
+    public static final ModelVersion VERSION_1_2_1 = ModelVersion.create(1, 2, 1);
     public static final ModelVersion VERSION_1_2_0 = ModelVersion.create(1, 2, 0);
     public static final ModelVersion VERSION_1_1_0 = ModelVersion.create(1, 1, 0);
 
@@ -153,6 +162,7 @@ public class MessagingExtension implements Extension {
         serverRegistration.registerSubModel(GenericTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(RemoteTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(InVMTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
+        serverRegistration.registerSubModel(new ServletConnectorDefinition(registerRuntimeOnly));
 
         // Bridges
         serverRegistration.registerSubModel(new BridgeDefinition(registerRuntimeOnly));
@@ -224,5 +234,6 @@ public class MessagingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_1.getUriString(), MessagingSubsystemParser.getInstance());
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_2.getUriString(), Messaging12SubsystemParser.getInstance());
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_3.getUriString(), Messaging13SubsystemParser.getInstance());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_4.getUriString(), Messaging14SubsystemParser.getInstance());
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -129,6 +129,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
             case MESSAGING_1_1:
             case MESSAGING_1_2:
             case MESSAGING_1_3:
+            case MESSAGING_1_4:
                 processHornetQServers(reader, address, list);
                 break;
             default:
@@ -833,7 +834,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
        }
     }
 
-    static void processAcceptors(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {
+   void processAcceptors(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             String name = null;
             String socketBinding = null;
@@ -1063,7 +1064,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         return reader.getListAttributeValue(index);
     }
 
-    static void processConnectors(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {
+     void processConnectors(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> updates) throws XMLStreamException {
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             String name = null;
             String socketBinding = null;
@@ -1186,7 +1187,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         return addressSettingsSpec;
     }
 
-    static void parseTransportConfiguration(final XMLExtendedStreamReader reader, final ModelNode operation, final boolean generic) throws XMLStreamException {
+   void parseTransportConfiguration(final XMLExtendedStreamReader reader, final ModelNode operation, final boolean generic) throws XMLStreamException {
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             Element element = Element.forName(reader.getLocalName());
             switch(element) {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -34,6 +34,7 @@ import static org.jboss.as.messaging.CommonAttributes.ID_CACHE_SIZE;
 import static org.jboss.as.messaging.CommonAttributes.RUNTIME_QUEUE;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_1_0;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_0;
+import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_1;
 import static org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Pooled;
 
 import java.util.Set;
@@ -64,6 +65,7 @@ public class MessagingTransformers {
     static void registerTransformers(final SubsystemRegistration subsystem) {
         registerTransformers_1_1_0(subsystem);
         registerTransformers_1_2_0(subsystem);
+        registerTransformers_1_2_1(subsystem);
     }
 
     private static void registerTransformers_1_1_0(final SubsystemRegistration subsystem) {
@@ -117,6 +119,8 @@ public class MessagingTransformers {
                             .addRejectCheck(SIMPLE_EXPRESSIONS, TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0)
                     .end();
         }
+
+        hornetqServer.rejectChildResource(ServletConnectorDefinition.PATH);
 
         hornetqServer.addChildResource(BroadcastGroupDefinition.PATH)
                 .getAttributeBuilder()
@@ -247,6 +251,20 @@ public class MessagingTransformers {
 
                 }, CommonAttributes.CLUSTERED)
                 .end();
+
+        hornetqServer.rejectChildResource(ServletConnectorDefinition.PATH);
+
         TransformationDescription.Tools.register(subsystemRoot.build(), subsystem, VERSION_1_2_0);
+    }
+
+    private static void registerTransformers_1_2_1(final SubsystemRegistration subsystem) {
+
+        final ResourceTransformationDescriptionBuilder subsystemRoot = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+
+        ResourceTransformationDescriptionBuilder hornetqServer = subsystemRoot.addChildResource(PathElement.pathElement(HORNETQ_SERVER));
+
+        hornetqServer.rejectChildResource(ServletConnectorDefinition.PATH);
+
+        TransformationDescription.Tools.register(subsystemRoot.build(), subsystem, VERSION_1_2_1);
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingXMLWriter.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingXMLWriter.java
@@ -35,6 +35,7 @@ import static org.jboss.as.messaging.CommonAttributes.DIVERT;
 import static org.jboss.as.messaging.CommonAttributes.DURABLE;
 import static org.jboss.as.messaging.CommonAttributes.GROUPING_HANDLER;
 import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.SERVLET_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
@@ -185,21 +186,38 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
             if(node.hasDefined(REMOTE_CONNECTOR)) {
                 for(final Property property : node.get(REMOTE_CONNECTOR).asPropertyList()) {
                     writer.writeStartElement(Element.NETTY_CONNECTOR.getLocalName());
-                    writeAcceptorAndConnectorContent(writer, property);
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                    RemoteTransportDefinition.SOCKET_BINDING.marshallAsAttribute(property.getValue(), writer);
+                    writeTransportParam(writer, property.getValue().get(PARAM));
+                    writer.writeEndElement();
+                }
+            }
+            if(node.hasDefined(SERVLET_CONNECTOR)) {
+                for(final Property property : node.get(SERVLET_CONNECTOR).asPropertyList()) {
+                    writer.writeStartElement(Element.SERVLET_CONNECTOR.getLocalName());
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                    ServletConnectorDefinition.HOST.marshallAsAttribute(property.getValue(), writer);
+                    ServletConnectorDefinition.SOCKET_BINDING.marshallAsAttribute(property.getValue(), writer);
+                    writeTransportParam(writer, property.getValue().get(PARAM));
                     writer.writeEndElement();
                 }
             }
             if(node.hasDefined(IN_VM_CONNECTOR)) {
                 for(final Property property : node.get(IN_VM_CONNECTOR).asPropertyList()) {
                     writer.writeStartElement(Element.IN_VM_CONNECTOR.getLocalName());
-                    writeAcceptorAndConnectorContent(writer, property);
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                    InVMTransportDefinition.SERVER_ID.marshallAsAttribute(property.getValue(), writer);
+                    writeTransportParam(writer, property.getValue().get(PARAM));
                     writer.writeEndElement();
                 }
             }
             if(node.hasDefined(CONNECTOR)) {
                 for(final Property property : node.get(CONNECTOR).asPropertyList()) {
                     writer.writeStartElement(Element.CONNECTOR.getLocalName());
-                    writeAcceptorAndConnectorContent(writer, property);
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                    GenericTransportDefinition.SOCKET_BINDING.marshallAsElement(property.getValue(), writer);
+                    CommonAttributes.FACTORY_CLASS.marshallAsElement(property.getValue(), writer);
+                    writeTransportParam(writer, property.getValue().get(PARAM));
                     writer.writeEndElement();
                 }
             }
@@ -214,21 +232,21 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
             if(node.hasDefined(REMOTE_ACCEPTOR)) {
                 for(final Property property : node.get(REMOTE_ACCEPTOR).asPropertyList()) {
                     writer.writeStartElement(Element.NETTY_ACCEPTOR.getLocalName());
-                    writeAcceptorAndConnectorContent(writer, property);
+                    writeAcceptorContent(writer, property);
                     writer.writeEndElement();
                 }
             }
             if(node.hasDefined(IN_VM_ACCEPTOR)) {
                 for(final Property property : node.get(IN_VM_ACCEPTOR).asPropertyList()) {
                     writer.writeStartElement(Element.IN_VM_ACCEPTOR.getLocalName());
-                    writeAcceptorAndConnectorContent(writer, property);
+                    writeAcceptorContent(writer, property);
                     writer.writeEndElement();
                 }
             }
             if(node.hasDefined(ACCEPTOR)) {
                 for(final Property property : node.get(ACCEPTOR).asPropertyList()) {
                     writer.writeStartElement(Element.ACCEPTOR.getLocalName());
-                    writeAcceptorAndConnectorContent(writer, property);
+                    writeAcceptorContent(writer, property);
                     writer.writeEndElement();
                 }
             }
@@ -237,7 +255,7 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
         }
     }
 
-    private static void writeAcceptorAndConnectorContent(final XMLExtendedStreamWriter writer, final Property property) throws XMLStreamException {
+    private static void writeAcceptorContent(final XMLExtendedStreamWriter writer, final Property property) throws XMLStreamException {
         writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
         final ModelNode value = property.getValue();
 
@@ -245,9 +263,12 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
         InVMTransportDefinition.SERVER_ID.marshallAsAttribute(value, writer);
         CommonAttributes.FACTORY_CLASS.marshallAsElement(value, writer);
 
-        // TODO use a custom attribute marshaller
-        if (value.hasDefined(PARAM)) {
-            for(final Property parameter : value.get(PARAM).asPropertyList()) {
+        writeTransportParam(writer, value.get(PARAM));
+    }
+
+    private static void writeTransportParam(final XMLExtendedStreamWriter writer, final ModelNode param) throws XMLStreamException {
+        if (param.isDefined()) {
+            for(final Property parameter : param.asPropertyList()) {
                 writer.writeStartElement(Element.PARAM.getLocalName());
                 writer.writeAttribute(Attribute.KEY.getLocalName(), parameter.getName());
                 writer.writeAttribute(Attribute.VALUE.getLocalName(), parameter.getValue().get(TransportParamDefinition.VALUE.getName()).asString());

--- a/messaging/src/main/java/org/jboss/as/messaging/Namespace.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Namespace.java
@@ -39,12 +39,13 @@ public enum Namespace {
    MESSAGING_1_0("urn:jboss:domain:messaging:1.0"),
    MESSAGING_1_1("urn:jboss:domain:messaging:1.1"),
    MESSAGING_1_2("urn:jboss:domain:messaging:1.2"),
-   MESSAGING_1_3("urn:jboss:domain:messaging:1.3");
+   MESSAGING_1_3("urn:jboss:domain:messaging:1.3"),
+   MESSAGING_1_4("urn:jboss:domain:messaging:1.4");
 
    /**
     * The current namespace version.
     */
-   public static final Namespace CURRENT = MESSAGING_1_3;
+   public static final Namespace CURRENT = MESSAGING_1_4;
 
    private final String name;
 

--- a/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorAdd.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import java.util.List;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+
+/**
+ * The add handler for a servlet-connector resource.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class ServletConnectorAdd extends TransportConfigOperationHandlers.BasicTransportConfigAdd implements DescriptionProvider {
+
+    static final OperationStepHandler INSTANCE = new ServletConnectorAdd();
+
+    private ServletConnectorAdd() {
+        super(false, ServletConnectorDefinition.ATTRIBUTES);
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        super.performRuntime(context, operation, model, verificationHandler, newControllers);
+
+        PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+        String hornetqServerName = address.getElement(address.size() - 2).getValue();
+        String connectorName = address.getLastElement().getValue();
+        String host = ServletConnectorDefinition.HOST.resolveModelAttribute(context, model).asString();
+
+        // that's counter-intuitive but the http-connector will only be created by HornetQ after a reload.
+        // if the hornetq service is already installed, it will not be ready to create the http connector service
+        // because the required connector and acceptor will not be started.
+        if (!HornetQService.isHornetQServiceInstalled(context, operation)) {
+            final ServiceController<Void> serviceController = ServletConnectorService.addService(context.getServiceTarget(), verificationHandler, host, hornetqServerName, connectorName);
+            newControllers.add(serviceController);
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorDefinition.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.messaging.CommonAttributes.SERVLET_CONNECTOR;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
+
+/**
+ * HTTP connector resource definition
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+public class ServletConnectorDefinition extends SimpleResourceDefinition {
+
+    public static final PathElement PATH = PathElement.pathElement(SERVLET_CONNECTOR);
+
+    private final boolean registerRuntimeOnly;
+
+    // the http connector defines a socket-binding attribute to be able to fill the host & port
+    // parameters required by the connector. However, the connector will *not* bind the socket, this is done
+    // by the web container that deploys the netty servlet.
+    static final SimpleAttributeDefinition SOCKET_BINDING = create(GenericTransportDefinition.SOCKET_BINDING)
+            .setAllowExpression(false) // references another resource
+            .setAllowNull(false)
+            .setRestartAllServices()
+            .build();
+
+    static final SimpleAttributeDefinition HOST = SimpleAttributeDefinitionBuilder.create(CommonAttributes.HOST, ModelType.STRING)
+            .setAllowExpression(false) // references another resource
+            .setAllowNull(false)
+            .setRestartAllServices()
+            .build();
+
+    static AttributeDefinition[] ATTRIBUTES = { SOCKET_BINDING, HOST };
+
+    ServletConnectorDefinition(final boolean registerRuntimeOnly) {
+        super(PATH,
+                new StandardResourceDescriptionResolver(CommonAttributes.CONNECTOR, MessagingExtension.RESOURCE_NAME, MessagingExtension.class.getClassLoader(), true, false) {
+                    @Override
+                    public String getResourceDescription(Locale locale, ResourceBundle bundle) {
+                        return bundle.getString(SERVLET_CONNECTOR);
+                    }
+                },
+                ServletConnectorAdd.INSTANCE,
+                ServletConnectorRemove.INSTANCE);
+        this.registerRuntimeOnly = registerRuntimeOnly;
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registry) {
+        super.registerAttributes(registry);
+
+        OperationStepHandler attributeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
+        for (AttributeDefinition attr : ATTRIBUTES) {
+            if (registerRuntimeOnly || !attr.getFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME)) {
+                registry.registerReadWriteAttribute(attr, null, attributeHandler);
+            }
+        }
+    }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration registry) {
+        super.registerChildren(registry);
+
+        registry.registerSubModel(new TransportParamDefinition());
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorRemove.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * The remove handler for a servlet-connector resource.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class ServletConnectorRemove extends AbstractRemoveStepHandler {
+
+    static final OperationStepHandler INSTANCE = new ServletConnectorRemove();
+
+    private ServletConnectorRemove() {
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        if (HornetQService.isHornetQServiceInstalled(context, operation)) {
+
+            PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+            String hornetqServerName = address.getElement(address.size() - 1).getValue();
+            String connectorName = address.getLastElement().getValue();
+
+            final ServiceName serviceName = ServletConnectorService.getServiceName(hornetqServerName, connectorName);
+            context.removeService(serviceName);
+
+            context.reloadRequired();
+        }
+    }
+
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {
+        if (HornetQService.isHornetQServiceInstalled(context, operation)) {
+            context.revertReloadRequired();
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ServletConnectorService.java
@@ -1,0 +1,161 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.SERVLET_CONNECTOR;
+import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+import static org.jboss.as.messaging.MessagingServices.getHornetQServiceName;
+
+import java.io.File;
+
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.ServerEnvironmentService;
+import org.jboss.as.web.host.ServletBuilder;
+import org.jboss.as.web.host.WebDeploymentBuilder;
+import org.jboss.as.web.host.WebDeploymentController;
+import org.jboss.as.web.host.WebHost;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.netty.channel.socket.http.HttpTunnelingServlet;
+
+/**
+ * A service that deploys a servlet to tunnel HornetQ protocol inside HTTP.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+class ServletConnectorService implements Service<Void> {
+
+    private final String hornetqServerName;
+    private final String connectorName;
+
+    private InjectedValue<ServerEnvironment> injectedServerEnvironment = new InjectedValue<ServerEnvironment>();
+    private final InjectedValue<WebHost> injectedVirtualHost = new InjectedValue<WebHost>();
+
+    private WebDeploymentController controller;
+
+    static ServiceName getServiceName(final String hornetqServerName, final String connectorName) {
+        return getHornetQServiceName(hornetqServerName).append(SERVLET_CONNECTOR, connectorName);
+    }
+
+    private static String getContextRoot() {
+        return "/" + HORNETQ_SERVER;
+    }
+
+    private static String getUrlMapping(String hornetqServerName, String connectorName) {
+        return "/" + hornetqServerName + "/" + connectorName;
+    }
+
+    static String getServletPath(String hornetqServerName, String connectorName) {
+        return getContextRoot() + getUrlMapping(hornetqServerName, connectorName);
+    }
+
+    static String getServletEndpoint(final String hornetqServerName, final String connectorName) {
+        return "org.hornetq." + hornetqServerName + "." + connectorName;
+    }
+
+    static ServiceController<Void> addService(ServiceTarget serviceTarget,
+                                              ServiceVerificationHandler verificationHandler,
+                                              String host, String hornetqServerName,
+                                              String connectorName) {
+        ServiceName hornetQServiceName = MessagingServices.getHornetQServiceName(hornetqServerName);
+
+        final ServiceName serviceName = ServletConnectorService.getServiceName(hornetqServerName, connectorName);
+        final ServletConnectorService service = new ServletConnectorService(hornetqServerName, connectorName);
+
+        return serviceTarget.addService(serviceName, service)
+                .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, service.injectedServerEnvironment)
+                .addDependency(WebHost.SERVICE_NAME.append(host), WebHost.class, service.injectedVirtualHost)
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hornetQServiceName))
+                .addListener(verificationHandler)
+                .setInitialMode(ServiceController.Mode.PASSIVE)
+                .install();
+    }
+
+    ServletConnectorService(final String hornetqServerName, final String connectorName) {
+        this.hornetqServerName = hornetqServerName;
+        this.connectorName = connectorName;
+        if(hornetqServerName == null) {
+            throw MESSAGES.nullVar("hornetqServerName");
+        }
+        if(connectorName == null) {
+            throw MESSAGES.nullVar("connectorName");
+        }
+    }
+
+    @Override
+    public synchronized void start(StartContext context) throws StartException {
+        try {
+            WebDeploymentBuilder deployment = createWebDeployment(hornetqServerName, connectorName);
+            controller = injectedVirtualHost.getValue().addWebDeployment(deployment);
+            controller.create();
+            controller.start();
+        } catch (Exception e) {
+            throw new StartException(e);
+        }
+    }
+
+    @Override
+    public synchronized void stop(StopContext context) {
+        try {
+            controller.stop();
+            controller.destroy();
+        } catch (Exception e) {
+            MESSAGING_LOGGER.failedToDestroy(e, "web deployment", controller.toString());
+        }
+    }
+
+    @Override
+    public Void getValue() throws IllegalStateException {
+        return null;
+    }
+
+    private WebDeploymentBuilder createWebDeployment(String hornetqServerName, String connectorName) throws Exception {
+        WebDeploymentBuilder builder = new WebDeploymentBuilder();
+        builder.setContextRoot(getContextRoot());
+        File documentRoot = new File(injectedServerEnvironment.getValue().getServerTempDir() + File.separator + hornetqServerName + File.separator + connectorName + "-root");
+        // JBoss Web requires a document root. Undertow doesn't.
+        builder.setDocumentRoot(documentRoot);
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        builder.setClassLoader(classLoader);
+
+        ServletBuilder servlet = new ServletBuilder();
+        servlet.setServletName(hornetqServerName + "-" + connectorName);
+        servlet.setServletClass(classLoader.loadClass(HttpTunnelingServlet.class.getName()));
+        servlet.addUrlMapping(getUrlMapping(hornetqServerName, connectorName));
+        servlet.addInitParam("endpoint", "local:" + getServletEndpoint(hornetqServerName, connectorName));
+        servlet.setForceInit(true);
+        builder.addServlet(servlet);
+
+        return builder;
+    }
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
@@ -25,11 +25,16 @@ package org.jboss.as.messaging;
 import static org.jboss.as.messaging.CommonAttributes.ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.FACTORY_CLASS;
+import static org.jboss.as.messaging.CommonAttributes.HOST;
+import static org.jboss.as.messaging.CommonAttributes.SERVLET_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.PARAM;
 import static org.jboss.as.messaging.CommonAttributes.REMOTE_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.REMOTE_CONNECTOR;
+import static org.jboss.as.messaging.CommonAttributes.SERVLET_PATH;
+import static org.jboss.as.messaging.CommonAttributes.USE_INVM;
+import static org.jboss.as.messaging.CommonAttributes.USE_SERVLET;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.HashMap;
@@ -162,6 +167,29 @@ class TransportConfigOperationHandlers {
                 final Map<String, Object> parameters = getParameters(context, config);
                 parameters.put(InVMTransportDefinition.SERVER_ID.getName(), InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
                 connectors.put(connectorName, new TransportConfiguration(InVMConnectorFactory.class.getName(), parameters, connectorName));
+            }
+        }
+        if (params.hasDefined(SERVLET_CONNECTOR)) {
+            final String serverName = configuration.getName();
+            for (final Property property : params.get(SERVLET_CONNECTOR).asPropertyList()) {
+                final String connectorName = property.getName();
+                final ModelNode config = property.getValue();
+                final Map<String, Object> parameters = getParameters(context, config);
+                parameters.put(USE_SERVLET, true);
+                parameters.put(SERVLET_PATH, ServletConnectorService.getServletPath(serverName, connectorName));
+                final String binding = config.get(ServletConnectorDefinition.SOCKET_BINDING.getName()).asString();
+                parameters.put(ServletConnectorDefinition.SOCKET_BINDING.getName(), binding);
+                bindings.add(binding);
+                connectors.put(connectorName, new TransportConfiguration(NettyConnectorFactory.class.getName(), parameters, connectorName));
+
+                // for each http connector added, we must add a corresponding special (use-invm) netty acceptor that will be used by the netty servlet
+                String acceptorName = connectorName + "-" + ACCEPTOR;
+                final Map<String, Object> acceptorParams = new HashMap<String, Object>();
+                acceptorParams.put(USE_INVM, true);
+                acceptorParams.put(HOST, ServletConnectorService.getServletEndpoint(serverName, connectorName));
+                TransportConfiguration httpAcceptor = new TransportConfiguration(NettyAcceptorFactory.class.getName(), acceptorParams, acceptorName);
+                configuration.getAcceptorConfigurations().add(httpAcceptor);
+
             }
         }
         configuration.setConnectorConfigurations(connectors);

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -194,9 +194,11 @@ address-setting.page-max-cache-size=The number of page files to keep in memory t
 address-setting.send-to-dla-on-no-route=If this parameter is set to true for that address, if the message is not routed to any queues it will instead be sent to the dead letter address (DLA) for that address, if it exists.
 
 connector=A connector can be used by a client to define how it connects to a server.
+servlet-connector=Used by a remote client to define how it connects to a server over HTTP using a Servlet.
 remote-connector=Used by a remote client to define how it connects to a server.
 in-vm-connector=Used by an in-VM client to define how it connects to a server.
 connector.factory-class=Class name of the factory class that can instantiate the connector.
+connector.host=The host of the HTTP connector.
 connector.socket-binding=The socket binding that the connector will use to create connections.
 connector.server-id=The server id.
 connector.add=Operation adding a connector
@@ -639,6 +641,7 @@ role.create-non-durable-queue=This permission allows the user to create a tempor
 role.delete-non-durable-queue=This permission allows the user to delete a temporary queue.
 role.manage=This permission allows the user to invoke management operations by sending management messages to the management address.
 
+host=The host of the HTTP connector.
 server-id=The connector server ID.
 
 socket-binding=The socket binding reference.

--- a/messaging/src/test/java/org/jboss/as/messaging/test/JMSBridge13ParsingUnitTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/JMSBridge13ParsingUnitTestCase.java
@@ -46,4 +46,10 @@ public class JMSBridge13ParsingUnitTestCase extends AbstractSubsystemBaseTest {
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.MANAGEMENT;
     }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        // XML from messaging 1.4 does not have the same output than 1.3
+        return;
+    }
 }

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem13TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem13TestCase.java
@@ -93,9 +93,9 @@ import org.junit.Test;
 /**
  *  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012 Red Hat inc
  */
-public class MessagingSubsystemTestCase extends AbstractSubsystemBaseTest {
+public class MessagingSubsystem13TestCase extends AbstractSubsystemBaseTest {
 
-    public MessagingSubsystemTestCase() {
+    public MessagingSubsystem13TestCase() {
         super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
     }
 
@@ -105,6 +105,12 @@ public class MessagingSubsystemTestCase extends AbstractSubsystemBaseTest {
     @Override
     protected String getSubsystemXml() throws IOException {
         return readResource("subsystem_incompatible_1_3.xml");
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        // XML from messaging 1.4 does not have the same output than 1.3
+        return;
     }
 
     @Test

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem14TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem14TestCase.java
@@ -1,0 +1,420 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.test;
+
+import static org.jboss.as.controller.PathElement.pathElement;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.messaging.CommonAttributes.CALL_FAILOVER_TIMEOUT;
+import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.PARAM;
+import static org.jboss.as.messaging.HornetQServerResourceDefinition.HORNETQ_SERVER_PATH;
+import static org.jboss.as.messaging.MessagingExtension.VERSION_1_1_0;
+import static org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Regular.FACTORY_TYPE;
+import static org.jboss.as.model.test.ModelTestUtils.checkFailedTransformedBootOperations;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.messaging.AddressSettingDefinition;
+import org.jboss.as.messaging.BridgeDefinition;
+import org.jboss.as.messaging.BroadcastGroupDefinition;
+import org.jboss.as.messaging.ClusterConnectionDefinition;
+import org.jboss.as.messaging.CommonAttributes;
+import org.jboss.as.messaging.ConnectorServiceDefinition;
+import org.jboss.as.messaging.ConnectorServiceParamDefinition;
+import org.jboss.as.messaging.DiscoveryGroupDefinition;
+import org.jboss.as.messaging.DivertDefinition;
+import org.jboss.as.messaging.GroupingHandlerDefinition;
+import org.jboss.as.messaging.HornetQServerResourceDefinition;
+import org.jboss.as.messaging.ServletConnectorDefinition;
+import org.jboss.as.messaging.InVMTransportDefinition;
+import org.jboss.as.messaging.MessagingExtension;
+import org.jboss.as.messaging.QueueDefinition;
+import org.jboss.as.messaging.TransportParamDefinition;
+import org.jboss.as.messaging.jms.ConnectionFactoryAttributes;
+import org.jboss.as.messaging.jms.ConnectionFactoryDefinition;
+import org.jboss.as.messaging.jms.JMSQueueDefinition;
+import org.jboss.as.messaging.jms.JMSTopicDefinition;
+import org.jboss.as.messaging.jms.PooledConnectionFactoryDefinition;
+import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
+import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.FailedOperationTransformationConfig.ChainedConfig;
+import org.jboss.as.model.test.FailedOperationTransformationConfig.NewAttributesConfig;
+import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;
+import org.jboss.as.model.test.ModelFixer;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ *  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012 Red Hat inc
+ */
+public class MessagingSubsystem14TestCase extends AbstractSubsystemBaseTest {
+
+    public MessagingSubsystem14TestCase() {
+        super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
+    }
+
+    /*
+     * test 1.4-only features. Compatible features are tested in #testTransformers()
+     */
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("subsystem_incompatible_1_4.xml");
+    }
+
+    @Test
+    public void testTransformersAS712() throws Exception {
+        //Boot up empty controllers with the resources needed for the ops coming from the xml to work
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource("subsystem_1_4.xml");
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), ModelTestControllerVersion.V7_1_2_FINAL, VERSION_1_1_0)
+                .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.2.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-core:2.2.16.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-jms:2.2.16.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.16.Final")
+                .configureReverseControllerCheck(null, DEFAULT_PATH_FIXER);
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        assertTrue(mainServices.getLegacyServices(VERSION_1_1_0).isSuccessfulBoot());
+    }
+
+    @Test
+    public void testTransformersAS713() throws Exception {
+        //Boot up empty controllers with the resources needed for the ops coming from the xml to work
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource("subsystem_1_4.xml");
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), ModelTestControllerVersion.V7_1_3_FINAL, VERSION_1_1_0)
+                .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.3.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-core:2.2.21.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-jms:2.2.21.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.21.Final")
+                .configureReverseControllerCheck(null, DEFAULT_PATH_FIXER);
+
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        assertTrue(mainServices.getLegacyServices(VERSION_1_1_0).isSuccessfulBoot());
+    }
+
+    @Test
+    public void testRejectExpressionsAS712() throws Exception {
+        // AS7 7.1.2.Final does not allow to add an empty messaging subsystem [AS7-5767]
+        // To work around that, we add an empty "stuff" hornetq-server to boot the conf with AS7 7.1.2.Final
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource("empty_subsystem_1_4.xml");
+
+        // create builder for legacy subsystem version
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), ModelTestControllerVersion.V7_1_2_FINAL, VERSION_1_1_0)
+                .addMavenResourceURL("org.hornetq:hornetq-core:2.2.16.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-jms:2.2.16.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.16.Final")
+                .configureReverseControllerCheck(null, DEFAULT_PATH_FIXER)
+                .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.2.Final");
+
+        doTestRejectExpressions_1_1_0(builder);
+    }
+
+    @Test
+    public void testRejectExpressionsAS713() throws Exception {
+        // AS7 7.1.3.Final does not allow to add an empty messaging subsystem [AS7-5767]
+        // To work around that, we add an empty "stuff" hornetq-server to boot the conf with AS7 7.1.2.Final
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource("empty_subsystem_1_4.xml");
+
+        // create builder for legacy subsystem version
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), ModelTestControllerVersion.V7_1_3_FINAL, VERSION_1_1_0)
+                .addMavenResourceURL("org.hornetq:hornetq-core:2.2.21.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-jms:2.2.21.Final")
+                .addMavenResourceURL("org.hornetq:hornetq-ra:2.2.21.Final")
+                .configureReverseControllerCheck(null, DEFAULT_PATH_FIXER)
+                .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.1.3.Final");
+
+        doTestRejectExpressions_1_1_0(builder);
+    }
+
+    @Test
+    public void testClusteredTo120() throws Exception {
+        ModelVersion version120 = ModelVersion.create(1, 2);
+        // create builder for current subsystem version
+       KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                      .setSubsystemXmlResource("empty_subsystem_1_4.xml");
+       builder.createLegacyKernelServicesBuilder(null, ModelTestControllerVersion.MASTER, version120)
+                       .addMavenResourceURL("org.hornetq:hornetq-server:2.3.0.CR1")
+                       .addMavenResourceURL("org.hornetq:hornetq-jms-server:2.3.0.CR1")
+                       .addMavenResourceURL("org.hornetq:hornetq-core-client:2.3.0.CR1")
+                       .addMavenResourceURL("org.hornetq:hornetq-jms-client:2.3.0.CR1")
+                       .addMavenResourceURL("org.hornetq:hornetq-ra:2.3.0.CR1")
+                       .configureReverseControllerCheck(null, DEFAULT_PATH_FIXER)
+                       .addMavenResourceURL("org.jboss.as:jboss-as-messaging:7.2.0.Final");
+
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(version120);
+        assertNotNull(legacyServices);
+        assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+        clusteredTo120Test(version120, mainServices, true);
+        clusteredTo120Test(version120, mainServices, false);
+    }
+
+    private void clusteredTo120Test(ModelVersion version120, KernelServices mainServices, boolean clustered) throws OperationFailedException {
+
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME),
+                PathElement.pathElement(HornetQServerResourceDefinition.HORNETQ_SERVER_PATH.getKey(), String.valueOf(clustered)));
+
+        ModelNode addOp = Util.createAddOperation(pa);
+        addOp.get(CommonAttributes.CLUSTERED.getName()).set(clustered);
+
+        OperationTransformer.TransformedOperation transformedOperation = mainServices.transformOperation(version120, addOp);
+        assertFalse(transformedOperation.getTransformedOperation().has(CommonAttributes.CLUSTERED.getName()));
+
+        ModelNode result = new ModelNode();
+        result.get(OUTCOME).set(SUCCESS);
+        result.get(RESULT);
+        assertFalse(transformedOperation.rejectOperation(result));
+        assertEquals(result, transformedOperation.transformResult(result));
+
+        ModelNode writeOp = Util.createEmptyOperation(WRITE_ATTRIBUTE_OPERATION, pa);
+        writeOp.get(NAME).set(CommonAttributes.CLUSTERED.getName());
+        writeOp.get(VALUE).set(clustered);
+
+        transformedOperation = mainServices.transformOperation(version120, writeOp);
+        assertNull(transformedOperation.getTransformedOperation());
+    }
+
+    private static class RejectExpressionsConfigWithAddOnlyParam extends RejectExpressionsConfig {
+
+        RejectExpressionsConfigWithAddOnlyParam(String... attributes) {
+            super(attributes);
+        }
+
+        @Override
+        protected boolean isAttributeWritable(String attributeName) {
+            if (PARAM.equals(attributeName)) {
+                return false;
+            }
+            return super.isAttributeWritable(attributeName);
+        }
+    }
+
+    /**
+     * Tests rejection of expressions in 1.1.0 model.
+     *
+     * @throws Exception
+     */
+    private void doTestRejectExpressions_1_1_0(KernelServicesBuilder builder) throws Exception {
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_1_0);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+
+        //Use the real xml with expressions for testing all the attributes
+        PathAddress subsystemAddress = PathAddress.pathAddress(pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME));
+        List<ModelNode> modelNodes = builder.parseXmlResource("subsystem_incompatible_1_4.xml");
+        // remote the messaging subsystem add operation that fails on AS7 7.1.2.Final
+        modelNodes.remove(0);
+        checkFailedTransformedBootOperations(
+                mainServices,
+                VERSION_1_1_0,
+                modelNodes,
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH),
+                                createChainedConfig(
+                                        HornetQServerResourceDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
+                                        HornetQServerResourceDefinition.ATTRIBUTES_ADDED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(ModelDescriptionConstants.PATH)),
+                                new RejectExpressionsConfig(ModelDescriptionConstants.PATH))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.IN_VM_ACCEPTOR)),
+                                new RejectExpressionsConfigWithAddOnlyParam(concat(InVMTransportDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0, PARAM)))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.IN_VM_ACCEPTOR)).append(TransportParamDefinition.PATH),
+                                new RejectExpressionsConfig(TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.IN_VM_CONNECTOR)),
+                                new RejectExpressionsConfigWithAddOnlyParam(concat(InVMTransportDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0, PARAM)))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.IN_VM_CONNECTOR)).append(TransportParamDefinition.PATH),
+                                new RejectExpressionsConfig(TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.REMOTE_ACCEPTOR)),
+                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.REMOTE_ACCEPTOR)).append(TransportParamDefinition.PATH),
+                                new RejectExpressionsConfig(TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.REMOTE_CONNECTOR)),
+                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.REMOTE_CONNECTOR)).append(TransportParamDefinition.PATH),
+                                new RejectExpressionsConfig(TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(ServletConnectorDefinition.PATH),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.ACCEPTOR)),
+                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.ACCEPTOR)).append(TransportParamDefinition.PATH),
+                                new RejectExpressionsConfig(TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.CONNECTOR)),
+                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(pathElement(CommonAttributes.CONNECTOR)).append(TransportParamDefinition.PATH),
+                                new RejectExpressionsConfig(TransportParamDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(BroadcastGroupDefinition.PATH),
+                                new RejectExpressionsConfig(BroadcastGroupDefinition.BROADCAST_PERIOD) {
+                                    @Override
+                                    public boolean expectFailed(ModelNode operation) {
+                                        if ("groupT".equals(operation.get(OP_ADDR).get(2).get(CommonAttributes.BROADCAST_GROUP).asString())) {
+                                            // groupT use JGroups and do not define socket-binding or local address
+                                            return true;
+                                        }
+                                        return super.expectFailed(operation);
+                                    }
+                                })
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(DiscoveryGroupDefinition.PATH),
+                                new RejectExpressionsConfig(DiscoveryGroupDefinition.REFRESH_TIMEOUT, DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT) {
+                                    @Override
+                                    public boolean expectFailed(ModelNode operation) {
+                                        if ("groupU".equals(operation.get(OP_ADDR).get(2).get(CommonAttributes.DISCOVERY_GROUP).asString())) {
+                                            // groupU use JGroups and do not define socket-binding or local address
+                                            return true;
+                                        }
+                                        return super.expectFailed(operation);
+                                    }
+                                })
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(DivertDefinition.PATH),
+                                new RejectExpressionsConfig(DivertDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(QueueDefinition.PATH),
+                                new RejectExpressionsConfig(QueueDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(ClusterConnectionDefinition.PATH),
+                                createChainedConfig(ClusterConnectionDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
+                                        ClusterConnectionDefinition.ATTRIBUTES_ADDED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(BridgeDefinition.PATH),
+                                new RejectExpressionsConfig(BridgeDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(GroupingHandlerDefinition.PATH),
+                                new RejectExpressionsConfig(GroupingHandlerDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(AddressSettingDefinition.PATH),
+                                new RejectExpressionsConfig(AddressSettingDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(ConnectorServiceDefinition.PATH).append(ConnectorServiceParamDefinition.PATH),
+                                new RejectExpressionsConfig(ConnectorServiceParamDefinition.VALUE))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(ConnectionFactoryDefinition.PATH),
+                                createChainedConfig(ConnectionFactoryDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
+                                        new AttributeDefinition[]{CALL_FAILOVER_TIMEOUT}).setReadOnly(FACTORY_TYPE))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(PooledConnectionFactoryDefinition.PATH),
+                                createChainedConfig(PooledConnectionFactoryDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
+                                        PooledConnectionFactoryDefinition.ATTRIBUTES_ADDED_IN_1_2_0).setReadOnly(ConnectionFactoryAttributes.Pooled.TRANSACTION))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(JMSQueueDefinition.PATH),
+                                new RejectExpressionsConfig(JMSQueueDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(JMSTopicDefinition.PATH),
+                                new RejectExpressionsConfig(JMSTopicDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0))
+                        .addFailedAttribute(
+                                subsystemAddress.append(JMSBridgeDefinition.PATH),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+        );
+    }
+
+
+    private static String[] concat(AttributeDefinition[] attrs1, String... attrs2) {
+        String[] newAttrs = new String[attrs1.length + attrs2.length];
+        for(int i = 0; i < attrs1.length; i++) {
+            newAttrs[i] = attrs1[i].getName();
+        }
+        for(int i = 0; i < attrs2.length; i++) {
+            newAttrs[attrs1.length + i] = attrs2[i];
+        }
+        return newAttrs;
+    }
+
+    private static ChainedConfig createChainedConfig(AttributeDefinition[] rejectedExpression, AttributeDefinition[] newAttributes) {
+        AttributeDefinition[] allAttributes = new AttributeDefinition[rejectedExpression.length + newAttributes.length];
+        System.arraycopy(rejectedExpression, 0, allAttributes, 0, rejectedExpression.length);
+        System.arraycopy(newAttributes, 0, allAttributes, rejectedExpression.length, newAttributes.length);
+
+        return ChainedConfig.createBuilder(allAttributes)
+            .addConfig(new RejectExpressionsConfig(rejectedExpression))
+            .addConfig(new NewAttributesConfig(newAttributes)).build();
+    }
+
+    private static final ModelFixer DEFAULT_PATH_FIXER = new ModelFixer() {
+        @Override
+        public ModelNode fixModel(ModelNode modelNode) {
+            // Since AS7-5417, messaging's paths resources are always created.
+            // however for legacy version, they were only created if the path attributes were different from the defaults.
+            // The 'empty' hornetq-server does not set any messaging's path so we discard them to "fix" the model and
+            // compare the current and legacy versions
+            for (String serverWithDefaultPath  : new String[] {"empty", "stuff"}) {
+                if (modelNode.get(HORNETQ_SERVER).has(serverWithDefaultPath)) {
+                    modelNode.get(HORNETQ_SERVER, serverWithDefaultPath, PATH).set(new ModelNode());
+                }
+            }
+            return modelNode;
+        }
+    };
+}

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/empty_subsystem_1_4.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/empty_subsystem_1_4.xml
@@ -1,0 +1,4 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:1.4">
+        <hornetq-server name="stuff" />
+    </subsystem>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_4.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_4.xml
@@ -1,0 +1,414 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:1.4">
+        <hornetq-server>
+            <clustered>true</clustered>
+            <!-- disable messaging persistence -->
+            <persistence-enabled>false</persistence-enabled>
+            <scheduled-thread-pool-max-size>${messaging.scheduled.thread.pool.max.size:6}</scheduled-thread-pool-max-size>
+            <thread-pool-max-size>${messaging.thread.pool.max.size:5}</thread-pool-max-size>
+            <security-domain>someDomain</security-domain>
+            <security-enabled>false</security-enabled>
+            <security-invalidation-interval>1234</security-invalidation-interval>
+            <wild-card-routing-enabled>false</wild-card-routing-enabled>
+            <management-address>my.management.address</management-address>
+            <management-notification-address>my.management.notif.address</management-notification-address>
+            <cluster-user>${messaging.cluster.user.name}</cluster-user>
+            <cluster-password>${messaging.cluster.user.password}</cluster-password>
+            <jmx-management-enabled>false</jmx-management-enabled>
+            <jmx-domain>my.jmx.domain</jmx-domain>
+            <message-counter-enabled>true</message-counter-enabled>
+            <message-counter-sample-period>7654</message-counter-sample-period>
+            <message-counter-max-day-history>23</message-counter-max-day-history>
+            <connection-ttl-override>5432</connection-ttl-override>
+            <async-connection-execution-enabled>false</async-connection-execution-enabled>
+            <transaction-timeout>4321</transaction-timeout>
+            <transaction-timeout-scan-period>5432</transaction-timeout-scan-period>
+            <message-expiry-scan-period>7654</message-expiry-scan-period>
+            <message-expiry-thread-priority>7</message-expiry-thread-priority>
+            <id-cache-size>102030</id-cache-size>
+            <persist-id-cache>false</persist-id-cache>
+            <remoting-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-interceptors>
+            <backup>false</backup>
+            <allow-failback>false</allow-failback>
+            <failback-delay>9876</failback-delay>
+            <failover-on-shutdown>true</failover-on-shutdown>
+            <shared-store>true</shared-store>
+            <persist-delivery-count-before-delivery>true</persist-delivery-count-before-delivery>
+            <page-max-concurrent-io>10</page-max-concurrent-io>
+            <create-bindings-dir>false</create-bindings-dir>
+            <create-journal-dir>true</create-journal-dir>
+            <journal-type>NIO</journal-type>
+            <journal-buffer-timeout>1357</journal-buffer-timeout>
+            <journal-buffer-size>2468</journal-buffer-size>
+            <journal-sync-transactional>false</journal-sync-transactional>
+            <journal-sync-non-transactional>true</journal-sync-non-transactional>
+            <log-journal-write-rate>true</log-journal-write-rate>
+            <!-- Default journal file size is 10Mb, reduced here to 100k for faster first boot -->
+            <journal-file-size>102400</journal-file-size>
+            <journal-min-files>2</journal-min-files>
+            <journal-compact-percentage>83</journal-compact-percentage>
+            <journal-compact-min-files>2</journal-compact-min-files>
+            <journal-max-io>50</journal-max-io>
+            <perf-blast-pages>70</perf-blast-pages>
+            <run-sync-speed-test>false</run-sync-speed-test>
+            <server-dump-interval>8642</server-dump-interval>
+            <memory-warning-threshold>1024</memory-warning-threshold>
+            <memory-measure-interval>2048</memory-measure-interval>
+            <paging-directory path="test" relative-to="test" />
+            <bindings-directory path="test" relative-to="test" />
+            <journal-directory path="test" relative-to="test" />
+            <large-messages-directory path="test" relative-to="test" />
+            <connectors>
+               <netty-connector name="netty" socket-binding="messaging" />
+               <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+               </netty-connector>
+               <in-vm-connector name="in-vm" server-id="0" />
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+               </connector>
+            </connectors>
+            <acceptors>
+               <netty-acceptor name="netty" socket-binding="messaging" />
+               <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+                  <param key="direct-deliver" value="false"/>
+               </netty-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0">
+                  <param key="direct-deliver" value="true"/>
+               </in-vm-acceptor>
+               <acceptor name="myacceptor">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
+                  <param key="batch-delay" value="50"/>
+               </acceptor>
+            </acceptors>
+            <broadcast-groups>
+                <broadcast-group name="groupA">
+                    <local-bind-address>localhost</local-bind-address>
+                    <local-bind-port>12345</local-bind-port>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>23456</group-port>
+                    <broadcast-period>2500</broadcast-period>
+                    <connector-ref>netty</connector-ref>
+                    <connector-ref>netty-throughput</connector-ref>
+                </broadcast-group>
+                <broadcast-group name="groupB">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>34567</group-port>
+                </broadcast-group>
+                <broadcast-group name="groupS">
+                    <socket-binding>group-s-binding</socket-binding>
+                </broadcast-group>
+            </broadcast-groups>
+            <discovery-groups>
+                <discovery-group name="groupC">
+                    <local-bind-address>localhost</local-bind-address>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>45678</group-port>
+                    <refresh-timeout>3500</refresh-timeout>
+                    <initial-wait-timeout>7500</initial-wait-timeout>
+                </discovery-group>
+                <discovery-group name="groupD">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>56789</group-port>
+                </discovery-group>
+                <discovery-group name="groupT">
+                    <socket-binding>group-t-binding</socket-binding>
+                </discovery-group>
+            </discovery-groups>
+            <diverts>
+                <divert name="testDivert1">
+                    <routing-name>routing</routing-name>
+                    <address>address1</address>
+                    <forwarding-address>forwardingaddress1</forwarding-address>
+                    <filter string="afilter"/>
+                    <transformer-class-name>org.jboss.test.Transformer</transformer-class-name>
+                    <exclusive>true</exclusive>
+                </divert>
+                <divert name="testDivert2">
+                    <address>address2</address>
+                    <forwarding-address>forwardingaddress2</forwarding-address>
+                </divert>
+            </diverts>
+            <core-queues>
+                <queue name="coreQueueA">
+                    <address>addressA</address>
+                    <filter string="afilter"/>
+                    <durable>true</durable>
+                </queue>
+                <queue name="coreQueueB">
+                    <address>addressB</address>
+                </queue>
+            </core-queues>
+            <bridges>
+                <bridge name="bridge1">
+                    <queue-name>coreQueueA</queue-name>
+                    <forwarding-address>forwardingaddress1</forwarding-address>
+                    <ha>true</ha>
+                    <filter string="afilter"/>
+                    <transformer-class-name>foo.bar</transformer-class-name>
+                    <min-large-message-size>10240</min-large-message-size>
+                    <check-period>666</check-period>
+                    <connection-ttl>36000</connection-ttl>
+                    <retry-interval>750</retry-interval>
+                    <retry-interval-multiplier>2</retry-interval-multiplier>
+                    <max-retry-interval>3000</max-retry-interval>
+                    <reconnect-attempts>3</reconnect-attempts>
+                    <use-duplicate-detection>true</use-duplicate-detection>
+                    <confirmation-window-size>350</confirmation-window-size>
+                    <user>${user:Brian}</user>
+                    <password>${password:secret}</password>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </bridge>
+                <bridge name="bridge2">
+                    <queue-name>coreQueueB</queue-name>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </bridge>
+            </bridges>
+            <cluster-connections>
+                <cluster-connection name="cc1">
+                    <address>cc1-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <check-period>2345</check-period>
+                    <connection-ttl>1234</connection-ttl>
+                    <min-large-message-size>10245</min-large-message-size>
+                    <call-timeout>3456</call-timeout>
+                    <retry-interval>987</retry-interval>
+                    <retry-interval-multiplier>3.0</retry-interval-multiplier>
+                    <max-retry-interval>3600</max-retry-interval>
+                    <reconnect-attempts>-1</reconnect-attempts>
+                    <use-duplicate-detection>true</use-duplicate-detection>
+                    <forward-when-no-consumers>true</forward-when-no-consumers>
+                    <max-hops>7</max-hops>
+                    <confirmation-window-size>459</confirmation-window-size>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc2">
+                    <address>cc2-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <static-connectors allow-direct-connections-only="true">
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc3">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </cluster-connection>
+                <cluster-connection name="cc4">
+                    <address>cc4-address</address>
+                    <connector-ref>netty-throughput</connector-ref>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <!--  it is valid to have a cluster connection without
+                      a static-connector or discovery-group-ref when the node
+                      must accept connections from other cluster nodes but
+                      not connect to any other nodes.
+                 -->
+                <cluster-connection name="cc5">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                </cluster-connection>
+            </cluster-connections>
+            <grouping-handler name="grouping-handler">
+                <type>LOCAL</type>
+                <address>handler-address</address>
+                <timeout>5000</timeout>
+            </grouping-handler>
+            <security-settings>
+               <security-setting match="#">
+                   <permission roles="guest" type="send"/>
+                   <permission roles="guest" type="consume"/>
+                   <permission roles="guest" type="createNonDurableQueue"/>
+                   <permission roles="guest" type="deleteNonDurableQueue"/>
+                   <permission roles="adming" type="manage"/>
+               </security-setting>
+            </security-settings>
+            <address-settings>
+               <!--default for catch all-->
+               <address-setting match="#">
+                  <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+                  <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+                  <redelivery-delay>0</redelivery-delay>
+                  <max-delivery-attempts>5</max-delivery-attempts>
+                  <max-size-bytes>10485760</max-size-bytes>
+                  <page-size-bytes>10485760</page-size-bytes>
+                  <page-max-cache-size>7</page-max-cache-size>
+                  <address-full-policy>BLOCK</address-full-policy>
+                  <message-counter-history-day-limit>10</message-counter-history-day-limit>
+                  <last-value-queue>false</last-value-queue>
+                  <redistribution-delay>0</redistribution-delay>
+                  <send-to-dla-on-no-route>false</send-to-dla-on-no-route>
+               </address-setting>
+            </address-settings>
+
+            <connector-services>
+                <connector-service name="a">
+                    <factory-class>foo.bar</factory-class>
+                </connector-service>
+                <connector-service name="b">
+                    <factory-class>bar.foo</factory-class>
+                    <param key="foo" value="bar"/>
+                    <param key="bar" value="2"/>
+                </connector-service>
+            </connector-services>
+
+            <!--JMS Stuff-->
+            <jms-connection-factories>
+              <connection-factory name="InVmConnectionFactory">
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/ConnectionFactory"/>
+                 </entries>
+              </connection-factory>
+              <connection-factory name="RemoteConnectionFactory">
+                 <factory-type>XA_QUEUE</factory-type>
+                 <connectors>
+                    <connector-ref connector-name="netty"/>
+                 </connectors>
+                 <entries>
+                    <entry name="RemoteConnectionFactory"/>
+                 </entries>
+                 <client-id>testClient</client-id>
+              </connection-factory>
+              <connection-factory name="otherConnectionFactory">
+                 <discovery-group-ref discovery-group-name="groupC"/>
+                 <entries>
+                    <entry name="otherConnectionFactory"/>
+                 </entries>
+                 <ha>true</ha>
+                 <client-failure-check-period>12345</client-failure-check-period>
+                 <connection-ttl>56789</connection-ttl>
+                 <call-timeout>123</call-timeout>
+                 <consumer-window-size>456</consumer-window-size>
+                 <consumer-max-rate>789</consumer-max-rate>
+                 <confirmation-window-size>-1</confirmation-window-size>
+			     <producer-window-size>-1</producer-window-size>
+			     <producer-max-rate>1024</producer-max-rate>
+			     <cache-large-message-client>false</cache-large-message-client>
+			     <min-large-message-size>2048</min-large-message-size>
+			     <client-id>myClientID</client-id>
+			     <dups-ok-batch-size>256</dups-ok-batch-size>
+			     <transaction-batch-size>512</transaction-batch-size>
+			     <block-on-acknowledge>false</block-on-acknowledge>
+			     <block-on-non-durable-send>false</block-on-non-durable-send>
+			     <block-on-durable-send>false</block-on-durable-send>
+			     <auto-group>true</auto-group>
+			     <pre-acknowledge>true</pre-acknowledge>
+			     <retry-interval>500</retry-interval>
+			     <retry-interval-multiplier>2.5</retry-interval-multiplier>
+			     <max-retry-interval>10000</max-retry-interval>
+			     <reconnect-attempts>2</reconnect-attempts>
+			     <failover-on-initial-connection>true</failover-on-initial-connection>
+			     <failover-on-server-shutdown>true</failover-on-server-shutdown>
+				 <connection-load-balancing-policy-class-name>not.a.real.Class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>true</use-global-pools>
+				 <scheduled-thread-pool-max-size>24</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>48</thread-pool-max-size>
+				 <group-id>myGroup</group-id>
+              </connection-factory>
+              <pooled-connection-factory name="hornetq-ra">
+                 <inbound-config>
+                     <use-jndi>false</use-jndi>
+                     <jndi-params>whatever</jndi-params>
+                     <use-local-tx>true</use-local-tx>
+                     <setup-attempts>123</setup-attempts>
+                     <setup-interval>456</setup-interval>
+                 </inbound-config>
+                 <transaction mode="xa"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <min-pool-size>42</min-pool-size>
+                 <max-pool-size>242</max-pool-size>
+				 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsXA"/>
+                 </entries>
+                 <ha>true</ha>
+                 <client-failure-check-period>12345</client-failure-check-period>
+                 <connection-ttl>56789</connection-ttl>
+                 <call-timeout>123</call-timeout>
+                 <consumer-window-size>456</consumer-window-size>
+                 <consumer-max-rate>789</consumer-max-rate>
+                 <confirmation-window-size>-1</confirmation-window-size>
+			     <producer-window-size>-1</producer-window-size>
+			     <producer-max-rate>1024</producer-max-rate>
+                 <cache-large-message-client>false</cache-large-message-client>
+			     <min-large-message-size>2048</min-large-message-size>
+			     <client-id>myClientID</client-id>
+			     <dups-ok-batch-size>256</dups-ok-batch-size>
+			     <transaction-batch-size>512</transaction-batch-size>
+			     <block-on-acknowledge>false</block-on-acknowledge>
+			     <block-on-non-durable-send>false</block-on-non-durable-send>
+			     <block-on-durable-send>false</block-on-durable-send>
+			     <auto-group>true</auto-group>
+			     <pre-acknowledge>true</pre-acknowledge>
+			     <retry-interval>500</retry-interval>
+			     <retry-interval-multiplier>2.5</retry-interval-multiplier>
+			     <max-retry-interval>10000</max-retry-interval>
+			     <reconnect-attempts>2</reconnect-attempts>
+			     <failover-on-initial-connection>true</failover-on-initial-connection>
+			     <failover-on-server-shutdown>true</failover-on-server-shutdown>
+				 <connection-load-balancing-policy-class-name>not.a.real.Class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>true</use-global-pools>
+				 <scheduled-thread-pool-max-size>24</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>48</thread-pool-max-size>
+				 <group-id>myGroup</group-id>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-local">
+                 <transaction mode="local"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsLocal"/>
+                 </entries>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-none">
+                 <transaction mode="none"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsNone"/>
+                 </entries>
+              </pooled-connection-factory>
+           </jms-connection-factories>
+
+           <jms-destinations>
+              <jms-queue name="testQueue">
+                 <entry name="queue/test"/>
+                 <selector string="color='red'"/>
+                 <durable>true</durable>
+              </jms-queue>
+              <jms-topic name="testTopic">
+                 <entry name="topic/test"/>
+              </jms-topic>
+           </jms-destinations>
+        </hornetq-server>
+
+        <hornetq-server name="empty"/>
+    </subsystem>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_4.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_4.xml
@@ -1,0 +1,456 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:1.4">
+        <hornetq-server>
+            <clustered>true</clustered>
+            <!-- disable messaging persistence -->
+            <persistence-enabled>${persistence.enabled:false}</persistence-enabled>
+            <scheduled-thread-pool-max-size>${messaging.scheduled.thread.pool.max.size:6}</scheduled-thread-pool-max-size>
+            <thread-pool-max-size>${messaging.thread.pool.max.size:5}</thread-pool-max-size>
+            <security-domain>someDomain</security-domain>
+            <security-enabled>${security.enabled:false}</security-enabled>
+            <security-invalidation-interval>${security.invalidation.interval:1234}</security-invalidation-interval>
+            <wild-card-routing-enabled>${wild.card.routing.enabled:false}</wild-card-routing-enabled>
+            <management-address>${management.address:my.management.address}</management-address>
+            <management-notification-address>${management.notification.address:my.management.notif.address}</management-notification-address>
+            <cluster-user>${messaging.cluster.user.name}</cluster-user>
+            <cluster-password>${messaging.cluster.user.password}</cluster-password>
+            <jmx-management-enabled>${jmx.management.enabled:false}</jmx-management-enabled>
+            <jmx-domain>${jmx.domain:my.jmx.domain}</jmx-domain>
+            <message-counter-enabled>${message.counter.enabled:true}</message-counter-enabled>
+            <message-counter-sample-period>${message.counter.sample.period:7654}</message-counter-sample-period>
+            <message-counter-max-day-history>${message.counter.max.day.history:23}</message-counter-max-day-history>
+            <connection-ttl-override>${connection.ttl.override:5432}</connection-ttl-override>
+            <async-connection-execution-enabled>${async.connection.execution.enabled:false}</async-connection-execution-enabled>
+            <transaction-timeout>${transaction.timeout:4321}</transaction-timeout>
+            <transaction-timeout-scan-period>${transaction.timeout.scan.period:5432}</transaction-timeout-scan-period>
+            <message-expiry-scan-period>${message.expiry.scan.period:7654}</message-expiry-scan-period>
+            <message-expiry-thread-priority>${message.expiry.thread.priority:7}</message-expiry-thread-priority>
+            <id-cache-size>${id.cache.size:102030}</id-cache-size>
+            <persist-id-cache>${persist.id.cache:false}</persist-id-cache>
+            <remoting-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-interceptors>
+            <remoting-incoming-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-incoming-interceptors>
+            <remoting-outgoing-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-outgoing-interceptors>
+            <backup>${backup:false}</backup>
+            <allow-failback>${allow.failback:false}</allow-failback>
+            <failback-delay>${failback.delay:9876}</failback-delay>
+            <failover-on-shutdown>${failover.on.shutdown:true}</failover-on-shutdown>
+            <shared-store>${shared.store:true}</shared-store>
+            <persist-delivery-count-before-delivery>${persist.delivery.count.before.delivery:true}</persist-delivery-count-before-delivery>
+            <page-max-concurrent-io>${page.max.concurrent.io:10}</page-max-concurrent-io>
+            <create-bindings-dir>${create.bindings.dir:false}</create-bindings-dir>
+            <create-journal-dir>${create.journal.dir:true}</create-journal-dir>
+            <journal-type>${journal.type:NIO}</journal-type>
+            <journal-buffer-timeout>${journal.buffer.timeout:1357}</journal-buffer-timeout>
+            <journal-buffer-size>${journal.buffer.size:2468}</journal-buffer-size>
+            <journal-sync-transactional>${journal.sync.transactional:false}</journal-sync-transactional>
+            <journal-sync-non-transactional>${journal.sync.non.transactional:true}</journal-sync-non-transactional>
+            <log-journal-write-rate>${log.journal.write.rate:true}</log-journal-write-rate>
+            <!-- Default journal file size is 10Mb, reduced here to 100k for faster first boot -->
+            <journal-file-size>${journal.file.size:102400}</journal-file-size>
+            <journal-min-files>${journal.min.files:2}</journal-min-files>
+            <journal-compact-percentage>${journal.compact.percentage:83}</journal-compact-percentage>
+            <journal-compact-min-files>${journal.compact.min.files:2}</journal-compact-min-files>
+            <journal-max-io>${journal.max.io:50}</journal-max-io>
+            <perf-blast-pages>${perf.blast.pages:70}</perf-blast-pages>
+            <run-sync-speed-test>${run.sync.speed.test:false}</run-sync-speed-test>
+            <server-dump-interval>${server.dump.interval:8642}</server-dump-interval>
+            <memory-warning-threshold>1024</memory-warning-threshold>
+            <memory-measure-interval>2048</memory-measure-interval>
+            <check-for-live-server>${check.for.live.server:false}</check-for-live-server>
+            <backup-group-name>${backup.group.name:ngname}</backup-group-name>
+            <replication-clustername>${replication.clustername:repclustername}</replication-clustername>
+            <paging-directory path="${my.paging.dir:test}" relative-to="test" />
+            <bindings-directory path="${my.bindings.dir:test}" relative-to="test" />
+            <journal-directory path="${my.journal.dir:test}" relative-to="test" />
+            <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test" />
+            <connectors>
+               <netty-connector name="netty" socket-binding="messaging" />
+               <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="${batch.delay:50}"/>
+               </netty-connector>
+               <servlet-connector name="servlet" host="default-host" socket-binding="http" />
+               <servlet-connector name="servlet2" host="default-host2" socket-binding="http">
+                  <param key="batch-delay" value="${batch.delay:50}"/>
+               </servlet-connector>
+               <in-vm-connector name="in-vm" server-id="${my.server-id:0}">
+                  <param key="batch-delay" value="${batch.delay:50}"/>
+               </in-vm-connector>
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+                  <param key="key-store-path" value="path/to/server.jks"/>
+                  <param key="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+               </connector>
+            </connectors>
+            <acceptors>
+               <netty-acceptor name="netty" socket-binding="messaging" />
+               <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+                  <param key="direct-deliver" value="false"/>
+               </netty-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}">
+                   <param key="batch-delay" value="${batch.delay:50}"/>
+               </in-vm-acceptor>
+               <acceptor name="myacceptor">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
+                  <param key="batch-delay" value="${batch.delay:50}"/>
+               </acceptor>
+            </acceptors>
+            <broadcast-groups>
+                <broadcast-group name="groupA">
+                    <local-bind-address>localhost</local-bind-address>
+                    <local-bind-port>12345</local-bind-port>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>23456</group-port>
+                    <broadcast-period>${broadcast.period:2500}</broadcast-period>
+                    <connector-ref>netty</connector-ref>
+                    <connector-ref>netty-throughput</connector-ref>
+                </broadcast-group>
+                <broadcast-group name="groupB">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>34567</group-port>
+                </broadcast-group>
+                <broadcast-group name="groupS">
+                    <socket-binding>group-s-binding</socket-binding>
+                </broadcast-group>
+                <broadcast-group name="groupT">
+                    <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
+                    <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                </broadcast-group>
+            </broadcast-groups>
+            <discovery-groups>
+                <discovery-group name="groupC">
+                    <local-bind-address>localhost</local-bind-address>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>45678</group-port>
+                    <refresh-timeout>${refresh.timeout:3500}</refresh-timeout>
+                    <initial-wait-timeout>${initial.wait.timeout:7500}</initial-wait-timeout>
+                </discovery-group>
+                <discovery-group name="groupD">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>56789</group-port>
+                </discovery-group>
+                <discovery-group name="groupT">
+                    <socket-binding>group-t-binding</socket-binding>
+                </discovery-group>
+                <discovery-group name="groupU">
+                    <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
+                    <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                </discovery-group>
+            </discovery-groups>
+            <diverts>
+                <divert name="testDivert1">
+                    <routing-name>${routing.name:routing}</routing-name>
+                    <address>${address:address1}</address>
+                    <forwarding-address>${forwarding.address:forwardingaddress1}</forwarding-address>
+                    <filter string="${filter:afilter}"/>
+                    <transformer-class-name>org.jboss.test.Transformer</transformer-class-name>
+                    <exclusive>${exclusive:true}</exclusive>
+                </divert>
+                <divert name="testDivert2">
+                    <address>address2</address>
+                    <forwarding-address>forwardingaddress2</forwarding-address>
+                </divert>
+            </diverts>
+            <core-queues>
+                <queue name="coreQueueA">
+                    <address>${address:addressA}</address>
+                    <filter string="${filter:afilter}"/>
+                    <durable>${durable:true}</durable>
+                </queue>
+                <queue name="coreQueueB">
+                    <address>addressB</address>
+                </queue>
+            </core-queues>
+            <bridges>
+                <bridge name="bridge1">
+                    <queue-name>${queue.name:coreQueueA}</queue-name>
+                    <forwarding-address>${forwarding.address:forwardingaddress1}</forwarding-address>
+                    <ha>${ha:true}</ha>
+                    <filter string="${filter:afilter}"/>
+                    <transformer-class-name>foo.bar</transformer-class-name>
+                    <min-large-message-size>${min.large.message.size:10240}</min-large-message-size>
+                    <check-period>${check.period:666}</check-period>
+                    <connection-ttl>${connection.tt:36000}</connection-ttl>
+                    <retry-interval>${retry.interval:750}</retry-interval>
+                    <retry-interval-multiplier>${retry.interval.multiplier:2}</retry-interval-multiplier>
+                    <max-retry-interval>${max.retry.interval:3000}</max-retry-interval>
+                    <reconnect-attempts>${reconnect-attempts:3}</reconnect-attempts>
+                    <use-duplicate-detection>${use.duplicate.detection:true}</use-duplicate-detection>
+                    <confirmation-window-size>${confirmation.window.size:350}</confirmation-window-size>
+                    <user>${user:Brian}</user>
+                    <password>${password:secret}</password>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </bridge>
+                <bridge name="bridge2">
+                    <queue-name>coreQueueB</queue-name>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </bridge>
+            </bridges>
+            <cluster-connections>
+                <cluster-connection name="cc1">
+                    <address>${address:cc1-address}</address>
+                    <connector-ref>netty</connector-ref>
+                    <check-period>${check.period:2345}</check-period>
+                    <connection-ttl>${connection.ttl:1234}</connection-ttl>
+                    <min-large-message-size>${min.large.message.size:10245}</min-large-message-size>
+                    <call-timeout>${call.timeout:3456}</call-timeout>
+                    <call-failover-timeout>${call.failover.timeout:7890}</call-failover-timeout>
+                    <retry-interval>${retry.interval:987}</retry-interval>
+                    <retry-interval-multiplier>${retry.interval.multiplier:3.0}</retry-interval-multiplier>
+                    <max-retry-interval>${max.retry.interval:3600}</max-retry-interval>
+                    <reconnect-attempts>${reconnect.attempts:-1}</reconnect-attempts>
+                    <use-duplicate-detection>${use.duplicate.detection:true}</use-duplicate-detection>
+                    <forward-when-no-consumers>${forward.when.no.consumers:true}</forward-when-no-consumers>
+                    <max-hops>${max.hops:7}</max-hops>
+                    <confirmation-window-size>${confirmation.windows.size:459}</confirmation-window-size>
+                    <notification-attempts>${notification.attempts:2}</notification-attempts>
+                    <notification-interval>${notification.interval:1}</notification-interval>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc2">
+                    <address>cc2-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <static-connectors allow-direct-connections-only="true">
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc3">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </cluster-connection>
+                <cluster-connection name="cc4">
+                    <address>cc4-address</address>
+                    <connector-ref>netty-throughput</connector-ref>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+            </cluster-connections>
+            <grouping-handler name="grouping-handler">
+                <type>${grouping.type:LOCAL}</type>
+                <address>${address:handler-address}</address>
+                <timeout>${timeout:5000}</timeout>
+            </grouping-handler>
+            <security-settings>
+               <security-setting match="#">
+                   <permission roles="guest" type="send"/>
+                   <permission roles="guest" type="consume"/>
+                   <permission roles="guest" type="createNonDurableQueue"/>
+                   <permission roles="guest" type="deleteNonDurableQueue"/>
+                   <permission roles="adming" type="manage"/>
+               </security-setting>
+            </security-settings>
+            <address-settings>
+               <!--default for catch all-->
+               <address-setting match="#">
+                  <dead-letter-address>${dead.letter.address:jms.queue.DLQ}</dead-letter-address>
+                  <expiry-address>${expiry.address:jms.queue.ExpiryQueue}</expiry-address>
+                  <redelivery-delay>${redelivery.delay:0}</redelivery-delay>
+                  <max-delivery-attempts>${max.delivery.attempts:5}</max-delivery-attempts>
+                  <max-size-bytes>${max.size.bytes:10485760}</max-size-bytes>
+                  <page-size-bytes>${page.size.bytes:10485760}</page-size-bytes>
+                  <page-max-cache-size>${page.max.cache.size:7}</page-max-cache-size>
+                  <address-full-policy>${address.full.policy:BLOCK}</address-full-policy>
+                  <message-counter-history-day-limit>${message.counter.history.day.limit:10}</message-counter-history-day-limit>
+                  <last-value-queue>${last.value.queue:false}</last-value-queue>
+                  <redistribution-delay>${redistribution.delay:0}</redistribution-delay>
+                  <send-to-dla-on-no-route>${send.to.dla.on.no.route:false}</send-to-dla-on-no-route>
+               </address-setting>
+            </address-settings>
+
+            <connector-services>
+                <connector-service name="a">
+                    <factory-class>foo.bar</factory-class>
+                </connector-service>
+                <connector-service name="b">
+                    <factory-class>bar.foo</factory-class>
+                    <param key="foo" value="${connector.value:bar}"/>
+                    <param key="bar" value="2"/>
+                </connector-service>
+            </connector-services>
+
+            <!--JMS Stuff-->
+            <jms-connection-factories>
+              <connection-factory name="InVmConnectionFactory">
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="${connection-factory.entries.entry:java:/ConnectionFactory}"/>
+                 </entries>
+              </connection-factory>
+              <connection-factory name="RemoteConnectionFactory">
+                 <factory-type>XA_QUEUE</factory-type>
+                 <connectors>
+                    <connector-ref connector-name="netty"/>
+                 </connectors>
+                 <entries>
+                    <entry name="RemoteConnectionFactory"/>
+                 </entries>
+                 <client-id>testClient</client-id>
+              </connection-factory>
+              <connection-factory name="otherConnectionFactory">
+                 <discovery-group-ref discovery-group-name="groupC"/>
+                 <entries>
+                    <entry name="otherConnectionFactory"/>
+                 </entries>
+                 <ha>${ha:true}</ha>
+                 <client-failure-check-period>${client.failure.check.period:12345}</client-failure-check-period>
+                 <connection-ttl>${connection.ttl:56789}</connection-ttl>
+                 <call-timeout>${call.timeout:123}</call-timeout>
+                 <call-failover-timeout>${call.failover.timeout:456}</call-failover-timeout>
+                 <consumer-window-size>${consumer.window.size:456}</consumer-window-size>
+                 <consumer-max-rate>${consumer.max.rate:789}</consumer-max-rate>
+                 <confirmation-window-size>${confirmation.window.size:-1}</confirmation-window-size>
+			     <producer-window-size>${producer.window.size:-1}</producer-window-size>
+			     <producer-max-rate>${producer.max.rate:1024}</producer-max-rate>
+			     <compress-large-messages>${compress.large.messages:true}</compress-large-messages>
+			     <cache-large-message-client>${cache.large.message.client:false}</cache-large-message-client>
+			     <min-large-message-size>${min.large.message.size:2048}</min-large-message-size>
+			     <client-id>${client.id:myClientID}</client-id>
+			     <dups-ok-batch-size>${dups.ok.batch.size:256}</dups-ok-batch-size>
+			     <transaction-batch-size>${transaction.batch.size:512}</transaction-batch-size>
+			     <block-on-acknowledge>${block.on.acknowledge:false}</block-on-acknowledge>
+			     <block-on-non-durable-send>${block.on.non.durable.send:false}</block-on-non-durable-send>
+			     <block-on-durable-send>${block.on.durable.send:false}</block-on-durable-send>
+			     <auto-group>${auto.group:true}</auto-group>
+			     <pre-acknowledge>${pre.acknowledge:true}</pre-acknowledge>
+			     <retry-interval>${retry.interval:500}</retry-interval>
+			     <retry-interval-multiplier>${retry.interval.multiplier:2.5}</retry-interval-multiplier>
+			     <max-retry-interval>${max.retry.interval:10000}</max-retry-interval>
+			     <reconnect-attempts>${reconnect.attempts:2}</reconnect-attempts>
+			     <failover-on-initial-connection>${failover.on.initial.connection:true}</failover-on-initial-connection>
+				 <connection-load-balancing-policy-class-name>connection.load.balancy.policy.class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>${use.global.pools:true}</use-global-pools>
+				 <scheduled-thread-pool-max-size>${scheduled.thread.pool.max.size:24}</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>${thread.pool.max.size:48}</thread-pool-max-size>
+				 <group-id>${group.id:myGroup}</group-id>
+              </connection-factory>
+              <pooled-connection-factory name="hornetq-ra">
+                 <inbound-config>
+                     <use-jndi>${use.jndi:false}</use-jndi>
+                     <jndi-params>${jndi.params:whatever}</jndi-params>
+                     <use-local-tx>${use.local.tx:true}</use-local-tx>
+                     <setup-attempts>${setup-attempts:123}</setup-attempts>
+                     <setup-interval>${setup-interval:456}</setup-interval>
+                 </inbound-config>
+                 <transaction mode="${transaction:xa}"/>
+                 <user>${user:alice}</user>
+                 <password>${password:alicepassword}</password>
+                 <min-pool-size>${min.pool.size:42}</min-pool-size>
+                 <max-pool-size>${max.pool.size:242}</max-pool-size>
+                 <initial-message-packet-size>${initial.message.packet.size:9876}</initial-message-packet-size>
+                 <initial-connect-attempts>${initial.connect.attempts:5432}</initial-connect-attempts>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="${pooled-connection-factory.entries.entry:java:/JmsXA}"/>
+                 </entries>
+                 <ha>${ha:true}</ha>
+                 <client-failure-check-period>${client.failure.check.period:12345}</client-failure-check-period>
+                 <connection-ttl>${connection.ttl:6789}</connection-ttl>
+                 <call-timeout>${call.timeout:123}</call-timeout>
+                 <call-failover-timeout>${call.failover.timeout:456}</call-failover-timeout>
+                 <consumer-window-size>${consumer.window.size:456}</consumer-window-size>
+                 <consumer-max-rate>${consumer.max.rate:789}</consumer-max-rate>
+                 <confirmation-window-size>${confirmation.window.size:-1}</confirmation-window-size>
+			     <producer-window-size>${producer.window.size:-1}</producer-window-size>
+			     <producer-max-rate>${producer.max.rate:1024}</producer-max-rate>
+			     <compress-large-messages>${compress.large.messages:true}</compress-large-messages>
+			     <cache-large-message-client>${cache.large.message.client:false}</cache-large-message-client>
+			     <min-large-message-size>${min.large.message.size:2048}</min-large-message-size>
+			     <client-id>${client.id:myClientID}</client-id>
+			     <dups-ok-batch-size>${dups.ok.batch.size:256}</dups-ok-batch-size>
+			     <transaction-batch-size>${transaction.batch.size:512}</transaction-batch-size>
+			     <block-on-acknowledge>${block.on.acknowledge:false}</block-on-acknowledge>
+			     <block-on-non-durable-send>${block.on.non.durable.send:false}</block-on-non-durable-send>
+			     <block-on-durable-send>${block.on.durable.send:false}</block-on-durable-send>
+			     <auto-group>${auto.group:true}</auto-group>
+			     <pre-acknowledge>${pre.acknowledge:true}</pre-acknowledge>
+			     <retry-interval>${retry.interval:500}</retry-interval>
+			     <retry-interval-multiplier>${retry.interval.multiplier:2.5}</retry-interval-multiplier>
+			     <max-retry-interval>${max.retry.interval:10000}</max-retry-interval>
+			     <reconnect-attempts>${reconnect.attempts:2}</reconnect-attempts>
+			     <failover-on-initial-connection>${failover.on.initial.connection:true}</failover-on-initial-connection>
+				 <connection-load-balancing-policy-class-name>connection.load.balancing.policy.class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>${use.global.pools:true}</use-global-pools>
+				 <scheduled-thread-pool-max-size>${scheduled.thread.pool.max.size:24}</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>${thread.pool.max.size:48}</thread-pool-max-size>
+				 <group-id>${group.id:myGroup}</group-id>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-local">
+                 <transaction mode="local"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <use-auto-recovery>${use.auto.recovery:true}</use-auto-recovery>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsLocal"/>
+                 </entries>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-none">
+                 <transaction mode="none"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsNone"/>
+                 </entries>
+              </pooled-connection-factory>
+           </jms-connection-factories>
+
+           <jms-destinations>
+              <jms-queue name="testQueue">
+                 <entry name="${jms-queue.entry:queue/test}"/>
+                 <selector string="${selector:color='red'}"/>
+                 <durable>${durable:true}</durable>
+              </jms-queue>
+              <jms-topic name="testTopic">
+                 <entry name="${jms-topic.entry:topic/test}"/>
+              </jms-topic>
+           </jms-destinations>
+        </hornetq-server>
+
+        <hornetq-server name="empty"/>
+
+        <jms-bridge>
+            <source>
+                <connection-factory name="/cf/sourceCF" />
+                <destination name="/topic/anotherSourceTopic" />
+            </source>
+            <target>
+                <connection-factory name="/cf/targetCF" />
+                <destination name="anotherMQ/jms/queue/anotherTargetQueue" />
+            </target>
+            <quality-of-service>${quality.of.service:AT_MOST_ONCE}</quality-of-service>
+            <failure-retry-interval>${failure.retry.interval:45678}</failure-retry-interval>
+            <max-retries>${max.retries:7890}</max-retries>
+            <max-batch-size>${max.batch.size:12345}</max-batch-size>
+            <max-batch-time>${max.batch.time:10000}</max-batch-time>
+        </jms-bridge>
+    </subsystem>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/jms/JmsClientTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/jms/JmsClientTestCase.java
@@ -22,23 +22,6 @@
 
 package org.jboss.as.test.smoke.messaging.client.jms;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageListener;
-import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
-import javax.jms.QueueReceiver;
-import javax.jms.QueueSender;
-import javax.jms.QueueSession;
-import javax.jms.TextMessage;
-import javax.naming.Context;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
@@ -46,9 +29,21 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.jms.*;
+import javax.naming.Context;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.jms.Session.AUTO_ACKNOWLEDGE;
+import static org.junit.Assert.*;
 
 /**
  * Demo using the AS management API to create and destroy a JMS queue.
@@ -68,42 +63,62 @@ public class JmsClientTestCase {
     @ContainerResource
     private ManagementClient managementClient;
 
+    @Before
+
+    public void setUp() throws IOException {
+        // Create the destination using the management API
+        ModelNode op = new ModelNode();
+        op.get("operation").set("add");
+        op.get("address").add("subsystem", "messaging");
+        op.get("address").add("hornetq-server", "default");
+        op.get("address").add("jms-queue", QUEUE_NAME);
+        op.get("entries").add(EXPORTED_QUEUE_NAME);
+        applyUpdate(op, managementClient.getControllerClient());
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        // Remove the queue using the management API
+        ModelNode op = new ModelNode();
+        op.get("operation").set("remove");
+        op.get("address").add("subsystem", "messaging");
+        op.get("address").add("hornetq-server", "default");
+        op.get("address").add("jms-queue", QUEUE_NAME);
+        applyUpdate(op, managementClient.getControllerClient());
+    }
+
     @Test
-    public void testMessagingClient() throws Exception {
-        QueueConnection conn = null;
-        QueueSession session = null;
-        ModelControllerClient client = managementClient.getControllerClient();
+    public void testJMSOverTCP() throws  Exception {
+        doSendAndReceive("jms/RemoteConnectionFactory");
+    }
 
-        boolean actionsApplied = false;
+    @Test
+    public void testJMSOverHTTPWithServlet() throws  Exception {
+        doSendAndReceive("jms/ServletConnectionFactory");
+    }
+
+    private void doSendAndReceive(final String connectionFactoryLookupName) throws Exception {
+        Connection conn = null;
         try {
+            ConnectionFactory cf = (ConnectionFactory) remoteContext.lookup(connectionFactoryLookupName);
+            assertNotNull(cf);
+            Destination destination = (Destination) remoteContext.lookup(QUEUE_NAME);
+            assertNotNull(destination);
 
-            // Create the queue using the management API
-            ModelNode op = new ModelNode();
-            op.get("operation").set("add");
-            op.get("address").add("subsystem", "messaging");
-            op.get("address").add("hornetq-server", "default");
-            op.get("address").add("jms-queue", QUEUE_NAME);
-            op.get("entries").add(EXPORTED_QUEUE_NAME);
-            applyUpdate(op, client);
-            actionsApplied = true;
-
-            QueueConnectionFactory qcf = (QueueConnectionFactory) remoteContext.lookup("jms/RemoteConnectionFactory");
-            Queue queue = (Queue) remoteContext.lookup(QUEUE_NAME);
-
-            conn = qcf.createQueueConnection("guest", "guest");
+            conn = cf.createConnection("guest", "guest");
             conn.start();
-            session = conn.createQueueSession(false, QueueSession.AUTO_ACKNOWLEDGE);
+            Session session = conn.createSession(false, AUTO_ACKNOWLEDGE);
 
             final CountDownLatch latch = new CountDownLatch(10);
             final List<String> result = new ArrayList<String>();
 
             // Set the async listener
-            QueueReceiver recv = session.createReceiver(queue);
-            recv.setMessageListener(new MessageListener() {
+            MessageConsumer consumer = session.createConsumer(destination);
+            consumer.setMessageListener(new MessageListener() {
 
                 @Override
                 public void onMessage(Message message) {
-                    TextMessage msg = (TextMessage)message;
+                    TextMessage msg = (TextMessage) message;
                     try {
                         result.add(msg.getText());
                         latch.countDown();
@@ -113,41 +128,23 @@ public class JmsClientTestCase {
                 }
             });
 
-            QueueSender sender = session.createSender(queue);
+            MessageProducer producer = session.createProducer(destination);
             for (int i = 0 ; i < 10 ; i++) {
                 String s = "Test" + i;
                 TextMessage msg = session.createTextMessage(s);
-                sender.send(msg);
+                producer.send(msg);
             }
 
-            Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
-            Assert.assertEquals(10, result.size());
+            assertTrue(latch.await(3, SECONDS));
+            assertEquals(10, result.size());
             for (int i = 0 ; i < result.size() ; i++) {
-                Assert.assertEquals("Test" + i, result.get(i));
+                assertEquals("Test" + i, result.get(i));
             }
 
         } finally {
             try {
-                conn.stop();
-            } catch (Exception ignore) {
-            }
-            try {
-                session.close();
-            } catch (Exception ignore) {
-            }
-            try {
                 conn.close();
             } catch (Exception ignore) {
-            }
-
-            if(actionsApplied) {
-                // Remove the queue using the management API
-                ModelNode op = new ModelNode();
-                op.get("operation").set("remove");
-                op.get("address").add("subsystem", "messaging");
-                op.get("address").add("hornetq-server", "default");
-                op.get("address").add("jms-queue", QUEUE_NAME);
-                applyUpdate(op, client);
             }
         }
     }

--- a/testsuite/integration/src/test/xslt/addMessagingBackup.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingBackup.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:messaging="urn:jboss:domain:messaging:1.3">
+                xmlns:messaging="urn:jboss:domain:messaging:1.4">
 
 <xsl:output method="xml" indent="yes"/>
     <xsl:template match="//messaging:subsystem/messaging:hornetq-server">

--- a/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:messaging="urn:jboss:domain:messaging:1.3">
+                xmlns:messaging="urn:jboss:domain:messaging:1.4">
 
 <xsl:output method="xml" indent="yes"/>
     <xsl:template match="//messaging:subsystem/messaging:hornetq-server">


### PR DESCRIPTION
_Do not merge before Undertow 1.0.0.Alpha8 is integrated (that contains the [fix](https://github.com/undertow-io/undertow/commit/a52a4d09b26243b09526bd04407ef695c6f6e7b8)) to make the testJMSOverHTTPWithServlet test pass._
- bump messaging subsystem XML schema to urn:jboss:domain:messaging:1.4
- bump messaging management version to 1.3.0
- add servlet-connector resource to hornetq-server to define a connector
  that will connect to the HornetQ server over HTTP by tunneling through
  a Servlet
- add to the messaging subsystem XML config a servlet-connector and a
  JMS ConnectionFactory that uses it.
- add an optional dependency to the org.jboss.as.web-common module to be able
  to deploy the servlet from the org.jboss.as.messaging module
- add test JMSClientTestCase#testJMSOverHTTPWithServlet()
