### PR TITLE
[WFLY-411] Support for dynamic trust store updates.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.security;
+
+import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableEntryException;
+import java.security.cert.CertificateException;
+
+import org.jboss.msc.service.StartException;
+
+/**
+ * Store the keystore and last modification date. Able to reload the keystore incase
+ * the file has changed
+ *
+ * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ *
+ */
+public final class FileKeystore {
+
+    private KeyStore keyStore;
+    private final String path;
+    private long lastModificationTime;
+    private final char[] keystorePassword;
+    private final char[] keyPassword;
+    private final String alias;
+
+    public FileKeystore(final String path, final char[] keystorePassword, final char[] keyPassword,final String alias) {
+        this.path = path;
+        this.keystorePassword = keystorePassword;
+        this.keyPassword = keyPassword;
+        this.alias = alias;
+        this.lastModificationTime = 0;
+    }
+
+    /**
+     * @return true if the keystore file is modified since it was loaded the first time
+     */
+    public boolean isModified() {
+        long lastModified = new File(path).lastModified();
+        if (lastModified > this.lastModificationTime) {
+            return true;
+        } else if (lastModified == 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Load the keystore file and cache the keystore. if the keystore file has changed
+     * call load() again for updating the keystore
+     * @throws StartException
+     */
+    public void load() throws StartException {
+        FileInputStream fis = null;
+        try {
+            KeyStore loadedKeystore = KeyStore.getInstance("JKS");
+
+            if (new File(path).exists()) {
+                fis = new FileInputStream(path);
+                loadedKeystore.load(fis, keystorePassword);
+            } else {
+                loadedKeystore.load(null);
+            }
+
+            if (alias == null) {
+                this.setKeyStore(loadedKeystore);
+            } else {
+                KeyStore newKeystore = KeyStore.getInstance("JKS");
+                newKeystore.load(null);
+
+                KeyStore.ProtectionParameter passParam = new KeyStore.PasswordProtection(keyPassword == null ? keystorePassword
+                        : keyPassword);
+                KeyStore.Entry entry = loadedKeystore.getEntry(this.alias, passParam);
+                newKeystore.setEntry(alias, entry, passParam);
+
+                this.setKeyStore(newKeystore);
+            }
+            this.lastModificationTime = new File(path).lastModified();
+        } catch (KeyStoreException e) {
+            throw MESSAGES.unableToStart(e);
+        } catch (NoSuchAlgorithmException e) {
+            throw MESSAGES.unableToStart(e);
+        } catch (CertificateException e) {
+            throw MESSAGES.unableToStart(e);
+        } catch (IOException e) {
+            throw MESSAGES.unableToStart(e);
+        } catch (UnrecoverableEntryException e) {
+            throw MESSAGES.unableToStart(e);
+        } finally {
+            safeClose(fis);
+        }
+    }
+
+    /**
+     * @return the current cached keystore.
+     */
+    public KeyStore getKeyStore() {
+        return keyStore;
+    }
+
+    private void setKeyStore(KeyStore keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    private void safeClose(Closeable c) {
+        if (c != null) {
+            try {
+                c.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+
+
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLIdentityService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLIdentityService.java
@@ -87,11 +87,11 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
             if (theTrustStore != null) {
                 trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
                 trustManagerFactory.init(theTrustStore.getKeyStore());
-                TrustManager[] tmpTrustManagers = trustManagerFactory.getTrustManagers();
 
+                TrustManager[] tmpTrustManagers = trustManagerFactory.getTrustManagers();
                 trustManagers = new TrustManager[tmpTrustManagers.length];
                 for (int i = 0; i < tmpTrustManagers.length; i++) {
-                    trustManagers[i] = new DeligatingTrustManager((X509TrustManager) tmpTrustManagers[i],theTrustStore);
+                    trustManagers[i] = new DeligatingTrustManager((X509TrustManager) tmpTrustManagers[i], theTrustStore);
                 }
             }
 
@@ -106,7 +106,7 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
                 sslContext.init(null, trustManagers, null);
             }
             trustOnlyContext = sslContext;
-       } catch (NoSuchAlgorithmException nsae) {
+        } catch (NoSuchAlgorithmException nsae) {
             throw MESSAGES.unableToStart(nsae);
         } catch (KeyManagementException kme) {
             throw MESSAGES.unableToStart(kme);
@@ -144,61 +144,61 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
         return (truststore.getOptionalValue() != null);
     }
 
-   private class DeligatingTrustManager implements X509TrustManager {
+    private class DeligatingTrustManager implements X509TrustManager {
 
-    private X509TrustManager delegate;
-    private final FileKeystore theTrustStore;
+        private X509TrustManager delegate;
+        private final FileKeystore theTrustStore;
 
-    public DeligatingTrustManager(X509TrustManager trustManager, FileKeystore theTrustStore) {
-        this.delegate = trustManager;
-        this.theTrustStore = theTrustStore;
-    }
+        public DeligatingTrustManager(X509TrustManager trustManager, FileKeystore theTrustStore) {
+            this.delegate = trustManager;
+            this.theTrustStore = theTrustStore;
+        }
 
-    @Override
-    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        getDelegate().checkClientTrusted(chain, authType);
-    }
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            getDelegate().checkClientTrusted(chain, authType);
+        }
 
-    @Override
-    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        getDelegate().checkServerTrusted(chain, authType);
-    }
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            getDelegate().checkServerTrusted(chain, authType);
+        }
 
-    @Override
-    public X509Certificate[] getAcceptedIssuers() {
-        return getDelegate().getAcceptedIssuers();
-    }
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return getDelegate().getAcceptedIssuers();
+        }
 
-    /*
-     * Internal Methods
-     */
-    private synchronized X509TrustManager getDelegate() {
-        if (theTrustStore.isModified()) {
-            try {
-                theTrustStore.load();
-            } catch (StartException e1) {
-                throw new IllegalStateException("Unable to load key trust file.");
-            }
-            try {
-                trustManagerFactory.init(theTrustStore.getKeyStore());
-                TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-                for (TrustManager current : trustManagers) {
-                    if (current instanceof X509TrustManager) {
-                        delegate = (X509TrustManager) current;
-                        break;
-                    }
+        /*
+         * Internal Methods
+         */
+        private synchronized X509TrustManager getDelegate() {
+            if (theTrustStore.isModified()) {
+                try {
+                    theTrustStore.load();
+                } catch (StartException e1) {
+                    throw new IllegalStateException("Unable to load key trust file.");
                 }
-            } catch (GeneralSecurityException e) {
-                throw new IllegalStateException("Unable to operate on trust store.", e);
+                try {
+                    trustManagerFactory.init(theTrustStore.getKeyStore());
+                    TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+                    for (TrustManager current : trustManagers) {
+                        if (current instanceof X509TrustManager) {
+                            delegate = (X509TrustManager) current;
+                            break;
+                        }
+                    }
+                } catch (GeneralSecurityException e) {
+                    throw new IllegalStateException("Unable to operate on trust store.", e);
 
+                }
             }
-        }
-        if (delegate == null) {
-            throw new IllegalStateException("Unable to create delegate trust manager.");
+            if (delegate == null) {
+                throw new IllegalStateException("Unable to create delegate trust manager.");
+            }
+
+            return delegate;
         }
 
-        return delegate;
     }
-
-   }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLIdentityService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLIdentityService.java
@@ -24,17 +24,20 @@ package org.jboss.as.domain.management.security;
 
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
 
+import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
-import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 import org.jboss.as.domain.management.SSLIdentity;
 import org.jboss.msc.service.Service;
@@ -55,11 +58,13 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
     private final String protocol;
     private final char[] keystorePassword;
     private final char[] keyPassword;
-    private final InjectedValue<KeyStore> keystore = new InjectedValue<KeyStore>();
-    private final InjectedValue<KeyStore> truststore = new InjectedValue<KeyStore>();
+    private final InjectedValue<FileKeystore> keystore = new InjectedValue<FileKeystore>();
+    private final InjectedValue<FileKeystore> truststore = new InjectedValue<FileKeystore>();
 
     private volatile SSLContext fullContext;
     private volatile SSLContext trustOnlyContext;
+
+    private TrustManagerFactory trustManagerFactory;
 
     public SSLIdentityService(String protocol, char[] keystorePassword, char[] keyPassword) {
         this.protocol = protocol;
@@ -70,19 +75,24 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
     public void start(StartContext context) throws StartException {
         try {
             KeyManager[] keyManagers = null;
-            KeyStore theKeyStore = keystore.getOptionalValue();
-            if (theKeyStore != null) {
+            FileKeystore theKeyStore = keystore.getOptionalValue();
+            if (theKeyStore.getKeyStore() != null) {
                 KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-                keyManagerFactory.init(theKeyStore, keyPassword == null ? keystorePassword : keyPassword);
+                keyManagerFactory.init(theKeyStore.getKeyStore(), keyPassword == null ? keystorePassword : keyPassword);
                 keyManagers = keyManagerFactory.getKeyManagers();
             }
 
             TrustManager[] trustManagers = null;
-            KeyStore theTrustStore = truststore.getOptionalValue();
+            FileKeystore theTrustStore = truststore.getOptionalValue();
             if (theTrustStore != null) {
-                TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-                trustManagerFactory.init(theTrustStore);
-                trustManagers = trustManagerFactory.getTrustManagers();
+                trustManagerFactory = TrustManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                trustManagerFactory.init(theTrustStore.getKeyStore());
+                TrustManager[] tmpTrustManagers = trustManagerFactory.getTrustManagers();
+
+                trustManagers = new TrustManager[tmpTrustManagers.length];
+                for (int i = 0; i < tmpTrustManagers.length; i++) {
+                    trustManagers[i] = new DeligatingTrustManager((X509TrustManager) tmpTrustManagers[i],theTrustStore);
+                }
             }
 
             SSLContext sslContext = SSLContext.getInstance(protocol);
@@ -114,11 +124,11 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
         return this;
     }
 
-    public InjectedValue<KeyStore> getKeyStoreInjector() {
+    public InjectedValue<FileKeystore> getKeyStoreInjector() {
         return keystore;
     }
 
-    public InjectedValue<KeyStore> getTrustStoreInjector() {
+    public InjectedValue<FileKeystore> getTrustStoreInjector() {
         return truststore;
     }
 
@@ -134,4 +144,61 @@ class SSLIdentityService implements Service<SSLIdentity>, SSLIdentity {
         return (truststore.getOptionalValue() != null);
     }
 
+   private class DeligatingTrustManager implements X509TrustManager {
+
+    private X509TrustManager delegate;
+    private final FileKeystore theTrustStore;
+
+    public DeligatingTrustManager(X509TrustManager trustManager, FileKeystore theTrustStore) {
+        this.delegate = trustManager;
+        this.theTrustStore = theTrustStore;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        getDelegate().checkClientTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        getDelegate().checkServerTrusted(chain, authType);
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return getDelegate().getAcceptedIssuers();
+    }
+
+    /*
+     * Internal Methods
+     */
+    private synchronized X509TrustManager getDelegate() {
+        if (theTrustStore.isModified()) {
+            try {
+                theTrustStore.load();
+            } catch (StartException e1) {
+                throw new IllegalStateException("Unable to load key trust file.");
+            }
+            try {
+                trustManagerFactory.init(theTrustStore.getKeyStore());
+                TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+                for (TrustManager current : trustManagers) {
+                    if (current instanceof X509TrustManager) {
+                        delegate = (X509TrustManager) current;
+                        break;
+                    }
+                }
+            } catch (GeneralSecurityException e) {
+                throw new IllegalStateException("Unable to operate on trust store.", e);
+
+            }
+        }
+        if (delegate == null) {
+            throw new IllegalStateException("Unable to create delegate trust manager.");
+        }
+
+        return delegate;
+    }
+
+   }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -35,11 +35,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USERS;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.KEYSTORE_PATH;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.PASSWORD;
-import static org.jboss.as.domain.management.ModelDescriptionConstants.PROPERTY;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.PLUG_IN;
+import static org.jboss.as.domain.management.ModelDescriptionConstants.PROPERTY;
 import static org.jboss.msc.service.ServiceController.Mode.ON_DEMAND;
 
-import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -408,10 +407,10 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
         ServiceBuilder<?> sslBuilder = serviceTarget.addService(sslServiceName, sslIdentityService);
 
         if (keystoreServiceName != null) {
-            sslBuilder.addDependency(keystoreServiceName, KeyStore.class, sslIdentityService.getKeyStoreInjector());
+            sslBuilder.addDependency(keystoreServiceName, FileKeystore.class, sslIdentityService.getKeyStoreInjector());
         }
         if (truststoreServiceName != null) {
-            sslBuilder.addDependency(truststoreServiceName, KeyStore.class, sslIdentityService.getTrustStoreInjector());
+            sslBuilder.addDependency(truststoreServiceName, FileKeystore.class, sslIdentityService.getTrustStoreInjector());
         }
 
         final ServiceController<?> serviceController = sslBuilder.setInitialMode(ON_DEMAND).install();


### PR DESCRIPTION
This pull request is a contribution from Flemming Harms to add support for dynamic updates to the trust store used for domain management and Remoting.

The end result is users certificates can be added to or removed from the truststore without the need to restart the server or restart the interfaces.
