### PR TITLE
[WLFY-509] JMS 2.0 API support

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -158,7 +158,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
-            <artifactId>jboss-jms-api_1.1_spec</artifactId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/build/build.xml
+++ b/build/build.xml
@@ -462,7 +462,7 @@
         </module-def>
 
         <module-def name="javax.jms.api">
-            <maven-resource group="org.jboss.spec.javax.jms" artifact="jboss-jms-api_1.1_spec"/>
+            <maven-resource group="org.jboss.spec.javax.jms" artifact="jboss-jms-api_2.0_spec"/>
         </module-def>
 
         <module-def name="javax.jws.api">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1592,7 +1592,7 @@
 
                 <dependency>
                     <groupId>org.jboss.spec.javax.jms</groupId>
-                    <artifactId>jboss-jms-api_1.1_spec</artifactId>
+                    <artifactId>jboss-jms-api_2.0_spec</artifactId>
                 </dependency>
 
                 <dependency>
@@ -2082,7 +2082,7 @@
                                         <include>org.jboss.spec.javax.el:jboss-el-api_2.2_spec</include>
                                         <include>org.jboss.spec.javax.faces:jboss-jsf-api_2.2_spec</include>
                                         <include>org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.1_spec</include>
-                                        <include>org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec</include>
+                                        <include>org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec</include>
                                         <include>org.jboss.spec.javax.management.j2ee:jboss-j2eemgmt-api_1.1_spec</include>
                                         <include>org.jboss.spec.javax.resource:jboss-connector-api_1.6_spec</include>
                                         <include>org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec</include>

--- a/build/src/license/licenses.xml
+++ b/build/src/license/licenses.xml
@@ -2899,7 +2899,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.jms</groupId>
-      <artifactId>jboss-jms-api_1.1_spec</artifactId>
+      <artifactId>jboss-jms-api_2.0_spec</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License, Version 2.1</name>

--- a/build/src/main/resources/bin/client/README-EJB-JMS.txt
+++ b/build/src/main/resources/bin/client/README-EJB-JMS.txt
@@ -3,7 +3,7 @@ with standalone clients only, not with deployments are that deployed to an AS7 i
 
 This jar contains the classes required for remote JMS and EJB usage, and consists of the following shaded artifacts:
 
-org.jboss.spec.javax.jms:jboss-jms-api_1.1_spec
+org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec
 org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec
 org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec
 

--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -99,7 +99,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
-            <artifactId>jboss-jms-api_1.1_spec</artifactId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -166,7 +166,7 @@ projects that depend on this project.-->
 
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
-            <artifactId>jboss-jms-api_1.1_spec</artifactId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>
         <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>2.2.0-m13</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Alpha3</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
-        <version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec>
+        <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>
         <version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>1.0.1.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.6_spec>
         <version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>1.0.4.Final</version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>
@@ -3624,6 +3624,12 @@
                         <groupId>org.jboss.naming</groupId>
                         <artifactId>jnpserver</artifactId>
                     </exclusion>
+                    <exclusion>
+                       <!-- TODO remove this exclusion once HornetQ supports JMS 2.0 -->
+                       <!-- superseded by org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec -->
+                       <groupId>org.jboss.spec.javax.jms</groupId>
+                       <artifactId>jboss-jms-api_1.1_spec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -3631,6 +3637,14 @@
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-jms-client</artifactId>
                 <version>${version.org.hornetq}</version>
+                <exclusions>
+                   <exclusion>
+                      <!-- TODO remove this exclusion once HornetQ supports JMS 2.0 -->
+                      <!-- superseded by org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec -->
+                      <groupId>org.jboss.spec.javax.jms</groupId>
+                      <artifactId>jboss-jms-api_1.1_spec</artifactId>
+                   </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -5011,8 +5025,8 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.jms</groupId>
-                <artifactId>jboss-jms-api_1.1_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_1.1_spec}</version>
+                <artifactId>jboss-jms-api_2.0_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec}</version>
             </dependency>
 
             <dependency>
@@ -5757,6 +5771,11 @@
                     <exclusion>
                         <groupId>org.jboss.spec.javax.ejb</groupId>
                         <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- superseded by org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec -->
+                        <groupId>org.jboss.spec.javax.jms</groupId>
+                        <artifactId>jboss-jms-api_1.1_spec</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>javax.xml.stream.api</groupId>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.jms</groupId>
-      <artifactId>jboss-jms-api_1.1_spec</artifactId>
+      <artifactId>jboss-jms-api_2.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.resource</groupId>

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -54,6 +54,7 @@
         />
         <ts.config-as.add-port-offset name="jbossas-with-remote-outbound-connection" offset="100" nativePort="9999" httpPort="9990"/>
 
+        <delete dir="target/jbossas-messaging-failover"/>
         <echo message="Copying and configuring instance jbossas-messaging-failover"/>
         <copy todir="target/jbossas-messaging-failover">
             <fileset dir="target/jbossas"/>


### PR DESCRIPTION
- update maven GAV for JMS API to:
  
  org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec:1.0.0.Alpha1-SNAPSHOT
- exclude the JMS 1.1 spec artifact from
  org.jboss.ws.cxf:jbossws-cxf-server dependencies
- exclude temporarily the JMS 1.1 spec artifact from
  org.hornetq:hornetq-jms-server and org.hornetq:hornetq-jms-client
  depedencies until HornetQ supports JMS 2.0

---

JMS 2.0 support has been split into several issues, all linked from [WFLY-509](https://issues.jboss.org/browse/WFLY-509)

This PR makes available the JMS 2.0 API so that we can work on these issues in parallel
