### PR TITLE
fix for WFLY-1282

### DIFF
--- a/web/src/main/java/org/jboss/as/web/WebReWriteConditionDefinition.java
+++ b/web/src/main/java/org/jboss/as/web/WebReWriteConditionDefinition.java
@@ -57,6 +57,7 @@ public class WebReWriteConditionDefinition extends SimpleResourceDefinition {
     protected static final SimpleAttributeDefinition FLAGS =
             new SimpleAttributeDefinitionBuilder(Constants.FLAGS, ModelType.STRING, false)
                     .setAllowExpression(true)
+                    .setAllowNull(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setValidator(new StringLengthValidator(1, false, true))
                     .build();

--- a/web/src/main/java/org/jboss/as/web/WebVirtualHostAdd.java
+++ b/web/src/main/java/org/jboss/as/web/WebVirtualHostAdd.java
@@ -177,7 +177,7 @@ class WebVirtualHostAdd extends AbstractAddStepHandler {
             if (prop.getValue().hasDefined(Constants.CONDITION)) {
                 for (Property conditionProp : prop.getValue().get(Constants.CONDITION).asPropertyList()) {
                     ModelNode resolvedCondition = resolveExpressions(context, conditionProp.getValue(), WebReWriteConditionDefinition.ATTRIBUTES);
-                    resolvedParent.get(Constants.CONDITION, conditionProp.getName()).set(resolvedCondition);
+                    result.get(prop.getName()).get(Constants.CONDITION, conditionProp.getName()).set(resolvedCondition);
                 }
             }
         }


### PR DESCRIPTION
The conditions of rules in the rewrite valves were ignored.
Additionally the default value for flags in conditions is AND and flags was mandatory so not way to get AND working.
