### PR TITLE
Fix @Ignore which was pointing to wrong JIRA number

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -62,7 +62,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("AS7-6379")
+@Ignore("AS7-6604") // now WFLY-828
 public class RemoteEJBClientStatefulBeanFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final Logger logger = Logger.getLogger(RemoteEJBClientStatefulBeanFailoverTestCase.class);


### PR DESCRIPTION
The commit here fixes the JIRA number associated with the @Ignore of a testcase.
