### PR TITLE
Allow to add modcluster without specifying a advertise-socket.

### DIFF
--- a/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterService.java
+++ b/modcluster/src/main/java/org/jboss/as/modcluster/ModClusterService.java
@@ -90,8 +90,8 @@ class ModClusterService implements Service<ModCluster>, ModCluster {
 
         // Read node to set configuration.
         if (config.getAdvertise()) {
-            // There should be a socket-binding....
-            final SocketBinding binding = this.binding.getValue();
+            // There should be a socket-binding.... Well no it needs an advertise socket :-(
+            final SocketBinding binding = this.binding.getOptionalValue();
             if (binding != null) {
                 config.setAdvertiseSocketAddress(binding.getMulticastSocketAddress());
                 config.setAdvertiseInterface(binding.getSocketAddress().getAddress());


### PR DESCRIPTION
It use the default 224.0.1.105:23364.
That allows the minimal add:
batch
/subsystem=modcluster:add
/subsystem=modcluster/mod-cluster-config=configuration:add(connector=ajp)
run-batch
