### PR TITLE
[AS7-6927] add broadcast-group with non-existing connector-refs

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/BroadcastGroupAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BroadcastGroupAdd.java
@@ -24,6 +24,8 @@ package org.jboss.as.messaging;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.messaging.BroadcastGroupDefinition.CONNECTOR_REFS;
+import static org.jboss.as.messaging.BroadcastGroupDefinition.validateConnectors;
 import static org.jboss.as.messaging.CommonAttributes.JGROUPS_STACK;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
@@ -46,6 +48,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.interfaces.InetAddressUtil;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.network.NetworkInterfaceBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
@@ -72,8 +75,19 @@ public class BroadcastGroupAdd extends AbstractAddStepHandler {
     }
 
     @Override
+    protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.populateModel(context, operation, resource);
+
+        ModelNode connectorRefs = resource.getModel().get(CONNECTOR_REFS.getName());
+        if (connectorRefs.isDefined()) {
+            validateConnectors(context, operation, connectorRefs);
+        }
+    }
+
+    @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
         model.setEmptyObject();
+
         VALIDATOR.validateAndSet(operation, model);
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/BroadcastGroupWriteAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BroadcastGroupWriteAttributeHandler.java
@@ -23,17 +23,10 @@
 package org.jboss.as.messaging;
 
 import static org.jboss.as.controller.OperationContext.Stage.MODEL;
-import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 /**
@@ -60,32 +53,9 @@ public class BroadcastGroupWriteAttributeHandler extends ReloadRequiredWriteAttr
     protected void finishModelStage(final OperationContext context,final ModelNode operation,final String attributeName,final ModelNode newValue,
             final ModelNode oldValue,final Resource model) throws OperationFailedException {
             if(attributeName.equals(BroadcastGroupDefinition.CONNECTOR_REFS.getName())){
-                this.validateConnectorsUpdate(context, operation, newValue, oldValue,model);
+                BroadcastGroupDefinition.validateConnectors(context, operation, newValue);
             }
         super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
     }
 
-    private void validateConnectorsUpdate(OperationContext context, ModelNode operation, ModelNode newValue,
-            ModelNode oldValue, Resource model) throws OperationFailedException {
-        final Set<String> availableConnectors =  getAvailableConnectors(context,operation);
-        final List<ModelNode> operationAddress = operation.get(ModelDescriptionConstants.ADDRESS).asList();
-        final String broadCastGroup = operationAddress.get(operationAddress.size()-1).get(CommonAttributes.BROADCAST_GROUP).asString();
-        for(ModelNode connectorRef:newValue.asList()){
-            final String connectorName = connectorRef.asString();
-            if(!availableConnectors.contains(connectorName)){
-                throw MESSAGES.wrongConnectorRefInBroadCastGroup(broadCastGroup,connectorName,availableConnectors);
-            }
-        }
-    }
-
-    private Set<String> getAvailableConnectors(final OperationContext context,final ModelNode operation) throws OperationFailedException{
-        PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
-        PathAddress hornetqServer = MessagingServices.getHornetQServerPathAddress(address);
-        Resource hornetQServerResource = context.readResourceFromRoot(hornetqServer);
-        Set<String> availableConnectors = new HashSet<String>();
-        availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.IN_VM_CONNECTOR));
-        availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.REMOTE_CONNECTOR));
-        availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.CONNECTOR));
-        return availableConnectors;
-    }
 }


### PR DESCRIPTION
when a broadcast-group resource is created, validate that the
connector-refs exists (like it is already done when writing the
attribute)
- move common validateConnectors() method to BroadcastGroupDefinition
