### PR TITLE
Undertow: do not require to know both listener type and listener name 

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AJPListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AJPListenerAdd.java
@@ -40,7 +40,7 @@ class AJPListenerAdd extends AbstractListenerAdd {
     }
 
     protected ServiceName constructServiceName(final String name) {
-        return UndertowService.AJP_LISTENER.append(name);
+        return UndertowService.LISTENER.append(name);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
@@ -43,6 +43,7 @@ public interface Constants {
     String PATH = "path";
     String HTTP_LISTENER = "http-listener";
     String HTTPS_LISTENER = "https-listener";
+    String LISTENER = "listener";
     String INSTANCE_ID = "instance-id";
     String NAME = "name";
     String WORKER = "worker";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -40,7 +40,7 @@ public class HttpListenerAdd extends AbstractListenerAdd {
     }
 
     protected ServiceName constructServiceName(final String name) {
-        return UndertowService.HTTP_LISTENER.append(name);
+        return UndertowService.LISTENER.append(name);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
@@ -45,7 +45,7 @@ public class HttpsListenerAdd extends AbstractListenerAdd {
 
     @Override
     protected ServiceName constructServiceName(String name) {
-        return UndertowService.HTTPS_LISTENER.append(name);
+        return UndertowService.LISTENER.append(name);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowService.java
@@ -48,11 +48,9 @@ public class UndertowService implements Service<UndertowService> {
     public static final ServiceName SERVLET_CONTAINER = UNDERTOW.append(Constants.SERVLET_CONTAINER);
     public static final ServiceName SERVER = UNDERTOW.append(Constants.SERVER);
     /**
-     * The base name for jboss.web connector services.
+     * The base name for listener/handler/filter services.
      */
-    public static final ServiceName AJP_LISTENER = UNDERTOW.append("ajp-listener");
-    public static final ServiceName HTTP_LISTENER = UNDERTOW.append("http-listener");
-    public static final ServiceName HTTPS_LISTENER = UNDERTOW.append("https-listener");
+    public static final ServiceName LISTENER = UNDERTOW.append(Constants.LISTENER);
     public static final ServiceName HANDLER = UNDERTOW.append(Constants.HANDLER);
     public static final ServiceName FILTER = UNDERTOW.append(Constants.FILTER);
     public static final ServiceName ERROR_HANDLER = UNDERTOW.append(Constants.ERROR_HANDLER);


### PR DESCRIPTION
I think its unnecessary complexity to have to specify both listener type and listener name to be able to use/depend on this service.

(I am running into this with modcluster integration)
