### PR TITLE
WFLY-1327 WFLY-901

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -231,7 +231,8 @@ public abstract class AttributeDefinition {
 
     /**
      * Finds a value in the given {@code model} whose key matches this attribute's {@link #getName() name},
-     * resolves it and validates it using this attribute's {@link #getValidator() validator}. If the value is
+     * uses the given {@code context} to {@link OperationContext#resolveExpressions(org.jboss.dmr.ModelNode) resolve}
+     * it and validates it using this attribute's {@link #getValidator() validator}. If the value is
      * undefined and a {@link #getDefaultValue() default value} is available, the default value is used.
      *
      * @param context the operation context
@@ -250,11 +251,62 @@ public abstract class AttributeDefinition {
         }, model);
     }
 
+    /**
+     * Finds a value in the given {@code model} whose key matches this attribute's {@link #getName() name},
+     * uses the given {@code resolver} to {@link ExpressionResolver#resolveExpressions(org.jboss.dmr.ModelNode)} resolve}
+     * it and validates it using this attribute's {@link #getValidator() validator}. If the value is
+     * undefined and a {@link #getDefaultValue() default value} is available, the default value is used.
+     *
+     * @param resolver the expression resolver
+     * @param model model node of type {@link ModelType#OBJECT}, typically representing a model resource
+     *
+     * @return the resolved value, possibly the default value if the model does not have a defined value matching
+     *              this attribute's name
+     * @throws OperationFailedException if the value is not valid
+     */
     public ModelNode resolveModelAttribute(final ExpressionResolver resolver, final ModelNode model) throws OperationFailedException {
         final ModelNode node = new ModelNode();
         if(model.has(name)) {
             node.set(model.get(name));
         }
+        return resolveValue(resolver, node);
+    }
+
+    /**
+     * Takes the given {@code value}, resolves it using the given {@code context}
+     * and validates it using this attribute's {@link #getValidator() validator}. If the value is
+     * undefined and a {@link #getDefaultValue() default value} is available, the default value is used.
+     *
+     * @param context the context to use to {@link OperationContext#resolveExpressions(org.jboss.dmr.ModelNode) resolve} the value
+     * @param value a node that is expected to be a valid value for an attribute defined by this definition
+     *
+     * @return the resolved value, possibly the default value if {@code value} is not defined
+     *
+     * @throws OperationFailedException if the value is not valid
+     */
+    public ModelNode resolveValue(final OperationContext context, final ModelNode value) throws OperationFailedException {
+        return resolveValue(new ExpressionResolver() {
+            @Override
+            public ModelNode resolveExpressions(ModelNode node) throws OperationFailedException {
+                return context.resolveExpressions(node);
+            }
+        }, value);
+    }
+
+    /**
+     * Takes the given {@code value}, resolves it using the given {@code resolver}
+     * and validates it using this attribute's {@link #getValidator() validator}. If the value is
+     * undefined and a {@link #getDefaultValue() default value} is available, the default value is used.
+     *
+     * @param resolver the expression resolver
+     * @param value a node that is expected to be a valid value for an attribute defined by this definition
+     *
+     * @return the resolved value, possibly the default value if {@code value} is not defined
+     *
+     * @throws OperationFailedException if the value is not valid
+     */
+    public ModelNode resolveValue(final ExpressionResolver resolver, final ModelNode value) throws OperationFailedException {
+        final ModelNode node = value.clone();
         if (!node.isDefined() && defaultValue.isDefined()) {
             node.set(defaultValue);
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentRuntimeHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentRuntimeHandler.java
@@ -43,6 +43,7 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 import static org.jboss.as.ejb3.subsystem.deployment.AbstractEJBComponentResourceDefinition.COMPONENT_CLASS_NAME;
 import static org.jboss.as.ejb3.subsystem.deployment.AbstractEJBComponentResourceDefinition.DECLARED_ROLES;
@@ -54,6 +55,7 @@ import static org.jboss.as.ejb3.subsystem.deployment.AbstractEJBComponentResourc
 import static org.jboss.as.ejb3.subsystem.deployment.AbstractEJBComponentResourceDefinition.POOL_REMOVE_COUNT;
 import static org.jboss.as.ejb3.subsystem.deployment.AbstractEJBComponentResourceDefinition.RUN_AS_ROLE;
 import static org.jboss.as.ejb3.subsystem.deployment.AbstractEJBComponentResourceDefinition.SECURITY_DOMAIN;
+
 /**
  * Base class for operation handlers that provide runtime management for {@link EJBComponent}s.
  *
@@ -174,7 +176,7 @@ public abstract class AbstractEJBComponentRuntimeHandler<T extends EJBComponent>
     protected void executeWriteAttribute(String attributeName, OperationContext context, ModelNode operation, T component,
                                          PathAddress address) throws OperationFailedException {
         if (componentType.hasPool() && POOL_MAX_SIZE.getName().equals(attributeName)) {
-            int newSize = POOL_MAX_SIZE.resolveModelAttribute(context, operation).asInt();
+            int newSize = POOL_MAX_SIZE.resolveValue(context, operation.get(VALUE)).asInt();
             final Pool<?> pool = componentType.getPool(component);
             final int oldSize = pool.getMaxSize();
             componentType.getPool(component).setMaxSize(newSize);


### PR DESCRIPTION
WFLY-1327 Make it easier to use AttributeDefinition in a runtime-only write-attribute handler

WFLY-901 use WFLY-1327 solution in fix for bug where write-attribute handler was using the wrong parameter name

Supersedes #4378.
