### PR TITLE
Fix for WFLY-1308 

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbLogger.java
@@ -24,6 +24,14 @@
 
 package org.jboss.as.ejb3;
 
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.sql.SQLException;
+import java.util.Date;
+
+import javax.ejb.Timer;
+
 import org.jboss.as.ejb3.component.entity.EntityBeanComponentInstance;
 import org.jboss.as.ejb3.component.stateful.StatefulSessionComponentInstance;
 import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
@@ -40,13 +48,6 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.MessageInputStream;
-
-import javax.ejb.Timer;
-import java.io.File;
-import java.lang.reflect.Method;
-import java.net.InetAddress;
-import java.sql.SQLException;
-import java.util.Date;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
@@ -523,8 +524,8 @@ public interface EjbLogger extends BasicLogger {
     void couldNotWriteMethodInvocation(@Cause Throwable cause, Method invokedMethod, String beanName, String appName, String moduleName, String distinctName);
 
     @LogMessage(level = ERROR)
-    @Message(id = 14251, value = "IOException while generating session id for invocation id: %s on channel %s")
-    void exceptionGeneratingSessionId(@Cause Throwable cause, short invocationId, Channel channel);
+    @Message(id = 14251, value = "Exception while generating session id for component %s with invocation id: %s on channel %s")
+    void exceptionGeneratingSessionId(@Cause Throwable cause, String componentName, short invocationId, Channel channel);
 
     @LogMessage(level = ERROR)
     @Message(id = 14252, value = "Could not write out message to channel due to")

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -66,6 +66,7 @@ import org.jboss.as.ee.component.ResourceInjectionTarget;
 import org.jboss.as.ejb3.cache.CacheFactory;
 import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.ejb3.component.EJBComponentUnavailableException;
 import org.jboss.as.ejb3.component.EJBViewDescription;
 import org.jboss.as.ejb3.component.MethodIntf;
 import org.jboss.as.ejb3.component.entity.EntityBeanComponentInstance;
@@ -2392,7 +2393,7 @@ public interface EjbMessages {
     IllegalStateException noEjbContextAvailable();
 
     @Message(id = 14559, value = "Invocation cannot proceed as component is shutting down")
-    EJBException componentIsShuttingDown();
+    EJBComponentUnavailableException componentIsShuttingDown();
 
     @Message(id = 14560, value = "Could not open message outputstream for writing to Channel")
     IOException failedToOpenMessageOutputStream(@Cause Throwable e);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentUnavailableException.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentUnavailableException.java
@@ -1,0 +1,28 @@
+package org.jboss.as.ejb3.component;
+
+import javax.ejb.EJBException;
+
+/**
+ * An exception which can be used to indicate that a particular EJB component is (no longer) available for handling invocations. This typically is thrown when an EJB is invoked
+ * after the EJB component has been marked for shutdown.
+ *
+ * @author: Jaikiran Pai
+ */
+public class EJBComponentUnavailableException extends EJBException {
+
+    public EJBComponentUnavailableException() {
+
+    }
+
+    public EJBComponentUnavailableException(final String msg) {
+        super(msg);
+    }
+
+    public EJBComponentUnavailableException(final String msg, final Exception e) {
+        super(msg, e);
+    }
+
+    public EJBComponentUnavailableException(final Exception e) {
+        super(e);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/EJBIdentifierBasedMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/EJBIdentifierBasedMessageHandler.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.ejb3.remote.protocol.versionone;
 
+import java.util.Map;
+
 import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
 import org.jboss.as.ejb3.deployment.DeploymentRepository;
 import org.jboss.as.ejb3.deployment.EjbDeploymentInformation;
@@ -41,7 +43,11 @@ abstract class EJBIdentifierBasedMessageHandler extends AbstractMessageHandler {
 
     protected EjbDeploymentInformation findEJB(final String appName, final String moduleName, final String distinctName, final String beanName) {
         final DeploymentModuleIdentifier ejbModule = new DeploymentModuleIdentifier(appName, moduleName, distinctName);
-        final ModuleDeployment moduleDeployment = this.deploymentRepository.getModules().get(ejbModule);
+        final Map<DeploymentModuleIdentifier, ModuleDeployment> modules = this.deploymentRepository.getModules();
+        if (modules == null || modules.isEmpty()) {
+            return null;
+        }
+        final ModuleDeployment moduleDeployment = modules.get(ejbModule);
         if (moduleDeployment == null) {
             return null;
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -22,11 +22,23 @@
 
 package org.jboss.as.ejb3.remote.protocol.versionone;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentView;
 import org.jboss.as.ee.component.interceptors.InvocationType;
 import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.EjbMessages;
+import org.jboss.as.ejb3.component.EJBComponentUnavailableException;
 import org.jboss.as.ejb3.component.entity.EntityBeanComponent;
 import org.jboss.as.ejb3.component.interceptors.CancellationFlag;
 import org.jboss.as.ejb3.component.session.SessionBeanComponent;
@@ -49,17 +61,6 @@ import org.jboss.marshalling.Unmarshaller;
 import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoUtils;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.ObjectStreamException;
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 
 /**
@@ -201,8 +202,15 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                         result = invokeMethod(invocationId, componentView, invokedMethod, methodParams, locator, attachments);
                     } catch (Throwable throwable) {
                         try {
-                            // write out the failure
-                            MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, throwable, attachments);
+                            // if the EJB is shutting down when the invocation was done, then it's as good as the EJB not being available. The client has to know about this as
+                            // a "no such EJB" failure so that it can retry the invocation on a different node if possible.
+                            if (throwable instanceof EJBComponentUnavailableException) {
+                                EjbLogger.EJB3_INVOCATION_LOGGER.debug("Cannot handle method invocation: " + invokedMethod + " on bean: " + beanName + " due to EJB component unavailability exception. Returning a no such EJB available message back to client");
+                                MethodInvocationMessageHandler.this.writeNoSuchEJBFailureMessage(channelAssociation, invocationId, appName, moduleName, distinctName, beanName, viewClassName);
+                            } else {
+                                // write out the failure
+                                MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, throwable, attachments);
+                            }
                         } catch (Throwable ioe) {
                             // we couldn't write out a method invocation failure message. So let's at least log the
                             // actual method invocation exception, for debugging/reference
@@ -310,7 +318,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
             // keep track of the cancellation flag for this invocation
             this.remoteAsyncInvocationCancelStatus.registerAsyncInvocation(invocationId, asyncInvocationCancellationFlag);
             try {
-                return ((Future)componentView.invoke(interceptorContext)).get();
+                return ((Future) componentView.invoke(interceptorContext)).get();
             } finally {
                 // now that the async invocation is done, we no longer need to keep track of the
                 // cancellation flag for this invocation

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/SessionOpenRequestHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/SessionOpenRequestHandler.java
@@ -22,6 +22,11 @@
 
 package org.jboss.as.ejb3.remote.protocol.versionone;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.EjbMessages;
@@ -36,11 +41,6 @@ import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoUtils;
-
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 
 /**
  * @author Jaikiran Pai
@@ -145,6 +145,7 @@ class SessionOpenRequestHandler extends EJBIdentifierBasedMessageHandler {
                 try {
                     sessionID = statefulSessionComponent.createSession();
                 } catch (Throwable t) {
+                    EjbLogger.ROOT_LOGGER.exceptionGeneratingSessionId(t, statefulSessionComponent.getComponentName(), invocationId, channelAssociation.getChannel());
                     SessionOpenRequestHandler.this.writeException(channelAssociation, SessionOpenRequestHandler.this.marshallerFactory, invocationId, t, null);
                     return;
                 }
@@ -152,7 +153,7 @@ class SessionOpenRequestHandler extends EJBIdentifierBasedMessageHandler {
                 final Affinity hardAffinity = statefulSessionComponent.getCache().getStrictAffinity();
                 SessionOpenRequestHandler.this.writeSessionId(channelAssociation, invocationId, sessionID, hardAffinity);
             } catch (IOException ioe) {
-                EjbLogger.ROOT_LOGGER.exceptionGeneratingSessionId(ioe, invocationId, channelAssociation.getChannel());
+                EjbLogger.ROOT_LOGGER.exceptionGeneratingSessionId(ioe, statefulSessionComponent.getComponentName(), invocationId, channelAssociation.getChannel());
                 // close the channel
                 IoUtils.safeClose(this.channelAssociation.getChannel());
                 return;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -22,6 +22,16 @@
 
 package org.jboss.as.ejb3.remote.protocol.versionone;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
 import org.jboss.as.clustering.registry.Registry;
 import org.jboss.as.clustering.registry.RegistryCollector;
 import org.jboss.as.ejb3.EjbLogger;
@@ -40,16 +50,6 @@ import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoUtils;
-
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
 
 /**
  * @author Jaikiran Pai
@@ -420,7 +420,15 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             outputStream = new DataOutputStream(messageOutputStream);
             final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
             try {
-                EjbLogger.ROOT_LOGGER.debug(removedNodes.size() + " nodes removed from cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
+                if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
+                    EjbLogger.ROOT_LOGGER.debug("Following " + removedNodes.size() + " nodes removed from cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
+                    final StringBuffer sb = new StringBuffer();
+                    for (final String nodeName : removedNodes) {
+                        sb.append(nodeName);
+                        sb.append("\n");
+                    }
+                    EjbLogger.ROOT_LOGGER.debug(sb.toString());
+                }
                 clusterTopologyWriter.writeNodesRemoved(outputStream, clusterName, removedNodes);
             } finally {
                 channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);
@@ -439,7 +447,16 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             outputStream = new DataOutputStream(messageOutputStream);
             final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
             try {
-                EjbLogger.ROOT_LOGGER.debug(addedNodes.size() + " nodes added to cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
+                if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
+                    EjbLogger.ROOT_LOGGER.debug("Following " + addedNodes.size() + " nodes added to cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
+                    final StringBuffer sb = new StringBuffer();
+                    for (final String nodeName : addedNodes.keySet()) {
+                        sb.append(nodeName);
+                        sb.append("\n");
+                    }
+                    EjbLogger.ROOT_LOGGER.debug(sb.toString());
+                }
+
                 clusterTopologyWriter.writeNewNodesAdded(outputStream, clusterName, addedNodes);
             } finally {
                 channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.jboss-common-core>2.2.17.GA</version.org.jboss.jboss-common-core>
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb-client>1.0.19.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.20.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.0.0</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.0.Beta1</version.org.jboss.invocation>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -56,7 +56,7 @@ public final class NodeUtil {
             deployer.deploy(deployment);
             log.info("Started deployment=" + deployment + ", container=" + container);
         } catch (Throwable e) {
-            log.error(e);
+            log.error("Failed to start container(s)", e);
         }
     }
 
@@ -67,7 +67,7 @@ public final class NodeUtil {
                 log.info("Starting deployment=NONE, container=" + containers[i]);
                 controller.start(containers[i]);
             } catch (Throwable e) {
-                log.error(e);
+                log.error("Failed to start containers", e);
             }
         }
     }
@@ -77,7 +77,7 @@ public final class NodeUtil {
             log.info("Starting deployment=NONE, container=" + container);
             controller.start(container);
         } catch (Throwable e) {
-            log.error(e);
+            log.error("Failed to start containers", e);
         }
     }
 
@@ -88,7 +88,7 @@ public final class NodeUtil {
                 controller.stop(containers[i]);
                 log.info("Stopped container=" + containers[i]);
             } catch (Throwable e) {
-                log.error(e);
+                log.error("Failed to stop containers", e);
             }
         }
     }
@@ -100,7 +100,7 @@ public final class NodeUtil {
             controller.stop(container);
             log.info("Stopped deployment=" + deployment + ", container=" + container);
         } catch (Throwable e) {
-            log.error(e);
+            log.error("Failed to stop containers", e);
         }
     }
 
@@ -109,7 +109,7 @@ public final class NodeUtil {
             controller.stop(container);
             log.info("Stopped deployment=NONE, container=" + container);
         } catch (Throwable e) {
-            log.error(e);
+            log.error("Failed to stop containers", e);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/SlowUndeployingClusteredSFSB.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/SlowUndeployingClusteredSFSB.java
@@ -1,0 +1,33 @@
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+import javax.annotation.PreDestroy;
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.logging.Logger;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateful
+@Clustered
+@Remote(NodeNameRetriever.class)
+public class SlowUndeployingClusteredSFSB implements NodeNameRetriever {
+
+    private static final Logger logger = Logger.getLogger(SlowUndeployingClusteredSFSB.class);
+
+    @Override
+    public String getNodeName() {
+        return System.getProperty("jboss.node.name");
+    }
+
+    @PreDestroy
+    private void preDestroy() throws Exception {
+        final int sleepTime = TimeoutUtil.adjust(3000);
+        logger.info("Going to sleep for " + sleepTime + " to intentionally slow down the undeployment and test failover cases");
+        // slow down the undeployment process
+        Thread.sleep(sleepTime);
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/SlowUndeployingClusteredSLSB.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/SlowUndeployingClusteredSLSB.java
@@ -1,0 +1,34 @@
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+import javax.annotation.PreDestroy;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.ejb3.annotation.Clustered;
+import org.jboss.logging.Logger;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateless
+@Clustered
+@Remote(NodeNameRetriever.class)
+public class SlowUndeployingClusteredSLSB implements NodeNameRetriever {
+
+    private final Logger logger = Logger.getLogger(SlowUndeployingClusteredSLSB.class);
+
+    @Override
+    public String getNodeName() {
+        return System.getProperty("jboss.node.name");
+    }
+
+    @PreDestroy
+    private void preDestroy() throws Exception {
+        final int sleepTime = TimeoutUtil.adjust(3000);
+        logger.info("Going to sleep for " + sleepTime + " to intentionally slow down the undeployment and test failover cases");
+        // slow down the undeployment process
+        Thread.sleep(sleepTime);
+    }
+
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/SlowUndeploymentRemoteFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/SlowUndeploymentRemoteFailoverTestCase.java
@@ -1,0 +1,313 @@
+package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusteringTestConstants;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
+import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that if a EJB client invokes on a EJB method when the server is in the process of undeploying the deployment, then the EJB client is returned an appropriate "bean isn't available"
+ * message, so that the EJB client can retry the invocation on a different eligible server node.
+ *
+ * @author: Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SlowUndeploymentRemoteFailoverTestCase {
+
+    private static final Logger logger = Logger.getLogger(SlowUndeploymentRemoteFailoverTestCase.class);
+
+    private static final String MODULE_NAME = "slow-undeployment-failover-testcase";
+
+    private static Context jndiContext;
+
+    @ArquillianResource
+    protected ContainerController controller;
+    @ArquillianResource
+    protected Deployer deployer;
+
+    private ContextSelector<EJBClientContext> previousSelector;
+    private InvocationCountTrackingClientInterceptor clientInterceptor;
+
+    private Collection<String> undeployedDeployments = new HashSet<>();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        final Properties props = new Properties();
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        jndiContext = new InitialContext(props);
+
+    }
+
+    @Deployment(name = ClusteringTestConstants.DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(ClusteringTestConstants.CONTAINER_1)
+    public static Archive<?> createDeploymentForContainer1() {
+        return createDeployment();
+    }
+
+    @Deployment(name = ClusteringTestConstants.DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(ClusteringTestConstants.CONTAINER_2)
+    public static Archive<?> createDeploymentForContainer2() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        ejbJar.addClasses(NodeNameRetriever.class, TimeoutUtil.class, SlowUndeployingClusteredSFSB.class, SlowUndeployingClusteredSLSB.class);
+        return ejbJar;
+    }
+
+    @Before
+    public void before() throws Exception {
+        // start containers
+        NodeUtil.start(controller, ClusteringTestConstants.CONTAINERS);
+        // Also deploy
+        NodeUtil.deploy(deployer, ClusteringTestConstants.DEPLOYMENTS);
+        undeployedDeployments.clear();
+
+        // setup selector
+        previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/slow-undeployment-failover-jboss-ejb-client.properties");
+        clientInterceptor = new InvocationCountTrackingClientInterceptor();
+        EJBClientContext.getCurrent().registerInterceptor(99999, clientInterceptor);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (previousSelector != null) {
+            EJBClientContext.setSelector(previousSelector);
+        }
+        if (!undeployedDeployments.contains(ClusteringTestConstants.DEPLOYMENT_1)) {
+            try {
+                NodeUtil.undeploy(deployer, ClusteringTestConstants.DEPLOYMENT_1);
+            } catch (Throwable t) {
+                logger.info("Failed to undeploy " + ClusteringTestConstants.DEPLOYMENT_1);
+            }
+        }
+        if (!undeployedDeployments.contains(ClusteringTestConstants.DEPLOYMENT_2)) {
+            try {
+                NodeUtil.undeploy(deployer, ClusteringTestConstants.DEPLOYMENT_2);
+            } catch (Throwable t) {
+                logger.info("Failed to undeploy " + ClusteringTestConstants.DEPLOYMENT_2);
+            }
+        }
+        // stop the containers
+        NodeUtil.stop(controller, ClusteringTestConstants.CONTAINERS);
+    }
+
+    /**
+     * Two servers (Server A and Server B) in a cluster. Both servers host the same deployment "foo" which contains a SLSB.
+     * <p/>
+     * Tests that when a SLSB is invoked on a server (for example, Server A) and the deployment "foo" that's hosting the SLSB, is being currently undeployed, then the server sends back an appropriate message which then triggers the
+     * client to retry the invocation on the other eligible node (Server B)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSLSBInvocationRetryWhenOriginalInvocationHappensDuringEJBContainerShutdown() throws Exception {
+        final NodeNameRetriever bean = (NodeNameRetriever) jndiContext.lookup("ejb:/" + MODULE_NAME + "/" + "" + "/" + SlowUndeployingClusteredSLSB.class.getSimpleName() + "!" + NodeNameRetriever.class.getName());
+        doTest(bean);
+    }
+
+    /**
+     * Two servers (Server A and Server B) in a cluster. Both servers host the same deployment "foo" which contains a SFSB.
+     * <p/>
+     * Tests that when a SFSB is invoked on a server (for example, Server A) and the deployment "foo" that's hosting the SFSB, is being currently undeployed, then the server sends back an appropriate message which then triggers the
+     * client to retry the invocation on the other eligible node (Server B)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSFSBInvocationRetryWhenOriginalInvocationHappensDuringEJBContainerShutdown() throws Exception {
+        final NodeNameRetriever bean = (NodeNameRetriever) jndiContext.lookup("ejb:/" + MODULE_NAME + "/" + "" + "/" + SlowUndeployingClusteredSFSB.class.getSimpleName() + "!" + NodeNameRetriever.class.getName() + "?stateful");
+        doTest(bean);
+    }
+
+    /**
+     * Two servers (Server A and Server B) in a cluster. Both servers host the same deployment "foo" which contains a SFSB.
+     * <p/>
+     * Tests that when a session creation request for SFSB is received on a server (for example, Server A) and the deployment "foo" that's hosting the SFSB, is being currently undeployed, then the client retries the session
+     * creation request on the other eligible node (Server B)
+     *
+     * @throws Exception
+     */
+    @Test
+    @Ignore("https://issues.jboss.org/browse/WFLY-1306")
+    public void testSFSBSessionCreationDuringEJBContainerShutdown() throws Exception {
+        final StopSignal stopSignal = new StopSignal();
+        final Callable<Void> task = new StatefulSessionCreatingTask(stopSignal);
+        final ExecutorService executorService = Executors.newFixedThreadPool(1);
+        try {
+            // trigger the session creation
+            final Future<Void> futureResult = executorService.submit(task);
+            final long waitTimeBeforeUndeployment = TimeoutUtil.adjust(250);
+            logger.info("Sleeping for " + waitTimeBeforeUndeployment + " milli. sec to let the EJB sessions be created a few times, before undeploying it");
+            Thread.sleep(waitTimeBeforeUndeployment);
+            // now undeploy from one of the nodes
+            undeploy(ClusteringTestConstants.DEPLOYMENT_1);
+            // now wait for a few more moments to let the session creation continue
+            final long waitTimeAfterUndeployment = TimeoutUtil.adjust(500);
+            logger.info("Sleeping for " + waitTimeAfterUndeployment + " milli. sec to let the EJB sessions be created, after the deployment has been undeployed from one of the nodes");
+            Thread.sleep(waitTimeAfterUndeployment);
+            // time to stop the invocations
+            stopSignal.stop = true;
+            // get the result
+            futureResult.get();
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+    private void doTest(final NodeNameRetriever bean) throws Exception {
+        final StopSignal stopSignal = new StopSignal();
+        final Callable<Integer> task = new EJBInvokingTask(bean, stopSignal);
+        final ExecutorService executorService = Executors.newFixedThreadPool(1);
+        try {
+            final Future<Integer> futureResult = executorService.submit(task);
+            final long initialFewInvocationsWaitTime = TimeoutUtil.adjust(500);
+            logger.info("Sleeping for " + initialFewInvocationsWaitTime + " milli. sec to let the EJB be invoked a few times");
+            Thread.sleep(initialFewInvocationsWaitTime);
+            // stop the invocations
+            stopSignal.stop = true;
+            final int numberOfExplicitClientTriggeredInvocations = futureResult.get();
+            logger.info("Explicit client triggered invocations on the bean was " + numberOfExplicitClientTriggeredInvocations + " times and client interceptor was invoked " + clientInterceptor.invocationCount + " times");
+            Assert.assertTrue("No invocations were done on the bean", numberOfExplicitClientTriggeredInvocations > 0);
+            Assert.assertEquals("Unexpected number of invocations on the client interceptor", numberOfExplicitClientTriggeredInvocations, clientInterceptor.invocationCount);
+
+            // now that we have ensured that invocations are working fine on the bean and the client interceptor, let's re-trigger the invocations
+            // and after a while undeploy the deployment from one of the nodes and expect a retry.
+            // let's first reset the counters and other flags
+            clientInterceptor.invocationCount = 0;
+            stopSignal.stop = false;
+            final Future<Integer> futureResultExpectingRetry = executorService.submit(task);
+            final long waitTimeBeforeUndeployment = TimeoutUtil.adjust(500);
+            logger.info("Sleeping for " + waitTimeBeforeUndeployment + " milli. sec to let the EJB be invoked a few times, before undeploying it");
+            Thread.sleep(waitTimeBeforeUndeployment);
+            // now undeploy from one of the nodes
+            undeploy(ClusteringTestConstants.DEPLOYMENT_1);
+            // now wait for a few more moments to let the retry happen and EJB invocations continue for a while
+            final long waitTimeAfterUndeployment = TimeoutUtil.adjust(1000);
+            logger.info("Sleeping for " + waitTimeAfterUndeployment + " milli. sec to let the EJB be invoked a few times, after the deployment has been undeployed from one of the nodes");
+            Thread.sleep(waitTimeAfterUndeployment);
+            // time to stop the invocations
+            stopSignal.stop = true;
+            // get the result
+            final int explicitClientTriggeredInvocationsOnBeanExpectingFailover = futureResultExpectingRetry.get();
+            logger.info("Explicit client triggered invocations on the bean was " + explicitClientTriggeredInvocationsOnBeanExpectingFailover + " times and client interceptor was invoked " + clientInterceptor.invocationCount + " times");
+            Assert.assertTrue("No invocations were done on the bean", explicitClientTriggeredInvocationsOnBeanExpectingFailover > 0);
+            final int NUM_RETRIES_EXPECTED = 1;
+            Assert.assertEquals("Client interceptor invocation count = " + clientInterceptor.invocationCount + " was expected to be " + NUM_RETRIES_EXPECTED + " greater than the explicit client triggered invocations on the bean, " +
+                    "since we are expecting " + NUM_RETRIES_EXPECTED + " implicit retry/retries during failover", explicitClientTriggeredInvocationsOnBeanExpectingFailover + NUM_RETRIES_EXPECTED, clientInterceptor.invocationCount);
+
+        } finally {
+            executorService.shutdown();
+        }
+
+    }
+
+    private void undeploy(final String deploymentName) {
+        NodeUtil.undeploy(deployer, deploymentName);
+        logger.info("Undeployed " + deploymentName);
+        undeployedDeployments.add(deploymentName);
+    }
+
+    private class EJBInvokingTask implements Callable<Integer> {
+
+        private final StopSignal stopSignalled;
+        private final NodeNameRetriever bean;
+
+        EJBInvokingTask(final NodeNameRetriever bean, final StopSignal stopSignalled) {
+            this.bean = bean;
+            this.stopSignalled = stopSignalled;
+        }
+
+        @Override
+        public Integer call() throws Exception {
+            if (stopSignalled.stop) {
+                return 0;
+            }
+            int invocationCount = 0;
+            // keep invoking on the bean until a stop is requested by the testcase
+            while (!stopSignalled.stop) {
+                invocationCount++;
+                bean.getNodeName();
+            }
+            return invocationCount;
+        }
+    }
+
+    private class StatefulSessionCreatingTask implements Callable<Void> {
+
+        private final StopSignal stopSignalled;
+
+        StatefulSessionCreatingTask(final StopSignal stopSignalled) {
+            this.stopSignalled = stopSignalled;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            if (stopSignalled.stop) {
+                return null;
+            }
+            // keep creating EJB session until a stop is requested by the testcase
+            while (!stopSignalled.stop) {
+                final NodeNameRetriever bean = (NodeNameRetriever) jndiContext.lookup("ejb:/" + MODULE_NAME + "/" + "" + "/" + SlowUndeployingClusteredSFSB.class.getSimpleName() + "!" + NodeNameRetriever.class.getName() + "?stateful");
+            }
+            return null;
+        }
+    }
+
+    private class StopSignal {
+        volatile boolean stop = false;
+    }
+
+    // A EJB client interceptor which keeps track of the number of times its handleInvocation() method has been invoked
+    private class InvocationCountTrackingClientInterceptor implements EJBClientInterceptor {
+
+        volatile int invocationCount;
+
+        @Override
+        public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+            invocationCount += 1;
+            context.sendRequest();
+        }
+
+        @Override
+        public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+            return context.getResult();
+        }
+    }
+
+}

--- a/testsuite/integration/clust/src/test/resources/cluster/ejb3/stateful/failover/slow-undeployment-failover-jboss-ejb-client.properties
+++ b/testsuite/integration/clust/src/test/resources/cluster/ejb3/stateful/failover/slow-undeployment-failover-jboss-ejb-client.properties
@@ -1,0 +1,35 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=${node0:localhost}
+remote.connection.default.port=4447
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+callback.handler.class=org.jboss.as.test.shared.integration.ejb.security.CallbackHandler
+
+remote.clusters=ejb
+
+remote.cluster.ejb.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.cluster.ejb.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false


### PR DESCRIPTION
The commits here fix the issue explained in https://issues.jboss.org/browse/WFLY-1308 where a remote EJB invocation couldn't be retried if the server was in the process of undeploying the target bean.

This includes a testcase which tests the fix.

P.S: The import re-ordering in this PR, for files which were changed for this fix, are relevant since they now conform to the expected ordering.
