### PR TITLE
AS7-6949 Don't read child resource twice; avoid NPE

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/model/RootResourceIterator.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/RootResourceIterator.java
@@ -50,9 +50,8 @@ class RootResourceIterator<T> {
                 if (current.hasChildren(type)) {
                     for (ResourceEntry entry : current.getChildren(type)) {
                         final PathElement pathElement = entry.getPathElement();
-                        final Resource child = current.getChild(pathElement);
                         final PathAddress childAddress = address.append(pathElement);
-                        doIterate(child, childAddress);
+                        doIterate(entry, childAddress);
                     }
                 }
             }


### PR DESCRIPTION
Kabir needs to review this, as there may have been a reason for reading the child resource twice, in which case a slightly different fix is needed.
