### PR TITLE
Add a module for the EL3 reference implementation

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -679,6 +679,10 @@
             <maven-resource group="org.codehaus.jettison" artifact="jettison" />
         </module-def>
 
+        <module-def name="org.glassfish.javax.el">
+            <maven-resource group="org.glassfish" artifact="javax.el"/>
+        </module-def>
+
         <module-def name="org.glassfish.javax.json">
             <maven-resource group="org.glassfish" artifact="javax.json"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -693,6 +693,11 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>org.hibernate</groupId>
                     <artifactId>hibernate-core</artifactId>
                 </dependency>
@@ -2167,6 +2172,7 @@
                                         <exclude>org.codehaus.woodstox:woodstox-core-asl</exclude>
                                         <exclude>org.eclipse.jdt.core.compiler:ecj</exclude>
                                         <exclude>org.fusesource.jansi:jansi</exclude>
+                                        <exclude>org.glassfish:javax.el</exclude>
                                         <exclude>org.glassfish:javax.json</exclude>
                                         <exclude>org.hornetq:hornetq-ra</exclude>
                                         <exclude>org.infinispan:infinispan-cachestore-jdbc</exclude>
@@ -2765,6 +2771,10 @@
                                         <group>
                                             <title>Module org.codehaus.jettison</title>
                                             <packages>org.codehaus.jettison:org.codehaus.jettison.badgerfish:org.codehaus.jettison.json:org.codehaus.jettison.mapped:org.codehaus.jettison.util</packages>
+                                        </group>
+                                        <group>
+                                            <title>Module org.glassfish.javax.el</title>
+                                            <packages>javax.el:com.sun.glassfish:com.sun.el</packages>
                                         </group>
                                         <group>
                                             <title>Module org.glassfish.javax.json</title>

--- a/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.glassfish.javax.el">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
         <version.org.codehaus.woodstox.woodstox-core-asl>4.2.0</version.org.codehaus.woodstox.woodstox-core-asl>
         <version.org.eclipse.jdt.core.compiler>3.7.2</version.org.eclipse.jdt.core.compiler>
         <version.org.fusesource.jansi>1.9</version.org.fusesource.jansi>
+        <version.org.glassfish.javax.el>3.0-b07</version.org.glassfish.javax.el>
         <version.org.hibernate>4.2.0.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
@@ -3412,6 +3413,13 @@
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.json</artifactId>
                 <version>${version.javax.json-api}</version>
+            </dependency>
+
+            <!-- EL3 RI implementation -->
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>javax.el</artifactId>
+                <version>${version.org.glassfish.javax.el}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Will be used by Jasper. One issue is that Sun's JAR also includes javax.el, but I don't think it will cause problems.
