### PR TITLE
[AS7-6968] Fix issues building on IBM JDK 7

### DIFF
--- a/osgi/service/pom.xml
+++ b/osgi/service/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-subsystem-test</artifactId>
-						<type>pom</type>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiSubsystemTestCase.java
+++ b/osgi/service/src/test/java/org/jboss/as/osgi/parser/OSGiSubsystemTestCase.java
@@ -257,7 +257,7 @@ public class OSGiSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
     @Test
     public void testTransformerAS712() throws Exception {
-        testTransformers1_0_0(ModelTestControllerVersion.V7_1_2_FINAL, "org.jboss.as:jboss-as-osgi-service:7.1.2.Final");
+        testTransformers1_0_0(ModelTestControllerVersion.V7_1_2_FINAL, "org.jboss.as:jboss-as-osgi-service:7.1.2.Final", "org.jboss.osgi.framework:jbosgi-framework-core:1.3.0.Final");
     }
 
     @Test
@@ -300,22 +300,26 @@ public class OSGiSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testRejectExpressionsAS712() throws Exception {
-        testRejectExpressions1_0_0(ModelTestControllerVersion.V7_1_2_FINAL);
+        testRejectExpressions1_0_0(ModelTestControllerVersion.V7_1_2_FINAL, "org.jboss.osgi.framework:jbosgi-framework-core:1.3.0.Final");
     }
 
     @Test
     public void testRejectExpressionsAS713() throws Exception {
-        testRejectExpressions1_0_0(ModelTestControllerVersion.V7_1_3_FINAL);
+        testRejectExpressions1_0_0(ModelTestControllerVersion.V7_1_3_FINAL, "org.jboss.osgi.framework:jbosgi-framework-core:1.3.1.CR1");
     }
 
-    private void testRejectExpressions1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
+    private void testRejectExpressions1_0_0(ModelTestControllerVersion controllerVersion, String... mavenGAVs) throws Exception {
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
         // create builder for legacy subsystem version
         ModelVersion version_1_0_0 = ModelVersion.create(1, 0, 0);
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version_1_0_0)
+        LegacyKernelServicesInitializer legacyInitializer = builder.createLegacyKernelServicesBuilder(null, controllerVersion, version_1_0_0)
                 .addMavenResourceURL("org.jboss.as:jboss-as-osgi-service:" + controllerVersion.getMavenGavVersion());
+        for (String mavenGAV : mavenGAVs) {
+            legacyInitializer.addMavenResourceURL(mavenGAV);
+        }
+
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(version_1_0_0);

--- a/pom.xml
+++ b/pom.xml
@@ -3305,6 +3305,12 @@
                 <groupId>org.apache.ws.xmlschema</groupId>
                 <artifactId>xmlschema-core</artifactId>
                 <version>${version.org.apache.ws.xmlschema}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.bcel</groupId>
+                        <artifactId>bcel</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
o Fix osgi unit tests to load older versions of jbosgi-framework-core
o xmlschema-core pom contains a profile with a transitive dependency on bcel when using IBM JDK.
