### PR TITLE
[JBPAPP6-1774] jconsole fails if trying to connect to a standalone EAP i...

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -23,6 +23,7 @@ package org.jboss.as.cli;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import com.sun.tools.jconsole.JConsoleContext;
 
 /**
  *
@@ -50,6 +51,8 @@ public abstract class CommandContextFactory {
     protected CommandContextFactory() {}
 
     public abstract CommandContext newCommandContext() throws CliInitializationException;
+
+    public abstract CommandContext newCommandContext(JConsoleContext jconsoleContext) throws CliInitializationException;
 
     public abstract CommandContext newCommandContext(String username, char[] password) throws CliInitializationException;
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -27,6 +27,8 @@ import java.io.OutputStream;
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
+import com.sun.tools.jconsole.JConsoleContext;
+import sun.tools.jconsole.ProxyClient;
 
 /**
  *
@@ -40,6 +42,19 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     @Override
     public CommandContext newCommandContext() throws CliInitializationException {
         final CommandContextImpl cmdCtx = new CommandContextImpl();
+        addShutdownHook(cmdCtx);
+        return cmdCtx;
+    }
+
+    public CommandContext newCommandContext(JConsoleContext jconsoleContext) throws CliInitializationException {
+        final CommandContextImpl cmdCtx = new CommandContextImpl();
+        ProxyClient proxyClient = (ProxyClient) jconsoleContext;
+        if (cmdCtx.getDefaultControllerPort() != proxyClient.getPort()) {
+            cmdCtx.setControllerPort(proxyClient.getPort());
+        }
+        if (!cmdCtx.getDefaultControllerHost().equalsIgnoreCase(proxyClient.getHostName())) {
+            cmdCtx.setControllerHost(proxyClient.getHostName());
+        }
         addShutdownHook(cmdCtx);
         return cmdCtx;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1052,6 +1052,14 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         return defaultControllerPort;
     }
 
+    public void setControllerHost(String controllerHost) {
+        this.controllerHost = controllerHost;
+    }
+
+    public void setControllerPort(int controllerPort) {
+        this.controllerPort = controllerPort;
+    }
+
     private void resetArgs(String cmdLine) throws CommandFormatException {
         if (cmdLine != null) {
             parsedCmd.parse(prefix, cmdLine);


### PR DESCRIPTION
...nstance running with offset ports

After this fix JConsole will not throw NullPointerException.  And all the following conditions will run successfully.

1).
###### 

./standalone.sh -Djboss.socket.binding.port-offset=100

JConsole URL
service:jmx:remoting-jmx://localhost:10099

2).
###### 

./standalone.sh -Djboss.socket.binding.port-offset=100 -bmanagement 10.3.238.71

JConsole URL
service:jmx:remoting-jmx://10.3.238.71:10099

3).
###### 

./standalone.sh -bmanagement 10.3.238.71

JConsole URL
service:jmx:remoting-jmx://10.3.238.71:9999

4).
###### 

./standalone.sh 

JConsole URL
service:jmx:remoting-jmx://localhost:9999
