### PR TITLE
fixes for WFLY-1318 and WFLY-1329

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiCheckHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiCheckHandler.java
@@ -34,7 +34,7 @@ import io.undertow.util.Methods;
 
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
-import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.ModelController;
 import org.jboss.as.domain.http.server.security.SubjectAssociationHandler;
 
 /**
@@ -51,7 +51,7 @@ class DomainApiCheckHandler implements HttpHandler {
     private final MultiPartHandler uploadHandler = new MultiPartHandler();;
 
 
-    DomainApiCheckHandler(final ModelControllerClient modelController, final ControlledProcessStateService controlledProcessStateService) {
+    DomainApiCheckHandler(final ModelController modelController, final ControlledProcessStateService controlledProcessStateService) {
         this.controlledProcessStateService = controlledProcessStateService;
         domainApiHandler = new BlockingHandler(new SubjectAssociationHandler(new DomainApiHandler(modelController)));
         uploadHandler.setNext(new BlockingHandler(new SubjectAssociationHandler(new DomainApiUploadHandler(modelController))));

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiUploadHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiUploadHandler.java
@@ -32,8 +32,9 @@ import io.undertow.server.handlers.form.FormData;
 import io.undertow.server.handlers.form.FormData.FormValue;
 import io.undertow.server.handlers.form.FormDataParser;
 import io.undertow.util.Headers;
-import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.dmr.ModelNode;
 import org.xnio.IoUtils;
 import org.xnio.streams.ChannelOutputStream;
@@ -49,9 +50,9 @@ import static org.jboss.as.domain.http.server.HttpServerLogger.ROOT_LOGGER;
  */
 class DomainApiUploadHandler implements HttpHandler {
 
-    private final ModelControllerClient modelController;
+    private final ModelController modelController;
 
-    public DomainApiUploadHandler(ModelControllerClient modelController) {
+    public DomainApiUploadHandler(ModelController modelController) {
         this.modelController = modelController;
     }
 
@@ -73,7 +74,7 @@ class DomainApiUploadHandler implements HttpHandler {
 
                     OperationBuilder operation = new OperationBuilder(dmr);
                     operation.addInputStream(in);
-                    response = modelController.execute(operation.build());
+                    response = modelController.execute(dmr, OperationMessageHandler.logging, ModelController.OperationTransactionControl.COMMIT, operation.build());
                     if (!response.get(OUTCOME).asString().equals(SUCCESS)){
                         Common.sendError(exchange, false, false, response.get(FAILURE_DESCRIPTION).asString());
                         return;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/WhoAmIOperation.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/WhoAmIOperation.java
@@ -65,6 +65,7 @@ public class WhoAmIOperation implements OperationStepHandler {
             .build();
     public static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(WHOAMI, ControllerResolver.getResolver("core", "management"))
             .setParameters(VERBOSE)
+            .setReadOnly()
             .build();
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
@@ -22,12 +22,9 @@
 
 package org.jboss.as.host.controller.operations;
 
-import static java.security.AccessController.doPrivileged;
 import static org.jboss.as.host.controller.HostControllerLogger.AS_ROOT_LOGGER;
 
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -49,14 +46,12 @@ import org.jboss.as.remoting.RemotingHttpUpgradeService;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.mgmt._UndertowHttpManagementService;
 import org.jboss.as.server.services.net.NetworkInterfaceService;
-import org.wildfly.security.manager.GetAccessControlContextAction;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.threads.JBossThreadFactory;
 import org.xnio.OptionMap;
 
 /**
@@ -130,9 +125,6 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
 
         AS_ROOT_LOGGER.creatingHttpManagementService(interfaceName, port, securePort);
 
-        final ThreadFactory httpMgmtThreads = new JBossThreadFactory(new ThreadGroup("HttpManagementService-threads"),
-                Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
-
         ConsoleMode consoleMode = ConsoleMode.CONSOLE;
         if (runningMode == RunningMode.ADMIN_ONLY) {
             consoleMode = ConsoleMode.ADMIN_ONLY;
@@ -148,8 +140,7 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
                 .addDependency(DomainModelControllerService.SERVICE_NAME, ModelController.class, service.getModelControllerInjector())
                 .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, service.getControlledProcessStateServiceInjector())
                 .addInjection(service.getPortInjector(), port)
-                .addInjection(service.getSecurePortInjector(), securePort)
-                .addInjection(service.getExecutorServiceInjector(), Executors.newCachedThreadPool(httpMgmtThreads));
+                .addInjection(service.getSecurePortInjector(), securePort);
 
         ServiceName realmSvcName = null;
         if (securityRealm != null) {

--- a/server/src/main/java/org/jboss/as/server/mgmt/_UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/_UndertowHttpManagementService.java
@@ -23,12 +23,10 @@ package org.jboss.as.server.mgmt;
 
 import java.net.BindException;
 import java.net.InetSocketAddress;
-import java.util.concurrent.ExecutorService;
 
 import io.undertow.server.handlers.ChannelUpgradeHandler;
 import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.ModelController;
-import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.domain.http.server.ConsoleMode;
 import org.jboss.as.domain.http.server.ManagementHttpServer;
 import org.jboss.as.domain.management.security.SecurityRealmService;
@@ -67,7 +65,6 @@ public class _UndertowHttpManagementService implements Service<HttpManagement>{
     private final InjectedValue<SocketBindingManager> injectedSocketBindingManager = new InjectedValue<SocketBindingManager>();
     private final InjectedValue<Integer> portValue = new InjectedValue<Integer>();
     private final InjectedValue<Integer> securePortValue = new InjectedValue<Integer>();
-    private final InjectedValue<ExecutorService> executorServiceValue = new InjectedValue<ExecutorService>();
     private final InjectedValue<SecurityRealmService> securityRealmServiceValue = new InjectedValue<SecurityRealmService>();
     private final InjectedValue<ControlledProcessStateService> controlledProcessStateServiceValue = new InjectedValue<ControlledProcessStateService>();
     private final ConsoleMode consoleMode;
@@ -156,8 +153,6 @@ public class _UndertowHttpManagementService implements Service<HttpManagement>{
     public synchronized void start(StartContext context) throws StartException {
         final ModelController modelController = modelControllerValue.getValue();
         final ControlledProcessStateService controlledProcessStateService = controlledProcessStateServiceValue.getValue();
-        final ExecutorService executorService = executorServiceValue.getValue();
-        final ModelControllerClient modelControllerClient = modelController.createClient(executorService);
         socketBindingManager = injectedSocketBindingManager.getOptionalValue();
 
         final SecurityRealmService securityRealmService = securityRealmServiceValue.getOptionalValue();
@@ -199,8 +194,9 @@ public class _UndertowHttpManagementService implements Service<HttpManagement>{
 
         try {
 
-            serverManagement = ManagementHttpServer.create(bindAddress, secureBindAddress, 50, modelControllerClient,
-                    executorService, securityRealmService, controlledProcessStateService, consoleMode, consoleSlot, upgradeHandler);
+            serverManagement = ManagementHttpServer.create(bindAddress, secureBindAddress, 50, modelController,
+                    securityRealmService, controlledProcessStateService, consoleMode, consoleSlot, upgradeHandler);
+
             serverManagement.start();
 
             // Register the now-created sockets with the SBM
@@ -295,15 +291,6 @@ public class _UndertowHttpManagementService implements Service<HttpManagement>{
 
     public Injector<SocketBinding> getSecureSocketBindingInjector() {
         return injectedSecureSocketBindingValue;
-    }
-
-    /**
-     * Get the executor service injector.
-     *
-     * @return The injector
-     */
-    public Injector<ExecutorService> getExecutorServiceInjector() {
-        return executorServiceValue;
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.server.operations;
 
-import static java.security.AccessController.doPrivileged;
 import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.HTTPS_PORT;
 import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.HTTP_PORT;
 import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.INTERFACE;
@@ -32,7 +31,6 @@ import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.SOCKET_B
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Executors;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -61,13 +59,11 @@ import org.jboss.as.server.mgmt.HttpManagementResourceDefinition;
 import org.jboss.as.server.mgmt._UndertowHttpManagementService;
 import org.jboss.as.server.mgmt.domain.HttpManagement;
 import org.jboss.as.server.services.net.NetworkInterfaceService;
-import org.wildfly.security.manager.GetAccessControlContextAction;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.threads.JBossThreadFactory;
 import org.xnio.OptionMap;
 
 /**
@@ -232,8 +228,7 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
         ServiceBuilder<HttpManagement> undertowBuilder = serviceTarget.addService(_UndertowHttpManagementService.SERVICE_NAME, undertowService)
                 .addDependency(Services.JBOSS_SERVER_CONTROLLER, ModelController.class, undertowService.getModelControllerInjector())
                 .addDependency(SocketBindingManagerImpl.SOCKET_BINDING_MANAGER, SocketBindingManager.class, undertowService.getSocketBindingManagerInjector())
-                .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, undertowService.getControlledProcessStateServiceInjector())
-                .addInjection(undertowService.getExecutorServiceInjector(), Executors.newCachedThreadPool(new JBossThreadFactory(new ThreadGroup("HttpManagementService-threads"), Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()))));
+                .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, undertowService.getControlledProcessStateServiceInjector());
 
         if (interfaceSvcName != null) {
             undertowBuilder.addDependency(interfaceSvcName, NetworkInterfaceBinding.class, undertowService.getInterfaceInjector())


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-1318 executing a :reload using the http interface fails
https://issues.jboss.org/browse/WFLY-1329 'whoami' operation unexpectedly requires the domain wide configuration lock
