### PR TITLE
WFLY-1383 Disable pooling of stateless EJBs, by default

### DIFF
--- a/build/src/main/resources/configuration/subsystems/ejb3.xml
+++ b/build/src/main/resources/configuration/subsystems/ejb3.xml
@@ -4,15 +4,13 @@
    <extension-module>org.jboss.as.ejb3</extension-module>
    <subsystem xmlns="urn:jboss:domain:ejb3:2.0">
        <session-bean>
-           <stateless>
-               <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
-           </stateless>
            <?STATEFUL-BEAN?>
            <singleton default-access-timeout="5000"/>
        </session-bean>
        <?MDB?>
        <pools>
            <bean-instance-pools>
+               <!-- A sample strict max pool configuration -->
                <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
                <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
            </bean-instance-pools>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/ManagedStatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/ManagedStatelessBean.java
@@ -29,6 +29,7 @@ import javax.ejb.Stateless;
 import javax.ejb.Timeout;
 import javax.ejb.Timer;
 
+import org.jboss.ejb3.annotation.Pool;
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
@@ -40,6 +41,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @SecurityDomain("other")
 @DeclareRoles(value = {"Role1", "Role2", "Role3"})
 @RunAs("Role3")
+@Pool("slsb-strict-max-pool")
 public class ManagedStatelessBean extends AbstractManagedBean implements BusinessInterface {
     @Timeout
     @Schedule(second="15", persistent = false)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerStatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerStatelessBean.java
@@ -26,6 +26,7 @@ import javax.annotation.security.DeclareRoles;
 import javax.annotation.security.RunAs;
 import javax.ejb.Stateless;
 
+import org.jboss.ejb3.annotation.Pool;
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
@@ -37,6 +38,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @SecurityDomain("other")
 @DeclareRoles(value = {"Role1", "Role2", "Role3"})
 @RunAs("Role3")
+@Pool("slsb-strict-max-pool")
 public class NoTimerStatelessBean implements BusinessInterface {
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
@@ -16,9 +16,6 @@
  */
 package org.jboss.as.test.integration.ejb.pool.lifecycle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.InputStream;
 import java.util.logging.Logger;
 
@@ -47,6 +44,9 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests if pooled EJBs have proper lifecycle.
@@ -167,10 +167,11 @@ public class PooledEJBLifecycleTestCase {
             assertEquals("Wrong preDestroy calls count", 0, cycleCounter.getPreDestroyCount());
             triggerSLSB();
             assertEquals("Wrong postCreate calls count, after EJB has been triggered", 1, cycleCounter.getPostCreateCount());
-            assertEquals("Wrong preDestroy calls count, after EJB has been triggered", 0, cycleCounter.getPreDestroyCount());
+            // Note: we do not check the pre-destroy count since we can assume whether or not the SLSB instance is pooled by the container
             log.info("-->About to undeploy SLSB archive");
             deployer.undeploy(SLSB_DEPLOYMENT_NAME);
             assertEquals("Wrong postCreate calls count, after EJB has been undeployed", 1, cycleCounter.getPostCreateCount());
+            // We can now test the pre-destroy count since a undeployment is expected to trigger a @PreDestroy
             assertEquals("Wrong preDestroy calls count, after EJB has been undeployed", 1, cycleCounter.getPreDestroyCount());
         } finally {
             cycleCounter.reset();


### PR DESCRIPTION
The commit here disables pooling of stateless EJBs by default. This relates to https://issues.jboss.org/browse/WFLY-1383. 

Although this disables pooling by default for SLSBs, it intentionally leaves around the SLSB pool configuration(s) which have been shipped in previous releases. This allows (existing) user applications to still rely on them (for example through the use of @Pool(name="slsb-strict-max-pool"). It will also serve as an example pool configuration.

Individual applications which require pooling of stateless EJBs can configure it either individually at the bean level or by re-enabling this at the subsytem level.
