### PR TITLE
[AS7-6876] defines security policy for JMS pooled cf

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
@@ -388,7 +388,11 @@ public class PooledConnectionFactoryService implements Service<Void> {
             pool = new CommonPoolImpl(minSize, maxSize, prefill, useStrictMin, flushStrategy);
         }
         CommonTimeOutImpl timeOut = new CommonTimeOutImpl(null, null, null, null, null);
-        CommonSecurityImpl security = null;
+        // <security>
+        //   <application />
+        // </security>
+        // => PoolStrategy.POOL_BY_CRI
+        CommonSecurityImpl security = new CommonSecurityImpl(null, null, true);
         // register the XA Connection *without* recovery. HornetQ already takes care of the registration with the correct credentials
         // when its ResourceAdapter is started
         Recovery recovery = new Recovery(new CredentialImpl(null, null, null), null, Boolean.TRUE);


### PR DESCRIPTION
create a security policy for JMS pooled-connection-factory with
application set to true in order to use a pool strategy of POOL_BY_CRI
instead of ONE_POOL.
