### PR TITLE
WFLY-1370 Allow CDI Extension to be loaded from static modules

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsCdiIntegrationProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsCdiIntegrationProcessor.java
@@ -32,17 +32,12 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.web.common.WarMetaData;
 import org.jboss.as.weld.WeldDeploymentMarker;
-import org.jboss.as.weld.deployment.WeldAttachments;
 import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.modules.Module;
-import org.jboss.resteasy.cdi.ResteasyCdiExtension;
-import org.jboss.weld.bootstrap.spi.Metadata;
 
-import javax.enterprise.inject.spi.Extension;
 import java.util.ArrayList;
 import java.util.List;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * @author Stuart Douglas
@@ -74,42 +69,6 @@ public class JaxrsCdiIntegrationProcessor implements DeploymentUnitProcessor {
             if (WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
                 JAXRS_LOGGER.debug("Found CDI, adding injector factory class");
                 setContextParameter(webdata, "resteasy.injector.factory", CDI_INJECTOR_FACTORY_CLASS);
-                //now we need to add the CDI extension, if it has not
-                //already been added
-                synchronized (parent) {
-                    boolean found = false;
-                    final List<Metadata<Extension>> extensions = parent.getAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS);
-                    for (Metadata<Extension> extension : extensions) {
-                        if (extension.getValue() instanceof ResteasyCdiExtension) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
-
-                        final ClassLoader classLoader = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-                        try {
-                            //MASSIVE HACK
-                            //the resteasy Logger throws a NPE if the TCCL is null
-                            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(ResteasyCdiExtension.class.getClassLoader());
-                            final ResteasyCdiExtension ext = new ResteasyCdiExtension();
-                            Metadata<Extension> metadata = new Metadata<Extension>() {
-                                @Override
-                                public Extension getValue() {
-                                    return ext;
-                                }
-
-                                @Override
-                                public String getLocation() {
-                                    return "org.jboss.as.jaxrs.JaxrsExtension";
-                                }
-                            };
-                            parent.addToAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS, metadata);
-                        } finally {
-                            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-                        }
-                    }
-                }
             }
         } catch (ClassNotFoundException ignored) {
         }

--- a/weld/src/main/java/org/jboss/as/weld/WeldMessages.java
+++ b/weld/src/main/java/org/jboss/as/weld/WeldMessages.java
@@ -63,8 +63,8 @@ public interface WeldMessages {
     @Message(id= 16052, value = "Could not load interceptor class : %s")
     DeploymentUnitProcessingException couldNotLoadInterceptorClass(String interceptorClass, @Cause Throwable cause);
 
-    @Message(id=16053, value = "Service class %s didn't implement the javax.enterprise.inject.spi.Extension interface")
-    DeploymentUnitProcessingException extensionDoesNotImplementExtension(String className, @Cause Throwable throwable);
+    @Message(id=16053, value = "Service %s didn't implement the javax.enterprise.inject.spi.Extension interface")
+    DeploymentUnitProcessingException extensionDoesNotImplementExtension(Class<?> clazz);
 
     @Message(id = 16054, value = "View of type %s not found on EJB %s")
     IllegalArgumentException viewNotFoundOnEJB(String viewType, String ejb);

--- a/weld/src/main/java/org/jboss/as/weld/deployment/WeldAttachments.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/WeldAttachments.java
@@ -21,11 +21,9 @@
  */
 package org.jboss.as.weld.deployment;
 
-import javax.enterprise.inject.spi.Extension;
 
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.AttachmentList;
-import org.jboss.weld.bootstrap.spi.Metadata;
 
 /**
  * {@link AttachmentKey}s for weld attachments
@@ -56,9 +54,4 @@ public class WeldAttachments {
      */
     public static final AttachmentKey<BeanDeploymentArchiveImpl> DEPLOYMENT_ROOT_BEAN_DEPLOYMENT_ARCHIVE = AttachmentKey.create(BeanDeploymentArchiveImpl.class);
 
-    /**
-     * Portable extensions discovered in sub deployments. All sub deployments may contain portable extensions, even ones without
-     * beans.xml files
-     */
-    public static final AttachmentKey<AttachmentList<Metadata<Extension>>> PORTABLE_EXTENSIONS = AttachmentKey.createList(Metadata.class);
 }

--- a/weld/src/main/java/org/jboss/as/weld/deployment/WeldPortableExtensions.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/WeldPortableExtensions.java
@@ -1,0 +1,71 @@
+package org.jboss.as.weld.deployment;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import javax.enterprise.inject.spi.Extension;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.weld.WeldLogger;
+import org.jboss.as.weld.WeldMessages;
+import org.jboss.weld.bootstrap.spi.Metadata;
+import org.jboss.weld.metadata.MetadataImpl;
+
+/**
+ * Container class that is attached to the top level deployment that holds all portable extension metadata.
+ * <p/>
+ * A portable extension may be available to multiple deployment class loaders, however for each PE we
+ * only want to register a single instance.
+ * <p/>
+ * This container provides a mechanism for making sure that only a single PE of a given type is registered.
+ *
+ * @author Stuart Douglas
+ */
+public class WeldPortableExtensions {
+
+    private static final AttachmentKey<WeldPortableExtensions> ATTACHMENT_KEY = AttachmentKey.create(WeldPortableExtensions.class);
+
+    public static WeldPortableExtensions getPortableExtensions(final DeploymentUnit deploymentUnit) {
+        if (deploymentUnit.getParent() == null) {
+            WeldPortableExtensions pes = deploymentUnit.getAttachment(WeldPortableExtensions.ATTACHMENT_KEY);
+            if (pes == null) {
+                deploymentUnit.putAttachment(ATTACHMENT_KEY, pes = new WeldPortableExtensions());
+            }
+            return pes;
+        } else {
+            return getPortableExtensions(deploymentUnit.getParent());
+        }
+    }
+
+    private final Map<Class<?>, Metadata<Extension>> extensions = new HashMap<>();
+
+    public synchronized void tryRegisterExtension(final Class<?> extensionClass, final DeploymentUnit deploymentUnit) throws DeploymentUnitProcessingException {
+        if (!Extension.class.isAssignableFrom(extensionClass)) {
+            throw WeldMessages.MESSAGES.extensionDoesNotImplementExtension(extensionClass);
+        }
+        if (extensions.containsKey(extensionClass)) {
+            return;
+        }
+        try {
+            extensions.put(extensionClass, new MetadataImpl<>((Extension) extensionClass.newInstance(), deploymentUnit.getName()));
+        } catch (InstantiationException e) {
+            WeldLogger.DEPLOYMENT_LOGGER.couldNotLoadPortableExceptionClass(extensionClass.getName(), e);
+        } catch (IllegalAccessException e) {
+            WeldLogger.DEPLOYMENT_LOGGER.couldNotLoadPortableExceptionClass(extensionClass.getName(), e);
+        }
+
+    }
+
+    public synchronized void registerExtensionInstance(final Extension extension, final DeploymentUnit deploymentUnit) {
+        extensions.put(extension.getClass(), new MetadataImpl<>(extension, deploymentUnit.getName()));
+    }
+
+    public Collection<Metadata<Extension>> getExtensions() {
+        return new HashSet<>(extensions.values());
+    }
+
+}

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
@@ -22,6 +22,7 @@
 package org.jboss.as.weld.deployment.processors;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +65,7 @@ import org.jboss.as.weld.deployment.BeanDeploymentModule;
 import org.jboss.as.weld.deployment.CdiAnnotationMarker;
 import org.jboss.as.weld.deployment.WeldAttachments;
 import org.jboss.as.weld.deployment.WeldDeployment;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
 import org.jboss.as.weld.services.TCCLSingletonService;
 import org.jboss.as.weld.services.bootstrap.WeldEjbInjectionServices;
 import org.jboss.as.weld.services.bootstrap.WeldEjbServices;
@@ -215,7 +217,7 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
             additional.addService(ResourceInjectionServices.class, resourceInjectionServices);
         }
 
-        final List<Metadata<Extension>> extensions = deploymentUnit.getAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS);
+        final Collection<Metadata<Extension>> extensions = WeldPortableExtensions.getPortableExtensions(deploymentUnit).getExtensions();
 
         final WeldDeployment deployment = new WeldDeployment(beanDeploymentArchives, extensions, module, subDeploymentLoaders, deploymentUnit);
 

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldPortableExtensionProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldPortableExtensionProcessor.java
@@ -21,7 +21,13 @@
  */
 package org.jboss.as.weld.deployment.processors;
 
-import java.lang.reflect.Constructor;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 
 import javax.enterprise.inject.spi.Extension;
@@ -34,16 +40,12 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.PrivateSubDeploymentMarker;
-import org.jboss.as.server.deployment.ServicesAttachment;
-import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.as.weld.WeldDeploymentMarker;
 import org.jboss.as.weld.WeldLogger;
-import org.jboss.as.weld.WeldMessages;
-import org.jboss.as.weld.deployment.WeldAttachments;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
 import org.jboss.as.weld.services.bootstrap.HackValidationExtension;
 import org.jboss.modules.Module;
-import org.jboss.weld.bootstrap.spi.Metadata;
-import org.jboss.weld.metadata.MetadataImpl;
+import org.jboss.vfs.VFSUtils;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -64,38 +66,27 @@ public class WeldPortableExtensionProcessor implements DeploymentUnitProcessor {
             if (!WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
                 return;
             }
-        } else if (deploymentUnit.getParent() == null) {
-            // if any sub deployments have beans.xml then the top level deployment is
-            // marked as a weld deployment
-            if (!WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
-                return;
-            }
         } else {
             // if any deployments have a beans.xml we need to load portable extensions
             // even if this one does not.
-            if (!WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit.getParent())) {
+            if (!WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
                 return;
             }
         }
 
-        // we attach extensions directly to the top level deployment
-        final DeploymentUnit topLevelDeployment = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit
-                .getParent();
-
-        final ServicesAttachment services = deploymentUnit.getAttachment(Attachments.SERVICES);
+        WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(deploymentUnit);
 
         final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
         ClassLoader oldCl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
-            loadAttachments(services, module, deploymentUnit, topLevelDeployment);
+            loadAttachments(module, deploymentUnit, extensions);
 
-            if(deploymentUnit.getParent() == null) {
+            if (deploymentUnit.getParent() == null) {
                 //TEMP HACK
                 //Remove once we have Hibernate Validator 5 support
                 ValidatorFactory validatorFactory = deploymentUnit.getAttachment(BeanValidationAttachments.VALIDATOR_FACTORY);
-                Metadata<Extension> metadata = new MetadataImpl<Extension>(new HackValidationExtension(validatorFactory), deploymentUnit.getName());
-                topLevelDeployment.addToAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS, metadata);
+                extensions.registerExtensionInstance(new HackValidationExtension(validatorFactory), deploymentUnit);
             }
 
         } finally {
@@ -103,35 +94,50 @@ public class WeldPortableExtensionProcessor implements DeploymentUnitProcessor {
         }
     }
 
-    private void loadAttachments(final ServicesAttachment servicesAttachment, Module module, DeploymentUnit deploymentUnit, DeploymentUnit topLevelDeployment) throws DeploymentUnitProcessingException {
+    private void loadAttachments(Module module, DeploymentUnit deploymentUnit, WeldPortableExtensions extensions) throws DeploymentUnitProcessingException {
         // now load extensions
-        final DeploymentReflectionIndex index = deploymentUnit.getAttachment(Attachments.REFLECTION_INDEX);
-        final List<String> services = servicesAttachment.getServiceImplementations(Extension.class.getName());
-        if (services == null) {
-            return;
-        }
-        for (String service : services) {
-            final Extension extension = loadExtension(service, index,  module.getClassLoader());
-            if(extension == null) {
-                continue;
+        try {
+            Enumeration<URL> resources = module.getClassLoader().getResources("META-INF/services/" + Extension.class.getName());
+            final List<String> services = new ArrayList<>();
+            while (resources.hasMoreElements()) {
+                URL resource = resources.nextElement();
+                final InputStream stream = resource.openStream();
+                try {
+                    final BufferedReader reader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        final int commentIdx = line.indexOf('#');
+                        final String className;
+                        if (commentIdx == -1) {
+                            className = line.trim();
+                        } else {
+                            className = line.substring(0, commentIdx).trim();
+                        }
+                        if (className.length() == 0) {
+                            continue;
+                        }
+                        services.add(className);
+                    }
+                } finally {
+                    VFSUtils.safeClose(stream);
+                }
             }
-            Metadata<Extension> metadata = new MetadataImpl<Extension>(extension, deploymentUnit.getName());
-            WeldLogger.DEPLOYMENT_LOGGER.debug("Loaded portable extension " + extension);
-            topLevelDeployment.addToAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS, metadata);
+            for (String service : services) {
+                final Class<Extension> extensionClass = loadExtension(service, module.getClassLoader());
+                if (extensionClass == null) {
+                    continue;
+                }
+                extensions.tryRegisterExtension(extensionClass, deploymentUnit);
+            }
+        } catch (IOException e) {
+            throw new DeploymentUnitProcessingException(e);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private Extension loadExtension(String serviceClassName, final DeploymentReflectionIndex index, final ClassLoader loader) throws DeploymentUnitProcessingException {
-        Class<?> clazz;
-        Class<Extension> serviceClass;
+    private Class<Extension> loadExtension(String serviceClassName, final ClassLoader loader) throws DeploymentUnitProcessingException {
         try {
-            clazz = loader.loadClass(serviceClassName);
-            serviceClass = (Class<Extension>) clazz;
-            final Constructor<Extension> ctor = index.getClassIndex(serviceClass).getConstructor(EMPTY_STRING_ARRAY);
-            return ctor.newInstance();
-        }  catch (ClassCastException e) {
-            throw WeldMessages.MESSAGES.extensionDoesNotImplementExtension(serviceClassName, e);
+            return (Class<Extension>) loader.loadClass(serviceClassName);
         } catch (Exception e) {
             WeldLogger.DEPLOYMENT_LOGGER.couldNotLoadPortableExceptionClass(serviceClassName, e);
         } catch (LinkageError e) {

--- a/xts/src/main/java/org/jboss/as/xts/CDIExtensionProcessor.java
+++ b/xts/src/main/java/org/jboss/as/xts/CDIExtensionProcessor.java
@@ -27,13 +27,7 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
-import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
-import org.jboss.as.weld.deployment.WeldAttachments;
-import org.jboss.weld.bootstrap.spi.Metadata;
-import org.jboss.weld.metadata.MetadataImpl;
-
-import javax.enterprise.inject.spi.Extension;
-import java.lang.reflect.Constructor;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
 
 /**
  * @author paul.robinson@redhat.com, 2012-02-09
@@ -50,23 +44,22 @@ public class CDIExtensionProcessor implements DeploymentUnitProcessor {
             return;
         }
 
-        final DeploymentReflectionIndex index = unit.getAttachment(Attachments.REFLECTION_INDEX);
         final ClassLoader cl = unit.getAttachment(Attachments.MODULE).getClassLoader();
-        for (String fqn : EXTENSIONS) {
-            final Extension extension = loadExtension(fqn, index, cl);
-            final Metadata<Extension> metadata = new MetadataImpl<Extension>(extension, unit.getName());
-            unit.addToAttachmentList(WeldAttachments.PORTABLE_EXTENSIONS, metadata);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private Extension loadExtension(final String serviceClassName, final DeploymentReflectionIndex index, final ClassLoader loader) throws DeploymentUnitProcessingException {
+        WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(unit);
+        ClassLoader old = Thread.currentThread().getContextClassLoader();
         try {
-            final Class<Extension> serviceClass = (Class<Extension>) loader.loadClass(serviceClassName);
-            final Constructor<Extension> ctor = index.getClassIndex(serviceClass).getConstructor(EMPTY_STRING_ARRAY);
-            return ctor.newInstance();
-        } catch (Exception e) {
-            throw XtsAsMessages.MESSAGES.cannotLoadCDIExtension();
+            Thread.currentThread().setContextClassLoader(cl);
+            for (String fqn : EXTENSIONS) {
+
+                try {
+                    final Class<?> extension = Class.forName(fqn, true, cl);
+                    extensions.tryRegisterExtension(extension, unit);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(old);
         }
     }
 


### PR DESCRIPTION
This commit changes the way CDI portable extensions are loaded,
so they will be picked up from any module that has its services
exposed to the deployment.

This will both allow users to register portable extensions from
static modules, and also allow subsystems to more easily register
extensions.
