### PR TITLE
WFLY-330 - Allow defining server http port (and other basic properties) ...

### DIFF
--- a/build/src/main/resources/configuration/subsystems/remoting.xml
+++ b/build/src/main/resources/configuration/subsystems/remoting.xml
@@ -5,5 +5,5 @@
    <subsystem xmlns="urn:jboss:domain:remoting:1.1">
        <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
    </subsystem>
-   <socket-binding name="remoting" port="${jboss.http.port:4447}"/>
+   <socket-binding name="remoting" port="${jboss.remoting.port:4447}"/>
 </config>

--- a/build/src/main/resources/configuration/subsystems/remoting.xml
+++ b/build/src/main/resources/configuration/subsystems/remoting.xml
@@ -5,5 +5,5 @@
    <subsystem xmlns="urn:jboss:domain:remoting:1.1">
        <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
    </subsystem>
-   <socket-binding name="remoting" port="4447"/>
+   <socket-binding name="remoting" port="${jboss.http.port:4447}"/>
 </config>

--- a/build/src/main/resources/configuration/subsystems/undertow.xml
+++ b/build/src/main/resources/configuration/subsystems/undertow.xml
@@ -51,7 +51,7 @@
         </replacement>
     </supplement>
     <socket-binding name="http" port="${jboss.http.port:8080}"/>
-    <socket-binding name="https" port="${jboss.http.port:8443}"/>
+    <socket-binding name="https" port="${jboss.https.port:8443}"/>
     <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
 </config>
 

--- a/build/src/main/resources/configuration/subsystems/undertow.xml
+++ b/build/src/main/resources/configuration/subsystems/undertow.xml
@@ -50,8 +50,8 @@
             <ajp-listener name="ajp-connector" socket-binding="ajp"/>
         </replacement>
     </supplement>
-    <socket-binding name="http" port="8080"/>
-    <socket-binding name="https" port="8443"/>
-    <socket-binding name="ajp" port="8009"/>
+    <socket-binding name="http" port="${jboss.http.port:8080}"/>
+    <socket-binding name="https" port="${jboss.http.port:8443}"/>
+    <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
 </config>
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/BasicOperationsUnitTestCase.java
@@ -205,7 +205,7 @@ public class BasicOperationsUnitTestCase {
         final List<ModelNode> steps = getSteps(result.get(RESULT));
         Assert.assertEquals(1, steps.size());
         final ModelNode httpBinding = steps.get(0);
-        Assert.assertEquals(8080, httpBinding.get(RESULT, "port").asInt());
+        Assert.assertEquals(8080, httpBinding.get(RESULT, "port").resolve().asInt());
 
     }
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -187,6 +187,10 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.domain.master.port:9999}", "9999");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");
         result = result.replace("${jboss.socket.binding.port-offset:0}", "0");
+        result = result.replace("${jboss.http.port:8080}", "8080");
+        result = result.replace("${jboss.https.port:8443}", "8443");
+        result = result.replace("${jboss.remoting.port:4447}", "4447");
+        result = result.replace("${jboss.ajp.port:8009}", "8009");
         return result;
     }
 }


### PR DESCRIPTION
...via jvm arguments Obs: This is working, but the final tests on subsystem.xml fails because the final value is not int.

I change the ajp, http, https and remoting.
These parameteres can be configurated on Jvm Parameters like that:
-Djboss.http.port=9080
-Djboss.https.port=9843
-Djboss.remoting.port=4487
-Djboss.ajp.port=8010

If not set, the default is configurated.

This is work OK, but the surefire final test fails on:
org.jboss.as.test.smoke.subsystem.xml.StandardConfigsXMLValidationUnitTestCase

and

org.jboss.as.test.smoke.mgmt.BasicOperationsUnitTestCase

OBS: close the PR #4485

We need adjust the tests Too.
