### PR TITLE
Rename JBOSS_HOME to WILDFLY_HOME

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/DistributionContainerConfiguration.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/DistributionContainerConfiguration.java
@@ -26,7 +26,7 @@ import org.jboss.arquillian.container.spi.client.deployment.Validate;
  */
 public class DistributionContainerConfiguration extends CommonContainerConfiguration {
 
-    private String jbossHome = System.getenv("JBOSS_HOME");
+    private String jbossHome = System.getenv("WILDFLY_HOME");
 
     private String javaHome = System.getenv("JAVA_HOME");
 

--- a/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedContainerConfiguration.java
+++ b/arquillian/container-embedded/src/main/java/org/jboss/as/arquillian/container/embedded/EmbeddedContainerConfiguration.java
@@ -29,7 +29,7 @@ import org.jboss.as.embedded.EmbeddedStandAloneServerFactory;
  */
 public class EmbeddedContainerConfiguration extends CommonContainerConfiguration {
 
-    private String jbossHome = System.getenv("JBOSS_HOME");
+    private String jbossHome = System.getenv("WILDFLY_HOME");
 
     private String modulePath = System.getProperty("module.path");
 

--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
@@ -29,7 +29,7 @@ import org.jboss.as.arquillian.container.domain.CommonDomainContainerConfigurati
  */
 public class ManagedDomainContainerConfiguration extends CommonDomainContainerConfiguration {
 
-    private String jbossHome = System.getenv("JBOSS_HOME");
+    private String jbossHome = System.getenv("WILDFLY_HOME");
 
     private String javaHome = System.getenv("JAVA_HOME");
 

--- a/build/build.xml
+++ b/build/build.xml
@@ -93,7 +93,7 @@
         <mkdir dir="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled"/>
         <copy file="${org.jboss.seam.integration:jboss-seam-int-jbossas:jar}" tofile="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled/jboss-seam-int.jar"/>
 
-        <!-- Copy the EJB specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the EJB specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-ejb:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="schema/*.xsd"/>
@@ -102,7 +102,7 @@
             <mapper type="flatten"/>
         </unzip>
 
-        <!-- Copy the jboss-metadata-appclient specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the jboss-metadata-appclient specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-appclient:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="schema/*.xsd"/>
@@ -110,7 +110,7 @@
             <mapper type="flatten"/>
         </unzip>
 
-        <!-- Copy the jboss-metadata-ear specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the jboss-metadata-ear specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-ear:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="dtd/*.dtd"/>
@@ -120,7 +120,7 @@
             <mapper type="flatten"/>
         </unzip>
 
-        <!-- Copy the jboss-metadata-common specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the jboss-metadata-common specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-common:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="dtd/*.dtd"/>
@@ -132,7 +132,7 @@
             <mapper type="flatten"/>
         </unzip>
 
-        <!-- Copy the jboss-metadata-web specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the jboss-metadata-web specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-web:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="dtd/*.dtd"/>
@@ -141,14 +141,14 @@
             <mapper type="flatten"/>
         </unzip>
 
-        <!-- Copy the JBoss AS7 EJB specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the JBoss AS7 EJB specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.as:jboss-as-ejb3:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="*.xsd"/>
             </patternset>
             <mapper type="flatten"/>
         </unzip>
-        <!-- Copy the JBoss Modules specific schemas to the JBOSS_HOME/docs/schema folder -->
+        <!-- Copy the JBoss Modules specific schemas to the WILDFLY_HOME/docs/schema folder -->
         <unzip src="${org.jboss.modules:jboss-modules:jar}" dest="${output.dir}/docs/schema/">
             <patternset>
                 <include name="schema/*.xsd"/>

--- a/build/src/main/resources/README.txt
+++ b/build/src/main/resources/README.txt
@@ -44,9 +44,9 @@ Starting a Standalone Server
 ----------------------------
 An AS7 standalone server runs a single instance of AS7.
 
-<JBOSS_HOME>/bin/standalone.sh      (Unix / Linux)
+<WILDFLY_HOME>/bin/standalone.sh      (Unix / Linux)
 
-<JBOSS_HOME>\bin\standalone.bat     (Windows)
+<WILDFLY_HOME>\bin\standalone.bat     (Windows)
 
 
 Starting a Managed Domain
@@ -56,9 +56,9 @@ of AS7, potentially across several physical (or virtual) machines.  The default
 configuration includes a domain controller and a single server group with three 
 servers (two of which start automatically), all running on the localhost.
 
-<JBOSS_HOME>/bin/domain.sh      (Unix / Linux)
+<WILDFLY_HOME>/bin/domain.sh      (Unix / Linux)
 
-<JBOSS_HOME>\bin\domain.bat     (Windows)
+<WILDFLY_HOME>\bin\domain.bat     (Windows)
  
 
 Accessing the Web Console
@@ -77,5 +77,5 @@ The JBoss AS7 server can be stopped by pressing Ctrl-C on the command line.
 If the server is running in a background process, the server can be stopped
 using the JBoss CLI:
 
-<JBOSS_HOME>/bin/jboss-cli.sh --connect --command=:shutdown
+<WILDFLY_HOME>/bin/jboss-cli.sh --connect --command=:shutdown
 

--- a/build/src/main/resources/bin/add-user.bat
+++ b/build/src/main/resources/bin/add-user.bat
@@ -18,19 +18,19 @@ if "%OS%" == "Windows_NT" (
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%" 
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
+    echo WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
 )
 
 set DIRNAME=
@@ -51,10 +51,10 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -63,14 +63,14 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%WILDFLY_HOME%\modules"
 )
 
 rem Uncomment to override standalone and domain user location  
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.config.user.dir=..\standalone\configuration -Djboss.domain.config.user.dir=..\domain\configuration"
 
 "%JAVA%" %JAVA_OPTS% ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.domain-add-user ^
      %*

--- a/build/src/main/resources/bin/add-user.sh
+++ b/build/src/main/resources/bin/add-user.sh
@@ -16,27 +16,27 @@ fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -48,12 +48,12 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
@@ -64,7 +64,7 @@ fi
 #JAVA_OPTS="$JAVA_OPTS -Djboss.server.config.user.dir=../standalone/configuration -Djboss.domain.config.user.dir=../domain/configuration"
 
 eval \"$JAVA\" $JAVA_OPTS \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.domain-add-user \
          '"$@"'

--- a/build/src/main/resources/bin/appclient.bat
+++ b/build/src/main/resources/bin/appclient.bat
@@ -26,19 +26,19 @@ if exist "%APPCLIENT_CONF%" (
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
+    echo WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
 )
 
 set DIRNAME=
@@ -67,10 +67,10 @@ if not errorlevel == 1 (
 )
 
 rem Find run.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -79,15 +79,15 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%WILDFLY_HOME%\modules"
 )
 
 "%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\appclient.log" ^
- "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+ "-Dorg.jboss.boot.log.file=%WILDFLY_HOME%\appclient\log\appclient.log" ^
+ "-Dlogging.configuration=file:%WILDFLY_HOME%/appclient/configuration/logging.properties" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.appclient ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-    -Djboss.server.base.dir="%JBOSS_HOME%\appclient" ^
+    -Djboss.home.dir="%WILDFLY_HOME%" ^
+    -Djboss.server.base.dir="%WILDFLY_HOME%\appclient" ^
      %*

--- a/build/src/main/resources/bin/appclient.conf.bat
+++ b/build/src/main/resources/bin/appclient.conf.bat
@@ -19,7 +19,7 @@ rem # Specify the JBoss Profiler configuration file to load.
 rem #
 rem # Default is to not load a JBoss Profiler configuration file.
 rem #
-rem set "PROFILER=%JBOSS_HOME%\bin\jboss-profiler.properties"
+rem set "PROFILER=%WILDFLY_HOME%\bin\jboss-profiler.properties"
 
 rem #
 rem # Specify the location of the Java home directory (it is recommended that

--- a/build/src/main/resources/bin/appclient.sh
+++ b/build/src/main/resources/bin/appclient.sh
@@ -35,27 +35,27 @@ fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -100,27 +100,27 @@ else
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
-CLASSPATH="$CLASSPATH:$JBOSS_HOME/jboss-modules.jar"
+CLASSPATH="$CLASSPATH:$WILDFLY_HOME/jboss-modules.jar"
 
 # Execute the JVM in the foreground
 eval \"$JAVA\" $JAVA_OPTS \
  -cp "$CLASSPATH" \
- \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/appclient/log/appclient.log\" \
- \"-Dlogging.configuration=file:$JBOSS_HOME/appclient/configuration/logging.properties\" \
+ \"-Dorg.jboss.boot.log.file=$WILDFLY_HOME/appclient/log/appclient.log\" \
+ \"-Dlogging.configuration=file:$WILDFLY_HOME/appclient/configuration/logging.properties\" \
  org.jboss.modules.Main \
  -mp \"${JBOSS_MODULEPATH}\" \
  org.jboss.as.appclient \
- -Djboss.home.dir=\"$JBOSS_HOME\" \
- -Djboss.server.base.dir=\"$JBOSS_HOME/appclient\" \
+ -Djboss.home.dir=\"$WILDFLY_HOME\" \
+ -Djboss.server.base.dir=\"$WILDFLY_HOME/appclient\" \
  '"$@"'
 JBOSS_STATUS=$?
 exit $JBOSS_STATUS

--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -28,19 +28,19 @@ if exist "%DOMAIN_CONF%" (
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
+    echo WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
 )
 
 set DIRNAME=
@@ -70,10 +70,10 @@ if not errorlevel == 1 (
 )
 
 rem Find run.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -112,12 +112,12 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%WILDFLY_HOME%\modules"
 )
 
 rem Set the domain base dir
 if "x%JBOSS_BASE_DIR%" == "x" (
-  set  "JBOSS_BASE_DIR=%JBOSS_HOME%\domain"
+  set  "JBOSS_BASE_DIR=%WILDFLY_HOME%\domain"
 )
 rem Set the domain log dir
 if "x%JBOSS_LOG_DIR%" == "x" (
@@ -132,7 +132,7 @@ echo ===========================================================================
 echo.
 echo   JBoss Bootstrap Environment
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   WILDFLY_HOME: %WILDFLY_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
@@ -145,10 +145,10 @@ echo.
 "%JAVA%" %PROCESS_CONTROLLER_JAVA_OPTS% ^
  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\process-controller.log" ^
  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.process-controller ^
-    -jboss-home "%JBOSS_HOME%" ^
+    -jboss-home "%WILDFLY_HOME%" ^
     -jvm "%JAVA%" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -- ^

--- a/build/src/main/resources/bin/domain.conf.bat
+++ b/build/src/main/resources/bin/domain.conf.bat
@@ -22,7 +22,7 @@ rem # Specify the JBoss Profiler configuration file to load.
 rem #
 rem # Default is to not load a JBoss Profiler configuration file.
 rem #
-rem set "PROFILER=%JBOSS_HOME%\bin\jboss-profiler.properties"
+rem set "PROFILER=%WILDFLY_HOME%\bin\jboss-profiler.properties"
 
 rem #
 rem # Specify the location of the Java home directory (it is recommended that

--- a/build/src/main/resources/bin/domain.sh
+++ b/build/src/main/resources/bin/domain.sh
@@ -39,27 +39,27 @@ fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -110,7 +110,7 @@ else
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 if $linux || $solaris; then
@@ -155,7 +155,7 @@ if $darwin; then
 fi
 # determine the default base dir, if not set
 if [ "x$JBOSS_BASE_DIR" = "x" ]; then
-   JBOSS_BASE_DIR="$JBOSS_HOME/domain"
+   JBOSS_BASE_DIR="$WILDFLY_HOME/domain"
 fi
 # determine the default log dir, if not set
 if [ "x$JBOSS_LOG_DIR" = "x" ]; then
@@ -172,7 +172,7 @@ JAVA_FROM_JVM="$JAVA"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JAVA_FROM_JVM=`cygpath --path --absolute --windows "$JAVA_FROM_JVM"`
     JBOSS_BASE_DIR=`cygpath --path --windows "$JBOSS_BASE_DIR"`
@@ -186,7 +186,7 @@ echo "========================================================================="
 echo ""
 echo "  JBoss Bootstrap Environment"
 echo ""
-echo "  JBOSS_HOME: $JBOSS_HOME"
+echo "  WILDFLY_HOME: $WILDFLY_HOME"
 echo ""
 echo "  JAVA: $JAVA"
 echo ""
@@ -201,10 +201,10 @@ while true; do
       eval \"$JAVA\" -D\"[Process Controller]\" $PROCESS_CONTROLLER_JAVA_OPTS \
          \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/process-controller.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.process-controller \
-         -jboss-home \"$JBOSS_HOME\" \
+         -jboss-home \"$WILDFLY_HOME\" \
          -jvm \"$JAVA_FROM_JVM\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          -- \
@@ -220,10 +220,10 @@ while true; do
       eval \"$JAVA\" -D\"[Process Controller]\" $PROCESS_CONTROLLER_JAVA_OPTS \
          \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/process-controller.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.process-controller \
-         -jboss-home \"$JBOSS_HOME\" \
+         -jboss-home \"$WILDFLY_HOME\" \
          -jvm \"$JAVA_FROM_JVM\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          -- \

--- a/build/src/main/resources/bin/init.d/jboss-as-domain.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-domain.sh
@@ -24,10 +24,10 @@ fi
 
 # Set defaults.
 
-if [ -z "$JBOSS_HOME" ]; then
-  JBOSS_HOME=/usr/share/jboss-as
+if [ -z "$WILDFLY_HOME" ]; then
+  WILDFLY_HOME=/usr/share/jboss-as
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 if [ -z "$JBOSS_PIDFILE" ]; then
   JBOSS_PIDFILE=/var/run/jboss-as/jboss-as-domain.pid
@@ -54,7 +54,7 @@ if [ -z "$JBOSS_HOST_CONFIG" ]; then
   JBOSS_HOST_CONFIG=host.xml
 fi
 
-JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
+JBOSS_SCRIPT=$WILDFLY_HOME/bin/domain.sh
 
 prog='jboss-as'
 

--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -24,10 +24,10 @@ fi
 
 # Set defaults.
 
-if [ -z "$JBOSS_HOME" ]; then
-  JBOSS_HOME=/usr/share/jboss-as
+if [ -z "$WILDFLY_HOME" ]; then
+  WILDFLY_HOME=/usr/share/jboss-as
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 if [ -z "$JBOSS_PIDFILE" ]; then
   JBOSS_PIDFILE=/var/run/jboss-as/jboss-as-standalone.pid
@@ -50,7 +50,7 @@ if [ -z "$JBOSS_CONFIG" ]; then
   JBOSS_CONFIG=standalone.xml
 fi
 
-JBOSS_SCRIPT=$JBOSS_HOME/bin/standalone.sh
+JBOSS_SCRIPT=$WILDFLY_HOME/bin/standalone.sh
 
 prog='jboss-as'
 

--- a/build/src/main/resources/bin/jboss-cli.bat
+++ b/build/src/main/resources/bin/jboss-cli.bat
@@ -15,19 +15,19 @@ if "%OS%" == "Windows_NT" (
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
+    echo WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
 )
 
 set DIRNAME=
@@ -50,10 +50,10 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find run.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -62,8 +62,8 @@ rem Add base package for L&F
 set JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=com.sun.java.swing
 
 "%JAVA%" %JAVA_OPTS% ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%JBOSS_HOME%\modules" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
+    -mp "%WILDFLY_HOME%\modules" ^
      org.jboss.as.cli ^
      %*
 

--- a/build/src/main/resources/bin/jboss-cli.sh
+++ b/build/src/main/resources/bin/jboss-cli.sh
@@ -22,27 +22,27 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -55,7 +55,7 @@ fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
 fi
 
@@ -70,4 +70,4 @@ fi
 # Sample JPDA settings for remote socket debugging
 #JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
-eval \"$JAVA\" $JAVA_OPTS \"-Dlogging.configuration=file:$JBOSS_HOME/bin/jboss-cli-logging.properties\" -jar \"$JBOSS_HOME/jboss-modules.jar\" -mp \"$JBOSS_HOME/modules\" org.jboss.as.cli '"$@"'
+eval \"$JAVA\" $JAVA_OPTS \"-Dlogging.configuration=file:$WILDFLY_HOME/bin/jboss-cli-logging.properties\" -jar \"$WILDFLY_HOME/jboss-modules.jar\" -mp \"$WILDFLY_HOME/modules\" org.jboss.as.cli '"$@"'

--- a/build/src/main/resources/bin/jconsole.bat
+++ b/build/src/main/resources/bin/jconsole.bat
@@ -17,19 +17,19 @@ if "%OS%" == "Windows_NT" (
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
+    echo WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
 )
 
 set DIRNAME=
@@ -47,17 +47,17 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%WILDFLY_HOME%\modules"
 )
 
 rem Setup The Classpath

--- a/build/src/main/resources/bin/jconsole.sh
+++ b/build/src/main/resources/bin/jconsole.sh
@@ -26,27 +26,27 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -59,12 +59,12 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi

--- a/build/src/main/resources/bin/jdr.bat
+++ b/build/src/main/resources/bin/jdr.bat
@@ -20,19 +20,19 @@ if "%OS%" == "Windows_NT" (
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%" 
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
+    echo WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
 )
 
 set DIRNAME=
@@ -53,10 +53,10 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -65,12 +65,12 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%WILDFLY_HOME%\modules"
 )
 
 "%JAVA%" ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -Djboss.home.dir="%WILDFLY_HOME%" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.jdr ^
      %*

--- a/build/src/main/resources/bin/jdr.sh
+++ b/build/src/main/resources/bin/jdr.sh
@@ -18,27 +18,27 @@ fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -50,18 +50,18 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
 eval \"$JAVA\" $JAVA_OPTS \
-         -Djboss.home.dir=\"$JBOSS_HOME\" \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -Djboss.home.dir=\"$WILDFLY_HOME\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.jdr \
          "$@" 

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -59,22 +59,22 @@ rem $Id$
 )
 
 pushd %DIRNAME%..
-set "RESOLVED_JBOSS_HOME=%CD%"
+set "RESOLVED_WILDFLY_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+if "x%WILDFLY_HOME%" == "x" (
+  set "WILDFLY_HOME=%RESOLVED_WILDFLY_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
-set "SANITIZED_JBOSS_HOME=%CD%"
+pushd "%WILDFLY_HOME%"
+set "SANITIZED_WILDFLY_HOME=%CD%"
 popd
 
-if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+if /i "%RESOLVED_WILDFLY_HOME%" NEQ "%SANITIZED_WILDFLY_HOME%" (
    echo.
-   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo   WARNING:  WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur.
    echo.
-   echo             JBOSS_HOME: %JBOSS_HOME%
+   echo             WILDFLY_HOME: %WILDFLY_HOME%
    echo.
    rem 2 seconds pause
    ping 127.0.0.1 -n 3 > nul
@@ -149,10 +149,10 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%WILDFLY_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%WILDFLY_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%WILDFLY_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -191,12 +191,12 @@ for /f "tokens=1* delims= " %%i IN ("%CONSOLIDATED_OPTS%") DO (
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%WILDFLY_HOME%\modules"
 )
 
 rem Set the standalone base dir
 if "x%JBOSS_BASE_DIR%" == "x" (
-  set  "JBOSS_BASE_DIR=%JBOSS_HOME%\standalone"
+  set  "JBOSS_BASE_DIR=%WILDFLY_HOME%\standalone"
 )
 rem Set the standalone log dir
 if "x%JBOSS_LOG_DIR%" == "x" (
@@ -211,7 +211,7 @@ echo ===========================================================================
 echo.
 echo   JBoss Bootstrap Environment
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   WILDFLY_HOME: %WILDFLY_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
@@ -224,10 +224,10 @@ echo.
 "%JAVA%" %JAVA_OPTS% ^
  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.standalone ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
+    -Djboss.home.dir="%WILDFLY_HOME%" ^
      %SERVER_OPTS%
 
 if ERRORLEVEL 10 goto RESTART

--- a/build/src/main/resources/bin/standalone.conf.bat
+++ b/build/src/main/resources/bin/standalone.conf.bat
@@ -25,7 +25,7 @@ rem # Specify the JBoss Profiler configuration file to load.
 rem #
 rem # Default is to not load a JBoss Profiler configuration file.
 rem #
-rem set "PROFILER=%JBOSS_HOME%\bin\jboss-profiler.properties"
+rem set "PROFILER=%WILDFLY_HOME%\bin\jboss-profiler.properties"
 
 rem #
 rem # Specify the location of the Java home directory (it is recommended that

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -61,31 +61,31 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
    echo ""
-   echo "   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+   echo "   WARNING:  WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
-   echo "             JBOSS_HOME: $JBOSS_HOME"
+   echo "             WILDFLY_HOME: $WILDFLY_HOME"
    echo ""
    sleep 2s
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Read an optional running configuration file
 if [ "x$RUN_CONF" = "x" ]; then
@@ -156,7 +156,7 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 if $linux || $solaris; then
@@ -206,7 +206,7 @@ fi
 
 # determine the default base dir, if not set
 if [ "x$JBOSS_BASE_DIR" = "x" ]; then
-   JBOSS_BASE_DIR="$JBOSS_HOME/standalone"
+   JBOSS_BASE_DIR="$WILDFLY_HOME/standalone"
 fi
 # determine the default log dir, if not set
 if [ "x$JBOSS_LOG_DIR" = "x" ]; then
@@ -219,7 +219,7 @@ fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
     JBOSS_BASE_DIR=`cygpath --path --windows "$JBOSS_BASE_DIR"`
@@ -232,7 +232,7 @@ echo "========================================================================="
 echo ""
 echo "  JBoss Bootstrap Environment"
 echo ""
-echo "  JBOSS_HOME: $JBOSS_HOME"
+echo "  WILDFLY_HOME: $WILDFLY_HOME"
 echo ""
 echo "  JAVA: $JAVA"
 echo ""
@@ -247,10 +247,10 @@ while true; do
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
          \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.standalone \
-         -Djboss.home.dir=\"$JBOSS_HOME\" \
+         -Djboss.home.dir=\"$WILDFLY_HOME\" \
          -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
          "$SERVER_OPTS"
       JBOSS_STATUS=$?
@@ -259,10 +259,10 @@ while true; do
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
          \"-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log\" \
          \"-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties\" \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.standalone \
-         -Djboss.home.dir=\"$JBOSS_HOME\" \
+         -Djboss.home.dir=\"$WILDFLY_HOME\" \
          -Djboss.server.base.dir=\"$JBOSS_BASE_DIR\" \
          "$SERVER_OPTS" "&"
       JBOSS_PID=$!

--- a/build/src/main/resources/bin/vault.bat
+++ b/build/src/main/resources/bin/vault.bat
@@ -8,8 +8,8 @@ set DIRNAME="%~dp0"
 call :DeQuote DIRNAME
 set PROGNAME=%0
 
-rem Setup JBOSS_HOME
-set JBOSS_HOME=%DIRNAME%\..
+rem Setup WILDFLY_HOME
+set WILDFLY_HOME=%DIRNAME%\..
 
 rem Setup the JVM
 IF NOT DEFINED JAVA (
@@ -22,7 +22,7 @@ IF NOT DEFINED JAVA (
 )
 
 IF NOT DEFINED MODULEPATH (
-    set MODULEPATH="%JBOSS_HOME%\modules"
+    set MODULEPATH="%WILDFLY_HOME%\modules"
 	call :DeQuote MODULEPATH
 )
 
@@ -33,14 +33,14 @@ echo =========================================================================
 echo.
 echo   JBoss Vault
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   WILDFLY_HOME: %WILDFLY_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
 echo =========================================================================
 echo.
 
-%JAVA% -jar %JBOSS_HOME%\jboss-modules.jar -mp %MODULEPATH% org.jboss.as.vault-tool %*
+%JAVA% -jar %WILDFLY_HOME%\jboss-modules.jar -mp %MODULEPATH% org.jboss.as.vault-tool %*
 
 ENDLOCAL
 

--- a/build/src/main/resources/bin/vault.sh
+++ b/build/src/main/resources/bin/vault.sh
@@ -42,28 +42,28 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
     [ -n "$JAVAC_JAR" ] &&
         JAVAC_JAR=`cygpath --unix "$JAVAC_JAR"`
 fi
 
-# Setup JBOSS_HOME
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME/.."; pwd`
- if [ "$RESOLVED_JBOSS" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME/.."; pwd`
+ if [ "$RESOLVED_JBOSS" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -75,7 +75,7 @@ if [ "x$JAVA" = "x" ]; then
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
-    JBOSS_MODULEPATH="$JBOSS_HOME/modules"
+    JBOSS_MODULEPATH="$WILDFLY_HOME/modules"
 fi
 
 ###
@@ -85,7 +85,7 @@ fi
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
@@ -94,7 +94,7 @@ echo "========================================================================="
 echo ""
 echo "  JBoss Vault"
 echo ""
-echo "  JBOSS_HOME: $JBOSS_HOME"
+echo "  WILDFLY_HOME: $WILDFLY_HOME"
 echo ""
 echo "  JAVA: $JAVA"
 echo ""
@@ -102,7 +102,7 @@ echo "========================================================================="
 echo ""
 
 eval \"$JAVA\" $JAVA_OPTS \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
+         -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
          -mp \"${JBOSS_MODULEPATH}\" \
          org.jboss.as.vault-tool \
          '"$@"'

--- a/build/src/main/resources/bin/wsconsume.bat
+++ b/build/src/main/resources/bin/wsconsume.bat
@@ -15,12 +15,12 @@ if "x%JAVA_HOME%" == "x" (
 ) else (
   set "JAVA=%JAVA_HOME%\bin\java"
 )
-set JBOSS_HOME=%DIRNAME%\..
+set WILDFLY_HOME=%DIRNAME%\..
 
 rem Execute the command
 "%JAVA%" %JAVA_OPTS% ^
-    -classpath "%JAVA_HOME%\lib\tools.jar;%JBOSS_HOME%\jboss-modules.jar" ^
+    -classpath "%JAVA_HOME%\lib\tools.jar;%WILDFLY_HOME%\jboss-modules.jar" ^
     org.jboss.modules.Main ^
-    -mp "%JBOSS_HOME%\modules" ^
+    -mp "%WILDFLY_HOME%\modules" ^
     org.jboss.ws.tools.wsconsume ^
     %*

--- a/build/src/main/resources/bin/wsconsume.sh
+++ b/build/src/main/resources/bin/wsconsume.sh
@@ -25,25 +25,25 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -61,11 +61,11 @@ fi
 JAVA_OPTS="$JAVA_OPTS"
 
 # Setup classpath
-JBOSS_CLASSPATH=$JAVA_HOME/lib/tools.jar:$JBOSS_HOME/jboss-modules.jar
+JBOSS_CLASSPATH=$JAVA_HOME/lib/tools.jar:$WILDFLY_HOME/jboss-modules.jar
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
     JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
 fi
@@ -74,6 +74,6 @@ fi
 eval \"$JAVA\" $JAVA_OPTS \
     -classpath \"$JBOSS_CLASSPATH\" \
     org.jboss.modules.Main \
-    -mp \"$JBOSS_HOME/modules\" \
+    -mp \"$WILDFLY_HOME/modules\" \
     org.jboss.ws.tools.wsconsume \
     '"$@"'

--- a/build/src/main/resources/bin/wsprovide.bat
+++ b/build/src/main/resources/bin/wsprovide.bat
@@ -15,11 +15,11 @@ if "x%JAVA_HOME%" == "x" (
 ) else (
   set "JAVA=%JAVA_HOME%\bin\java"
 )
-set JBOSS_HOME=%DIRNAME%\..
+set WILDFLY_HOME=%DIRNAME%\..
 
 rem Execute the command
 "%JAVA%" %JAVA_OPTS% ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%JBOSS_HOME%\modules" ^
+    -jar "%WILDFLY_HOME%\jboss-modules.jar" ^
+    -mp "%WILDFLY_HOME%\modules" ^
     org.jboss.ws.tools.wsprovide ^
     %*

--- a/build/src/main/resources/bin/wsprovide.sh
+++ b/build/src/main/resources/bin/wsprovide.sh
@@ -25,25 +25,25 @@ esac
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched
 if $cygwin ; then
-    [ -n "$JBOSS_HOME" ] &&
-        JBOSS_HOME=`cygpath --unix "$JBOSS_HOME"`
+    [ -n "$WILDFLY_HOME" ] &&
+        WILDFLY_HOME=`cygpath --unix "$WILDFLY_HOME"`
     [ -n "$JAVA_HOME" ] &&
         JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
 fi
 
-# Setup JBOSS_HOME
-RESOLVED_JBOSS_HOME=`cd "$DIRNAME/.."; pwd`
-if [ "x$JBOSS_HOME" = "x" ]; then
+# Setup WILDFLY_HOME
+RESOLVED_WILDFLY_HOME=`cd "$DIRNAME/.."; pwd`
+if [ "x$WILDFLY_HOME" = "x" ]; then
     # get the full path (without any relative bits)
-    JBOSS_HOME=$RESOLVED_JBOSS_HOME
+    WILDFLY_HOME=$RESOLVED_WILDFLY_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
-   echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+ SANITIZED_WILDFLY_HOME=`cd "$WILDFLY_HOME"; pwd`
+ if [ "$RESOLVED_WILDFLY_HOME" != "$SANITIZED_WILDFLY_HOME" ]; then
+   echo "WARNING WILDFLY_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi
 fi
-export JBOSS_HOME
+export WILDFLY_HOME
 
 # Setup the JVM
 if [ "x$JAVA" = "x" ]; then
@@ -62,13 +62,13 @@ JAVA_OPTS="$JAVA_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
-    JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
+    WILDFLY_HOME=`cygpath --path --windows "$WILDFLY_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
 fi
 
 # Execute the command
 eval \"$JAVA\" $JAVA_OPTS \
-    -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-    -mp \"$JBOSS_HOME/modules\" \
+    -jar \"$WILDFLY_HOME/jboss-modules.jar\" \
+    -mp \"$WILDFLY_HOME/modules\" \
     org.jboss.ws.tools.wsprovide \
     '"$@"'

--- a/cli/src/main/java/org/jboss/as/cli/handlers/VersionHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/VersionHandler.java
@@ -66,7 +66,7 @@ public class VersionHandler implements CommandHandler {
     public void handle(CommandContext ctx) throws CommandFormatException {
         final StringBuilder buf = new StringBuilder();
         buf.append("JBoss Admin Command-line Interface\n");
-        buf.append("JBOSS_HOME: ").append(SecurityActions.getEnvironmentVariable("JBOSS_HOME")).append('\n');
+        buf.append("WILDFLY_HOME: ").append(SecurityActions.getEnvironmentVariable("WILDFLY_HOME")).append('\n');
         buf.append("JBoss AS release: ");
         final ModelControllerClient client = ctx.getModelControllerClient();
         if(client == null) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/module/ASModuleHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/module/ASModuleHandler.java
@@ -75,7 +75,7 @@ public class ASModuleHandler extends CommandHandlerWithHelp {
         }
     }
 
-    private static final String JBOSS_HOME = "JBOSS_HOME";
+    private static final String WILDFLY_HOME = "WILDFLY_HOME";
 
     private static final String PATH_SEPARATOR = File.pathSeparator;
     private static final String MODULE_SEPARATOR = ",";
@@ -357,9 +357,9 @@ public class ASModuleHandler extends CommandHandlerWithHelp {
         if(modulesDir != null) {
             return modulesDir;
         }
-        final String modulesDirStr = SecurityActions.getEnvironmentVariable(JBOSS_HOME);
+        final String modulesDirStr = SecurityActions.getEnvironmentVariable(WILDFLY_HOME);
         if(modulesDirStr == null) {
-            throw new CommandLineException(JBOSS_HOME + " environment variable is not set.");
+            throw new CommandLineException(WILDFLY_HOME + " environment variable is not set.");
         }
         modulesDir = new File(modulesDirStr, "modules");
         if(!modulesDir.exists()) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -105,7 +105,7 @@ class CliConfigImpl implements CliConfig {
     }
 
     private static File findCLIFileInJBossHome() {
-        final String jbossHome = SecurityActions.getEnvironmentVariable("JBOSS_HOME");
+        final String jbossHome = SecurityActions.getEnvironmentVariable("WILDFLY_HOME");
         if (jbossHome == null) return null;
 
         File jbossCliFile = new File(jbossHome + File.separatorChar + "bin", JBOSS_CLI_FILE);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -177,11 +177,11 @@ public interface DomainManagementMessages {
     IllegalStateException noConsoleAvailable();
 
     /**
-     * A message indicating JBOSS_HOME not set.
+     * A message indicating WILDFLY_HOME not set.
      *
      * @return a {@link String} for the message.
      */
-    @Message(id = 15233, value = "JBOSS_HOME environment variable not set.")
+    @Message(id = 15233, value = "WILDFLY_HOME environment variable not set.")
     String jbossHomeNotSet();
 
     /**

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/AddPropertiesUser.java
@@ -70,7 +70,7 @@ public class AddPropertiesUser {
     protected AddPropertiesUser(ConsoleWrapper console) {
         theConsole = console;
         StateValues stateValues = new StateValues();
-        stateValues.setJBossHome(System.getenv("JBOSS_HOME"));
+        stateValues.setJBossHome(System.getenv("WILDFLY_HOME"));
 
         if (theConsole.getConsole() == null) {
             throw MESSAGES.noConsoleAvailable();
@@ -80,7 +80,7 @@ public class AddPropertiesUser {
 
     private AddPropertiesUser(ConsoleWrapper console, final boolean management, final String user, final String password, final String realm) {
         StateValues stateValues = new StateValues();
-        stateValues.setJBossHome(System.getenv("JBOSS_HOME"));
+        stateValues.setJBossHome(System.getenv("WILDFLY_HOME"));
 
         final Interactiveness howInteractive;
         boolean silent = Boolean.valueOf(argsCliProps.getProperty(CommandLineArgument.SILENT.key()));

--- a/embedded/src/main/java/org/jboss/as/embedded/EmbeddedServerFactory.java
+++ b/embedded/src/main/java/org/jboss/as/embedded/EmbeddedServerFactory.java
@@ -67,7 +67,7 @@ public class EmbeddedServerFactory {
     private static final String SYSPROP_KEY_CLASS_PATH = "java.class.path";
     private static final String SYSPROP_KEY_MODULE_PATH = "module.path";
     private static final String SYSPROP_KEY_LOGMANAGER = "java.util.logging.manager";
-    private static final String SYSPROP_KEY_JBOSS_HOME_DIR = "jboss.home.dir";
+    private static final String SYSPROP_KEY_WILDFLY_HOME_DIR = "jboss.home.dir";
     private static final String SYSPROP_KEY_JBOSS_MODULES_DIR = "jboss.modules.dir";
     private static final String SYSPROP_KEY_JBOSS_BUNDLES_DIR = "jboss.bundles.dir";
     private static final String SYSPROP_VALUE_JBOSS_LOGMANAGER = "org.jboss.logmanager.LogManager";
@@ -108,7 +108,7 @@ public class EmbeddedServerFactory {
         setupLoggingSystem(moduleLoader);
 
         // Embedded Server wants this, too. Seems redundant, but supply it.
-        SecurityActions.setSystemProperty(SYSPROP_KEY_JBOSS_HOME_DIR, jbossHomeDir.getAbsolutePath());
+        SecurityActions.setSystemProperty(SYSPROP_KEY_WILDFLY_HOME_DIR, jbossHomeDir.getAbsolutePath());
 
         // Load the Embedded Server Module
         final Module embeddedModule;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -579,7 +579,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
 
     /**
      * Gets the base directory in which managed domain files are stored.
-     * <p>Defaults to {@link #getHomeDir() JBOSS_HOME}/domain</p>
+     * <p>Defaults to {@link #getHomeDir() WILDFLY_HOME}/domain</p>
      *
      * @return the domain base directory.
      */

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/commands/JdrEnvironment.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/commands/JdrEnvironment.java
@@ -31,7 +31,7 @@ import org.jboss.as.jdr.util.JdrZipFile;
  * Most commands will need to interact with the {@link JdrZipFile} zip member.
  */
 public class JdrEnvironment {
-    private String jbossHome = System.getenv("JBOSS_HOME");
+    private String jbossHome = System.getenv("WILDFLY_HOME");
     private String username;
     private String password;
     private String host;

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
@@ -114,14 +114,14 @@ public class JdrZipFile {
     /**
      * Adds the content of the {@link InputStream} to the zip in a location that mirrors where {@link VirtualFile file} is located.
      *
-     * For example if {@code file} is at {@code /tmp/foo/bar} and {@code $JBOSS_HOME} is {@code tmp} then the destination will be {@code JBOSSHOME/foo/bar}
+     * For example if {@code file} is at {@code /tmp/foo/bar} and {@code $WILDFLY_HOME} is {@code tmp} then the destination will be {@code JBOSSHOME/foo/bar}
      *
      * @param file {@link VirtualFile} where metadata is read from
      * @param is content to write to the zip file
      * @throws Exception
      */
     public void add(VirtualFile file, InputStream is) throws Exception {
-        String name = "JBOSS_HOME" + file.getPathName().substring(this.jbossHome.length());
+        String name = "WILDFLY_HOME" + file.getPathName().substring(this.jbossHome.length());
         this.add(is, name);
     }
 

--- a/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/EmbeddedFrameworkFactory.java
+++ b/osgi/launcher/src/main/java/org/jboss/as/osgi/launcher/EmbeddedFrameworkFactory.java
@@ -38,7 +38,7 @@ public final class EmbeddedFrameworkFactory implements FrameworkFactory {
 
     private static Logger log = Logger.getLogger(EmbeddedFrameworkFactory.class);
 
-    private static final String SYSPROP_KEY_JBOSS_HOME = "jboss.home";
+    private static final String SYSPROP_KEY_WILDFLY_HOME = "jboss.home";
     private static final String SYSPROP_KEY_MODULE_PATH = "module.path";
     private static final String SYSPROP_KEY_BUNDLE_PATH = "bundle.path";
     private static final String SYSPROP_KEY_JBOSS_SERVER_CONFIG = "jboss.server.config.file.name";
@@ -70,7 +70,7 @@ public final class EmbeddedFrameworkFactory implements FrameworkFactory {
         addConfiguredPackages(syspackages, props, Constants.FRAMEWORK_SYSTEMPACKAGES_EXTRA);
         addConfiguredPackages(syspackages, props, Constants.FRAMEWORK_BOOTDELEGATION);
 
-        String jbossHome = getProperty(props, SYSPROP_KEY_JBOSS_HOME, null);
+        String jbossHome = getProperty(props, SYSPROP_KEY_WILDFLY_HOME, null);
         String modulePath = getProperty(props, SYSPROP_KEY_MODULE_PATH, null);
         String bundlePath = getProperty(props, SYSPROP_KEY_BUNDLE_PATH, null);
         String serverConfig = getProperty(props, SYSPROP_KEY_JBOSS_SERVER_CONFIG, "standalone-osgi.xml");

--- a/osgi/service/src/main/java/org/jboss/as/osgi/service/BootstrapBundlesIntegration.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/service/BootstrapBundlesIntegration.java
@@ -305,10 +305,10 @@ class BootstrapBundlesIntegration extends BootstrapBundlesInstall<Void> {
             }
         }
 
-        // Check for a jbosgi-xservice.properties in the root of a module directory under $JBOSS_HOME/modules
+        // Check for a jbosgi-xservice.properties in the root of a module directory under $WILDFLY_HOME/modules
         // Following https://issues.jboss.org/browse/AS7-6344 this will no longer find any standard module shipped
         // with the AS or by a layered distribution or add-on based upon it.  It may, however, find user provided
-        // modules, since $JBOSS_HOME/modules is a valid root for user modules. Layered distributions/add-ons should
+        // modules, since $WILDFLY_HOME/modules is a valid root for user modules. Layered distributions/add-ons should
         // not be using this mechanism to provide bundles anyway. Any bundles they ship in the modules repo should
         // be discoverable via the module.getClassLoader().getResource(JarFile.MANIFEST_NAME) mechanism used above
         File homeDir = injectedServerEnvironment.getValue().getHomeDir();

--- a/osgi/service/src/main/java/org/jboss/as/osgi/service/ModuleIdentityRepository.java
+++ b/osgi/service/src/main/java/org/jboss/as/osgi/service/ModuleIdentityRepository.java
@@ -83,9 +83,9 @@ final class ModuleIdentityRepository extends AbstractRepository {
                     contentFile = getRepositoryEntryFromModuleLoader(moduleIdentifier);
                 }
                 if (contentFile == null) {
-                    // As a last gasp, try $JBOSS_HOME/modules. Following AS7-6344 this will no longer
+                    // As a last gasp, try $WILDFLY_HOME/modules. Following AS7-6344 this will no longer
                     // find any standard module shipped with the AS or by a layered distribution or
-                    // add-on based upon it. It may, however, find user provided modules, since $JBOSS_HOME/modules
+                    // add-on based upon it. It may, however, find user provided modules, since $WILDFLY_HOME/modules
                     // is a valid root for user modules.
                     contentFile = getRepositoryEntry(modulesDir, moduleIdentifier);
                 }

--- a/process-controller/src/main/java/org/jboss/as/process/Main.java
+++ b/process-controller/src/main/java/org/jboss/as/process/Main.java
@@ -167,12 +167,12 @@ public final class Main {
         }
         if (modulePath == null) {
             // if "-mp" (i.e. module path) wasn't part of the command line args, then check the system property.
-            // if system property not set, then default to JBOSS_HOME/modules
+            // if system property not set, then default to WILDFLY_HOME/modules
             // TODO: jboss-modules setting module.path is not a reliable API; log a WARN or something if we get here
             modulePath = SecurityActions.getSystemProperty("module.path", jbossHome + File.separator + "modules");
         }
         if (bootJar == null) {
-            // if "-jar" wasn't part of the command line args, then default to JBOSS_HOME/jboss-modules.jar
+            // if "-jar" wasn't part of the command line args, then default to WILDFLY_HOME/jboss-modules.jar
             bootJar = jbossHome + File.separator + "jboss-modules.jar";
         }
 

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -852,7 +852,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
 
     /**
      * Gets the base directory in which managed domain files are stored.
-     * <p>Defaults to {@link #getHomeDir() JBOSS_HOME}/domain</p>
+     * <p>Defaults to {@link #getHomeDir() WILDFLY_HOME}/domain</p>
      *
      * @return the domain base directory, or {@code null} if this server is not running in a managed domain.
      */

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
@@ -49,7 +49,7 @@ public class CliArgumentsTestCase extends CliScriptTestBase {
         execute(false, "--version");
         final String result = getLastCommandOutput();
         assertNotNull(result);
-        assertTrue(result, result.contains("JBOSS_HOME"));
+        assertTrue(result, result.contains("WILDFLY_HOME"));
         assertTrue(result, result.contains("JBoss AS release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
@@ -64,7 +64,7 @@ public class CliArgumentsTestCase extends CliScriptTestBase {
         execute(false, "--command=version");
         final String result = getLastCommandOutput();
         assertNotNull(result);
-        assertTrue(result, result.contains("JBOSS_HOME"));
+        assertTrue(result, result.contains("WILDFLY_HOME"));
         assertTrue(result, result.contains("JBoss AS release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
@@ -86,7 +86,7 @@ public class CliArgumentsTestCase extends CliScriptTestBase {
         execute(false, "--file=" + cliScriptFile.getAbsolutePath());
         final String result = getLastCommandOutput();
         assertNotNull(result);
-        assertTrue(result, result.contains("JBOSS_HOME"));
+        assertTrue(result, result.contains("WILDFLY_HOME"));
         assertTrue(result, result.contains("JBoss AS release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
@@ -104,7 +104,7 @@ public class CliArgumentsTestCase extends CliScriptTestBase {
 
         final String result = getLastCommandOutput();
         assertNotNull(result);
-        assertTrue(result, result.contains("JBOSS_HOME"));
+        assertTrue(result, result.contains("WILDFLY_HOME"));
         assertTrue(result, result.contains("JBoss AS release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));


### PR DESCRIPTION
The commit here renames JBOSS_HOME and its usages to WILDFLY_HOME. 

This commit does **not** rename the Java system properties that are published by the server.
