### PR TITLE
Variables need a $ in scripts to retrieve the value.

### DIFF
--- a/build/src/main/resources/bin/domain.sh
+++ b/build/src/main/resources/bin/domain.sh
@@ -134,7 +134,7 @@ if $linux || $solaris; then
 fi
 
 # No readlink -m on BSD
-if darwin; then
+if $darwin; then
     # consolidate the host-controller and command line opts
     HOST_CONTROLLER_OPTS="$HOST_CONTROLLER_JAVA_OPTS $@"
     # process the host-controller options


### PR DESCRIPTION
Variables need a $ in scripts to retrieve the value.
