### PR TITLE
Initial remoting via HTTP upgrade support

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -147,7 +147,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
 

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/CommonDomainContainerConfiguration.java
@@ -47,7 +47,7 @@ public class CommonDomainContainerConfiguration implements ContainerConfiguratio
 
     public CommonDomainContainerConfiguration() {
         managementAddress = getInetAddress("127.0.0.1");
-        managementPort = 9999;
+        managementPort = 9990;
     }
 
     public InetAddress getManagementAddress() {

--- a/arquillian/common-domain/src/test/java/org/jboss/as/arquillian/container/domain/ManagementClientManualTestCase.java
+++ b/arquillian/common-domain/src/test/java/org/jboss/as/arquillian/container/domain/ManagementClientManualTestCase.java
@@ -51,36 +51,36 @@ public class ManagementClientManualTestCase {
         rename.put("master:server-three", "front-1");
         rename.put("main-server-group", "backend");
         rename.put("other-server-group", "front");
-        
+
         System.out.println("Domain");
         Domain domain = client.createDomain(rename);
         for(Server server: domain.getServers()) {
             System.out.println(server);
-            
+
             System.out.println("Started: " + client.isServerStarted(server));
         }
-        
+
         System.out.println(domain.getHosts());
         System.out.println(domain.getServerGroups());
-        
+
     }
 
 
     @Test
     public void shouldBeAbleToReadMetadata() throws Exception {
-        String uniqueName = null; 
+        String uniqueName = null;
         try {
             uniqueName = deployer.deploy(
                     ShrinkWrap.create(EnterpriseArchive.class, "test1.ear")
                         .addAsModule(
                                 ShrinkWrap.create(WebArchive.class)
-                                    .addClass(ManualTestServlet.class)),  
+                                    .addClass(ManualTestServlet.class)),
                     "main-server-group");
-            
+
             HTTPContext context = client.getHTTPDeploymentMetaData(
-                    new Server("server-one", "master", "main-server-group", false), 
+                    new Server("server-one", "master", "main-server-group", false),
                     "test1.ear");
-            
+
             System.out.println(context);
         }
         finally {
@@ -89,47 +89,47 @@ public class ManagementClientManualTestCase {
             }
         }
     }
-    
+
     //@Test
     public void shouldbeAbleToStopAndStartServerGroup() throws Exception
     {
         client.stopServerGroup("main-server-group");
-        
+
         Thread.sleep(5000);
-        
+
         client.startServerGroup("main-server-group");
     }
-    
+
     @Test
     public void shouldbeAbleToStpAndStartServer() throws Exception
     {
         Server server = new Server("server-one", "master", "main-server-group", false);
         client.stopServer(server);
         System.out.println("stopped");
-        
+
         Thread.sleep(5000);
-        
+
         client.startServer(server);
     }
 
     @Before
     public void createClient() throws Exception {
         InetAddress address = InetAddress.getLocalHost();
-        int port = 9999;
-        
+        int port = 9990;
+
         DomainClient domainClient = DomainClient.Factory.create(
                 address,
                 port,
                 Authentication.getCallbackHandler());
 
         client = new ManagementClient(
-                domainClient, 
-                address.getHostAddress(), 
+                domainClient,
+                address.getHostAddress(),
                 port);
-        
+
         deployer = new ArchiveDeployer(domainClient.getDeploymentManager());
     }
-    
+
     @After
     public void closeClient() throws Exception {
         if(client != null) {

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonContainerConfiguration.java
@@ -30,6 +30,7 @@ import org.jboss.arquillian.container.spi.client.container.ContainerConfiguratio
  */
 public class CommonContainerConfiguration implements ContainerConfiguration {
 
+    private String managementProtocol = "http-remoting";
     private String managementAddress;
     private int managementPort;
 
@@ -38,7 +39,7 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public CommonContainerConfiguration() {
         managementAddress = "127.0.0.1";
-        managementPort = 9999;
+        managementPort = 9990;
     }
 
     public String getManagementAddress() {
@@ -79,6 +80,14 @@ public class CommonContainerConfiguration implements ContainerConfiguration {
 
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public String getManagementProtocol() {
+        return managementProtocol;
+    }
+
+    public void setManagementProtocol(final String managementProtocol) {
+        this.managementProtocol = managementProtocol;
     }
 
     @Override

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -86,6 +86,7 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
         ModelControllerClient modelControllerClient = null;
         try {
             modelControllerClient = ModelControllerClient.Factory.create(
+                    containerConfig.getManagementProtocol(),
                     containerConfig.getManagementAddress(),
                     containerConfig.getManagementPort(),
                     getCallbackHandler());
@@ -93,7 +94,7 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
             throw new RuntimeException(e);
         }
 
-        ManagementClient client = new ManagementClient(modelControllerClient, containerConfig.getManagementAddress(), containerConfig.getManagementPort());
+        ManagementClient client = new ManagementClient(modelControllerClient, containerConfig.getManagementAddress(), containerConfig.getManagementPort(), containerConfig.getManagementProtocol());
         managementClient.set(client);
 
         ArchiveDeployer deployer = new ArchiveDeployer(modelControllerClient);

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -91,6 +91,7 @@ public class ManagementClient implements AutoCloseable, Closeable {
 
     private final String mgmtAddress;
     private final int mgmtPort;
+    private final String mgmtProtocol;
     private final ModelControllerClient client;
 
     private URI webUri;
@@ -102,13 +103,14 @@ public class ManagementClient implements AutoCloseable, Closeable {
     private MBeanServerConnection connection;
     private JMXConnector connector;
 
-    public ManagementClient(ModelControllerClient client, final String mgmtAddress, final int managementPort) {
+    public ManagementClient(ModelControllerClient client, final String mgmtAddress, final int managementPort, final String protocol) {
         if (client == null) {
             throw new IllegalArgumentException("Client must be specified");
         }
         this.client = client;
         this.mgmtAddress = mgmtAddress;
         this.mgmtPort = managementPort;
+        this.mgmtProtocol = protocol;
     }
 
     //-------------------------------------------------------------------------------------||
@@ -347,7 +349,13 @@ public class ManagementClient implements AutoCloseable, Closeable {
 
     public JMXServiceURL getRemoteJMXURL() {
         try {
-            return new JMXServiceURL("service:jmx:remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+            if (mgmtProtocol.equals("http-remoting")) {
+                return new JMXServiceURL("service:jmx:http-remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+            } else if (mgmtProtocol.equals("https-remoting")) {
+                return new JMXServiceURL("service:jmx:https-remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+            } else {
+                return new JMXServiceURL("service:jmx:remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+            }
         } catch (Exception e) {
             throw new RuntimeException("Could not create JMXServiceURL:" + this, e);
         }

--- a/arquillian/container-embedded/pom.xml
+++ b/arquillian/container-embedded/pom.xml
@@ -20,12 +20,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-  
-<!-- 
-  Set these VM properties in your IDE debugger 
+
+<!--
+  Set these VM properties in your IDE debugger
 
   -Djava.util.logging.manager=org.jboss.logmanager.LogManager
-  -Djboss.home=${workspace_loc:jboss-as-build}/target/jboss-as-8.0.0.Alpha1-SNAPSHOT 
+  -Djboss.home=${workspace_loc:jboss-as-build}/target/jboss-as-8.0.0.Alpha1-SNAPSHOT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -119,7 +119,7 @@
                         <module.path>${jboss.home}/modules</module.path>
                         <bundle.path>${jboss.home}/bundles</bundle.path>
                     </systemPropertyVariables>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
                 </configuration>
             </plugin>
 		</plugins>

--- a/arquillian/container-managed/pom.xml
+++ b/arquillian/container-managed/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
         <dependency>

--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/ArquillianServiceDeployer.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/ArquillianServiceDeployer.java
@@ -67,6 +67,7 @@ public class ArquillianServiceDeployer {
                 ObjectOutputStream out = new ObjectOutputStream(bytes);
                 out.writeObject(props.get("managementPort"));
                 out.writeObject(NetworkUtils.formatPossibleIpv6Address(props.get("managementAddress")));
+                out.writeObject(NetworkUtils.formatPossibleIpv6Address(props.get("managementProtocol")));
                 out.close();
                 serviceArchive.addAsManifestResource(new ByteArrayAsset(bytes.toByteArray()), "org.jboss.as.managementConnectionProps");
 

--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/InContainerManagementClientProvider.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/service/InContainerManagementClientProvider.java
@@ -58,24 +58,30 @@ public class InContainerManagementClientProvider implements ResourceProvider {
             InputStream in = null;
             String managementPort;
             String address;
+            String protocol;
             try {
                 in = resourceUrl.openStream();
                 ObjectInputStream inputStream = new ObjectInputStream(in);
                 managementPort = (String) inputStream.readObject();
                 address = (String) inputStream.readObject();
+                protocol = (String) inputStream.readObject();
                 if (address == null) {
                     address = "localhost";
                 }
                 if (managementPort == null) {
-                    managementPort = "9999";
+                    managementPort = "9990";
+                }
+                if (protocol == null) {
+                    protocol = "http-remoting";
                 }
                 ModelControllerClient modelControllerClient = null;
                 final int port = Integer.parseInt(managementPort);
                 modelControllerClient = ModelControllerClient.Factory.create(
+                        protocol,
                         address,
                         port,
                         getCallbackHandler());
-                current = new ManagementClient(modelControllerClient, address, port);
+                current = new ManagementClient(modelControllerClient, address, port, protocol);
 
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/build/build.xml
+++ b/build/build.xml
@@ -308,9 +308,11 @@
             <maven-resource group="org.jboss.logmanager" artifact="log4j-jboss-logmanager"/>
         </module-def>
 
-        <module-def name="org.jboss.remoting3">
-            <maven-resource group="org.jboss.remoting3" artifact="jboss-remoting"/>
+        <module-def name="org.jboss.remoting">
+            <maven-resource group="org.jboss.remoting" artifact="jboss-remoting"/>
         </module-def>
+
+        <module-def name="org.jboss.remoting3" />
 
         <module-def name="org.jboss.remoting3.remoting-jmx" />
 
@@ -392,7 +394,7 @@
 
         <module-def name="com.sun.jsf-impl">
             <maven-resource group="com.sun.faces" artifact="jsf-impl"/>
-        </module-def>        
+        </module-def>
 
         <module-def name="com.sun.xml.bind">
             <maven-resource group="com.sun.xml.bind" artifact="jaxb-impl"/>
@@ -436,7 +438,7 @@
         <module-def name="javax.el.api">
             <maven-resource group="org.jboss.spec.javax.el" artifact="jboss-el-api_2.2_spec"/>
         </module-def>
-    	       	
+
         <module-def name="javax.enterprise.api">
             <maven-resource group="javax.enterprise" artifact="cdi-api"/>
         </module-def>
@@ -444,11 +446,11 @@
     	<module-def name="javax.enterprise.concurrent.api">
     		<maven-resource group="org.jboss.spec.javax.enterprise.concurrent" artifact="jboss-concurrency-api_1.0_spec"/>
     	</module-def>
-    	
+
         <module-def name="javax.faces.api">
             <maven-resource group="org.jboss.spec.javax.faces" artifact="jboss-jsf-api_2.2_spec"/>
         </module-def>
-        
+
         <module-def name="javax.inject.api">
             <maven-resource group="javax.inject" artifact="javax.inject"/>
         </module-def>
@@ -896,11 +898,11 @@
 
         <module-def name="org.jboss.as.jsf-injection">
             <maven-resource group="org.wildfly" artifact="wildfly-jsf-injection" />
-        </module-def> 
+        </module-def>
 
         <module-def name="org.jboss.as.jsr77">
             <maven-resource group="org.wildfly" artifact="wildfly-jsr77"/>
-        </module-def>       
+        </module-def>
 
         <module-def name="org.jboss.as.logging">
             <maven-resource group="org.wildfly" artifact="wildfly-logging"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1426,7 +1426,7 @@
                 </dependency>
 
                 <dependency>
-                    <groupId>org.jboss.remoting3</groupId>
+                    <groupId>org.jboss.remoting</groupId>
                     <artifactId>jboss-remoting</artifactId>
                 </dependency>
 
@@ -2064,7 +2064,7 @@
                                         <include>org.jboss.logmanager:log4j-jboss-logmanager</include>
                                         <include>org.jboss.marshalling:jboss-marshalling</include>
                                         <include>org.jboss.msc:jboss-msc</include>
-                                        <include>org.jboss.remoting3:jboss-remoting</include>
+                                        <include>org.jboss.remoting:jboss-remoting</include>
                                         <include>org.jboss.remotingjmx:remoting-jmx</include>
                                         <include>org.jboss.resteasy:async-http-servlet-3.0</include>
                                         <include>org.jboss.resteasy:jaxrs-api</include>
@@ -2469,7 +2469,7 @@
                                             <packages>org.jboss.logmanager:org.jboss.logmanager.config:org.jboss.logmanager.errormanager:org.jboss.logmanager.filters:org.jboss.logmanager.formatters:org.jboss.logmanager.handlers</packages>
                                         </group>
                                         <group>
-                                            <title>Module org.jboss.remoting3</title>
+                                            <title>Module org.jboss.remoting</title>
                                             <packages>org.jboss.remoting3:org.jboss.remoting3.remote:org.jboss.remoting3.security:org.jboss.remoting3.spi</packages>
                                         </group>
                                         <group>

--- a/build/src/license/licenses.xml
+++ b/build/src/license/licenses.xml
@@ -2597,7 +2597,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.remoting3</groupId>
+      <groupId>org.jboss.remoting</groupId>
       <artifactId>jboss-remoting</artifactId>
       <licenses>
         <license>
@@ -2608,7 +2608,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.remoting3</groupId>
+      <groupId>org.jboss.remotejmx</groupId>
       <artifactId>remoting-jmx</artifactId>
       <licenses>
         <license>

--- a/build/src/main/resources/bin/client/README-EJB-JMS.txt
+++ b/build/src/main/resources/bin/client/README-EJB-JMS.txt
@@ -12,8 +12,8 @@ org.jboss:jboss-remote-naming
 org.jboss.logging:jboss-logging
 org.jboss.marshalling:jboss-marshalling
 org.jboss.marshalling:jboss-marshalling-river
-org.jboss.remoting3:jboss-remoting
-org.jboss.remoting3:remoting-jmx
+org.jboss.remoting:jboss-remoting
+org.jboss.remotingjmx:remoting-jmx
 org.jboss.sasl:jboss-sasl
 org.jboss.xnio:xnio-api
 org.jboss.xnio:xnio-nio

--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -3,20 +3,21 @@
 <!--
    JBoss AS7 Command-line Interface configuration.
 -->
-<jboss-cli xmlns="urn:jboss:cli:1.2">
+<jboss-cli xmlns="urn:jboss:cli:1.3">
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
+        <protocol>http-remoting</protocol>
         <host>localhost</host>
-        <port>9999</port>
+        <port>9990</port>
     </default-controller>
-    
+
     <validate-operation-requests>true</validate-operation-requests>
-    
+
     <!-- whether to resolve system properties specified as command argument or operation parameter values
          in the CLI VM before sending the operation requests to the controller -->
     <resolve-parameter-values>false</resolve-parameter-values>
-    
+
     <!-- Command and operation history log configuration -->
     <history>
         <enabled>true</enabled>
@@ -24,7 +25,7 @@
         <file-dir>${user.home}</file-dir>
         <max-size>500</max-size>
     </history>
-    
+
     <!-- Whether to write info and error messages to the terminal output -->
     <silent>false</silent>
 </jboss-cli>

--- a/build/src/main/resources/bin/jconsole.bat
+++ b/build/src/main/resources/bin/jconsole.bat
@@ -66,7 +66,7 @@ set CLASSPATH=%JAVA_HOME%\lib\jconsole.jar
 set CLASSPATH=%CLASSPATH%;%JAVA_HOME%\lib\tools.jar
 
 call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\remoting-jmx\main"
-call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\remoting3\main"
+call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\remoting\main"
 call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\logging\main"
 call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\xnio\main"
 call :SearchForJars "%JBOSS_MODULEPATH%\system\layers\base\org\jboss\xnio\nio\main"

--- a/build/src/main/resources/bin/jconsole.sh
+++ b/build/src/main/resources/bin/jconsole.sh
@@ -72,7 +72,7 @@ fi
 CLASSPATH=$JAVA_HOME/lib/jconsole.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
 
-MODULES="org/jboss/remoting-jmx org/jboss/remoting3 org/jboss/logging org/jboss/xnio org/jboss/xnio/nio org/jboss/sasl org/jboss/marshalling org/jboss/marshalling/river org/jboss/as/cli org/jboss/staxmapper org/jboss/as/protocol org/jboss/dmr org/jboss/as/controller-client org/jboss/threads"
+MODULES="org/jboss/remoting-jmx org/jboss/remoting org/jboss/logging org/jboss/xnio org/jboss/xnio/nio org/jboss/sasl org/jboss/marshalling org/jboss/marshalling/river org/jboss/as/cli org/jboss/staxmapper org/jboss/as/protocol org/jboss/dmr org/jboss/as/controller-client org/jboss/threads"
 
 for MODULE in $MODULES
 do

--- a/build/src/main/resources/configuration/standalone/template-osgi.xml
+++ b/build/src/main/resources/configuration/standalone/template-osgi.xml
@@ -25,10 +25,7 @@
             </security-realm>
         </security-realms>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket-binding native="management-native"/>
-            </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>
@@ -50,7 +47,6 @@
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
-        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
 

--- a/build/src/main/resources/configuration/standalone/template-osgi.xml
+++ b/build/src/main/resources/configuration/standalone/template-osgi.xml
@@ -25,6 +25,9 @@
             </security-realm>
         </security-realms>
         <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket-binding native="management-native"/>
+            </native-interface>
             <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
@@ -47,6 +50,7 @@
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
 

--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -25,10 +25,7 @@
             </security-realm>
         </security-realms>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket-binding native="management-native"/>
-            </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>
@@ -56,7 +53,6 @@
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
-        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
 

--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -25,6 +25,9 @@
             </security-realm>
         </security-realms>
         <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket-binding native="management-native"/>
+            </native-interface>
             <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
@@ -53,6 +56,7 @@
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
+        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
 

--- a/build/src/main/resources/docs/examples/configs/standalone-minimalistic.xml
+++ b/build/src/main/resources/docs/examples/configs/standalone-minimalistic.xml
@@ -11,10 +11,7 @@
             </security-realm>
         </security-realms>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket-binding native="management-native"/>
-            </native-interface>
-            <http-interface console-enabled="false" security-realm="ManagementRealm">
+            <http-interface console-enabled="false" security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
         </management-interfaces>

--- a/build/src/main/resources/docs/examples/configs/standalone-minimalistic.xml
+++ b/build/src/main/resources/docs/examples/configs/standalone-minimalistic.xml
@@ -11,6 +11,9 @@
             </security-realm>
         </security-realms>
         <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket-binding native="management-native"/>
+            </native-interface>
             <http-interface console-enabled="false" security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
@@ -28,7 +31,7 @@
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public">
-        <socket-binding name="management-native" interface="management" port="9999"/>
+        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="9990"/>
     </socket-binding-group>
 </server>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_1_3.xsd
@@ -23,8 +23,8 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:jboss:cli:1.2"
-           targetNamespace="urn:jboss:cli:1.2"
+           xmlns="urn:jboss:cli:1.3"
+           targetNamespace="urn:jboss:cli:1.3"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
         >
@@ -70,8 +70,9 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="protocol" type="xs:string" minOccurs="0" default="http-remoting"/>
                 <xs:element name="host" type="xs:string" minOccurs="0" default="localhost"/>
-                <xs:element name="port" type="xs:int" minOccurs="0" default="9999"/>
+                <xs:element name="port" type="xs:int" minOccurs="0" default="9990"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
@@ -689,7 +689,7 @@
 
     <xs:complexType name="host-management-interfacesType">
         <xs:sequence>
-            <xs:element name="native-interface" type="host-native-management-interfaceType"/>
+            <xs:element name="native-interface" type="host-native-management-interfaceType" />
             <xs:element name="http-interface" type="host-http-management-interfaceType" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>
@@ -769,6 +769,7 @@
                     <xs:element name="socket" type="http-management-socketType"/>
                 </xs:sequence>
                 <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="http-upgrade-enabled" type="xs:boolean" use="optional" default="true"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -880,6 +881,7 @@
                     <xs:element name="socket-binding" type="http-management-socket-binding-refType"/>
                 </xs:choice>
                 <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="http-upgrade-enabled" type="xs:boolean" use="optional" default="true"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/build/src/main/resources/domain/configuration/host-master.xml
+++ b/build/src/main/resources/domain/configuration/host-master.xml
@@ -28,7 +28,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="${jboss.management.native.port:9999}"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>
             </http-interface>
         </management-interfaces>

--- a/build/src/main/resources/domain/configuration/host.xml
+++ b/build/src/main/resources/domain/configuration/host.xml
@@ -24,7 +24,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="${jboss.management.native.port:9999}"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>
             </http-interface>
         </management-interfaces>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
@@ -37,7 +37,7 @@
         <module name="javax.api"/>
         <module name="org.apache.xalan" services="import"/>
         <module name="org.apache.xerces" services="import"/>
-        <module name="org.codehaus.woodstox" services="import"/>        
+        <module name="org.codehaus.woodstox" services="import"/>
         <module name="org.jboss.as.server" export="true"/>
         <module name="javax.api"/>
         <module name="org.jboss.dmr"/>
@@ -48,7 +48,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.log4j.logmanager"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.stdio"/>
         <module name="org.jboss.threads"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -41,7 +41,7 @@
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river" services="import"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.threads"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -87,7 +87,7 @@
         <module name="org.jboss.modules"/>
         <!-- Access to ServiceName -->
         <module name="org.jboss.msc"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.staxmapper"/>
         <!-- For parser DUP -->
         <module name="org.jboss.vfs"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -61,8 +61,8 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
-        <module name="org.jboss.remoting3"/>
-        <module name="org.jboss.remoting3.remoting-jmx"/>
+        <module name="org.jboss.remoting"/>
+        <module name="org.jboss.remoting-jmx"/>
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.stdio"/>
         <module name="org.jboss.threads"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -39,11 +39,10 @@
         <module name="org.jboss.as.remoting" />
         <module name="org.wildfly.security.manager"/>
         <module name="org.jboss.as.server" />
-        <module name="org.jboss.remoting3" />
-        <module name="org.jboss.remoting3.remoting-jmx" />
+        <module name="org.jboss.remoting" />
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.remoting3.remoting-jmx" services="import" />
+        <module name="org.jboss.remoting-jmx" services="import" />
         <module name="org.jboss.as.naming"/>                
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.remote-naming"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.threads"/>
         <module name="sun.jdk" />
     </dependencies>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
@@ -37,7 +37,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river" services="import"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.threads"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
@@ -43,11 +43,12 @@
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
-        <module name="org.jboss.msc"/>        
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.threads"/>
-        <module name="org.picketbox" optional="true"/>        
+        <module name="org.picketbox" optional="true"/>
+        <module name="io.undertow.core" optional="true" />
         <module name="javax.api" />
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -49,7 +49,7 @@
         <module name="org.jboss.metadata"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.security.negotiation"/>
         <module name="org.jboss.staxmapper"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -47,7 +47,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.log4j.logmanager"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.sasl"/>
         <module name="org.jboss.stdio"/>
         <module name="org.jboss.threads"/>
@@ -66,5 +66,6 @@
         <module name="org.jboss.as.security" optional="true" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox" optional="true"/>
+        <module name="io.undertow.core" optional="true" />
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
@@ -30,7 +30,7 @@
         <module name="javax.api"/>
         <module name="javax.ejb.api"/>
         <module name="javax.interceptor.api"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remote-naming/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remote-naming/main/module.xml
@@ -29,7 +29,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.jboss.ejb-client"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
@@ -29,7 +29,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.jboss.remoting3"/>
+        <module name="org.jboss.remoting"/>
         <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
@@ -22,26 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.controller">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.remoting">
     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.jboss.as.controller-client" export="true"/>
-        <module name="org.jboss.as.protocol"/>
-        <module name="org.wildfly.security.manager"/>
-        <module name="org.jboss.dmr" export="true"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.modules"/>
-        <module name="org.jboss.msc"/>
-        <module name="org.jboss.remoting"/>
-        <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.threads"/>
+        <module name="org.jboss.marshalling" export="true"/>
+        <module name="org.jboss.sasl" services="import"/>
+        <module name="org.jboss.xnio" export="true"/>
+        <module name="org.jboss.xnio.nio" services="import"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting3/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting3/main/module.xml
@@ -23,16 +23,16 @@
   -->
 
 <module xmlns="urn:jboss:module:1.1" name="org.jboss.remoting3">
+    <!-- This module is deprecated and subject to being removed in a subsequent release.      -->
+
+    <!-- Any use of the Remoting library should now reference the org.jboss.remoting          -->
+    <!-- module instead.                                                                      -->
+
     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling" export="true"/>
-        <module name="org.jboss.sasl" services="import"/>
-        <module name="org.jboss.xnio" export="true"/>
-        <module name="org.jboss.xnio.nio" services="import"/>
+        <module name="org.jboss.remoting" export="true" />
     </dependencies>
 </module>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -112,7 +112,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
 

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -30,6 +30,13 @@ package org.jboss.as.cli;
 public interface CliConfig {
 
     /**
+     * The default server controller protocol
+     *
+     * @return default server controller protocol
+     */
+    String getDefaultControllerProtocol();
+
+    /**
      * The default server controller host to connect to.
      *
      * @return default server controller host to connect to

--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -124,11 +124,12 @@ public interface CommandContext {
      * If the port is less than zero, the default controller port will be used,
      * which is 9999.
      *
+     * @param protocol the protocol to connect with, either remote, http or https
      * @param host the host to connect with
      * @param port the port to connect on
      * @throws CommandLineException  in case the attempt to connect failed
      */
-    void connectController(String host, int port) throws CommandLineException;
+    void connectController(String protocol, String host, int port) throws CommandLineException;
 
     /**
      * Bind the controller to an existing, connected client.

--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -53,10 +53,10 @@ public abstract class CommandContextFactory {
 
     public abstract CommandContext newCommandContext(String username, char[] password) throws CliInitializationException;
 
-    public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
+    public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
             String username, char[] password) throws CliInitializationException;
 
-    public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
+    public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
             String username, char[] password, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
 
     public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,

--- a/cli/src/main/java/org/jboss/as/cli/gui/JConsoleCLIPlugin.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/JConsoleCLIPlugin.java
@@ -101,7 +101,7 @@ public class JConsoleCLIPlugin extends JConsolePlugin {
             return connectUsingRemoting(cmdCtx, (RemotingMBeanServerConnection)mbeanServerConn);
         } else {
             try {
-                cmdCtx.connectController("localhost", 9999);
+                cmdCtx.connectController("http-remoting", "localhost", 9990);
             } catch (Exception e) {
                 String message = "CLI GUI unable to connect to JBoss AS with localhost:9999 \n";
                 message += "Go to Connection -> New Connection and enter a Remote Process \n";

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
@@ -62,6 +62,7 @@ public class ConnectHandler extends CommandHandlerWithHelp {
 
         int port = -1;
         String host = null;
+        String protocol = "http-remoting";
         final ParsedCommandLine parsedCmd = ctx.getParsedCommandLine();
         final List<String> args = parsedCmd.getOtherProperties();
 
@@ -69,7 +70,16 @@ public class ConnectHandler extends CommandHandlerWithHelp {
             if(args.size() != 1) {
                 throw new CommandFormatException("The command expects only one argument but got " + args);
             }
-            final String arg = args.get(0);
+            final String fullArg = args.get(0);
+            final String arg;
+            final int protocolEnd = fullArg.lastIndexOf("://");
+            if(protocolEnd == -1) {
+                arg = fullArg;
+            } else {
+                arg = fullArg.substring(protocolEnd + 3);
+                protocol = fullArg.substring(0, protocolEnd);
+            }
+
             String portStr = null;
             int colonIndex = arg.lastIndexOf(':');
             if(colonIndex < 0) {
@@ -112,6 +122,6 @@ public class ConnectHandler extends CommandHandlerWithHelp {
             }
         }
 
-        ctx.connectController(host, port);
+        ctx.connectController(protocol, host, port);
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -62,6 +62,7 @@ class CliConfigImpl implements CliConfig {
     private static final String HOST = "host";
     private static final String MAX_SIZE = "max-size";
     private static final String PORT = "port";
+    private static final String PROTOCOL = "protocol";
     private static final String CONNECTION_TIMEOUT = "connection-timeout";
     private static final String RESOLVE_PARAMETER_VALUES = "resolve-parameter-values";
     private static final String SILENT = "silent";
@@ -166,8 +167,9 @@ class CliConfigImpl implements CliConfig {
     }
 
     private CliConfigImpl() {
+        defaultControllerProtocol = "http-remoting";
         defaultControllerHost = "localhost";
-        defaultControllerPort = 9999;
+        defaultControllerPort = 9990;
 
         historyEnabled = true;
         historyFileName = ".jboss-cli-history";
@@ -177,6 +179,7 @@ class CliConfigImpl implements CliConfig {
         connectionTimeout = 5000;
     }
 
+    private String defaultControllerProtocol;
     private String defaultControllerHost;
     private int defaultControllerPort;
 
@@ -193,6 +196,11 @@ class CliConfigImpl implements CliConfig {
     private SSLConfig sslConfig;
 
     private boolean silent;
+
+    @Override
+    public String getDefaultControllerProtocol() {
+        return defaultControllerProtocol;
+    }
 
     @Override
     public String getDefaultControllerHost() {
@@ -329,6 +337,7 @@ class CliConfigImpl implements CliConfig {
                 case CLI_1_0:
                 case CLI_1_1:
                 case CLI_1_2:
+                case CLI_1_3:
                     readCLIElement_1_0(reader, readerNS, config);
                     break;
                 default:
@@ -389,6 +398,8 @@ class CliConfigImpl implements CliConfig {
                 final String resolved = resolveString(reader.getElementText());
                 if (HOST.equals(localName)) {
                     config.defaultControllerHost = resolved;
+                } else if (PROTOCOL.equals(localName)) {
+                    config.defaultControllerProtocol = resolved;
                 } else if (PORT.equals(localName)) {
                     try {
                         config.defaultControllerPort = Integer.parseInt(resolved);

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -53,17 +53,17 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     }
 
     @Override
-    public CommandContext newCommandContext(String controllerHost,
+    public CommandContext newCommandContext(String controllerProtocol, String controllerHost,
             int controllerPort, String username, char[] password)
             throws CliInitializationException {
-        return newCommandContext(controllerHost, controllerPort, username, password, false, -1);
+        return newCommandContext(controllerProtocol, controllerHost, controllerPort, username, password, false, -1);
     }
 
     @Override
-    public CommandContext newCommandContext(String controllerHost,
+    public CommandContext newCommandContext(String controllerProtocol, String controllerHost,
             int controllerPort, String username, char[] password,
             boolean initConsole, final int connectionTimeout) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, initConsole, connectionTimeout);
+        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -38,24 +38,24 @@ public interface ModelControllerClientFactory {
         void handleClose();
     }
 
-    ModelControllerClient getClient(String hostName, int port, CallbackHandler handler,
+    ModelControllerClient getClient(String protocol, String hostName, int port, CallbackHandler handler,
             SSLContext sslContext, int connectionTimeout, ConnectionCloseHandler closeHandler) throws IOException;
 
     ModelControllerClientFactory DEFAULT = new ModelControllerClientFactory() {
         @Override
-        public ModelControllerClient getClient(String hostName, int port, CallbackHandler handler,
+        public ModelControllerClient getClient(String protocol, String hostName, int port, CallbackHandler handler,
                 SSLContext sslContext, int connectionTimeout, ConnectionCloseHandler closeHandler) throws IOException {
-            return ModelControllerClient.Factory.create(hostName, port, handler, sslContext, connectionTimeout);
+            return ModelControllerClient.Factory.create(protocol, hostName, port, handler, sslContext, connectionTimeout);
         }
     };
 
     ModelControllerClientFactory CUSTOM = new ModelControllerClientFactory() {
 
         @Override
-        public ModelControllerClient getClient(final String hostName, final int port,
+        public ModelControllerClient getClient(String protocol, final String hostName, final int port,
                 final CallbackHandler handler, final SSLContext sslContext,
                 final int connectionTimeout, final ConnectionCloseHandler closeHandler) throws IOException {
 
-            return new CLIModelControllerClient(handler, hostName, connectionTimeout, closeHandler, port, sslContext);
+            return new CLIModelControllerClient(protocol, handler, hostName, connectionTimeout, closeHandler, port, sslContext);
         }};
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
@@ -44,7 +44,9 @@ public enum Namespace {
 
     CLI_1_1("urn:jboss:cli:1.1"),
 
-    CLI_1_2("urn:jboss:cli:1.2");
+    CLI_1_2("urn:jboss:cli:1.2"),
+
+    CLI_1_3("urn:jboss:cli:1.3");
 
     /**
      * The current namespace version.

--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -109,9 +109,20 @@ public class CLI {
      * @param password The password for logging in.
      */
     public void connect(String controllerHost, int controllerPort, String username, char[] password) {
+        connect("http-remoting", controllerHost, controllerPort, username, password);
+    }
+    /**
+     * Connect to the server using a specified host and port.
+     * @param protocol The protocol
+     * @param controllerHost The host name.
+     * @param controllerPort The port.
+     * @param username The user name for logging in.
+     * @param password The password for logging in.
+     */
+    public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password) {
         checkAlreadyConnected();
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(controllerHost, controllerPort, username, password);
+            ctx = CommandContextFactory.getInstance().newCommandContext(protocol, controllerHost, controllerPort, username, password);
             ctx.connectController();
         } catch (CliInitializationException e) {
             throw new IllegalStateException("Unable to initialize command context.", e);

--- a/cli/src/main/resources/help/connect.txt
+++ b/cli/src/main/resources/help/connect.txt
@@ -4,37 +4,43 @@ SYNOPSIS
 
 DESCRIPTION
 
-  Connects to the controller on the specified host and port.
+  Connects to the controller on the specified host and port using the specified protocol.
 
   The default values can be customized by specifying the desired defaults as
   command line arguments when launching the CLI. E.g.
- 
-  jboss-cli.sh controller=controller-host.net:1234
+
+  jboss-cli.sh controller=http-remoting://controller-host.net:1234
 
   Or
 
   jboss-cli.sh controller=controller-host.net
- 
-  In this case, the default port will be 9999.
+
+  In this case, the default port will be 9999 and the default protocol will be http.
 
   Note, specifying controller argument will only set the default host and port
   values for the connect command but will not automatically connect to the
   specified controller.
- 
+
   To connect automatically after the launch, use '--connect' switch. E.g.
- 
+
   jboss-cli.sh --connect
   jboss-cli.sh --connect controller=controller-host.net
   jboss-cli.sh --connect controller=controller-host.net:1234
- 
+  jboss-cli.sh --connect controller=remote://controller-host.net:1234
+  jboss-cli.sh --connect controller=http-remoting://controller-host.net:1234
+
   The host may be any of these formats:
   - a host name, e.g. localhost
   - an ipv4 address, e.g. 127.0.0.1
   - an ipv6 address, e.g. [::1]
 
 
+
+
 ARGUMENTS
 
-  host  - optional, default value is localhost;
+  protocol  - optional, default value is http.
 
-  port  - optional, default value is 9999.
+  host      - optional, default value is localhost.
+
+  port      - optional, default value is 9999.

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -37,13 +37,18 @@ public class MockCliConfig implements CliConfig {
     }
 
     @Override
+    public String getDefaultControllerProtocol() {
+        return "http-remoting";
+    }
+
+    @Override
     public String getDefaultControllerHost() {
         return "localhost";
     }
 
     @Override
     public int getDefaultControllerPort() {
-        return 9999;
+        return 9990;
     }
 
     @Override

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -187,7 +187,7 @@ public class MockCommandContext implements CommandContext {
     }
 
     @Override
-    public void connectController(String host, int port) {
+    public void connectController(String protocol, String host, int port) {
         throw new UnsupportedOperationException();
     }
 
@@ -329,7 +329,7 @@ public class MockCommandContext implements CommandContext {
 
     @Override
     public void connectController() {
-        connectController(null, -1);
+        connectController(null, null, -1);
     }
 
     @Override

--- a/client/ejb/pom.xml
+++ b/client/ejb/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
 

--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -88,7 +88,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
 

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -116,48 +116,101 @@ public interface ModelControllerClient extends Closeable {
          * Create a client instance for a remote address and port.
          *
          * @param address the address of the remote host
-         * @param port the port
+         * @param port    the port
          * @return A model controller client
          */
-        public static ModelControllerClient create(final InetAddress address, final int port){
+        public static ModelControllerClient create(final InetAddress address, final int port) {
             return create(ClientConfigurationImpl.create(address, port));
         }
 
         /**
          * Create a client instance for a remote address and port.
          *
-         * @param address the address of the remote host
-         * @param port the port
-         * @param handler  CallbackHandler to obtain authentication information for the call.
+         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param address  the address of the remote host
+         * @param port     the port
          * @return A model controller client
          */
-        public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler){
-            return create(ClientConfigurationImpl.create(address, port, handler));
+        public static ModelControllerClient create(final String protocol, final InetAddress address, final int port) {
+            return create(ClientConfigurationImpl.create(protocol, address, port));
         }
 
         /**
          * Create a client instance for a remote address and port.
          *
          * @param address the address of the remote host
-         * @param port the port
+         * @param port    the port
+         * @param handler CallbackHandler to obtain authentication information for the call.
+         * @return A model controller client
+         */
+        public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler) {
+            return create(ClientConfigurationImpl.create(address, port, handler));
+        }
+
+
+        /**
+         * Create a client instance for a remote address and port.
+         *
+         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param address  the address of the remote host
+         * @param port     the port
          * @param handler  CallbackHandler to obtain authentication information for the call.
+         * @return A model controller client
+         */
+        public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler) {
+            return create(ClientConfigurationImpl.create(protocol, address, port, handler));
+        }
+
+        /**
+         * Create a client instance for a remote address and port.
+         *
+         * @param address     the address of the remote host
+         * @param port        the port
+         * @param handler     CallbackHandler to obtain authentication information for the call.
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          */
-        public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions){
+        public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
             return create(ClientConfigurationImpl.create(address, port, handler, saslOptions));
         }
 
         /**
          * Create a client instance for a remote address and port.
          *
+         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used
+         * @param address     the address of the remote host
+         * @param port        the port
+         * @param handler     CallbackHandler to obtain authentication information for the call.
+         * @param saslOptions Additional options to be passed to the SASL mechanism.
+         * @return A model controller client
+         */
+        public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
+            return create(ClientConfigurationImpl.create(protocol, address, port, handler, saslOptions));
+        }
+
+        /**
+         * Create a client instance for a remote address and port.
+         *
          * @param hostName the remote host
-         * @param port the port
+         * @param port     the port
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port) throws UnknownHostException {
             return create(ClientConfigurationImpl.create(hostName, port));
+        }
+
+        /**
+         * Create a client instance for a remote address and port.
+         *
+         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName the remote host
+         * @param port     the port
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(protocol, hostName, port));
         }
 
         /**
@@ -170,7 +223,21 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-            return create(ClientConfigurationImpl.create(hostName,  port, handler));
+            return create(ClientConfigurationImpl.create(hostName, port, handler));
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
+         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName the remote host
+         * @param port     the port
+         * @param handler  CallbackHandler to obtain authentication information for the call.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(protocol, hostName, port, handler));
         }
 
         /**
@@ -184,7 +251,22 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
-            return create(ClientConfigurationImpl.create(hostName,  port, handler, sslContext));
+            return create(ClientConfigurationImpl.create(hostName, port, handler, sslContext));
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
+         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(protocol, hostName, port, handler, sslContext));
         }
 
         /**
@@ -198,21 +280,51 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
-            return create(ClientConfigurationImpl.create(hostName,  port, handler, sslContext, connectionTimeout));
+            return create(ClientConfigurationImpl.create(hostName, port, handler, sslContext, connectionTimeout));
         }
 
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param hostName the remote host
-         * @param port     the port
-         * @param handler  CallbackHandler to obtain authentication information for the call.
+         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(protocol, hostName, port, handler, sslContext, connectionTimeout));
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
+         * @param hostName    the remote host
+         * @param port        the port
+         * @param handler     CallbackHandler to obtain authentication information for the call.
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
             return create(ClientConfigurationImpl.create(hostName, port, handler, saslOptions));
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
+         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName    the remote host
+         * @param port        the port
+         * @param handler     CallbackHandler to obtain authentication information for the call.
+         * @param saslOptions Additional options to be passed to the SASL mechanism.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(protocol, hostName, port, handler, saslOptions));
         }
 
         /**

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientConfiguration.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientConfiguration.java
@@ -50,6 +50,12 @@ public interface ModelControllerClientConfiguration extends Closeable {
     int getPort();
 
     /**
+     * Returns the requested protocol. If this is null the remoting protocol will be used.
+     * If this is http or https then HTTP upgrade will be used.
+     */
+    String getProtocol();
+
+    /**
      * Get the connection timeout when trying to connect to the server.
      *
      * @return the connection timeout

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/DomainClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/DomainClient.java
@@ -142,6 +142,32 @@ public interface DomainClient extends ModelControllerClient {
         }
 
         /**
+         * Create an {@link org.jboss.as.controller.client.helpers.domain.DomainClient} instance for a remote address and port.
+         *
+         * @param protocol The protocol to use
+         * @param address The remote address to connect to
+         * @param port    The remote port
+         * @return A domain client
+         */
+        public static DomainClient create(String protocol, final InetAddress address, int port) {
+            return new DomainClientImpl(protocol, address, port);
+        }
+
+
+        /**
+         * Create an {@link org.jboss.as.controller.client.helpers.domain.DomainClient} instance for a remote address and port.
+         *
+         * @param protocol The protocol to use
+         * @param address The remote address to connect to
+         * @param port    The remote port
+         * @param handler CallbackHandler to prompt for authentication requirements.
+         * @return A domain client
+         */
+        public static DomainClient create(String protocol, final InetAddress address, int port, CallbackHandler handler) {
+            return new DomainClientImpl(protocol, address, port, handler);
+        }
+
+        /**
          * Create an {@link org.jboss.as.controller.client.helpers.domain.DomainClient} instance based on an existing
          * {@link ModelControllerClient}.
          *

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DomainClientImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DomainClientImpl.java
@@ -65,6 +65,13 @@ public class DomainClientImpl implements DomainClient {
         this.delegate = ModelControllerClient.Factory.create(address, port, handler);
     }
 
+    public DomainClientImpl(String protocol, InetAddress address, int port) {
+        this.delegate = ModelControllerClient.Factory.create(protocol, address, port);
+    }
+
+    public DomainClientImpl(String protocol, InetAddress address, int port, CallbackHandler handler) {
+        this.delegate = ModelControllerClient.Factory.create(protocol, address, port, handler);
+    }
     public DomainClientImpl(ModelControllerClient delegate) {
         this.delegate = delegate;
     }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/ServerDeploymentManager.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/ServerDeploymentManager.java
@@ -62,6 +62,21 @@ public interface ServerDeploymentManager extends Closeable {
          * This creates a {@code ModelControllerClient} which has to be closed using the
          * {@link org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager#close()} method.
          *
+         * @param protocol The protocol to use
+         * @param address The remote address to connect to
+         * @param port The remote port
+         * @return A domain client
+         */
+        public static ServerDeploymentManager create(final String protocol, final InetAddress address, int port) {
+            return create(ModelControllerClient.Factory.create(protocol,  address, port), true);
+        }
+
+        /**
+         * Create an {@link ServerDeploymentManager} instance for a remote address and port.
+         *
+         * This creates a {@code ModelControllerClient} which has to be closed using the
+         * {@link org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager#close()} method.
+         *
          * @param address The remote address to connect to
          * @param port The remote port
          * @param handler The CallbackHandler for authentication
@@ -69,6 +84,21 @@ public interface ServerDeploymentManager extends Closeable {
          */
         public static ServerDeploymentManager create(final InetAddress address, int port, CallbackHandler handler) {
             return create(ModelControllerClient.Factory.create(address, port, handler), true);
+        }
+        /**
+         * Create an {@link ServerDeploymentManager} instance for a remote address and port.
+         *
+         * This creates a {@code ModelControllerClient} which has to be closed using the
+         * {@link org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager#close()} method.
+         *
+         * @param protocol The protocol to use
+         * @param address The remote address to connect to
+         * @param port The remote port
+         * @param handler The CallbackHandler for authentication
+         * @return A domain client
+         */
+        public static ServerDeploymentManager create(final String protocol, final InetAddress address, int port, CallbackHandler handler) {
+            return create(ModelControllerClient.Factory.create(protocol, address, port, handler), true);
         }
 
         /**

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -70,18 +70,19 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     private final Map<String, String> saslOptions;
     private final SSLContext sslContext;
     private final ExecutorService executorService;
+    private final String protocol;
     private boolean shutdownExecutor;
     private final int connectionTimeout;
 
-    protected ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService) {
-        this(address, port, handler, saslOptions, sslContext, executorService, false, DEFAULT_CONNECTION_TIMEOUT);
+    protected ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, final String protocol) {
+        this(address, port, handler, saslOptions, sslContext, executorService, false, DEFAULT_CONNECTION_TIMEOUT, protocol);
     }
 
-    protected ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor) {
-        this(address, port, handler, saslOptions, sslContext, executorService, shutdownExecutor, DEFAULT_CONNECTION_TIMEOUT);
+    protected ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final String protocol) {
+        this(address, port, handler, saslOptions, sslContext, executorService, shutdownExecutor, DEFAULT_CONNECTION_TIMEOUT, protocol);
     }
 
-    protected ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final int connectionTimeout) {
+    protected ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final int connectionTimeout, final String protocol) {
         this.address = address;
         this.port = port;
         this.handler = handler;
@@ -89,6 +90,7 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
         this.sslContext = sslContext;
         this.executorService = executorService;
         this.shutdownExecutor = shutdownExecutor;
+        this.protocol = protocol;
         this.connectionTimeout = connectionTimeout > 0 ? connectionTimeout : DEFAULT_CONNECTION_TIMEOUT;
     }
 
@@ -101,6 +103,12 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     public int getPort() {
         return port;
     }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
 
     @Override
     public CallbackHandler getCallbackHandler() {
@@ -135,35 +143,66 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     }
 
     public static ModelControllerClientConfiguration create(final InetAddress address, final int port) {
-        return new ClientConfigurationImpl(address.getHostName(), port, null, null, null, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(address.getHostName(), port, null, null, null, createDefaultExecutor(), true, null);
+    }
+    public static ModelControllerClientConfiguration create(final String protocol, final InetAddress address, final int port) {
+        return new ClientConfigurationImpl(address.getHostName(), port, null, null, null, createDefaultExecutor(), true, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final InetAddress address, final int port, final CallbackHandler handler){
-        return new ClientConfigurationImpl(address.getHostName(), port, handler, null, null, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(address.getHostName(), port, handler, null, null, createDefaultExecutor(), true, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol,final InetAddress address, final int port, final CallbackHandler handler){
+        return new ClientConfigurationImpl(address.getHostName(), port, handler, null, null, createDefaultExecutor(), true, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions){
-        return new ClientConfigurationImpl(address.getHostName(), port, handler, saslOptions, null, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(address.getHostName(), port, handler, saslOptions, null, createDefaultExecutor(), true, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions){
+        return new ClientConfigurationImpl(address.getHostName(), port, handler, saslOptions, null, createDefaultExecutor(), true, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final String hostName, final int port) throws UnknownHostException {
-        return new ClientConfigurationImpl(hostName, port, null, null, null, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(hostName, port, null, null, null, createDefaultExecutor(), true, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol, final String hostName, final int port) throws UnknownHostException {
+        return new ClientConfigurationImpl(hostName, port, null, null, null, createDefaultExecutor(), true, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-        return new ClientConfigurationImpl(hostName, port, handler, null, null, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(hostName, port, handler, null, null, createDefaultExecutor(), true, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol, final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
+        return new ClientConfigurationImpl(hostName, port, handler, null, null, createDefaultExecutor(), true, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
-        return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
+        return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
-        return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true, connectionTimeout);
+        return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true, connectionTimeout, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
+        return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true, connectionTimeout, protocol);
     }
 
     public static ModelControllerClientConfiguration create(final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
-        return new ClientConfigurationImpl(hostName, port, handler, saslOptions, null, createDefaultExecutor(), true);
+        return new ClientConfigurationImpl(hostName, port, handler, saslOptions, null, createDefaultExecutor(), true, null);
+    }
+
+    public static ModelControllerClientConfiguration create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
+        return new ClientConfigurationImpl(hostName, port, handler, saslOptions, null, createDefaultExecutor(), true, protocol);
     }
 
     private static int getSystemProperty(final String name, final int defaultValue) {

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ProtocolConfigurationFactory.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ProtocolConfigurationFactory.java
@@ -44,7 +44,11 @@ class ProtocolConfigurationFactory {
     static ProtocolChannelClient.Configuration create(final ModelControllerClientConfiguration client) throws URISyntaxException {
         final ProtocolChannelClient.Configuration configuration = new ProtocolChannelClient.Configuration();
 
-        configuration.setUri(new URI("remote://" + formatPossibleIpv6Address(client.getHost()) +  ":" + client.getPort()));
+        if(client.getProtocol() == null) {
+            configuration.setUri(new URI("http-remoting://" + formatPossibleIpv6Address(client.getHost()) +  ":" + client.getPort()));
+        } else  {
+            configuration.setUri(new URI(client.getProtocol() + "://" + formatPossibleIpv6Address(client.getHost()) +  ":" + client.getPort()));
+        }
         configuration.setOptionMap(DEFAULT_OPTIONS);
         final long timeout = client.getConnectionTimeout();
         if(timeout > 0) {

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/RemotingModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/RemotingModelControllerClient.java
@@ -40,8 +40,10 @@ import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.remoting3.Remoting;
+import org.jboss.remoting3.remote.HttpUpgradeConnectionProviderFactory;
 import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
 import org.xnio.OptionMap;
+import org.xnio.Options;
 
 /**
  * {@link ModelControllerClient} based on a Remoting {@link Endpoint}.
@@ -121,6 +123,8 @@ public class RemotingModelControllerClient extends AbstractModelControllerClient
                 // TODO move the endpoint creation somewhere else?
                 endpoint = Remoting.createEndpoint("management-client", OptionMap.EMPTY);
                 endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
+                endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
+                endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
 
                 configuration.setEndpoint(endpoint);
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -113,6 +113,7 @@ public class ModelDescriptionConstants {
     public static final String HOST_FAILURE_DESCRIPTION = "host-failure-description";
     public static final String HOST_FAILURE_DESCRIPTIONS = "host-failure-descriptions";
     public static final String HOST_STATE = "host-state";
+    public static final String HTTP_UPGRADE_ENABLED = "http-upgrade-enabled";
     public static final String HTTP_INTERFACE = "http-interface";
     public static final String IGNORED = "ignored-by-unaffected-host-controller";
     public static final String IGNORED_RESOURCES = "ignored-resources";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -69,6 +69,7 @@ public enum Attribute {
     GROUP("group"),
     HOST("host"),
     HTTP("http"),
+    HTTP_UPGRADE_ENABLED("http-upgrade-enabled"),
     HTTPS("https"),
     IGNORE_UNUSED_CONFIG("ignore-unused-configuration"),
     INITIAL_CONTEXT_FACTORY("initial-context-factory"),

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementRemoveHandler.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.host.controller.HostControllerEnvironment;
+import org.jboss.as.host.controller.resources.HttpManagementResourceDefinition;
 import org.jboss.as.server.mgmt._UndertowHttpManagementService;
 import org.jboss.dmr.ModelNode;
 
@@ -57,7 +58,8 @@ public class HttpManagementRemoveHandler extends AbstractRemoveStepHandler {
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         HttpManagementAddHandler.populateHostControllerInfo(hostControllerInfo, context, model);
-        HttpManagementAddHandler.installHttpManagementServices(context.getRunningMode(), context.getServiceTarget(), hostControllerInfo, environment, null, false);
+        boolean httpUpgrade = HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.resolveModelAttribute(context, model).asBoolean();
+        HttpManagementAddHandler.installHttpManagementServices(context.getRunningMode(), context.getServiceTarget(), hostControllerInfo, environment, null, false, httpUpgrade, context.getServiceRegistry(false), null);
     }
 
     static void clearHostControllerInfo(LocalHostControllerInfoImpl hostControllerInfo) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementWriteAttributeHandler.java
@@ -75,7 +75,8 @@ public class HttpManagementWriteAttributeHandler extends AbstractWriteAttributeH
                                             final HostControllerEnvironment environment, final ServiceVerificationHandler verificationHandler) throws OperationFailedException {
         HttpManagementRemoveHandler.removeHttpManagementService(context);
         HttpManagementAddHandler.populateHostControllerInfo(hostControllerInfo, context, subModel);
-        HttpManagementAddHandler.installHttpManagementServices(context.getRunningMode(), context.getServiceTarget(), hostControllerInfo, environment, verificationHandler, false);
+        boolean httpUpgrade = HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.resolveModelAttribute(context, subModel).asBoolean();
+        HttpManagementAddHandler.installHttpManagementServices(context.getRunningMode(), context.getServiceTarget(), hostControllerInfo, environment, verificationHandler, false, httpUpgrade, context.getServiceRegistry(false), null);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/NativeManagementServices.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/NativeManagementServices.java
@@ -1,0 +1,62 @@
+package org.jboss.as.host.controller.operations;
+
+import java.util.List;
+
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
+import org.jboss.as.host.controller.DomainModelControllerService;
+import org.jboss.as.host.controller.jmx.RemotingConnectorService;
+import org.jboss.as.host.controller.mgmt.ServerToHostOperationHandlerFactoryService;
+import org.jboss.as.protocol.ProtocolChannelClient;
+import org.jboss.as.remoting.EndpointService;
+import org.jboss.as.remoting.management.ManagementChannelRegistryService;
+import org.jboss.as.remoting.management.ManagementRemotingServices;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.remoting3.RemotingOptions;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+
+/**
+ * Utility class that installs remoting services needed by both the native and HTTP upgrade
+ * based connector.
+ *
+ * @author Stuart Douglas
+ */
+public class NativeManagementServices {
+
+    private static final int heartbeatInterval = 15000;
+    private static final int WINDOW_SIZE = ProtocolChannelClient.Configuration.WINDOW_SIZE;
+
+    private static final OptionMap SERVICE_OPTIONS = OptionMap.create(RemotingOptions.TRANSMIT_WINDOW_SIZE, WINDOW_SIZE,
+                                                        RemotingOptions.RECEIVE_WINDOW_SIZE, WINDOW_SIZE);
+
+    public static final OptionMap CONNECTION_OPTIONS = OptionMap.create(RemotingOptions.HEARTBEAT_INTERVAL, heartbeatInterval,
+                                                        Options.READ_TIMEOUT, 45000);
+
+    static synchronized void installRemotingServicesIfNotInstalled(final ServiceTarget serviceTarget,
+                    final String hostName,
+                    final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final ServiceRegistry serviceContainer, boolean onDemand) {
+
+        if(serviceContainer.getService(ManagementRemotingServices.MANAGEMENT_ENDPOINT) == null) {
+
+            ManagementChannelRegistryService.addService(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT);
+
+            ManagementRemotingServices.installRemotingEndpoint(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
+                    hostName, EndpointService.EndpointType.MANAGEMENT, CONNECTION_OPTIONS, verificationHandler, newControllers);
+
+
+            ManagementRemotingServices.installManagementChannelOpenListenerService(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
+                    ManagementRemotingServices.SERVER_CHANNEL,
+                    ServerToHostOperationHandlerFactoryService.SERVICE_NAME, SERVICE_OPTIONS, verificationHandler, newControllers, onDemand);
+
+            ManagementRemotingServices.installManagementChannelServices(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
+                    new ModelControllerClientOperationHandlerFactoryService(),
+                    DomainModelControllerService.SERVICE_NAME, ManagementRemotingServices.MANAGEMENT_CHANNEL, verificationHandler, newControllers);
+
+            RemotingConnectorService.addService(serviceTarget, verificationHandler);
+
+        }
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -626,6 +626,12 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                         }
                         break;
                     }
+                    case HTTP_UPGRADE_ENABLED: {
+                        if (http) {
+                            HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.parseAndSetParameter(value, addOp, reader);
+                        }
+                        break;
+                    }
                     default:
                         throw unexpectedAttribute(reader, i);
                 }
@@ -1654,6 +1660,7 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
         writer.writeStartElement(Element.HTTP_INTERFACE.getLocalName());
         HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
         HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
+        HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.marshallAsAttribute(protocol, writer);
 
         writer.writeEmptyElement(Element.SOCKET.getLocalName());
         HttpManagementResourceDefinition.INTERFACE.marshallAsAttribute(protocol, writer);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
@@ -79,7 +79,13 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
                 .setDefaultValue(new ModelNode(true))
                 .build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM,CONSOLE_ENABLED};
+    public static final SimpleAttributeDefinition HTTP_UPGRADE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.HTTP_UPGRADE_ENABLED, ModelType.BOOLEAN, true)
+                    .setAllowExpression(true)
+                    .setXmlName(Attribute.HTTP_UPGRADE_ENABLED.getLocalName())
+                    .setDefaultValue(new ModelNode(false))
+                    .build();
+
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM,CONSOLE_ENABLED,HTTP_UPGRADE_ENABLED};
 
     public HttpManagementResourceDefinition(final LocalHostControllerInfoImpl hostControllerInfo,
                                              final HostControllerEnvironment environment) {

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -146,6 +146,7 @@ host.core.management.http-interface.port=The port on which the host controller's
 host.core.management.http-interface.secure-port=The port on which the host controller's socket for HTTPS management communication should be opened.
 host.core.management.http-interface.security-realm=The security realm to use for the HTTP management interface.
 host.core.management.http-interface.console-enabled=Flag that indicates admin console is enabled
+host.core.management.http-interface.http-upgrade-enabled=Flag that indicates HTTP Upgrade is enabled, which allows HTTP requests to be upgraded to native remoting connections
 host.core.management.security-realm=Security realm
 host.core.management.management-interface=Management interface
 host.core.management.ldap-connection=Ldap connection

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
@@ -50,6 +50,7 @@ public class CommandLineMain {
         options.addOption("h", "help", false, MESSAGES.jdrHelpMessage());
         options.addOption("H", "host", true, MESSAGES.jdrHostnameMessage());
         options.addOption("p", "port", true, MESSAGES.jdrPortMessage());
+        options.addOption("s", "protocol", true, MESSAGES.jdrProtocolMessage());
     }
 
     /**
@@ -61,6 +62,7 @@ public class CommandLineMain {
     public static void main(String[] args) {
         String port = "9999";
         String host = "localhost";
+        String protocol = "http-remoting";
 
         try {
             CommandLine line = parser.parse(options, args, false);
@@ -76,6 +78,10 @@ public class CommandLineMain {
             if (line.hasOption("port")) {
                 port = line.getOptionValue("port");
             }
+
+            if (line.hasOption("protocol")) {
+                protocol = line.getOptionValue("protocol");
+            }
         } catch (ParseException e) {
             System.out.println(e.getMessage());
             formatter.printHelp(usage, options);
@@ -88,7 +94,7 @@ public class CommandLineMain {
 
         JdrReport response = null;
         try {
-            response = reportService.standaloneCollect(host, port);
+            response = reportService.standaloneCollect(protocol, host, port);
         } catch (OperationFailedException e) {
             System.out.println("Failed to complete the JDR report: " + e.getMessage());
         }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrMessages.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrMessages.java
@@ -64,6 +64,9 @@ interface JdrMessages {
     @Message(id = Message.NONE, value = "port that the management api is bound to. (default: 9990)")
     String jdrPortMessage();
 
+        @Message(id = Message.NONE, value = "Protocol that is used to connect. Can be remote, http or https (default: http)")
+    String jdrProtocolMessage();
+
     @Message(id = 13352, value = "Zipfile could not be created.")
     OperationFailedException couldNotCreateZipfile();
 

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportService.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportService.java
@@ -77,7 +77,7 @@ public class JdrReportService implements JdrReportCollector, Service<JdrReportCo
     /**
      * Collect a JDR report when run outside the Application Server.
      */
-    public JdrReport standaloneCollect(String host, String port) throws OperationFailedException {
+    public JdrReport standaloneCollect(String protocol, String host, String port) throws OperationFailedException {
         String username = null;
         String password = null;
 
@@ -87,8 +87,11 @@ public class JdrReportService implements JdrReportCollector, Service<JdrReportCo
         if (port == null) {
             port = "9999";
         }
+        if(protocol == null) {
+            protocol = "http-remoting";
+        }
 
-        return new JdrRunner(username, password, host, port).collect();
+        return new JdrRunner(protocol, username, password, host, port).collect();
     }
 
     /**

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -51,13 +51,13 @@ public class JdrRunner implements JdrReportCollector {
     public JdrRunner() {
     }
 
-    public JdrRunner(String user, String pass, String host, String port) {
+    public JdrRunner(String protocol, String user, String pass, String host, String port) {
         this.env.setUsername(user);
         this.env.setPassword(pass);
         this.env.setHost(host);
         this.env.setPort(port);
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(host, Integer.valueOf(port), null, null);
+            ctx = CommandContextFactory.getInstance().newCommandContext(protocol, host, Integer.valueOf(port), null, null);
             ctx.connectController();
             this.env.setClient(ctx.getModelControllerClient());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -198,8 +198,8 @@
         <version.org.jboss.osgi.spi>4.0.0.CR2</version.org.jboss.osgi.spi>
         <version.org.jboss.osgi.vfs>2.0.0.Alpha3</version.org.jboss.osgi.vfs>
         <version.org.jboss.remote-naming>1.0.6.Final</version.org.jboss.remote-naming>
-        <version.org.jboss.remoting3>3.2.16.GA</version.org.jboss.remoting3>
-        <version.org.jboss.remotingjmx.remoting-jmx>1.1.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
+        <version.org.jboss.remoting>4.0.0.Beta1</version.org.jboss.remoting>
+        <version.org.jboss.remotingjmx.remoting-jmx>2.0.0.Beta1</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.resteasy>3.0-beta-4</version.org.jboss.resteasy>
         <version.org.jboss.sasl>1.0.3.Final</version.org.jboss.sasl>
         <version.org.jboss.seam.int>6.0.0.GA</version.org.jboss.seam.int>
@@ -246,7 +246,7 @@
         <version.org.jboss.ws.cxf>4.2.0.Alpha1</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>1.0.1.GA</version.org.jboss.ws.jaxws-jboss-httpserver-httpspi>
         <version.org.jboss.xb>2.0.3.GA</version.org.jboss.xb>
-        <version.org.jboss.xnio>3.1.0.CR2</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.1.0.CR3</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>3.2.7.Final</version.org.jgroups>
@@ -464,6 +464,7 @@
                                             <exclude>org.jboss.logging:jboss-logging-tools</exclude>
                                             <!-- replaced by io.netty:netty -->
                                             <exclude>org.jboss.netty:netty</exclude>
+                                            <exclude>org.jboss.remoting3:jboss-remoting</exclude>
                                             <exclude>org.jboss.security:jbosssx</exclude>
                                             <exclude>org.jboss.slf4j:slf4j-jboss-logging</exclude>
                                             <exclude>org.jboss.spec.javax.resource:jboss-connector-api_1.5_spec</exclude>
@@ -3798,6 +3799,12 @@
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-remote-naming</artifactId>
                 <version>${version.org.jboss.remote-naming}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.remoting3</groupId>
+                        <artifactId>jboss-remoting</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -3986,6 +3993,12 @@
                 <groupId>org.jboss</groupId>
                 <artifactId>jboss-ejb-client</artifactId>
                 <version>${version.org.jboss.ejb-client}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.remoting3</groupId>
+                        <artifactId>jboss-remoting</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- TODO: this is not the final API -->
@@ -4645,9 +4658,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.remoting3</groupId>
+                <groupId>org.jboss.remoting</groupId>
                 <artifactId>jboss-remoting</artifactId>
-                <version>${version.org.jboss.remoting3}</version>
+                <version>${version.org.jboss.remoting}</version>
             </dependency>
 
             <dependency>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -63,7 +63,7 @@
             <artifactId>jboss-marshalling</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
         <dependency>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -68,8 +68,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-domain-management</artifactId>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>wildflydomain-management</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
@@ -100,7 +105,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
         <dependency>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -73,8 +73,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.as</groupId>
-            <artifactId>wildflydomain-management</artifactId>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-domain-management</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/remoting/src/main/java/org/jboss/as/remoting/EndpointService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/EndpointService.java
@@ -31,6 +31,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.remoting3.Remoting;
+import org.jboss.remoting3.remote.HttpUpgradeConnectionProviderFactory;
 import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
 import org.xnio.OptionMap;
 
@@ -72,6 +73,8 @@ public final class EndpointService implements Service<Endpoint> {
             try {
                 // Reuse the options for the remote connection factory for now
                 endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), optionMap);
+                endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), optionMap);
+                endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(), optionMap);
                 ok = true;
             } finally {
                 if (! ok) {

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
@@ -1,0 +1,293 @@
+package org.jboss.as.remoting;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Constructor;
+import java.security.AccessController;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedExceptionAction;
+
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.ChannelUpgradeHandler;
+import io.undertow.server.handlers.HttpUpgradeHandshake;
+import io.undertow.util.HttpString;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.UnknownURISchemeException;
+import org.jboss.remoting3.security.ServerAuthenticationProvider;
+import org.jboss.remoting3.spi.ExternalConnectionProvider;
+import org.xnio.ChannelListener;
+import org.xnio.OptionMap;
+import org.xnio.StreamConnection;
+import org.xnio.channels.AssembledConnectedSslStreamChannel;
+import org.xnio.channels.AssembledConnectedStreamChannel;
+import org.xnio.channels.SslConnection;
+
+/**
+ * Service that registers a HTTP upgrade handler to enable remoting to be used via http upgrade.
+ *
+ * @author Stuart Douglas
+ */
+public class RemotingHttpUpgradeService implements Service<RemotingHttpUpgradeService> {
+
+    public static final String JBOSS_REMOTING = "jboss-remoting";
+
+    public static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("management", "http-upgrade");
+    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("management", "remoting-http-upgrade-service");
+
+
+    private final InjectedValue<ChannelUpgradeHandler> injectedRegistry = new InjectedValue<>();
+    private final InjectedValue<Endpoint> injectedEndpoint = new InjectedValue<>();
+    private final InjectedValue<RemotingSecurityProvider> securityProviderValue = new InjectedValue<>();
+    private final OptionMap connectorPropertiesOptionMap;
+
+    public RemotingHttpUpgradeService(final OptionMap connectorPropertiesOptionMap) {
+        this.connectorPropertiesOptionMap = connectorPropertiesOptionMap;
+    }
+
+    public static void installServices(final ServiceTarget serviceTarget, final String connectorName, final ServiceName endpointName, final OptionMap connectorPropertiesOptionMap, final ServiceVerificationHandler verificationHandler) {
+        final RemotingHttpUpgradeService service = new RemotingHttpUpgradeService(connectorPropertiesOptionMap);
+
+        final ServiceName securityProviderName = RealmSecurityProviderService.createName(connectorName);
+
+        ServiceBuilder<RemotingHttpUpgradeService> builder = serviceTarget.addService(SERVICE_NAME, service)
+                .setInitialMode(ServiceController.Mode.PASSIVE)
+                .addDependency(HTTP_UPGRADE_REGISTRY, ChannelUpgradeHandler.class, service.injectedRegistry)
+                .addDependency(endpointName, Endpoint.class, service.injectedEndpoint)
+                .addDependency(securityProviderName, RemotingSecurityProvider.class, service.securityProviderValue);
+
+        if (verificationHandler != null) {
+            builder.addListener(verificationHandler);
+        }
+
+        builder.install();
+    }
+
+
+
+    @Override
+    public void start(final StartContext context) throws StartException {
+        final Endpoint endpoint = injectedEndpoint.getValue();
+        RemotingSecurityProvider rsp = securityProviderValue.getValue();
+        ServerAuthenticationProvider sap = rsp.getServerAuthenticationProvider();
+        OptionMap.Builder builder = OptionMap.builder();
+        builder.addAll(rsp.getOptionMap());
+
+        if (connectorPropertiesOptionMap != null) {
+            builder.addAll(connectorPropertiesOptionMap);
+        }
+        OptionMap resultingMap = builder.getMap();
+        try {
+            final ExternalConnectionProvider provider = endpoint.getConnectionProviderInterface("http-remoting", ExternalConnectionProvider.class);
+            final ExternalConnectionProvider.ConnectionAdaptor adaptor = provider.createConnectionAdaptor(resultingMap, sap);
+
+            injectedRegistry.getValue().addProtocol(JBOSS_REMOTING, new ChannelListener<StreamConnection>() {
+                @Override
+                public void handleEvent(final StreamConnection channel) {
+                    if(channel instanceof SslConnection) {
+                        adaptor.adapt(new AssembledConnectedSslStreamChannel((SslConnection)channel, channel.getSourceChannel(), channel.getSinkChannel()));
+                    } else {
+                        adaptor.adapt(new AssembledConnectedStreamChannel(channel, channel.getSourceChannel(), channel.getSinkChannel()));
+                    }
+                }
+            }, new RemotingUpgradeHanshake());
+
+        } catch (UnknownURISchemeException e) {
+            throw new StartException(e);
+        } catch (IOException e) {
+            throw new StartException(e);
+        }
+    }
+
+    @Override
+    public void stop(final StopContext context) {
+        injectedRegistry.getValue().removeProtocol(JBOSS_REMOTING);
+    }
+
+    @Override
+    public RemotingHttpUpgradeService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    private static final class RemotingUpgradeHanshake implements HttpUpgradeHandshake {
+
+
+        /**
+         * Magic number used in the handshake.
+         * <p/>
+         * The handshake borrows heavily from the web socket protocol, but uses different header
+         * names and a different magic number.
+         */
+        public static final String MAGIC_NUMBER = "CF70DEB8-70F9-4FBA-8B4F-DFC3E723B4CD";
+
+        //headers
+        public static final HttpString SEC_JBOSS_REMOTING_KEY = new HttpString("Sec-JbossRemoting-Key");
+        public static final HttpString SEC_JBOSS_REMOTING_ACCEPT = new HttpString("Sec-JbossRemoting-Accept");
+
+        @Override
+        public boolean handleUpgrade(final HttpServerExchange exchange) throws IOException {
+            String key = exchange.getRequestHeaders().getFirst(SEC_JBOSS_REMOTING_KEY);
+            if (key == null) {
+                throw RemotingMessages.MESSAGES.upgradeRequestMissingKey();
+            }
+            exchange.getResponseHeaders().put(SEC_JBOSS_REMOTING_ACCEPT, createExpectedResponse(key));
+            return true;
+        }
+
+        protected String createExpectedResponse(String secKey) throws IOException {
+            try {
+                final String concat = secKey + MAGIC_NUMBER;
+                final MessageDigest digest = MessageDigest.getInstance("SHA1");
+
+                digest.update(concat.getBytes("UTF-8"));
+                final byte[] bytes = digest.digest();
+                return FlexBase64.encodeString(bytes, false);
+            } catch (NoSuchAlgorithmException e) {
+                throw new IOException(e);
+            }
+
+        }
+
+
+
+        private static class FlexBase64 {
+            /*
+             * Note that this code heavily favors performance over reuse and clean style.
+             */
+
+            private static final byte[] ENCODING_TABLE;
+            private static final byte[] DECODING_TABLE = new byte[80];
+            private static final Constructor<String> STRING_CONSTRUCTOR;
+
+            static {
+                try {
+                    ENCODING_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".getBytes("ASCII");
+                } catch (UnsupportedEncodingException e) {
+                    throw new IllegalStateException();
+                }
+
+                for (int i = 0; i < ENCODING_TABLE.length; i++) {
+                    int v = (ENCODING_TABLE[i] & 0xFF) - 43;
+                    DECODING_TABLE[v] = (byte) (i + 1);  // zero = illegal
+                }
+
+                Constructor<String> c = null;
+                try {
+                    PrivilegedExceptionAction<Constructor<String>> runnable = new PrivilegedExceptionAction<Constructor<String>>() {
+                        @Override
+                        public Constructor<String> run() throws Exception {
+                            Constructor<String> c;
+                            c = String.class.getDeclaredConstructor(char[].class, boolean.class);
+                            c.setAccessible(true);
+                            return c;
+                        }
+                    };
+                    if (System.getSecurityManager() != null) {
+                        c = AccessController.doPrivileged(runnable);
+                    } else {
+                        c = runnable.run();
+                    }
+                } catch (Throwable t) {
+                }
+
+                STRING_CONSTRUCTOR = c;
+            }
+
+            /**
+             * Encodes a fixed and complete byte array into a Base64 String.
+             *
+             * @param source the byte array to encode from
+             * @param wrap   whether or not to wrap the output at 76 chars with CRLFs
+             * @return a new String representing the Base64 output
+             */
+            public static String encodeString(byte[] source, boolean wrap) {
+                return encodeString(source, 0, source.length, wrap);
+            }
+
+
+            private static String encodeString(byte[] source, int pos, int limit, boolean wrap) {
+                int olimit = (limit - pos);
+                int remainder = olimit % 3;
+                olimit = (olimit + (remainder == 0 ? 0 : 3 - remainder)) / 3 * 4;
+                olimit += (wrap ? (olimit / 76) * 2 + 2 : 0);
+                char[] target = new char[olimit];
+                int opos = 0;
+                int last = 0;
+                int count = 0;
+                int state = 0;
+                final byte[] ENCODING_TABLE = FlexBase64.ENCODING_TABLE;
+
+                while (limit > pos) {
+                    //  ( 6 | 2) (4 | 4) (2 | 6)
+                    int b = source[pos++] & 0xFF;
+                    target[opos++] = (char) ENCODING_TABLE[b >>> 2];
+                    last = (b & 0x3) << 4;
+                    if (pos >= limit) {
+                        state = 1;
+                        break;
+                    }
+                    b = source[pos++] & 0xFF;
+                    target[opos++] = (char) ENCODING_TABLE[last | (b >>> 4)];
+                    last = (b & 0x0F) << 2;
+                    if (pos >= limit) {
+                        state = 2;
+                        break;
+                    }
+                    b = source[pos++] & 0xFF;
+                    target[opos++] = (char) ENCODING_TABLE[last | (b >>> 6)];
+                    target[opos++] = (char) ENCODING_TABLE[b & 0x3F];
+
+                    if (wrap) {
+                        count += 4;
+                        if (count >= 76) {
+                            count = 0;
+                            target[opos++] = 0x0D;
+                            target[opos++] = 0x0A;
+                        }
+                    }
+                }
+
+                complete(target, opos, state, last, wrap);
+
+                try {
+                    // Eliminate copying on Open/Oracle JDK
+                    if (STRING_CONSTRUCTOR != null) {
+                        return STRING_CONSTRUCTOR.newInstance(target, Boolean.TRUE);
+                    }
+                } catch (Exception e) {
+                }
+
+                return new String(target);
+            }
+
+            private static int complete(char[] target, int pos, int state, int last, boolean wrap) {
+                if (state > 0) {
+                    target[pos++] = (char) ENCODING_TABLE[last];
+                    for (int i = state; i < 3; i++) {
+                        target[pos++] = '=';
+                    }
+                }
+                if (wrap) {
+                    target[pos++] = 0x0D;
+                    target[pos++] = 0x0A;
+                }
+
+                return pos;
+            }
+
+        }
+
+    }
+
+}

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingMessages.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingMessages.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.remoting;
 
+import java.io.IOException;
 import java.net.BindException;
 import java.net.URISyntaxException;
 
@@ -108,4 +109,6 @@ public interface RemotingMessages {
     @Message(id = 17130, value = "Invalid Strength '%s' string given")
     IllegalArgumentException illegalStrength(String strength);
 
+    @Message(id = 17131, value = "HTTP Upgrade request missing Sec-JbossRemoting-Key header")
+    IOException upgradeRequestMissingKey();
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
@@ -69,6 +69,7 @@ public final class ManagementRemotingServices extends RemotingServices {
     public static final String SERVER_CHANNEL = "server";
 
     public static final String MANAGEMENT_CONNECTOR = "management";
+    public static final String HTTP_CONNECTOR = "http-management";
 
     /**
      * Installs a remoting stream server for a domain instance

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -115,7 +115,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
         <dependency>

--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -94,7 +94,11 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setDefaultValue(new ModelNode(true))
             .build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM, SOCKET_BINDING, SECURE_SOCKET_BINDING,CONSOLE_ENABLED};
+    public static final SimpleAttributeDefinition HTTP_UPGRADE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.HTTP_UPGRADE_ENABLED, ModelType.BOOLEAN, true)
+            .setXmlName(Attribute.HTTP_UPGRADE_ENABLED.getLocalName())
+            .setDefaultValue(new ModelNode(false))
+            .build();
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM, SOCKET_BINDING, SECURE_SOCKET_BINDING,CONSOLE_ENABLED, HTTP_UPGRADE_ENABLED};
 
     public static final HttpManagementResourceDefinition INSTANCE = new HttpManagementResourceDefinition();
 

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementRemoveHandler.java
@@ -25,6 +25,9 @@ package org.jboss.as.server.operations;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.remoting.RemotingHttpUpgradeService;
+import org.jboss.as.remoting.RemotingServices;
+import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.mgmt._UndertowHttpManagementService;
 import org.jboss.dmr.ModelNode;
 
@@ -50,6 +53,8 @@ public class HttpManagementRemoveHandler extends AbstractRemoveStepHandler {
 
         removeHttpManagementService(context);
 
+        RemotingServices.removeConnectorServices(context, ManagementRemotingServices.HTTP_CONNECTOR);
+        context.removeService(RemotingHttpUpgradeService.SERVICE_NAME);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementWriteAttributeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementWriteAttributeHandler.java
@@ -103,7 +103,7 @@ public class HttpManagementWriteAttributeHandler extends AbstractWriteAttributeH
 
     static void updateHttpManagementService(final OperationContext context, final ModelNode subModel, final ServiceVerificationHandler verificationHandler) throws OperationFailedException {
         HttpManagementRemoveHandler.removeHttpManagementService(context);
-        HttpManagementAddHandler.installHttpManagementConnector(context, subModel, context.getServiceTarget(), verificationHandler, null);
+        HttpManagementAddHandler.installHttpManagementConnector(context, subModel, context.getServiceTarget(), verificationHandler, null, false);
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.server.operations;
 
-import org.jboss.as.protocol.ProtocolChannelClient;
-import org.jboss.as.remoting.management.ManagementChannelRegistryService;
 import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.ATTRIBUTE_DEFINITIONS;
 import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.INTERFACE;
 import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.NATIVE_PORT;
@@ -39,22 +37,18 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
 import org.jboss.as.domain.management.security.SecurityRealmService;
 import org.jboss.as.network.SocketBinding;
-import org.jboss.as.remoting.EndpointService;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerLogger;
 import org.jboss.as.server.ServerMessages;
-import org.jboss.as.server.Services;
 import org.jboss.as.server.services.net.NetworkInterfaceService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.remoting3.RemotingOptions;
 import org.xnio.OptionMap;
 
 /**
@@ -68,8 +62,6 @@ public class NativeManagementAddHandler extends AbstractAddStepHandler {
     public static final NativeManagementAddHandler INSTANCE = new NativeManagementAddHandler();
     public static final String OPERATION_NAME = ModelDescriptionConstants.ADD;
 
-    private static final int WINDOW_SIZE = ProtocolChannelClient.Configuration.WINDOW_SIZE;
-    private static final OptionMap options = OptionMap.create(RemotingOptions.RECEIVE_WINDOW_SIZE, WINDOW_SIZE);
 
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
         for (AttributeDefinition definition : ATTRIBUTE_DEFINITIONS) {
@@ -90,17 +82,10 @@ public class NativeManagementAddHandler extends AbstractAddStepHandler {
 
         final ServiceName endpointName = ManagementRemotingServices.MANAGEMENT_ENDPOINT;
         final String hostName = SecurityActions.getSystemProperty(ServerEnvironment.NODE_NAME);
-        ManagementRemotingServices.installRemotingEndpoint(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT, hostName, EndpointService.EndpointType.MANAGEMENT, options, verificationHandler, newControllers);
+        NativeManagementServices.installRemotingServicesIfNotInstalled(serviceTarget, hostName, verificationHandler, newControllers, context.getServiceRegistry(false));
         installNativeManagementConnector(context, model, endpointName, serviceTarget, verificationHandler, newControllers);
 
-        ManagementChannelRegistryService.addService(serviceTarget, endpointName);
-        ManagementRemotingServices.installManagementChannelServices(serviceTarget,
-                endpointName,
-                new ModelControllerClientOperationHandlerFactoryService(),
-                Services.JBOSS_SERVER_CONTROLLER,
-                ManagementRemotingServices.MANAGEMENT_CHANNEL,
-                verificationHandler,
-                newControllers);
+
     }
 
     // TODO move this kind of logic into AttributeDefinition itself
@@ -186,6 +171,7 @@ public class NativeManagementAddHandler extends AbstractAddStepHandler {
                     ManagementRemotingServices.MANAGEMENT_CONNECTOR,
                     socketBindingServiceName, options, verificationHandler, newControllers);
         }
+
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementRemoveHandler.java
@@ -53,15 +53,16 @@ public class NativeManagementRemoveHandler extends AbstractRemoveStepHandler {
         final ServiceName endpointName = ManagementRemotingServices.MANAGEMENT_ENDPOINT;
 
         // Remove management Channel
-        ManagementRemotingServices.removeManagementChannelServices(context, endpointName, ManagementRemotingServices.MANAGEMENT_CHANNEL);
+        // ManagementRemotingServices.removeManagementChannelServices(context, endpointName, ManagementRemotingServices.MANAGEMENT_CHANNEL);
 
         // Remove management Connector
         final ModelNode portNode = NativeManagementResourceDefinition.NATIVE_PORT.resolveModelAttribute(context, model);
         int port = portNode.isDefined() ? portNode.asInt() : 0;
         ManagementRemotingServices.removeConnectorServices(context, ManagementRemotingServices.MANAGEMENT_CONNECTOR);
 
-        // Remove endpoint
-        context.removeService(endpointName);
+        // We don't remove the endpoint or other remoting services, as it may still be in use by the HTTP upgrade handler.
+        // TODO: figure out some way of removing it if it is not in use
+        // context.removeService(endpointName);
 
     }
 

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
@@ -1,0 +1,50 @@
+package org.jboss.as.server.operations;
+
+import java.util.List;
+
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
+import org.jboss.as.protocol.ProtocolChannelClient;
+import org.jboss.as.remoting.EndpointService;
+import org.jboss.as.remoting.management.ManagementChannelRegistryService;
+import org.jboss.as.remoting.management.ManagementRemotingServices;
+import org.jboss.as.server.Services;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.remoting3.RemotingOptions;
+import org.xnio.OptionMap;
+
+/**
+ * Utility class that installs remoting services needed by both the native and HTTP upgrade
+ * based connector.
+ *
+ * @author Stuart Douglas
+ */
+class NativeManagementServices {
+
+    private static final int WINDOW_SIZE = ProtocolChannelClient.Configuration.WINDOW_SIZE;
+    private static final OptionMap OPTIONS = OptionMap.create(RemotingOptions.RECEIVE_WINDOW_SIZE, WINDOW_SIZE);
+
+    static synchronized void installRemotingServicesIfNotInstalled(final ServiceTarget serviceTarget,
+                                                                   final String hostName,
+                                                                   final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final ServiceRegistry serviceContainer) {
+
+        if (serviceContainer.getService(ManagementRemotingServices.MANAGEMENT_ENDPOINT) == null) {
+
+            ManagementChannelRegistryService.addService(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT);
+
+            ManagementRemotingServices.installRemotingEndpoint(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT, hostName, EndpointService.EndpointType.MANAGEMENT, OPTIONS, verificationHandler, newControllers);
+
+
+            ManagementRemotingServices.installManagementChannelServices(serviceTarget,
+                    ManagementRemotingServices.MANAGEMENT_ENDPOINT,
+                    new ModelControllerClientOperationHandlerFactoryService(),
+                    Services.JBOSS_SERVER_CONTROLLER,
+                    ManagementRemotingServices.MANAGEMENT_CHANNEL,
+                    verificationHandler,
+                    newControllers);
+
+        }
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -681,6 +681,12 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
                         }
                         break;
                     }
+                    case HTTP_UPGRADE_ENABLED: {
+                        if (http) {
+                            HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.parseAndSetParameter(value, addOp, reader);
+                        }
+                        break;
+                    }
                     default:
                         throw unexpectedAttribute(reader, i);
                 }
@@ -1227,6 +1233,7 @@ public class StandaloneXml extends CommonXml implements ManagementXml.Delegate {
         if (!consoleEnabled) {
             HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
         }
+        HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.marshallAsAttribute(protocol, writer);
 
         if (HttpManagementResourceDefinition.INTERFACE.isMarshallable(protocol)) {
             writer.writeEmptyElement(Element.SOCKET.getLocalName());

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -95,6 +95,7 @@ core.management.http-interface.security-realm=The security realm to use for the 
 core.management.http-interface.socket-binding=The name of the socket binding configuration to use for the HTTP management interface's socket.
 core.management.http-interface.secure-socket-binding=The name of the socket binding configuration to use for the HTTPS management interface's socket.
 core.management.http-interface.console-enabled=Flag that indicates admin console is enabled
+core.management.http-interface.http-upgrade-enabled=Flag that indicates HTTP Upgrade is enabled, which allows HTTP requests to be upgraded to native remoting connections
 core.service-container=The central container that manages all services in a running standalone server or in a host controller in a management domain.
 core.module-loading=The modular classloading system.
 core.module-loading.module-roots=A list of filesystem locations under which the module loading system looks for modules, arranged in order of precedence.

--- a/testsuite/compat/src/test/resources/arquillian.xml
+++ b/testsuite/compat/src/test/resources/arquillian.xml
@@ -9,7 +9,7 @@
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
         </configuration>
     </container>
 </arquillian>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
@@ -50,7 +50,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="9999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="management" port="9990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
@@ -53,7 +53,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="19999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm" console-enabled="false">
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
                 <socket interface="management" port="19990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -48,7 +48,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="9999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="management" port="9990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -48,7 +48,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="public" port="9989"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="public" port="9980"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -48,7 +48,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="public" port="19999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="public" port="19990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -45,7 +45,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="9999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="management" port="9990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -48,7 +48,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="9999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="management" port="9990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -47,7 +47,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="19999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm" console-enabled="false">
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
                 <socket interface="management" port="19990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -51,7 +51,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="management" port="19999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm" console-enabled="false">
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
                 <socket interface="management" port="19990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -42,7 +42,7 @@
             <native-interface security-realm="ManagementRealm">
                 <socket interface="public" port="9999"/>
             </native-interface>
-            <http-interface security-realm="ManagementRealm">
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
                 <socket interface="public" port="9990"/>
             </http-interface>
         </management-interfaces>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -11,10 +11,10 @@
 			     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
 
             <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
@@ -72,7 +72,7 @@ import org.xml.sax.InputSource;
 
 /**
  * @author baranowb
- * 
+ *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -105,7 +105,7 @@ public class JMXPropertyEditorsTestCase {
         final String address = managementClient.getMgmtAddress()+":"+managementClient.getMgmtPort();
 //        return JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:remoting-jmx://localhost:9999"))
 //                .getMBeanServerConnection();
-        return JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:remoting-jmx://"+address))
+        return JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:http-remoting-jmx://"+address))
                 .getMBeanServerConnection();
 
     }
@@ -1250,7 +1250,7 @@ public class JMXPropertyEditorsTestCase {
                         System.err.println("------- 2");
                         return 1;
                     }
-                    
+
                     Set<Object> keys1 = p1.keySet();
                     for(Object key:keys1){
                         Object v1 = p1.get(key);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
@@ -248,7 +248,7 @@ public class ModelControllerMBeanTestCase {
     private MBeanServerConnection setupAndGetConnection() throws Exception {
         // Make sure that we can connect to the MBean server
         String urlString = System
-                .getProperty("jmx.service.url", "service:jmx:remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
+                .getProperty("jmx.service.url", "service:jmx:http-remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         connector = JMXConnectorFactory.connect(serviceURL, null);
         return connector.getMBeanServerConnection();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -69,9 +69,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAT
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@ServerSetup(ClientCompatibilityUnitTestCase.ClientCompatibilityUnitTestCaseServerSetup.class)
+//@ServerSetup(ClientCompatibilityUnitTestCase.ClientCompatibilityUnitTestCaseServerSetup.class)
 public class ClientCompatibilityUnitTestCase {
-
+    /* TODO: re-enable when the native interface is removed
     static class ClientCompatibilityUnitTestCaseServerSetup implements ServerSetupTask {
 
         @Override
@@ -100,6 +100,7 @@ public class ClientCompatibilityUnitTestCase {
                     .append(MANAGEMENT_INTERFACE, NATIVE_INTERFACE).toModelNode();
         }
     }
+    */
 
     @Deployment
     public static final Archive fakeDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/ArchiveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/ArchiveTestCase.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.cli.CommandContext;
-import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.SimpleServlet;
@@ -136,7 +135,7 @@ public class ArchiveTestCase {
     @Test
     public void testUnDeployArchive() throws Exception {
 
-        final CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
+        final CommandContext ctx = CLITestUtil.getCommandContext();
         try {
             ctx.connectController();
             ctx.handle("deploy " + cliArchiveFile.getAbsolutePath() + " --script=install.scr");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java
@@ -83,14 +83,14 @@ import org.picketbox.util.KeyStoreUtil;
 /**
  * A testcase for {@link org.jboss.as.security.remoting.RemotingLoginModule}. This test covers scenario, when an EJB clients use
  * certificate for authentication.
- * 
+ *
  * @author Josef Cacek
  */
 @RunWith(Arquillian.class)
 @ServerSetup({ RemotingLoginModuleTestCase.FilesSetup.class, //
-        RemotingLoginModuleTestCase.SecurityRealmsSetup.class, // 
-        RemotingLoginModuleTestCase.RemotingSetup.class, // 
-        RemotingLoginModuleTestCase.SecurityDomainsSetup.class // 
+        RemotingLoginModuleTestCase.SecurityRealmsSetup.class, //
+        RemotingLoginModuleTestCase.RemotingSetup.class, //
+        RemotingLoginModuleTestCase.SecurityDomainsSetup.class //
 })
 @RunAsClient
 public class RemotingLoginModuleTestCase {
@@ -130,7 +130,7 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * Creates a deployment application for this test.
-     * 
+     *
      * @return
      * @throws IOException
      */
@@ -144,7 +144,7 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * Tests that an authorized user has access to an EJB method.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -158,7 +158,7 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * Tests if role check is done correctly for authenticated user.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -177,7 +177,7 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * Tests if client access is denied for untrusted clients.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -197,13 +197,13 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * Configure {@link SSLContext} and create EJB client properties.
-     * 
+     *
      * @param clientName
      * @return
      * @throws Exception
      */
     private Properties configureEjbClient(String clientName) throws Exception {
-        // create new SSLContext based on client keystore and truststore and use this SSLContext instance as a default for this test            
+        // create new SSLContext based on client keystore and truststore and use this SSLContext instance as a default for this test
         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         keyManagerFactory.init(KeyStoreUtil.getKeyStore(getClientKeystoreFile(clientName), KEYSTORE_PASSWORD.toCharArray()),
                 KEYSTORE_PASSWORD.toCharArray());
@@ -231,7 +231,7 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * Returns {@link File} instance representing keystore of client with given name.
-     * 
+     *
      * @param clientName
      * @return
      */
@@ -243,14 +243,14 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * A {@link ServerSetupTask} instance which creates security domains for this test case.
-     * 
+     *
      * @author Josef Cacek
      */
     static class SecurityDomainsSetup extends AbstractSecurityDomainsServerSetupTask {
 
         /**
          * Returns SecurityDomains configuration for this testcase.
-         * 
+         *
          * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask#getSecurityDomains()
          */
         @Override
@@ -266,7 +266,7 @@ public class RemotingLoginModuleTestCase {
             //            <module-option name="rolesProperties" value="file:///${jboss.server.config.dir}/roles.properties"/>
             //        </login-module>
             //    </authentication>
-            //</security-domain>            
+            //</security-domain>
             final SecurityModule.Builder loginModuleBuilder = new SecurityModule.Builder().putOption("password-stacking",
                     "useFirstPass");
             final SecurityDomain sd = new SecurityDomain.Builder()
@@ -283,7 +283,7 @@ public class RemotingLoginModuleTestCase {
 
     /**
      * A {@link ServerSetupTask} instance which creates security realms for this test case.
-     * 
+     *
      * @author Josef Cacek
      */
     static class SecurityRealmsSetup extends AbstractSecurityRealmsServerSetupTask {

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -12,10 +12,10 @@
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="managementAddress">${node0}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
 
             <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
@@ -26,10 +26,10 @@
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-udp-jdbc-store</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="managementAddress">${node0}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
 
             <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
@@ -43,10 +43,10 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-0 -Djboss.node.name=node-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="managementAddress">${node0}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -57,10 +57,10 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-${cacheMode}-${stack}-1 -Djboss.node.name=node-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="managementAddress">${node1}</property>
-                <property name="managementPort">10099</property>
+                <property name="managementPort">10090</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -71,12 +71,12 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>
                 <property name="serverConfig">standalone.xml</property>
                 <property name="managementAddress">${node0}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
-        
+
     </group>
 
 </arquillian>

--- a/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
@@ -11,10 +11,10 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-iiop-client</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node0}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -26,10 +26,10 @@
                 <property name="javaVmArguments">${server.jvm.args}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node1}</property>
-                <property name="managementPort">10099</property>
+                <property name="managementPort">10090</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -11,10 +11,10 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -26,14 +26,14 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
-                <property name="managementPort">10099</property>
+                <property name="managementPort">10090</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
-        
+
         <container qualifier="jbossas-layered" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-layered</property>
@@ -41,11 +41,11 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
                 <property name="modulePath">${basedir}/target/jbossas-layered/modules</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -57,10 +57,10 @@
                 <property name="serverConfig">standalone-full.xml</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
@@ -72,10 +72,10 @@
                 <property name="serverConfig">standalone-full-backup.xml</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
-                <property name="managementPort">${as.managementPort:10099}</property>
+                <property name="managementPort">${as.managementPort:10090}</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port:8987} ${as.managementPort:10099}</property>
+                <property name="waitForPorts">${as.debug.port:8987} ${as.managementPort:10090}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/shutdown/RemoteCallWhileShuttingDownTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/shutdown/RemoteCallWhileShuttingDownTestCase.java
@@ -117,7 +117,7 @@ public class RemoteCallWhileShuttingDownTestCase {
         // First start the server which has a remote-outbound-connection
         this.container.start(CONTAINER);
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-        ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());
+        ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
         try {
             this.deployer.deploy(DEP1);
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
@@ -143,13 +143,13 @@ public class SSLEJBRemoteClientTestCase {
             log.info("*** starting server");
             container.start(DEFAULT_JBOSSAS);
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());
+            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
             log.info("*** will configure server now");
             SSLRealmSetupTool.setup(managementClient);
             log.info("*** restarting server");
             container.stop(DEFAULT_JBOSSAS);
             container.start(DEFAULT_JBOSSAS);
-            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());
+            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
             // write SSL realm config to output - debugging purposes
             SSLRealmSetupTool.readSSLRealmConfig(managementClient);
             previousClientContextSelector = setupEJBClientContextSelector();
@@ -165,7 +165,7 @@ public class SSLEJBRemoteClientTestCase {
             EJBClientContext.setSelector(previousClientContextSelector);
         }
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-        final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());
+        final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
         SSLRealmSetupTool.tearDown(mClient, container);
     }
 

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -12,7 +12,7 @@
                                                                                         <!-- jboss.node.name is defined in the test, not related to AS instance name! -->
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node0}</property>
-                <property name="managementPort">${as.managementPort:9999}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
 
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787}</property>
@@ -27,10 +27,10 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="managementAddress">${node1}</property>
-                <property name="managementPort">10099</property>
+                <property name="managementPort">10090</property>
 
                 <!-- AS7-4070 -->
-                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>

--- a/testsuite/integration/osgi/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/osgi/src/test/config/arq/arquillian.xml
@@ -11,10 +11,10 @@
 			     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
 
             <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -9,12 +9,12 @@
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
 
             <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>
-    
+
 </arquillian>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/DataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/DataSourceOperationsUnitTestCase.java
@@ -532,16 +532,6 @@ public class DataSourceOperationsUnitTestCase extends DsMgmtTestBase {
 
         Assert.assertNotNull("Reparsing failed:", newList);
 
-
-        try {
-            ModifiableXaDataSource jxaDS = lookup(getModelControllerClient(), xaDsJndi, ModifiableXaDataSource.class);
-
-            Assert.fail("found datasource after it was unbounded");
-        } catch (Exception e) {
-            // must be thrown NameNotFound exception - datasource is unbounded
-
-        }
-
         Assert.assertNotNull(findNodeWithProperty(newList, "jndi-name", xaDsJndi));
 
     }
@@ -770,15 +760,6 @@ public class DataSourceOperationsUnitTestCase extends DsMgmtTestBase {
         remove(address);
         remove(propAddress);
 
-    }
-
-    private static <T> T lookup(ModelControllerClient client, String name, Class<T> expected) throws Exception {
-        //TODO Don't do this FakeJndi stuff once we have remote JNDI working
-
-        MBeanServerConnection mbeanServer = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:remoting-jmx://127.0.0.1:9999")).getMBeanServerConnection();
-        ObjectName objectName = new ObjectName("jboss:name=test,type=fakejndi");
-        Object o = mbeanServer.invoke(objectName, "lookup", new Object[]{name}, new String[]{"java.lang.String"});
-        return expected.cast(o);
     }
 
 

--- a/testsuite/integration/xts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/xts/src/test/config/arq/arquillian.xml
@@ -9,7 +9,7 @@
             <property name="serverConfig">${jboss.server.config.file.name:standalone-xts.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
-            <property name="managementPort">${as.managementPort:9999}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
         </configuration>
     </container>
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
@@ -47,7 +47,7 @@ public class CLITestUtil {
 
     public static CommandContext getCommandContext() throws CliInitializationException {
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(serverAddr, serverPort, null, null);
+        return CommandContextFactory.getInstance().newCommandContext("http-remoting", serverAddr, serverPort, null, null);
     }
 
     public static CommandContext getCommandContext(String address, int port, String user, char[] pwd, InputStream in, OutputStream out)

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -117,7 +117,7 @@ public class CLIWrapper {
     public boolean sendConnect(String cliAddress) {
         String addr = cliAddress != null ? cliAddress : TestSuiteEnvironment.getServerAddress();
         try {
-            ctx.connectController(addr, TestSuiteEnvironment.getServerPort());
+            ctx.connectController("http-remoting", addr, TestSuiteEnvironment.getServerPort());
             return true;
         } catch (CommandLineException e) {
             e.printStackTrace();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -33,7 +33,7 @@ public class TestSuiteEnvironment {
      * @return The server port for node0
      */
     public static int getServerPort() {
-        return Integer.getInteger("as.managementPort", 9999);
+        return Integer.getInteger("as.managementPort", 9990);
     }
 
     /**

--- a/webservices/tests-integration/pom.xml
+++ b/webservices/tests-integration/pom.xml
@@ -95,7 +95,7 @@
             <artifactId>jboss-ejb-client</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.jboss.remoting3</groupId>
+                    <groupId>org.jboss.remoting</groupId>
                     <artifactId>jboss-remoting</artifactId>
                 </exclusion>
                 <exclusion>
@@ -135,7 +135,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jboss.remoting3</groupId>
+            <groupId>org.jboss.remoting</groupId>
             <artifactId>jboss-remoting</artifactId>
         </dependency>
         <dependency>

--- a/webservices/tests-integration/src/main/java/org/jboss/as/webservices/deployer/RemoteDeployer.java
+++ b/webservices/tests-integration/src/main/java/org/jboss/as/webservices/deployer/RemoteDeployer.java
@@ -94,9 +94,10 @@ import static org.jboss.as.security.Constants.SECURITY_DOMAIN;
 public final class RemoteDeployer implements Deployer {
 
     private static final Logger LOGGER = Logger.getLogger(RemoteDeployer.class);
-    private static final int DEFAULT_PORT = 9999;
+    private static final int DEFAULT_PORT = 9990;
     private static final String JBWS_DEPLOYER_HOST = "jbossws.deployer.host";
     private static final String JBWS_DEPLOYER_PORT = "jbossws.deployer.port";
+    private static final String JBWS_DEPLOYER_PROTOCOL = "jbossws.deployer.protocol";
     private static final String JBWS_DEPLOYER_AUTH_USER = "jbossws.deployer.authentication.username";
     private static final String JBWS_DEPLOYER_AUTH_PWD = "jbossws.deployer.authentication.password";
     private static final String JBWS_DEPLOYER_HTTPS_LISTENER_NAME = "jbws-test-https-listener";
@@ -105,6 +106,7 @@ public final class RemoteDeployer implements Deployer {
     private static final int TIMEOUT = 60000;
     private static InetAddress address;
     private static Integer port;
+    private static String protocol;
     private final Map<URL, String> url2Id = new HashMap<URL, String>();
     private final Map<String, Integer> securityDomainUsers = new HashMap<String, Integer>(1);
     private final Map<String, Integer> archiveCounters = new HashMap<String, Integer>();
@@ -118,6 +120,7 @@ public final class RemoteDeployer implements Deployer {
             final String host = System.getProperty(JBWS_DEPLOYER_HOST);
             address = host != null ? InetAddress.getByName(host) : InetAddress.getByName("localhost");
             port = Integer.getInteger(JBWS_DEPLOYER_PORT, DEFAULT_PORT);
+            protocol = System.getProperty(JBWS_DEPLOYER_PROTOCOL, "http-remoting");
         } catch (final IOException e) {
             LOGGER.fatal(e.getMessage(), e);
             System.exit(1);
@@ -428,7 +431,7 @@ public final class RemoteDeployer implements Deployer {
     }
 
     private static ModelControllerClient newModelControllerClient() throws Exception {
-        return ModelControllerClient.Factory.create(address.getHostAddress(), port, callbackHandler, null, TIMEOUT);
+        return ModelControllerClient.Factory.create(protocol, address.getHostAddress(), port, callbackHandler, null, TIMEOUT);
     }
 
     private static ServerDeploymentManager newDeploymentManager(ModelControllerClient client) throws Exception {


### PR DESCRIPTION
This commit adds support for multiplexing remoting over the
management HTTP server port. By default the management
remoting port will no longer be availble, which will
break out of the box compatibility with older clients.

This commit does not address the remoting subsystem
endpoint used by EJB and remoting naming. This will be
added in a later commit.
