### PR TITLE
WFLY-1332 Add support for handling compressed messages in EJB invocations

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/MessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/MessageHandler.java
@@ -22,16 +22,16 @@
 
 package org.jboss.as.ejb3.remote.protocol;
 
-import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
-import org.jboss.remoting3.MessageInputStream;
-
 import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 
 /**
  * User: jpai
  */
 public interface MessageHandler {
 
-    void processMessage(final ChannelAssociation channelAssociation, final MessageInputStream messageInputStream) throws IOException;
+    void processMessage(final ChannelAssociation channelAssociation, final InputStream inputStream) throws IOException;
 
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
@@ -26,10 +26,10 @@ import org.jboss.as.ejb3.component.interceptors.CancellationFlag;
 import org.jboss.as.ejb3.remote.RemoteAsyncInvocationCancelStatusService;
 import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
 import org.jboss.logging.Logger;
-import org.jboss.remoting3.MessageInputStream;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Handles a message corresponding to a invocation cancellation request
@@ -47,8 +47,8 @@ class InvocationCancellationMessageHandler extends AbstractMessageHandler {
     }
 
     @Override
-    public void processMessage(ChannelAssociation channelAssociation, MessageInputStream messageInputStream) throws IOException {
-        final DataInputStream input = new DataInputStream(messageInputStream);
+    public void processMessage(ChannelAssociation channelAssociation, InputStream inputStream) throws IOException {
+        final DataInputStream input = new DataInputStream(inputStream);
         // read the id of the invocation which needs to be cancelled
         final short invocationToCancel = input.readShort();
         // get the cancellation flag (if any) for the invocation id

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.remote.protocol.versionone;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectStreamException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -58,7 +59,6 @@ import org.jboss.marshalling.AbstractClassResolver;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Unmarshaller;
-import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoUtils;
 
@@ -86,9 +86,9 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
     }
 
     @Override
-    public void processMessage(final ChannelAssociation channelAssociation, final MessageInputStream messageInputStream) throws IOException {
+    public void processMessage(final ChannelAssociation channelAssociation, final InputStream inputStream) throws IOException {
 
-        final DataInputStream input = new DataInputStream(messageInputStream);
+        final DataInputStream input = new DataInputStream(inputStream);
         // read the invocation id
         final short invocationId = input.readShort();
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/SessionOpenRequestHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/SessionOpenRequestHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.remote.protocol.versionone;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.ee.component.Component;
@@ -38,7 +39,6 @@ import org.jboss.ejb.client.SessionID;
 import org.jboss.ejb.client.remoting.PackedInteger;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
-import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoUtils;
 
@@ -61,11 +61,11 @@ class SessionOpenRequestHandler extends EJBIdentifierBasedMessageHandler {
     }
 
     @Override
-    public void processMessage(ChannelAssociation channelAssociation, MessageInputStream messageInputStream) throws IOException {
-        if (messageInputStream == null) {
+    public void processMessage(ChannelAssociation channelAssociation, InputStream inputStream) throws IOException {
+        if (inputStream == null) {
             throw EjbMessages.MESSAGES.messageInputStreamCannotBeNull();
         }
-        final DataInputStream dataInputStream = new DataInputStream(messageInputStream);
+        final DataInputStream dataInputStream = new DataInputStream(inputStream);
         // read invocation id
         final short invocationId = dataInputStream.readShort();
         final String appName = dataInputStream.readUTF();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/TransactionRequestHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/TransactionRequestHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.remote.protocol.versionone;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -36,7 +37,6 @@ import org.jboss.ejb.client.UserTransactionID;
 import org.jboss.ejb.client.XidTransactionID;
 import org.jboss.ejb.client.remoting.PackedInteger;
 import org.jboss.marshalling.MarshallerFactory;
-import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 
 /**
@@ -71,8 +71,8 @@ class TransactionRequestHandler extends AbstractMessageHandler {
     }
 
     @Override
-    public void processMessage(final ChannelAssociation channelAssociation, final MessageInputStream messageInputStream) throws IOException {
-        final DataInputStream input = new DataInputStream(messageInputStream);
+    public void processMessage(final ChannelAssociation channelAssociation, final InputStream inputStream) throws IOException {
+        final DataInputStream input = new DataInputStream(inputStream);
         // read the invocation id
         final short invocationId = input.readShort();
         // read the transaction id length

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -24,6 +24,7 @@ package org.jboss.as.ejb3.remote.protocol.versionone;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -143,18 +144,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     @Override
     public void handleMessage(Channel channel, MessageInputStream messageInputStream) {
         try {
-            // read the first byte to see what type of a message it is
-            final int header = messageInputStream.read();
-            if (EjbLogger.ROOT_LOGGER.isTraceEnabled()) {
-                EjbLogger.ROOT_LOGGER.trace("Got message with header 0x" + Integer.toHexString(header) + " on channel " + channel);
-            }
-            final MessageHandler messageHandler = getMessageHandler((byte) header);
-            if (messageHandler == null) {
-                EjbLogger.ROOT_LOGGER.unsupportedMessageHeader(Integer.toHexString(header), channel);
-                return;
-            }
-            // process the message
-            messageHandler.processMessage(channelAssociation, messageInputStream);
+            this.processMessage(channel, messageInputStream);
             // enroll for next message (whenever it's available)
             channel.receiveMessage(this);
 
@@ -195,6 +185,21 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             default:
                 return null;
         }
+    }
+
+    protected void processMessage(final Channel channel, final InputStream inputStream) throws IOException {
+        // read the first byte to see what type of a message it is
+        final int header = inputStream.read();
+        if (EjbLogger.ROOT_LOGGER.isTraceEnabled()) {
+            EjbLogger.ROOT_LOGGER.trace("Got message with header 0x" + Integer.toHexString(header) + " on channel " + channel);
+        }
+        final MessageHandler messageHandler = getMessageHandler((byte) header);
+        if (messageHandler == null) {
+            EjbLogger.ROOT_LOGGER.unsupportedMessageHeader(Integer.toHexString(header), channel);
+            return;
+        }
+        // let the message handler process the message
+        messageHandler.processMessage(channelAssociation, inputStream);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/CompressedMessageRequestHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/CompressedMessageRequestHandler.java
@@ -1,0 +1,32 @@
+package org.jboss.as.ejb3.remote.protocol.versiontwo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.InflaterInputStream;
+
+import org.jboss.as.ejb3.EjbLogger;
+import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
+
+/**
+ * A {@link org.jboss.as.ejb3.remote.protocol.MessageHandler} responsible for handling messages which have been compressed using the EJB protocol
+ *
+ * @author: Jaikiran Pai
+ */
+class CompressedMessageRequestHandler extends AbstractMessageHandler {
+
+    private VersionTwoProtocolChannelReceiver ejbProtocolHandler;
+
+    CompressedMessageRequestHandler(final VersionTwoProtocolChannelReceiver ejbProtocolHandler) {
+        this.ejbProtocolHandler = ejbProtocolHandler;
+    }
+
+    @Override
+    public void processMessage(final ChannelAssociation channelAssociation, final InputStream inputStream) throws IOException {
+        EjbLogger.EJB3_INVOCATION_LOGGER.trace("Received a compressed message stream");
+        // use a inflater inputstream to inflate the contents
+        final InputStream inflaterInputStream = new InflaterInputStream(inputStream);
+        // let the EJB protocol handler process the stream
+        this.ejbProtocolHandler.processMessage(channelAssociation.getChannel(), inflaterInputStream);
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/TransactionRecoverMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/TransactionRecoverMessageHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.remote.protocol.versiontwo;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.ExecutorService;
 
 import javax.transaction.xa.Xid;
@@ -40,7 +41,6 @@ import org.jboss.ejb.client.remoting.PackedInteger;
 import org.jboss.logging.Logger;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
-import org.jboss.remoting3.MessageInputStream;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoUtils;
 
@@ -67,8 +67,8 @@ class TransactionRecoverMessageHandler extends AbstractMessageHandler {
     }
 
     @Override
-    public void processMessage(ChannelAssociation channelAssociation, MessageInputStream messageInputStream) throws IOException {
-        final DataInputStream input = new DataInputStream(messageInputStream);
+    public void processMessage(ChannelAssociation channelAssociation, InputStream inputStream) throws IOException {
+        final DataInputStream input = new DataInputStream(inputStream);
         // read the invocation id
         final short invocationId = input.readShort();
         final String txParentNodeName = input.readUTF();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/compression/CompressableDataBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/compression/CompressableDataBean.java
@@ -1,0 +1,28 @@
+package org.jboss.as.test.integration.ejb.compression;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateless
+@Remote(MethodOverrideDataCompressionRemoteView.class)
+public class CompressableDataBean implements MethodOverrideDataCompressionRemoteView {
+
+    @Override
+    public String echoWithRequestCompress(String msg) {
+        return msg;
+    }
+
+    @Override
+    public String echoWithNoExplicitDataCompressionHintOnMethod(String msg) {
+        return msg;
+    }
+
+    @Override
+    public String echoWithResponseCompress(String msg) {
+        return msg;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/compression/CompressionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/compression/CompressionTestCase.java
@@ -1,0 +1,72 @@
+package org.jboss.as.test.integration.ejb.compression;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the {@link org.jboss.ejb.client.annotation.CompressionHint} on remote view classes and the view methods is taken into account during EJB invocations
+ *
+ * @author: Jaikiran Pai
+ * @see https://issues.jboss.org/browse/EJBCLIENT-76
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class CompressionTestCase {
+
+    private static final String MODULE_NAME = "ejb-invocation-compression-test";
+
+    @Deployment
+    public static Archive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(CompressionTestCase.class.getPackage());
+        return jar;
+    }
+
+    /**
+     * Tests that EJB invocations that are marked with a compression hint can be invoked without any problems. This test doesn't actually poke in to verify if the data
+     * was actually compressed, because that's supposed to be transparent to the bean. All this test does is to make sure that when the hint is in place, the invocations can pass.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCompressedInvocation() throws Exception {
+        // set the system property which enables annotation scan on the client view
+        System.setProperty("org.jboss.ejb.client.view.annotation.scan.enabled", "true");
+        try {
+            // create a proxy for invocation
+            final Properties props = new Properties();
+            props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+            final Context jndiCtx = new InitialContext(props);
+            final MethodOverrideDataCompressionRemoteView bean = (MethodOverrideDataCompressionRemoteView) jndiCtx.lookup("ejb:" + "" + "/" + MODULE_NAME + "/" + "" + "/" + CompressableDataBean.class.getSimpleName() + "!" + MethodOverrideDataCompressionRemoteView.class.getName());
+            final String message = "some message";
+
+            // only request compression
+            final String echoWithRequestCompressed = bean.echoWithRequestCompress(message);
+            Assert.assertEquals("Unexpected response for invocation with only request compressed", message, echoWithRequestCompressed);
+
+            // only response compressed
+            final String echoWithResponseCompressed = bean.echoWithResponseCompress(message);
+            Assert.assertEquals("Unexpected response for invocation with only response compressed", message, echoWithResponseCompressed);
+
+            // both request and response compressed based on the annotation at the view class level
+            final String echoWithRequestAndResponseCompressed = bean.echoWithNoExplicitDataCompressionHintOnMethod(message);
+            Assert.assertEquals("Unexpected response for invocation with both request and response compressed", message, echoWithRequestAndResponseCompressed);
+
+        } finally {
+            // remove the system property which enables annotation scan on the client view
+            System.getProperties().remove("org.jboss.ejb.client.view.annotation.scan.enabled");
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/compression/MethodOverrideDataCompressionRemoteView.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/compression/MethodOverrideDataCompressionRemoteView.java
@@ -1,0 +1,19 @@
+package org.jboss.as.test.integration.ejb.compression;
+
+
+import org.jboss.ejb.client.annotation.CompressionHint;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@CompressionHint
+public interface MethodOverrideDataCompressionRemoteView {
+
+    @CompressionHint(compressRequest = false)
+    String echoWithResponseCompress(final String msg);
+
+    @CompressionHint(compressResponse = false)
+    String echoWithRequestCompress(final String msg);
+
+    String echoWithNoExplicitDataCompressionHintOnMethod(String msg);
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-76 introduced the support for compressing EJB protocol messages during EJB invocations. The commit here adds the necessary server side support to recognize such compressed messages. It also adds a testcase to verify that a EJB method marked with a @org.jboss.ejb.client.annotation.CompressionHint can be invoked without any problems.
