### PR TITLE
Fix jboss.web dependency version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,7 +234,7 @@
         <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.1.GA</version.org.jboss.stdio>
         <version.org.jboss.threads>2.1.0.Final</version.org.jboss.threads>
-        <version.org.jboss.web>8.0.0.Alpha2-SNAPSHOT</version.org.jboss.web>
+        <version.org.jboss.web>8.0.0.Alpha1</version.org.jboss.web>
         <version.org.jboss.web.jasper-jdt>7.0.3.Final</version.org.jboss.web.jasper-jdt>
         <version.org.jboss.weld.weld>2.0.0.CR4</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.0.CR4</version.org.jboss.weld.weld-api>


### PR DESCRIPTION
The commit here fixes the dependency on JBossWeb, which was unintentionally changed to 8.0.0.Alpha2-SNAPSHOT.
