### PR TITLE
Fix for WFLY-1344 

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -150,6 +150,9 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             }
             final MessageHandler messageHandler = getMessageHandler((byte) header);
             if (messageHandler == null) {
+                // enroll for next message (whenever it's available)
+                channel.receiveMessage(this);
+                // log a message that the message wasn't identified
                 EjbLogger.ROOT_LOGGER.unsupportedMessageHeader(Integer.toHexString(header), channel);
                 return;
             }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-1344 where the message receiver on the EJB channel would stop receiving subsequent messages after it received a message it doesn't recognize.
