### PR TITLE
[AS7-6892] fix wrong error message: pool-max-size may not be null

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentRuntimeHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentRuntimeHandler.java
@@ -174,7 +174,7 @@ public abstract class AbstractEJBComponentRuntimeHandler<T extends EJBComponent>
     protected void executeWriteAttribute(String attributeName, OperationContext context, ModelNode operation, T component,
                                          PathAddress address) throws OperationFailedException {
         if (componentType.hasPool() && POOL_MAX_SIZE.getName().equals(attributeName)) {
-            int newSize = POOL_MAX_SIZE.resolveModelAttribute(context, operation).asInt();
+            int newSize = operation.require(ModelDescriptionConstants.VALUE).asInt();
             final Pool<?> pool = componentType.getPool(component);
             final int oldSize = pool.getMaxSize();
             componentType.getPool(component).setMaxSize(newSize);


### PR DESCRIPTION
In jboss-cli I get:
/deployment=perftest-1.0.0.war/subsystem=ejb3/stateless-session-bean=PerfCall:write-attribute(name=pool-max-size,value=30)
{
    "outcome" => "failed",
    "failure-description" => "JBAS014746: pool-max-size may not be null",
    "rolled-back" => true
}
After this patch I get:
{
    "outcome" => "failed",
    "failure-description" => "JBAS014749: Operation handler failed: JBAS014338: Not implemented yet",
    "rolled-back" => true
}
which seems to be the right thing.
