### PR TITLE
[AS7-6881] JMSService error during :reload operation

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSService.java
@@ -45,6 +45,8 @@ import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 import static org.jboss.msc.service.ServiceController.Mode.ACTIVE;
 import static org.jboss.msc.service.ServiceController.Mode.PASSIVE;
+import static org.jboss.msc.service.ServiceController.State.REMOVED;
+import static org.jboss.msc.service.ServiceController.State.STOPPING;
 
 /**
  * The {@code JMSServerManager} service.
@@ -97,10 +99,11 @@ public class JMSService implements Service<JMSServerManager> {
 
                 public void deActivate() {
                     // passivate the activation service only if the HornetQ server is deactivated when it fails back
-                    // and *not* during AS7 service container shutdown (AS7-6840)
-                    if (hornetqActivationController != null &&
-                            !hornetqActivationController.getServiceContainer().isShutdown()) {
-                        hornetqActivationController.setMode(PASSIVE);
+                    // and *not* during AS7 service container shutdown or reload (AS7-6840 / AS7-6881)
+                    if (hornetqActivationController != null) {
+                        if (!hornetqActivationController.getState().in(STOPPING, REMOVED)) {
+                            hornetqActivationController.compareAndSetMode(ACTIVE, PASSIVE);
+                        }
                     }
                 }
             });


### PR DESCRIPTION
- fix condition before removing the activation controller to handle both a
  server shutdown and a reload.
- add tests to check reload behaviours for hornetq-server in live and
  backup (active and passive) mode
