### PR TITLE
get rid of servlet 2.5 dependency

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1347,8 +1347,8 @@
             <maven-bundle group="org.jboss.as" artifact="jboss-as-osgi-configadmin"/>
         </bundle-def>
 
-        <bundle-def name="javax.servlet.api" slot="v25">
-            <maven-bundle group="org.jboss.spec.javax.servlet" artifact="jboss-servlet-api_2.5_spec"/>
+        <bundle-def name="javax.servlet.api" slot="v31">
+            <maven-bundle group="org.jboss.spec.javax.servlet" artifact="jboss-servlet-api_3.1_spec"/>
         </bundle-def>
 
         <bundle-def name="org.jboss.osgi.logging">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1602,11 +1602,6 @@
 
                 <dependency>
                     <groupId>org.jboss.spec.javax.servlet</groupId>
-                    <artifactId>jboss-servlet-api_2.5_spec</artifactId>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.spec.javax.servlet</groupId>
                     <artifactId>jboss-servlet-api_3.1_spec</artifactId>
                 </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,6 @@
         <version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>1.0.4.Final</version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.0_spec>1.0.1.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.0_spec>
         <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>1.0.2.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>
-        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_2.5_spec>1.0.1.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_2.5_spec>
         <!-- needs to be removed when we swithc to undetow fully -->
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.0_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
@@ -4964,12 +4963,6 @@
                         <artifactId>jboss-servlet-api_3.0_spec</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.spec.javax.servlet</groupId>
-                <artifactId>jboss-servlet-api_2.5_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_2.5_spec}</version>
             </dependency>
 
             <!-- TODO This is workaround until all deps are in sync with 3.1 -->

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -768,7 +768,7 @@
                 </properties>
                 <capabilities>
                     <!-- modules registered with the OSGi layer on startup -->
-                    <capability name="javax.servlet.api:v25"/>
+                    <capability name="javax.servlet.api:v31"/>
                     <capability name="javax.transaction.api"/>
                     <!-- bundles started in startlevel 1 -->
                     <capability name="org.apache.felix.log" startlevel="1"/>


### PR DESCRIPTION
Only user left was OSGI and Thomas has no objections with upgrading this to 3.1
