### PR TITLE
[WFLY-1287] Provide JMS Default ConnectionFactory

### DIFF
--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -60,6 +60,8 @@
                        <connector-ref connector-name="in-vm"/>
                    </connectors>
                    <entries>
+                       <!-- Global JNDI entry used to provide a default JMS Connection factory to EE application -->
+                       <entry name="java:jboss/DefaultJMSConnectionFactory"/>
                        <entry name="java:/ConnectionFactory"/>
                    </entries>
                </connection-factory>

--- a/messaging/src/main/java/org/jboss/as/messaging/BinderServiceUtil.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BinderServiceUtil.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.messaging;
+
+import javax.naming.InitialContext;
+
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.ServiceBasedNamingStore;
+import org.jboss.as.naming.ValueManagedReference;
+import org.jboss.as.naming.ValueManagedReferenceFactory;
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.naming.service.BinderService;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.ImmediateValue;
+import org.jboss.msc.value.Values;
+
+/**
+ * Utility class to install BinderService (either to bind actual objects or create alias on another binding).
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+public class BinderServiceUtil {
+
+    public static void installBinderService(final ServiceTarget serviceTarget,
+                                                 final String name,
+                                                 final Object obj) {
+        final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(name);
+        final BinderService binderService = new BinderService(bindInfo.getBindName());
+
+        serviceTarget.addService(bindInfo.getBinderServiceName(), binderService)
+                .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
+                .addInjection(binderService.getManagedObjectInjector(), new ValueManagedReferenceFactory(Values.immediateValue(obj)))
+                .setInitialMode(ServiceController.Mode.ACTIVE)
+                .install();
+    }
+
+    public static void installAliasBinderService(final ServiceTarget serviceTarget,
+                                                 final ServiceName namingStoreServiceName,
+                                                 final String name,
+                                                 final ServiceName aliasServiceName,
+                                                 final String alias) {
+        final BinderService aliasBinderService = new BinderService(alias);
+        aliasBinderService.getManagedObjectInjector().inject(new AliasManagedReferenceFactory(name));
+
+        serviceTarget.addService(aliasServiceName, aliasBinderService)
+                .addDependency(namingStoreServiceName, ServiceBasedNamingStore.class, aliasBinderService.getNamingStoreInjector())
+                .addDependency(ContextNames.bindInfoFor(name).getBinderServiceName())
+                .install();
+    }
+
+    private static final class AliasManagedReferenceFactory implements ContextListAndJndiViewManagedReferenceFactory {
+
+        private final String name;
+
+        /**
+         * @param name original JNDI name
+         */
+        public AliasManagedReferenceFactory(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public ManagedReference getReference() {
+            try {
+                final Object value = new InitialContext().lookup(name);
+                return new ValueManagedReference(new ImmediateValue<Object>(value));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public String getInstanceClassName() {
+            final Object value = getReference().getInstance();
+            return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+        }
+
+        @Override
+        public String getJndiViewInstanceValue() {
+            return String.valueOf(getReference().getInstance());
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemAdd.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.messaging.deployment.MessagingJndiBindingProcessor;
 import org.jboss.as.messaging.deployment.MessagingXmlInstallDeploymentUnitProcessor;
 import org.jboss.as.messaging.deployment.MessagingXmlParsingDeploymentUnitProcessor;
 import org.jboss.as.server.AbstractDeploymentChainStep;
@@ -60,6 +61,7 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_MESSAGING_XML_RESOURCES, new MessagingXmlParsingDeploymentUnitProcessor());
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_MESSAGING_XML_RESOURCES, new MessagingXmlInstallDeploymentUnitProcessor());
+                processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JMS_BINDINGS, new MessagingJndiBindingProcessor());
             }
         }, OperationContext.Stage.RUNTIME);
     }

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJndiBindingProcessor.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJndiBindingProcessor.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.messaging.deployment;
+
+import static org.jboss.as.messaging.BinderServiceUtil.installAliasBinderService;
+
+import org.jboss.as.ee.component.Attachments;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.ComponentNamingMode;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ee.structure.DeploymentType;
+import org.jboss.as.ee.structure.DeploymentTypeMarker;
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * Processor responsible for binding JMS related resources to JNDI.
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+public class MessagingJndiBindingProcessor implements DeploymentUnitProcessor {
+
+    public static final String DEFAULT_JMS_CONNECTION_FACTORY = "DefaultJMSConnectionFactory";
+    public static final String JBOSS_DEFAULT_JMS_CONNECTION_FACTORY_LOOKUP = "java:jboss/DefaultJMSConnectionFactory";
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+
+        if(moduleDescription == null) {
+            return;
+        }
+
+        // do not alias the default JMS connection factory if there is no entry defined by the messaging subsystem
+        if (phaseContext.getServiceRegistry().getService(ContextNames.bindInfoFor(JBOSS_DEFAULT_JMS_CONNECTION_FACTORY_LOOKUP).getBinderServiceName()) == null) {
+            return;
+        }
+
+        final ServiceTarget serviceTarget = phaseContext.getServiceTarget();
+        if(DeploymentTypeMarker.isType(DeploymentType.WAR, deploymentUnit)) {
+            final ServiceName moduleContextServiceName = ContextNames.contextServiceNameOfModule(moduleDescription.getApplicationName(),moduleDescription.getModuleName());
+            bindAliasService(deploymentUnit, serviceTarget, moduleContextServiceName, JBOSS_DEFAULT_JMS_CONNECTION_FACTORY_LOOKUP);
+        }
+
+        for(ComponentDescription component : moduleDescription.getComponentDescriptions()) {
+            if(component.getNamingMode() == ComponentNamingMode.CREATE) {
+                final ServiceName compContextServiceName = ContextNames.contextServiceNameOfComponent(moduleDescription.getApplicationName(),moduleDescription.getModuleName(),component.getComponentName());
+                bindAliasService(deploymentUnit, serviceTarget, compContextServiceName, JBOSS_DEFAULT_JMS_CONNECTION_FACTORY_LOOKUP);
+            }
+        }
+    }
+
+    /**
+     * Binds the java:comp/DefaultJMSConnectionFactory by aliasing the connection factory lookup
+     * flagged as default by the messaging subsystem.
+     *
+     * @param deploymentUnit The deployment unit
+     * @param serviceTarget The service target
+     * @param contextServiceName The service name of the context to bind to
+     * @param connectionFactoryLookup the JNDI lookup of the default connection factory
+     *                                that will be aliased to.
+     *
+     */
+    private void bindAliasService(DeploymentUnit deploymentUnit, ServiceTarget serviceTarget, ServiceName contextServiceName, String connectionFactoryLookup) {
+        final ServiceName defaultJMSConnectionFactoryServiceName = contextServiceName.append(DEFAULT_JMS_CONNECTION_FACTORY);
+
+        installAliasBinderService(serviceTarget,
+                contextServiceName,
+                connectionFactoryLookup,
+                defaultJMSConnectionFactoryServiceName,
+                DEFAULT_JMS_CONNECTION_FACTORY);
+
+        deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES, defaultJMSConnectionFactoryServiceName);
+    }
+
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/AS7BindingRegistry.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/AS7BindingRegistry.java
@@ -23,20 +23,17 @@
 package org.jboss.as.messaging.jms;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.messaging.BinderServiceUtil.installBinderService;
 import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.Locale;
 
 import org.hornetq.spi.core.naming.BindingRegistry;
-import org.jboss.as.naming.ServiceBasedNamingStore;
-import org.jboss.as.naming.ValueManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
-import org.jboss.as.naming.service.BinderService;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.StabilityMonitor;
-import org.jboss.msc.value.Values;
 
 /**
  * A {@link BindingRegistry} implementation for JBoss AS7.
@@ -75,14 +72,8 @@ public class AS7BindingRegistry implements BindingRegistry {
         if (name == null || name.isEmpty()) {
             throw MESSAGES.cannotBindJndiName();
         }
-        final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(name);
-        final BinderService binderService = new BinderService(bindInfo.getBindName());
-        container.addService(bindInfo.getBinderServiceName(), binderService)
-                .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
-                .addInjection(binderService.getManagedObjectInjector(), new ValueManagedReferenceFactory(Values.immediateValue(obj)))
-                .setInitialMode(ServiceController.Mode.ACTIVE)
-                .install();
-        ROOT_LOGGER.boundJndiName(bindInfo.getAbsoluteJndiName());
+        installBinderService(container, name, obj);
+        ROOT_LOGGER.boundJndiName(name);
         return true;
     }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -460,6 +460,7 @@ public enum Phase {
     public static final int INSTALL_JSF_ANNOTATIONS                     = 0x1600;
     public static final int INSTALL_JDBC_DRIVER                         = 0x1800;
     public static final int INSTALL_TRANSACTION_BINDINGS                = 0x1900;
+    public static final int INSTALL_JMS_BINDINGS                        = 0x1A00;
     public static final int INSTALL_WELD_DEPLOYMENT                     = 0x1B00;
     public static final int INSTALL_WELD_BEAN_MANAGER                   = 0x1C00;
     public static final int INSTALL_JNDI_DEPENDENCIES                   = 0x1C01;

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/DefaultJMSConnectionFactoryTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/DefaultJMSConnectionFactoryTest.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.as.test.smoke.jms.auxiliary.SimplifiedMessageProducer;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests sending JMS messages using the server's default JMS Connection Factory.
+ *
+ * Java EE 7 spec, §EE.5.20 Default JMS Connection Factory
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(CreateQueueSetupTask.class)
+public class DefaultJMSConnectionFactoryTest {
+
+    private static final Logger logger = Logger.getLogger(DefaultJMSConnectionFactoryTest.class);
+
+    @EJB
+    private SimplifiedMessageProducer producerEJB;
+
+    @Resource(mappedName = "/queue/myAwesomeQueue")
+    private Queue queue;
+
+    // the tested ConnectionFactory resources are in the SimplifiedMessageProducer EJB.
+    // this one is only to check that messages have been effectively sent
+    @Resource(mappedName = "/ConnectionFactory")
+    private ConnectionFactory factory;
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "DefaultJMSConnectionFactoryTest.jar")
+                .addClass(SimplifiedMessageProducer.class)
+                .addClass(CreateQueueSetupTask.class)
+                .addPackage(JMSOperations.class.getPackage())
+                .addAsManifestResource(EmptyAsset.INSTANCE,
+                        ArchivePaths.create("beans.xml"))
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                        "MANIFEST.MF");
+    }
+
+    @Test
+    public void sendWithDefaultJMSConnectionFactory() throws Exception {
+        String text = UUID.randomUUID().toString();
+
+        producerEJB.sendWithDefaultJMSConnectionFactory(queue, text);
+
+        assertMessageInQueue(text);
+    }
+
+    @Test
+    public void sendWithRegularConnectionFactory() throws Exception {
+        String text = UUID.randomUUID().toString();
+
+        producerEJB.sendWithRegularConnectionFactory(queue, text);
+
+        assertMessageInQueue(text);
+    }
+
+    private void assertMessageInQueue(String text) throws JMSException {
+        Connection connection = factory.createConnection();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        MessageConsumer consumer = session.createConsumer(queue);
+        connection.start();
+
+        Message message = consumer.receive(2000);
+        assertNotNull(message);
+        assertTrue(message instanceof TextMessage);
+        assertEquals(text, ((TextMessage) message).getText());
+
+        connection.close();
+    }
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/SimplifiedMessageProducer.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/SimplifiedMessageProducer.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms.auxiliary;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateful;
+import javax.enterprise.context.RequestScoped;
+import javax.jms.*;
+
+/**
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+@Stateful
+@RequestScoped
+public class SimplifiedMessageProducer {
+
+    private static final Logger logger = Logger.getLogger(SimplifiedMessageProducer.class);
+
+    @Resource(name="myCF", lookup="java:comp/DefaultJMSConnectionFactory")
+    private ConnectionFactory defaultConnectionFactory;
+
+    @Resource(name = "java:/ConnectionFactory")
+    private ConnectionFactory regularConnectionFactory;
+
+    public void sendWithDefaultJMSConnectionFactory(Destination destination, String text) throws Exception {
+        send(defaultConnectionFactory, destination, text);
+    }
+
+    public void sendWithRegularConnectionFactory(Destination destination, String text) throws Exception {
+        send(regularConnectionFactory, destination, text);
+    }
+
+    private void send(ConnectionFactory cf, Destination destination, String text) throws Exception {
+        // TODO use JMS 2.0 context when HornetQ supports it
+        Connection connection = cf.createConnection();
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        MessageProducer producer = session.createProducer(destination);
+
+        Message message = session.createTextMessage(text);
+        message.setJMSDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.send(message);
+
+        connection.close();
+    }
+}


### PR DESCRIPTION
- add a java:jboss/DefaultJMSConnectionFactory entry to the
  InVmConnectorFactory that is used to alias the
  java:/comp/DefaultJMSConnectionFactory entry for EE deployments
- move all code related to BinderService (for alias and actual objects)
  in BunderServiceUtil
- add a INSTALL_JMS_BINDINGS (0x1A00) deployment phase to process this
  JMS binding

---

To be EE7-compliant, this means that the messaging subsystem _must_ always define a JMS connection factory with a JNDI entry `java:jboss/DefaultJMSConnectionFactory` (that is aliased for each deployed EE application)
