### PR TITLE
[AS7-6873] NPE when calling a runtime operation on non-existing resource

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
@@ -62,6 +62,11 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
     }
 
     @Override
+    protected boolean resourceMustExist(OperationContext context, ModelNode operation) {
+        return false;
+    }
+
+    @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
 
         if (rollbackOperationIfServerNotActive(context, operation)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueControlHandler.java
@@ -77,6 +77,17 @@ public class QueueControlHandler extends AbstractQueueControlHandler<QueueContro
         }, flags);
     }
 
+    /*
+     * Do not check whether the queue resource exists.
+     *
+     * In the core queue resource does not exist, the {@link #executeRuntimeStep(org.jboss.as.controller.OperationContext, org.jboss.dmr.ModelNode)}
+     * will forward the operation to the corresponding runtime-queue.
+     */
+    @Override
+    protected boolean resourceMustExist(OperationContext context, ModelNode operation) {
+        return false;
+    }
+
     @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
         if (forwardToRuntimeQueue(context, operation, INSTANCE)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
@@ -79,6 +79,11 @@ public class QueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
     }
 
     @Override
+    protected boolean resourceMustExist(OperationContext context, ModelNode operation) {
+        return false;
+    }
+
+    @Override
     public void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
         if(ignoreOperationIfServerNotActive(context, operation)) {
             return;

--- a/messaging/src/main/java/org/jboss/as/messaging/SecurityRoleReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/SecurityRoleReadAttributeHandler.java
@@ -48,6 +48,11 @@ public class SecurityRoleReadAttributeHandler extends AbstractRuntimeOnlyHandler
     }
 
     @Override
+    protected boolean resourceMustExist(OperationContext context, ModelNode operation) {
+        return false;
+    }
+
+    @Override
     public void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
         final String attributeName = operation.require(ModelDescriptionConstants.NAME).asString();
 

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
@@ -106,6 +106,11 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
     private static class ListModuleRootsHandler extends AbstractRuntimeOnlyHandler {
 
         @Override
+        protected boolean resourceMustExist(OperationContext context, ModelNode operation) {
+            return false;
+        }
+
+        @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
 
             final ModelNode list = context.getResult().setEmptyList();


### PR DESCRIPTION
before executing the runtime step, call
context.readResource(EMPTY_ADDRESS, false) to ensure that there is a
resource. If that's not the case, the operation will fail with a
descriptive message instead of reporting an exception later on (such as
a NPE)

The issue is about a messaging resource but the problem is more general.
I don't think it should be possible to execute a runtime operation on a resource that does not exist. Is there a counter-example?
context.readResource(EMPTY_ADDRESS, false) looked like the simplest way to ensure that the resource exists at the given operation address... 
