### PR TITLE
[WFLY-1358] Better support for spaces in paths on Windows

### DIFF
--- a/build/src/main/resources/bin/add-user.bat
+++ b/build/src/main/resources/bin/add-user.bat
@@ -21,16 +21,26 @@ pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%" 
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
+  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )
-
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
+   echo.
 )
 
 set DIRNAME=
@@ -51,10 +61,10 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -63,14 +73,14 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%UNQUOTED_JBOSS_HOME%\modules"
 )
 
 rem Uncomment to override standalone and domain user location  
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.server.config.user.dir=..\standalone\configuration -Djboss.domain.config.user.dir=..\domain\configuration"
 
 "%JAVA%" %JAVA_OPTS% ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -jar "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.domain-add-user ^
      %*

--- a/build/src/main/resources/bin/appclient.bat
+++ b/build/src/main/resources/bin/appclient.bat
@@ -29,16 +29,25 @@ pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
 )
-
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
+   echo.
 )
 
 set DIRNAME=
@@ -67,10 +76,10 @@ if not errorlevel == 1 (
 )
 
 rem Find run.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -79,15 +88,15 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%UNQUOTED_JBOSS_HOME%\modules"
 )
 
 "%JAVA%" %JAVA_OPTS% ^
- "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\appclient.log" ^
- "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+ "-Dorg.jboss.boot.log.file=%UNQUOTED_JBOSS_HOME%\appclient\log\appclient.log" ^
+ "-Dlogging.configuration=file:%UNQUOTED_JBOSS_HOME%/appclient/configuration/logging.properties" ^
+    -jar "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.appclient ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-    -Djboss.server.base.dir="%JBOSS_HOME%\appclient" ^
+    -Djboss.home.dir="%UNQUOTED_JBOSS_HOME%" ^
+    -Djboss.server.base.dir="%UNQUOTED_JBOSS_HOME%\appclient" ^
      %*

--- a/build/src/main/resources/bin/domain.bat
+++ b/build/src/main/resources/bin/domain.bat
@@ -31,16 +31,26 @@ pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
 )
 
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
+   echo.
 )
 
 set DIRNAME=
@@ -70,10 +80,10 @@ if not errorlevel == 1 (
 )
 
 rem Find run.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -112,12 +122,12 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%UNQUOTED_JBOSS_HOME%\modules"
 )
 
 rem Set the domain base dir
 if "x%JBOSS_BASE_DIR%" == "x" (
-  set  "JBOSS_BASE_DIR=%JBOSS_HOME%\domain"
+  set  "JBOSS_BASE_DIR=%UNQUOTED_JBOSS_HOME%\domain"
 )
 rem Set the domain log dir
 if "x%JBOSS_LOG_DIR%" == "x" (
@@ -132,7 +142,7 @@ echo ===========================================================================
 echo.
 echo   JBoss Bootstrap Environment
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   JBOSS_HOME: %UNQUOTED_JBOSS_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
@@ -145,10 +155,10 @@ echo.
 "%JAVA%" %PROCESS_CONTROLLER_JAVA_OPTS% ^
  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\process-controller.log" ^
  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -jar "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.process-controller ^
-    -jboss-home "%JBOSS_HOME%" ^
+    -jboss-home "%UNQUOTED_JBOSS_HOME%" ^
     -jvm "%JAVA%" ^
     -mp "%JBOSS_MODULEPATH%" ^
     -- ^

--- a/build/src/main/resources/bin/jboss-cli.bat
+++ b/build/src/main/resources/bin/jboss-cli.bat
@@ -18,16 +18,26 @@ pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
   set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )
-
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
+   echo.
 )
 
 set DIRNAME=
@@ -50,10 +60,10 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find run.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -62,8 +72,8 @@ rem Add base package for L&F
 set JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=com.sun.java.swing
 
 "%JAVA%" %JAVA_OPTS% ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
-    -mp "%JBOSS_HOME%\modules" ^
+    -jar "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" ^
+    -mp "%UNQUOTED_JBOSS_HOME%\modules" ^
      org.jboss.as.cli ^
      %*
 

--- a/build/src/main/resources/bin/jconsole.bat
+++ b/build/src/main/resources/bin/jconsole.bat
@@ -20,16 +20,26 @@ pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
   set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
 )
-
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
+   echo.
 )
 
 set DIRNAME=
@@ -47,17 +57,17 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%UNQUOTED_JBOSS_HOME%\modules"
 )
 
 rem Setup The Classpath

--- a/build/src/main/resources/bin/jdr.bat
+++ b/build/src/main/resources/bin/jdr.bat
@@ -23,16 +23,26 @@ pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
 
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%" 
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
+  set "JBOSS_HOME=%%RESOLVED_JBOSS_HOME%"
 )
-
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
-if "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
-    echo WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
+   echo.
+   echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
+   echo.
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
+   echo.
 )
 
 set DIRNAME=
@@ -53,10 +63,10 @@ if "x%JAVA_HOME%" == "x" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set "RUNJAR=%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -65,12 +75,12 @@ rem Setup JBoss specific properties
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%UNQUOTED_JBOSS_HOME%\modules"
 )
 
 "%JAVA%" ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -Djboss.home.dir="%UNQUOTED_JBOSS_HOME%" ^
+    -jar "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.jdr ^
      %*

--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -61,12 +61,16 @@ rem $Id$
 pushd %DIRNAME%..
 set "RESOLVED_JBOSS_HOME=%CD%"
 popd
-
-if "x%JBOSS_HOME%" == "x" (
-  set "JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+set UNQUOTED_JBOSS_HOME=%JBOSS_HOME:"=%
+rem attempt to unquote again to remove quote if envvar was not set
+set UNQUOTED_JBOSS_HOME=%UNQUOTED_JBOSS_HOME:"=%
+set QUOTED_JBOSS_HOME="%UNQUOTED_JBOSS_HOME%"
+rem should only a = if envvar was not set
+if "%UNQUOTED_JBOSS_HOME%" == "=" (
+  set "UNQUOTED_JBOSS_HOME=%RESOLVED_JBOSS_HOME%"
+  set QUOTED_JBOSS_HOME="%RESOLVED_JBOSS_HOME%"
 )
-
-pushd "%JBOSS_HOME%"
+pushd %QUOTED_JBOSS_HOME%
 set "SANITIZED_JBOSS_HOME=%CD%"
 popd
 
@@ -74,10 +78,8 @@ if /i "%RESOLVED_JBOSS_HOME%" NEQ "%SANITIZED_JBOSS_HOME%" (
    echo.
    echo   WARNING:  JBOSS_HOME may be pointing to a different installation - unpredictable results may occur.
    echo.
-   echo             JBOSS_HOME: %JBOSS_HOME%
+   echo       JBOSS_HOME: %QUOTED_JBOSS_HOME%
    echo.
-   rem 2 seconds pause
-   ping 127.0.0.1 -n 3 > nul
 )
 
 rem Read an optional configuration file.
@@ -149,10 +151,10 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
 )
 
 rem Find jboss-modules.jar, or we can't continue
-if exist "%JBOSS_HOME%\jboss-modules.jar" (
-    set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
+if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (
+    set RUNJAR="%UNQUOTED_JBOSS_HOME%\jboss-modules.jar"
 ) else (
-  echo Could not locate "%JBOSS_HOME%\jboss-modules.jar".
+  echo Could not locate "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar".
   echo Please check that you are in the bin directory when running this script.
   goto END
 )
@@ -191,12 +193,12 @@ for /f "tokens=1* delims= " %%i IN ("%CONSOLIDATED_OPTS%") DO (
 
 rem Set default module root paths
 if "x%JBOSS_MODULEPATH%" == "x" (
-  set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
+  set  "JBOSS_MODULEPATH=%UNQUOTED_JBOSS_HOME%\modules"
 )
 
 rem Set the standalone base dir
 if "x%JBOSS_BASE_DIR%" == "x" (
-  set  "JBOSS_BASE_DIR=%JBOSS_HOME%\standalone"
+  set  "JBOSS_BASE_DIR=%UNQUOTED_JBOSS_HOME%\standalone"
 )
 rem Set the standalone log dir
 if "x%JBOSS_LOG_DIR%" == "x" (
@@ -204,14 +206,14 @@ if "x%JBOSS_LOG_DIR%" == "x" (
 )
 rem Set the standalone configuration dir
 if "x%JBOSS_CONFIG_DIR%" == "x" (
-  set  "JBOSS_CONFIG_DIR=%JBOSS_BASE_DIR%/configuration"
+  set  "JBOSS_CONFIG_DIR=%JBOSS_BASE_DIR%\configuration"
 )
 
 echo ===============================================================================
 echo.
 echo   JBoss Bootstrap Environment
 echo.
-echo   JBOSS_HOME: %JBOSS_HOME%
+echo   JBOSS_HOME: %UNQUOTED_JBOSS_HOME%
 echo.
 echo   JAVA: %JAVA%
 echo.
@@ -224,10 +226,10 @@ echo.
 "%JAVA%" %JAVA_OPTS% ^
  "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
  "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
-    -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    -jar "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.standalone ^
-    -Djboss.home.dir="%JBOSS_HOME%" ^
+    -Djboss.home.dir="%UNQUOTED_JBOSS_HOME%" ^
      %SERVER_OPTS%
 
 if ERRORLEVEL 10 goto RESTART

--- a/build/src/main/resources/bin/vault.bat
+++ b/build/src/main/resources/bin/vault.bat
@@ -14,7 +14,7 @@ set JBOSS_HOME=%DIRNAME%\..
 rem Setup the JVM
 IF NOT DEFINED JAVA (
     IF DEFINED JAVA_HOME (
-        set JAVA="%JAVA_HOME%\bin\java"
+        set "JAVA=%JAVA_HOME%\bin\java"
     ) ELSE (
         set JAVA=java
     )
@@ -22,8 +22,8 @@ IF NOT DEFINED JAVA (
 )
 
 IF NOT DEFINED MODULEPATH (
-    set MODULEPATH="%JBOSS_HOME%\modules"
-	call :DeQuote MODULEPATH
+    set "MODULEPATH=%JBOSS_HOME%\modules"
+    call :DeQuote MODULEPATH
 )
 
 
@@ -40,7 +40,7 @@ echo.
 echo =========================================================================
 echo.
 
-%JAVA% -jar %JBOSS_HOME%\jboss-modules.jar -mp %MODULEPATH% org.jboss.as.vault-tool %*
+"%JAVA%" -jar "%JBOSS_HOME%\jboss-modules.jar" -mp "%MODULEPATH%" org.jboss.as.vault-tool %*
 
 ENDLOCAL
 


### PR DESCRIPTION
Also paths like `C:\Program Files (x86)\jboss-eap-6.1` caused scripts to fail to due the `()`.
