### PR TITLE
AS7-6029 AS7-6030 Add support for remote EJB tx recovery

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -68,7 +68,7 @@
         <module name="org.jboss.threads"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.common-core"/>
-        <module name="org.jboss.ejb-client"/>
+        <module name="org.jboss.ejb-client" services="import"/>
         <module name="org.jboss.ejb3"/>
         <module name="org.jboss.iiop-client"/>
         <module name="org.jboss.invocation"/>
@@ -76,6 +76,8 @@
         <module name="org.jboss.jandex"/>
         <!-- For SubordinationManager for remote Xid Transaction propagation -->
         <module name="org.jboss.jts"/>
+        <!-- For recovery manager (com.arjuna.ats.jbossatx.jta.RecoveryManagerService) -->
+        <module name="org.jboss.jts.integration"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river" services="import"/>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -24,14 +24,6 @@
 
 package org.jboss.as.ejb3;
 
-import java.io.File;
-import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.sql.SQLException;
-import java.util.Date;
-
-import javax.ejb.Timer;
-
 import org.jboss.as.ejb3.component.entity.EntityBeanComponentInstance;
 import org.jboss.as.ejb3.component.stateful.StatefulSessionComponentInstance;
 import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
@@ -48,6 +40,13 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.MessageInputStream;
+
+import javax.ejb.Timer;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.sql.SQLException;
+import java.util.Date;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
@@ -581,6 +580,11 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 14264, value = "Exception running timer task for timer %s on EJB %s")
     void exceptionRunningTimerTask(String timerId, String timedObjectId, @Cause  Exception e);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 14265, value = "Error during transaction recovery")
+    void errorDuringTransactionRecovery(@Cause Throwable cause);
+
 
 
     // Don't add message ids greater that 14299!!! If you need more first check what EjbMessages is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -21,6 +21,27 @@
  */
 package org.jboss.as.ejb3.component;
 
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.ejb.EJBHome;
+import javax.ejb.EJBLocalHome;
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagementType;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentView;
@@ -43,26 +64,6 @@ import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
-
-import javax.ejb.EJBHome;
-import javax.ejb.EJBLocalHome;
-import javax.ejb.TimerService;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagementType;
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.Principal;
-import java.security.PrivilegedAction;
-import java.util.Collections;
-import java.util.Map;
 
 import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -22,6 +22,21 @@
 
 package org.jboss.as.ejb3.component;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagementType;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponentCreateService;
 import org.jboss.as.ee.component.ComponentConfiguration;
@@ -40,20 +55,6 @@ import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
-
-import javax.ejb.TimerService;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagementType;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Jaikiran Pai

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -21,6 +21,19 @@
  */
 package org.jboss.as.ejb3.component;
 
+import java.beans.IntrospectionException;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
+
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.security.ServerSecurityManager;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
@@ -37,18 +50,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.util.propertyeditor.PropertyEditors;
-
-import javax.resource.ResourceException;
-import javax.resource.spi.ActivationSpec;
-import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
-import javax.transaction.UserTransaction;
-import java.beans.IntrospectionException;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 
 import static org.jboss.as.ejb3.EjbLogger.EJB3_LOGGER;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbDependencyDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbDependencyDeploymentUnitProcessor.java
@@ -83,7 +83,7 @@ public class EjbDependencyDeploymentUnitProcessor implements DeploymentUnitProce
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_IIOP_CLIENT, false, false, false, false));
 
         //we always have to add this, as even non-ejb deployments may still lookup IIOP ejb's
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_SUBSYSTEM, false, false, false, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_SUBSYSTEM, false, false, true, false));
 
         if (JacORBDeploymentMarker.isJacORBDeployment(deploymentUnit)) {
             //needed for dynamic IIOP stubs

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEjbClientContextService.java
@@ -90,7 +90,7 @@ public class DefaultEjbClientContextService implements Service<EJBClientContext>
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
-        final EJBClientContext clientContext = EJBClientContext.create(new LocalOnlyEjbClientConfiguration());
+        final EJBClientContext clientContext = EJBClientContext.create(new LocalOnlyEjbClientConfiguration(), this.getClass().getClassLoader());
         // register the default local EJB receiver (if present - app clients don't have local EJB receivers)
         final LocalEjbReceiver localEjbReceiver = this.defaultLocalEJBReceiver.getOptionalValue();
         if (localEjbReceiver != null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
@@ -27,6 +27,7 @@ import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 import org.jboss.as.ejb3.remote.protocol.versionone.VersionOneProtocolChannelReceiver;
+import org.jboss.as.ejb3.remote.protocol.versiontwo.VersionTwoProtocolChannelReceiver;
 import org.jboss.as.network.ClientMapping;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.remoting.AbstractStreamServerService;
@@ -265,18 +266,26 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
                     channel.close();
                     return;
                 }
+                final MarshallerFactory marshallerFactory = EJBRemoteConnectorService.this.getMarshallerFactory(clientMarshallingStrategy);
+                // enroll VersionOneProtocolChannelReceiver for handling subsequent messages on this channel
+                final DeploymentRepository deploymentRepository = EJBRemoteConnectorService.this.deploymentRepositoryInjectedValue.getValue();
+                final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector = EJBRemoteConnectorService.this.clusterRegistryCollector.getValue();
+                final RemoteAsyncInvocationCancelStatusService asyncInvocationCancelStatus = EJBRemoteConnectorService.this.remoteAsyncInvocationCancelStatus.getValue();
+
                 switch (version) {
                     case 0x01:
-                        final MarshallerFactory marshallerFactory = EJBRemoteConnectorService.this.getMarshallerFactory(clientMarshallingStrategy);
-                        // enroll VersionOneProtocolChannelReceiver for handling subsequent messages on this channel
-                        final DeploymentRepository deploymentRepository = EJBRemoteConnectorService.this.deploymentRepositoryInjectedValue.getValue();
-                        final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector = EJBRemoteConnectorService.this.clusterRegistryCollector.getValue();
-                        final RemoteAsyncInvocationCancelStatusService asyncInvocationCancelStatus = EJBRemoteConnectorService.this.remoteAsyncInvocationCancelStatus.getValue();
-                        final VersionOneProtocolChannelReceiver receiver = new VersionOneProtocolChannelReceiver(this.channelAssociation, deploymentRepository,
+                        final VersionOneProtocolChannelReceiver versionOneProtocolHandler = new VersionOneProtocolChannelReceiver(this.channelAssociation, deploymentRepository,
                                 EJBRemoteConnectorService.this.ejbRemoteTransactionsRepositoryInjectedValue.getValue(), clientMappingRegistryCollector,
                                 marshallerFactory, executorService.getValue(), asyncInvocationCancelStatus);
                         // trigger the receiving
-                        receiver.startReceiving();
+                        versionOneProtocolHandler.startReceiving();
+                        break;
+                    case 0x02:
+                        final VersionTwoProtocolChannelReceiver versionTwoProtocolHandler = new VersionTwoProtocolChannelReceiver(this.channelAssociation, deploymentRepository,
+                                EJBRemoteConnectorService.this.ejbRemoteTransactionsRepositoryInjectedValue.getValue(), clientMappingRegistryCollector,
+                                marshallerFactory, executorService.getValue(), asyncInvocationCancelStatus);
+                        // trigger the receiving
+                        versionTwoProtocolHandler.startReceiving();
                         break;
 
                     default:

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteTransactionsRepository.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteTransactionsRepository.java
@@ -27,8 +27,12 @@ import com.arjuna.ats.internal.jta.transaction.arjunacore.TransactionImple;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinateTransaction;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.SubordinationManager;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporter;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporterImple;
+import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.XATerminatorImple;
+import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import org.jboss.ejb.client.UserTransactionID;
 import org.jboss.ejb.client.XidTransactionID;
+import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -37,6 +41,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
+import javax.resource.spi.XATerminator;
 import javax.transaction.NotSupportedException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -44,14 +49,19 @@ import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.Xid;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Jaikiran Pai
  */
 public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransactionsRepository> {
+
+    private static final Logger logger = Logger.getLogger(EJBRemoteTransactionsRepository.class);
 
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("remote-transactions-repository");
 
@@ -59,10 +69,14 @@ public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransac
 
     private final InjectedValue<UserTransaction> userTransactionInjectedValue = new InjectedValue<UserTransaction>();
 
+    private final InjectedValue<RecoveryManagerService> recoveryManagerService = new InjectedValue<>();
+
     private final Map<UserTransactionID, Uid> userTransactions = Collections.synchronizedMap(new HashMap<UserTransactionID, Uid>());
 
     @Override
     public void start(StartContext context) throws StartException {
+        recoveryManagerService.getValue().addSerializableXAResourceDeserializer(EJBXAResourceDeserializer.INSTANCE);
+        logger.debug("Registered EJB XA resource deserializer " + EJBXAResourceDeserializer.INSTANCE);
     }
 
     @Override
@@ -150,6 +164,30 @@ public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransac
         return transactionImporter.importTransaction(xidTransactionID.getXid(), txTimeout);
     }
 
+    public Xid[] getXidsToRecoverForParentNode(final String parentNodeName, int recoveryFlags) throws XAException {
+        final Set<Xid> xidsToRecover = new HashSet<Xid>();
+        final TransactionImporter transactionImporter = SubordinationManager.getTransactionImporter();
+        if (transactionImporter instanceof TransactionImporterImple) {
+            final Set<Xid> inFlightXids = ((TransactionImporterImple) transactionImporter).getInflightXids(parentNodeName);
+            if (inFlightXids != null) {
+                xidsToRecover.addAll(inFlightXids);
+            }
+        }
+        final XATerminator xaTerminator = SubordinationManager.getXATerminator();
+        if (xaTerminator instanceof XATerminatorImple) {
+            final Xid[] inDoubtTransactions = ((XATerminatorImple) xaTerminator).doRecover(null, parentNodeName);
+            if (inDoubtTransactions != null) {
+                xidsToRecover.addAll(Arrays.asList(inDoubtTransactions));
+            }
+        } else {
+            final Xid[] inDoubtTransactions = xaTerminator.recover(recoveryFlags);
+            if (inDoubtTransactions != null) {
+                xidsToRecover.addAll(Arrays.asList(inDoubtTransactions));
+            }
+        }
+        return xidsToRecover.toArray(new Xid[0]);
+    }
+
     public UserTransaction getUserTransaction() {
         return this.userTransactionInjectedValue.getValue();
     }
@@ -160,6 +198,10 @@ public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransac
 
     public Injector<UserTransaction> getUserTransactionInjector() {
         return this.userTransactionInjectedValue;
+    }
+
+    public Injector<RecoveryManagerService> getRecoveryManagerInjector() {
+        return this.recoveryManagerService;
     }
 
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.transaction.xa.XAResource;
+
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientContextListener;
+import org.jboss.ejb.client.EJBClientManagedTransactionContext;
+import org.jboss.ejb.client.EJBReceiverContext;
+import org.jboss.logging.Logger;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.tm.XAResourceRecovery;
+
+/**
+ * Responsible for handing out the {@link #getXAResources() EJB XAResource(s)} during transaction recovery
+ *
+ * @author Jaikiran Pai
+ */
+public class EJBTransactionRecoveryService implements Service<EJBTransactionRecoveryService>, XAResourceRecovery, EJBClientContextListener {
+
+    private static final Logger logger = Logger.getLogger(EJBTransactionRecoveryService.class);
+
+    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("tx-recovery-service");
+    public static final EJBTransactionRecoveryService INSTANCE = new EJBTransactionRecoveryService();
+
+
+    private final List<EJBReceiverContext> receiverContexts = Collections.synchronizedList(new ArrayList<EJBReceiverContext>());
+    private final InjectedValue<RecoveryManagerService> recoveryManagerService = new InjectedValue<RecoveryManagerService>();
+    private final InjectedValue<CoreEnvironmentBean> arjunaTxCoreEnvironmentBean = new InjectedValue<CoreEnvironmentBean>();
+
+    private EJBTransactionRecoveryService() {
+    }
+
+    @Override
+    public void start(StartContext startContext) throws StartException {
+        // register ourselves to the recovery manager service
+        recoveryManagerService.getValue().addXAResourceRecovery(this);
+        logger.debug("Registered " + this + " with the transaction recovery manager");
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+        // we no longer bother about the XAResource(s)
+        this.receiverContexts.clear();
+        // un-register ourselves from the recovery manager service
+        recoveryManagerService.getValue().removeXAResourceRecovery(this);
+        logger.debug("Un-registered " + this + " from the transaction recovery manager");
+    }
+
+    @Override
+    public EJBTransactionRecoveryService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    @Override
+    public XAResource[] getXAResources() {
+        final XAResource[] xaResources = new XAResource[receiverContexts.size()];
+        synchronized (receiverContexts) {
+            for (int i = 0; i < receiverContexts.size(); i++) {
+                xaResources[i] = EJBClientManagedTransactionContext.getEJBXAResourceForRecovery(receiverContexts.get(i), arjunaTxCoreEnvironmentBean.getValue().getNodeIdentifier());
+            }
+        }
+        return xaResources;
+    }
+
+    @Override
+    public void contextClosed(EJBClientContext ejbClientContext) {
+    }
+
+    @Override
+    public void receiverRegistered(final EJBReceiverContext receiverContext) {
+        this.receiverContexts.add(receiverContext);
+    }
+
+    @Override
+    public void receiverUnRegistered(final EJBReceiverContext receiverContext) {
+        this.receiverContexts.remove(receiverContext);
+    }
+
+    public Injector<RecoveryManagerService> getRecoveryManagerServiceInjector() {
+        return this.recoveryManagerService;
+    }
+
+    public Injector<CoreEnvironmentBean> getCoreEnvironmentBeanInjector() {
+        return this.arjunaTxCoreEnvironmentBean;
+    }
+
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBXAResourceDeserializer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBXAResourceDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import com.arjuna.ats.jta.recovery.SerializableXAResourceDeserializer;
+import org.jboss.ejb.client.EJBClientManagedTransactionContext;
+import org.jboss.logging.Logger;
+
+import javax.transaction.xa.XAResource;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+/**
+ * A {@link SerializableXAResourceDeserializer} responsible for deserializing EJB XAResource(s)
+ *
+ * @author Jaikiran Pai
+ */
+class EJBXAResourceDeserializer implements SerializableXAResourceDeserializer {
+
+    private static final Logger logger = Logger.getLogger(EJBXAResourceDeserializer.class);
+
+    static final EJBXAResourceDeserializer INSTANCE = new EJBXAResourceDeserializer();
+
+    private EJBXAResourceDeserializer() {
+
+    }
+
+    @Override
+    public boolean canDeserialze(final String className) {
+        return EJBClientManagedTransactionContext.isEJBXAResourceClass(className);
+    }
+
+    @Override
+    public XAResource deserialze(final ObjectInputStream objectInputStream) throws IOException, ClassNotFoundException {
+        // just calling readObject is fine (see ObjectInputStream#latestUserDefinedLoader() for details on why we have to invoke this
+        // from within an EJB module class)
+        return (XAResource) objectInputStream.readObject();
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/TransactionRecoveryEJBClientContextInitializer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/TransactionRecoveryEJBClientContextInitializer.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote;
+
+import org.jboss.as.ejb3.EjbLogger;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientContextInitializer;
+
+/**
+ * Registers a {@link org.jboss.ejb.client.EJBClientContextListener} which will keep track of the EJB receivers that have been added to the EJB client contexts. Those receivers will then be used to query the server for
+ * any recoverable Xid(s)
+ *
+ * @author Jaikiran Pai
+ */
+public class TransactionRecoveryEJBClientContextInitializer implements EJBClientContextInitializer {
+    @Override
+    public void initialize(EJBClientContext context) {
+        context.registerEJBClientContextListener(EJBTransactionRecoveryService.INSTANCE);
+        EjbLogger.ROOT_LOGGER.debug("Registered " + EJBTransactionRecoveryService.INSTANCE + " as a listener to EJB client context " + context);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/AbstractMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/AbstractMessageHandler.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.ejb3.remote.protocol.versionone;
+package org.jboss.as.ejb3.remote.protocol;
 
 import java.io.DataInputStream;
 import java.io.DataOutput;
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.as.ejb3.EjbMessages;
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 import org.jboss.ejb.client.remoting.PackedInteger;
 import org.jboss.ejb.client.remoting.ProtocolV1ClassTable;
 import org.jboss.ejb.client.remoting.ProtocolV1ObjectTable;
@@ -53,7 +54,7 @@ import org.jboss.remoting3.MessageOutputStream;
 /**
  * @author Jaikiran Pai
  */
-abstract class AbstractMessageHandler implements MessageHandler {
+public abstract class AbstractMessageHandler implements MessageHandler {
 
     protected static final byte HEADER_NO_SUCH_EJB_FAILURE = 0x0A;
     protected static final byte HEADER_NO_SUCH_EJB_METHOD_FAILURE = 0x0B;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/MessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/MessageHandler.java
@@ -20,8 +20,9 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.ejb3.remote.protocol.versionone;
+package org.jboss.as.ejb3.remote.protocol;
 
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 import org.jboss.remoting3.MessageInputStream;
 
 import java.io.IOException;
@@ -29,7 +30,7 @@ import java.io.IOException;
 /**
  * User: jpai
  */
-interface MessageHandler {
+public interface MessageHandler {
 
     void processMessage(final ChannelAssociation channelAssociation, final MessageInputStream messageInputStream) throws IOException;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/EJBIdentifierBasedMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/EJBIdentifierBasedMessageHandler.java
@@ -26,6 +26,7 @@ import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.EjbDeploymentInformation;
 import org.jboss.as.ejb3.deployment.ModuleDeployment;
+import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
 
 /**
  * @author Jaikiran Pai

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
@@ -24,6 +24,7 @@ package org.jboss.as.ejb3.remote.protocol.versionone;
 
 import org.jboss.as.ejb3.component.interceptors.CancellationFlag;
 import org.jboss.as.ejb3.remote.RemoteAsyncInvocationCancelStatusService;
+import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
 import org.jboss.logging.Logger;
 import org.jboss.remoting3.MessageInputStream;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/TransactionRequestHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/TransactionRequestHandler.java
@@ -25,10 +25,12 @@ package org.jboss.as.ejb3.remote.protocol.versionone;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
+import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
 import org.jboss.ejb.client.TransactionID;
 import org.jboss.ejb.client.UserTransactionID;
 import org.jboss.ejb.client.XidTransactionID;
@@ -180,4 +182,9 @@ class TransactionRequestHandler extends AbstractMessageHandler {
         }
     }
 
+    // overridden here to allow package protected access to XidTransactionManagementTask
+    @Override
+    protected void writeException(ChannelAssociation channelAssociation, MarshallerFactory marshallerFactory, short invocationId, Throwable t, Map<String, Object> attachments) throws IOException {
+        super.writeException(channelAssociation, marshallerFactory, invocationId, t, attachments);
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -32,6 +32,7 @@ import org.jboss.as.ejb3.deployment.DeploymentRepositoryListener;
 import org.jboss.as.ejb3.deployment.ModuleDeployment;
 import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
 import org.jboss.as.ejb3.remote.RemoteAsyncInvocationCancelStatusService;
+import org.jboss.as.ejb3.remote.protocol.MessageHandler;
 import org.jboss.as.network.ClientMapping;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.remoting3.Channel;
@@ -65,14 +66,15 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     private static final byte HEADER_TX_FORGET_REQUEST = 0x12;
     private static final byte HEADER_TX_BEFORE_COMPLETION_REQUEST = 0x13;
 
-    private final ChannelAssociation channelAssociation;
-    private final DeploymentRepository deploymentRepository;
-    private final EJBRemoteTransactionsRepository transactionsRepository;
-    private final MarshallerFactory marshallerFactory;
-    private final ExecutorService executorService;
-    private final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector;
-    private final Set<ClusterTopologyUpdateListener> clusterTopologyUpdateListeners = Collections.synchronizedSet(new HashSet<ClusterTopologyUpdateListener>());
-    private final RemoteAsyncInvocationCancelStatusService remoteAsyncInvocationCancelStatus;
+
+    protected final ChannelAssociation channelAssociation;
+    protected final DeploymentRepository deploymentRepository;
+    protected final EJBRemoteTransactionsRepository transactionsRepository;
+    protected final MarshallerFactory marshallerFactory;
+    protected final ExecutorService executorService;
+    protected final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector;
+    protected final Set<ClusterTopologyUpdateListener> clusterTopologyUpdateListeners = Collections.synchronizedSet(new HashSet<ClusterTopologyUpdateListener>());
+    protected final RemoteAsyncInvocationCancelStatusService remoteAsyncInvocationCancelStatus;
 
     public VersionOneProtocolChannelReceiver(final ChannelAssociation channelAssociation, final DeploymentRepository deploymentRepository,
                                              final EJBRemoteTransactionsRepository transactionsRepository, final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector,
@@ -146,35 +148,10 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             if (EjbLogger.ROOT_LOGGER.isTraceEnabled()) {
                 EjbLogger.ROOT_LOGGER.trace("Got message with header 0x" + Integer.toHexString(header) + " on channel " + channel);
             }
-            MessageHandler messageHandler = null;
-            switch (header) {
-                case HEADER_INVOCATION_REQUEST:
-                    messageHandler = new MethodInvocationMessageHandler(this.deploymentRepository, this.marshallerFactory, this.executorService, this.remoteAsyncInvocationCancelStatus);
-                    break;
-                case HEADER_INVOCATION_CANCELLATION_REQUEST:
-                    messageHandler = new InvocationCancellationMessageHandler(this.remoteAsyncInvocationCancelStatus);
-                    break;
-                case HEADER_SESSION_OPEN_REQUEST:
-                    messageHandler = new SessionOpenRequestHandler(this.deploymentRepository, this.marshallerFactory, this.executorService);
-                    break;
-                case HEADER_TX_COMMIT_REQUEST:
-                    messageHandler = new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.COMMIT);
-                    break;
-                case HEADER_TX_ROLLBACK_REQUEST:
-                    messageHandler = new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.ROLLBACK);
-                    break;
-                case HEADER_TX_FORGET_REQUEST:
-                    messageHandler = new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.FORGET);
-                    break;
-                case HEADER_TX_PREPARE_REQUEST:
-                    messageHandler = new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.PREPARE);
-                    break;
-                case HEADER_TX_BEFORE_COMPLETION_REQUEST:
-                    messageHandler = new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.BEFORE_COMPLETION);
-                    break;
-                default:
-                    EjbLogger.ROOT_LOGGER.unsupportedMessageHeader(Integer.toHexString(header), channel);
-                    return;
+            final MessageHandler messageHandler = getMessageHandler((byte) header);
+            if (messageHandler == null) {
+                EjbLogger.ROOT_LOGGER.unsupportedMessageHeader(Integer.toHexString(header), channel);
+                return;
             }
             // process the message
             messageHandler.processMessage(channelAssociation, messageInputStream);
@@ -188,6 +165,35 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             IoUtils.safeClose(channel);
         } finally {
             IoUtils.safeClose(messageInputStream);
+        }
+    }
+
+    /**
+     * Returns a {@link MessageHandler} which can handle a message represented by the passed <code>header</code>. Returns null if there's no such {@link MessageHandler}
+     *
+     * @param header The message header
+     * @return
+     */
+    protected MessageHandler getMessageHandler(final byte header) {
+        switch (header) {
+            case HEADER_INVOCATION_REQUEST:
+                return new MethodInvocationMessageHandler(this.deploymentRepository, this.marshallerFactory, this.executorService, this.remoteAsyncInvocationCancelStatus);
+            case HEADER_INVOCATION_CANCELLATION_REQUEST:
+                return new InvocationCancellationMessageHandler(this.remoteAsyncInvocationCancelStatus);
+            case HEADER_SESSION_OPEN_REQUEST:
+                return new SessionOpenRequestHandler(this.deploymentRepository, this.marshallerFactory, this.executorService);
+            case HEADER_TX_COMMIT_REQUEST:
+                return new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.COMMIT);
+            case HEADER_TX_ROLLBACK_REQUEST:
+                return new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.ROLLBACK);
+            case HEADER_TX_FORGET_REQUEST:
+                return new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.FORGET);
+            case HEADER_TX_PREPARE_REQUEST:
+                return new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.PREPARE);
+            case HEADER_TX_BEFORE_COMPLETION_REQUEST:
+                return new TransactionRequestHandler(this.transactionsRepository, this.marshallerFactory, this.executorService, TransactionRequestHandler.TransactionRequestType.BEFORE_COMPLETION);
+            default:
+                return null;
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionCommitTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionCommitTask.java
@@ -57,11 +57,16 @@ class XidTransactionCommitTask extends XidTransactionManagementTask {
         // first associate the tx on this thread, by resuming the tx
         final Transaction transaction = this.transactionsRepository.getImportedTransaction(this.xidTransactionID);
         if (transaction == null) {
-            if (EjbLogger.EJB3_INVOCATION_LOGGER.isDebugEnabled()) {
-                //this happens if no ejb invocations where made within the TX
-                EjbLogger.EJB3_INVOCATION_LOGGER.debug("Not committing transaction " + this.xidTransactionID + " as is was not found on the server");
+            // check the recovery store - it's possible that the commit is coming in as part of recovery operation and the subordinate
+            // tx may not yet be in memory, but might be in the recovery store
+            final Transaction recoveredTransaction = tryRecoveryForImportedTransaction();
+            // still not found, so just return
+            if (recoveredTransaction == null) {
+                if (EjbLogger.EJB3_INVOCATION_LOGGER.isDebugEnabled()) {
+                    EjbLogger.EJB3_INVOCATION_LOGGER.debug("Not committing " + this.xidTransactionID + " as is was not found on the server");
+                }
+                return;
             }
-            return;
         }
         this.resumeTransaction(transaction);
         // now commit

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/TransactionRecoverMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/TransactionRecoverMessageHandler.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote.protocol.versiontwo;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+import javax.transaction.xa.Xid;
+
+import com.arjuna.ats.jta.utils.XAHelper;
+import org.jboss.as.ejb3.EjbLogger;
+import org.jboss.as.ejb3.EjbMessages;
+import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
+import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
+import org.jboss.ejb.client.XidTransactionID;
+import org.jboss.ejb.client.remoting.PackedInteger;
+import org.jboss.logging.Logger;
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.remoting3.MessageInputStream;
+import org.jboss.remoting3.MessageOutputStream;
+import org.xnio.IoUtils;
+
+/**
+ * Responsible for handling a transaction "recover" message from a EJB remote client
+ *
+ * @author Jaikiran Pai
+ */
+class TransactionRecoverMessageHandler extends AbstractMessageHandler {
+
+    private static final Logger logger = Logger.getLogger(TransactionRecoverMessageHandler.class);
+
+    private static final byte HEADER_TX_RECOVER_RESPONSE = 0x1A;
+
+    private final ExecutorService executorService;
+    private final MarshallerFactory marshallerFactory;
+    private final EJBRemoteTransactionsRepository transactionsRepository;
+
+    TransactionRecoverMessageHandler(final EJBRemoteTransactionsRepository transactionsRepository, final MarshallerFactory marshallerFactory,
+                                     final ExecutorService executorService) {
+        this.executorService = executorService;
+        this.transactionsRepository = transactionsRepository;
+        this.marshallerFactory = marshallerFactory;
+    }
+
+    @Override
+    public void processMessage(ChannelAssociation channelAssociation, MessageInputStream messageInputStream) throws IOException {
+        final DataInputStream input = new DataInputStream(messageInputStream);
+        // read the invocation id
+        final short invocationId = input.readShort();
+        final String txParentNodeName = input.readUTF();
+        final int recoveryFlags = input.readInt();
+        executorService.submit(new TxRecoveryTask(channelAssociation, invocationId, txParentNodeName, recoveryFlags));
+    }
+
+    private final class TxRecoveryTask implements Runnable {
+
+        private final String txParentNodeName;
+        private final short invocationId;
+        private final ChannelAssociation channelAssociation;
+        private final int recoveryFlags;
+
+        TxRecoveryTask(final ChannelAssociation channelAssociation, final short invocationId, final String txParentNodeName, final int recoveryFlags) {
+            this.txParentNodeName = txParentNodeName;
+            this.invocationId = invocationId;
+            this.channelAssociation = channelAssociation;
+            this.recoveryFlags = recoveryFlags;
+        }
+
+        @Override
+        public void run() {
+            Xid[] xidsToRecover = new Xid[0];
+            try {
+                xidsToRecover = transactionsRepository.getXidsToRecoverForParentNode(this.txParentNodeName, this.recoveryFlags);
+            } catch (Throwable t) {
+                try {
+                    EjbLogger.ROOT_LOGGER.errorDuringTransactionRecovery(t);
+                    // write out a failure message to the channel to let the client know that
+                    // the transaction operation failed
+                    TransactionRecoverMessageHandler.this.writeException(channelAssociation, marshallerFactory, invocationId, t, null);
+                } catch (IOException e) {
+                    EjbLogger.ROOT_LOGGER.couldNotWriteOutToChannel(e);
+                    // close the channel
+                    IoUtils.safeClose(channelAssociation.getChannel());
+                }
+                return;
+            }
+            try {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Returning " + xidsToRecover.length + " Xid(s) to recover for parent node: " + txParentNodeName);
+                    for (final Xid xid : xidsToRecover) {
+                        logger.trace("EJB Xid to recover " + XAHelper.xidToString(xid));
+                    }
+                }
+                // write out invocation success message to the channel
+                this.writeResponse(xidsToRecover);
+            } catch (IOException e) {
+                EjbLogger.ROOT_LOGGER.couldNotWriteInvocationSuccessMessage(e);
+                // close the channel
+                IoUtils.safeClose(this.channelAssociation.getChannel());
+            }
+        }
+
+        private void writeResponse(final Xid[] xids) throws IOException {
+            final DataOutputStream dataOutputStream;
+            final MessageOutputStream messageOutputStream;
+            try {
+                messageOutputStream = channelAssociation.acquireChannelMessageOutputStream();
+            } catch (Exception e) {
+                throw EjbMessages.MESSAGES.failedToOpenMessageOutputStream(e);
+            }
+            dataOutputStream = new DataOutputStream(messageOutputStream);
+            try {
+                // write header
+                dataOutputStream.writeByte(HEADER_TX_RECOVER_RESPONSE);
+                // write invocation id
+                dataOutputStream.writeShort(invocationId);
+                PackedInteger.writePackedInteger(dataOutputStream, xids.length);
+                if (xids.length > 0) {
+                    final Marshaller marshaller = TransactionRecoverMessageHandler.this.prepareForMarshalling(marshallerFactory, dataOutputStream);
+                    for (int i = 0; i < xids.length; i++) {
+                        marshaller.writeObject(new XidTransactionID(xids[i]));
+                    }
+                    // finish marshalling
+                    marshaller.finish();
+                }
+            } finally {
+                channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);
+                dataOutputStream.close();
+            }
+        }
+    }
+
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/VersionTwoProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/VersionTwoProtocolChannelReceiver.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.remote.protocol.versiontwo;
+
+import org.jboss.as.clustering.registry.RegistryCollector;
+import org.jboss.as.ejb3.deployment.DeploymentRepository;
+import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
+import org.jboss.as.ejb3.remote.RemoteAsyncInvocationCancelStatusService;
+import org.jboss.as.ejb3.remote.protocol.MessageHandler;
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
+import org.jboss.as.ejb3.remote.protocol.versionone.VersionOneProtocolChannelReceiver;
+import org.jboss.as.network.ClientMapping;
+import org.jboss.marshalling.MarshallerFactory;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class VersionTwoProtocolChannelReceiver extends VersionOneProtocolChannelReceiver {
+
+    private static final byte HEADER_TX_RECOVER_MESSAGE = 0x19;
+
+    public VersionTwoProtocolChannelReceiver(final ChannelAssociation channelAssociation, final DeploymentRepository deploymentRepository,
+                                             final EJBRemoteTransactionsRepository transactionsRepository, final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector,
+                                             final MarshallerFactory marshallerFactory, final ExecutorService executorService, final RemoteAsyncInvocationCancelStatusService asyncInvocationCancelStatusService) {
+        super(channelAssociation, deploymentRepository, transactionsRepository, clientMappingRegistryCollector, marshallerFactory, executorService, asyncInvocationCancelStatusService);
+    }
+
+
+    @Override
+    protected MessageHandler getMessageHandler(byte header) {
+        switch (header) {
+            case HEADER_TX_RECOVER_MESSAGE:
+                return new TransactionRecoverMessageHandler(this.transactionsRepository, this.marshallerFactory, this.executorService);
+            default:
+                return super.getMessageHandler(header);
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
@@ -25,10 +25,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
+import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import org.jboss.as.clustering.registry.RegistryCollector;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -48,6 +50,7 @@ import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
 import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
+import org.jboss.as.txn.service.TxnServices;
 import org.jboss.as.txn.service.UserTransactionService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -84,6 +87,7 @@ public class EJB3RemoteServiceAdd extends AbstractBoottimeAddStepHandler {
         final ServiceController transactionRepositoryServiceController = serviceTarget.addService(EJBRemoteTransactionsRepository.SERVICE_NAME, transactionsRepository)
                 .addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, transactionsRepository.getTransactionManagerInjector())
                 .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class, transactionsRepository.getUserTransactionInjector())
+                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, RecoveryManagerService.class, transactionsRepository.getRecoveryManagerInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
         newControllers.add(transactionRepositoryServiceController);
@@ -119,7 +123,7 @@ public class EJB3RemoteServiceAdd extends AbstractBoottimeAddStepHandler {
         final OptionMap channelCreationOptions = this.getChannelCreationOptions(context);
         // Install the EJB remoting connector service which will listen for client connections on the remoting channel
         // TODO: Externalize (expose via management API if needed) the version and the marshalling strategy
-        final EJBRemoteConnectorService ejbRemoteConnectorService = new EJBRemoteConnectorService((byte) 0x01, new String[]{"river"}, remotingServerServiceName, channelCreationOptions);
+        final EJBRemoteConnectorService ejbRemoteConnectorService = new EJBRemoteConnectorService((byte) 0x02, new String[]{"river"}, remotingServerServiceName, channelCreationOptions);
         final ServiceBuilder<EJBRemoteConnectorService> ejbRemoteConnectorServiceBuilder = serviceTarget.addService(EJBRemoteConnectorService.SERVICE_NAME, ejbRemoteConnectorService);
         // add dependency on the Remoting subsystem endpoint
         ejbRemoteConnectorServiceBuilder.addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, ejbRemoteConnectorService.getEndpointInjector());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
+import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 import org.jboss.as.clustering.registry.RegistryCollector;
 import org.jboss.as.clustering.registry.RegistryCollectorService;
 import org.jboss.as.connector.util.ConnectorServices;
@@ -97,6 +99,7 @@ import org.jboss.as.ejb3.iiop.RemoteObjectSubstitutionService;
 import org.jboss.as.ejb3.iiop.stub.DynamicStubFactoryFactory;
 import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
 import org.jboss.as.ejb3.remote.EJBRemoteConnectorService;
+import org.jboss.as.ejb3.remote.EJBTransactionRecoveryService;
 import org.jboss.as.ejb3.remote.LocalEjbReceiver;
 import org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService;
 import org.jboss.as.ejb3.util.ServiceLookupValue;
@@ -111,6 +114,7 @@ import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.server.deployment.jbossallxml.JBossAllXmlParserRegisteringProcessor;
+import org.jboss.as.txn.service.ArjunaRecoveryManagerService;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.as.txn.service.UserTransactionAccessControlService;
 import org.jboss.com.sun.corba.se.impl.javax.rmi.RemoteObjectSubstitutionManager;
@@ -374,6 +378,12 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         final ServiceBuilder<EJBClientContext> clientContextServiceBuilder = context.getServiceTarget().addService(DefaultEjbClientContextService.DEFAULT_SERVICE_NAME,
                 clientContextService).addDependency(TCCLEJBClientContextSelectorService.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME,
                 TCCLEJBClientContextSelectorService.class, clientContextService.getTCCLBasedEJBClientContextSelectorInjector());
+
+        // add the EJB remote tx recovery service
+        newControllers.add(serviceTarget.addService(EJBTransactionRecoveryService.SERVICE_NAME, EJBTransactionRecoveryService.INSTANCE)
+                .addDependency(ArjunaRecoveryManagerService.SERVICE_NAME, RecoveryManagerService.class, EJBTransactionRecoveryService.INSTANCE.getRecoveryManagerServiceInjector())
+                .addDependency(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT, CoreEnvironmentBean.class, EJBTransactionRecoveryService.INSTANCE.getCoreEnvironmentBeanInjector())
+                .install());
 
         if (!appclient) {
             // get the node name

--- a/ejb3/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientContextInitializer
+++ b/ejb3/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientContextInitializer
@@ -1,0 +1,1 @@
+org.jboss.as.ejb3.remote.TransactionRecoveryEJBClientContextInitializer

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb-client>1.0.17.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.19.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.0.0</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.0.Beta1</version.org.jboss.invocation>


### PR DESCRIPTION
The commits here fix the issues reported in:

https://issues.jboss.org/browse/AS7-6029
https://issues.jboss.org/browse/AS7-6030

which are related to transaction recovery not being functional. The commits introduce the necessary integration with the Narayana project recovery manager APIs to enable functioning of the remote EJB transactional XAResource.

P.S: There's a bug in Narayana project which will require a separate PR for upgrading it to a newer version, but this current PR need not wait for that.

Furthermore, this PR has around 3-4 classes which only differ in the import ordering. I've included them in this PR since the import ordering in those classes was messed up by me in one previous PR.
