### PR TITLE
[WFLY-1385] Override page-size-bytes default value

### DIFF
--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -51,6 +51,7 @@
 
                    <max-size-bytes>10485760</max-size-bytes>
                    <address-full-policy>BLOCK</address-full-policy>
+                   <page-size-bytes>2097152</page-size-bytes>
                    <message-counter-history-day-limit>10</message-counter-history-day-limit>
                </address-setting>
            </address-settings>


### PR DESCRIPTION
The max-size-bytes parameter default value (-1) is overridden in
messaging subsystem configuration to BLOCK at 10MiB.
If the admin changes the address-full-policy from BLOCK to PAGE, this
will conflict with the default value for page-size-bytes (10MiB) which
_must_ be smaller than max-size-bytes.
=> override it to 2MiB to avoid any issues when the queues are paging
(and it has no incidence when the queues are blocking)
