### PR TITLE
WFLY-292: Cachable Model Descriptions

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/Common.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/Common.java
@@ -50,6 +50,7 @@ public class Common {
     static final String APPLICATION_JSON = "application/json";
     static final String TEXT_PLAIN = "text/plain";
     static final String TEXT_HTML = "text/html";
+    static final int ONE_WEEK = 7 * 24 * 60 * 60;
 
 
     static String UTF_8 = "utf-8";

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiHandler.java
@@ -145,6 +145,7 @@ class DomainApiHandler implements HttpHandler {
             // Cache is validated against last modified dates. Entity tags are not supported.
             if (!DateUtils.handleIfModifiedSince(exchange, operationParameter.getLastModified())) {
                 exchange.setResponseCode(304);
+                DomainUtil.writeCacheHeaders(exchange, operationParameter);
                 exchange.endExchange();
                 return;
             }

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainUtil.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainUtil.java
@@ -57,13 +57,7 @@ public class DomainUtil {
         final String contentType = operationParameter.isEncode() ? Common.APPLICATION_DMR_ENCODED : Common.APPLICATION_JSON;
         responseHeaders.put(Headers.CONTENT_TYPE, contentType + ";" + Common.UTF_8);
 
-        // Write caching headers
-        if (operationParameter.getMaxAge() > 0) {
-            responseHeaders.put(Headers.CACHE_CONTROL, "max-age=" + operationParameter.getMaxAge() + ", private, must-revalidate");
-        }
-        if (operationParameter.getLastModified() != null) {
-            responseHeaders.put(Headers.LAST_MODIFIED, DateUtils.toDateString(operationParameter.getLastModified()));
-        }
+        writeCacheHeaders(exchange, operationParameter);
 
         if (operationParameter.isGet() && status == 200) {
             localResponse = localResponse.get(RESULT);
@@ -112,6 +106,16 @@ public class DomainUtil {
             length = json.length();
         }
         return length;
+    }
+
+    public static void writeCacheHeaders(final HttpServerExchange exchange, final OperationParameter operationParameter) {
+        final HeaderMap responseHeaders = exchange.getResponseHeaders();
+        if (operationParameter.getMaxAge() > 0) {
+            responseHeaders.put(Headers.CACHE_CONTROL, "max-age=" + operationParameter.getMaxAge() + ", private, must-revalidate");
+        }
+        if (operationParameter.getLastModified() != null) {
+            responseHeaders.put(Headers.LAST_MODIFIED, DateUtils.toDateString(operationParameter.getLastModified()));
+        }
     }
 
     /**

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/OperationParameter.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/OperationParameter.java
@@ -1,6 +1,6 @@
 package org.jboss.as.domain.http.server;
 
-import java.util.Date;
+import io.undertow.util.ETag;
 
 /**
  * Value class for describing the result of an operation against the {@link DomainApiHandler}.
@@ -12,14 +12,14 @@ import java.util.Date;
 public class OperationParameter {
     private final boolean get;
     private final int maxAge;
-    private final Date lastModified;
+    private final ETag etag;
     private final boolean encode;
     private final boolean pretty;
 
     private OperationParameter(Builder builder) {
         this.get = builder.get;
         this.maxAge = builder.maxAge;
-        this.lastModified = builder.lastModified;
+        this.etag = builder.etag;
         this.encode = builder.encode;
         this.pretty = builder.pretty;
     }
@@ -32,8 +32,8 @@ public class OperationParameter {
         return maxAge;
     }
 
-    public Date getLastModified() {
-        return lastModified;
+    public ETag getEtag() {
+        return etag;
     }
 
     public boolean isEncode() {
@@ -49,7 +49,7 @@ public class OperationParameter {
         final StringBuilder sb = new StringBuilder("OperationResult{");
         sb.append("get=").append(get);
         sb.append(", maxAge=").append(maxAge);
-        sb.append(", lastModified=").append(lastModified);
+        sb.append(", etag=").append(etag);
         sb.append(", encode=").append(encode);
         sb.append(", pretty=").append(pretty);
         sb.append('}');
@@ -64,7 +64,7 @@ public class OperationParameter {
         private final boolean get;
         // optional
         private int maxAge;
-        private Date lastModified;
+        private ETag etag;
         private boolean pretty;
         private boolean encode;
 
@@ -77,7 +77,7 @@ public class OperationParameter {
          * <p>Optional parameter (and their default values)</p>
          * <ul>
          *     <li>maxAge (0)</li>
-         *     <li>lastModified (null)</li>
+         *     <li>etag (null)</li>
          *     <li>encode (false)</li>
          *     <li>pretty (false)</li>
          * </ul>
@@ -87,7 +87,6 @@ public class OperationParameter {
         public Builder(final boolean get) {
             this.get = get;
             this.maxAge = 0;
-            this.lastModified = null;
             this.encode = false;
             this.pretty = false;
         }
@@ -97,8 +96,8 @@ public class OperationParameter {
             return this;
         }
 
-        public Builder lastModified(Date lastModified) {
-            this.lastModified = lastModified;
+        public Builder etag(ETag etag) {
+            this.etag = etag;
             return this;
         }
 

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/OperationParameter.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/OperationParameter.java
@@ -2,38 +2,30 @@ package org.jboss.as.domain.http.server;
 
 import java.util.Date;
 
-import org.jboss.dmr.ModelNode;
-
 /**
  * Value class for describing the result of an operation against the {@link DomainApiHandler}.
- * Used by {@link DomainUtil#writeResponse(io.undertow.server.HttpServerExchange, OperationResult)}
+ * Used by {@link DomainUtil#writeResponse(io.undertow.server.HttpServerExchange, int, org.jboss.dmr.ModelNode, OperationParameter)}
  *
  * @author Harald Pehl
  * @date 05/14/2013
  */
-public class OperationResult {
-    private final ModelNode response;
-    private final int status;
+public class OperationParameter {
+    private final boolean get;
     private final int maxAge;
     private final Date lastModified;
     private final boolean encode;
     private final boolean pretty;
 
-    private OperationResult(Builder builder) {
-        this.response = builder.response;
-        this.status = builder.status;
+    private OperationParameter(Builder builder) {
+        this.get = builder.get;
         this.maxAge = builder.maxAge;
         this.lastModified = builder.lastModified;
         this.encode = builder.encode;
         this.pretty = builder.pretty;
     }
 
-    public ModelNode getResponse() {
-        return response;
-    }
-
-    public int getStatus() {
-        return status;
+    public boolean isGet() {
+        return get;
     }
 
     public int getMaxAge() {
@@ -52,13 +44,24 @@ public class OperationResult {
         return pretty;
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("OperationResult{");
+        sb.append("get=").append(get);
+        sb.append(", maxAge=").append(maxAge);
+        sb.append(", lastModified=").append(lastModified);
+        sb.append(", encode=").append(encode);
+        sb.append(", pretty=").append(pretty);
+        sb.append('}');
+        return sb.toString();
+    }
+
     /**
-     * Builder for {@link OperationResult}.
+     * Builder for {@link OperationParameter}.
      */
     public static class Builder {
-        private final int status;
         // mandatory
-        private ModelNode response;
+        private final boolean get;
         // optional
         private int maxAge;
         private Date lastModified;
@@ -69,8 +72,7 @@ public class OperationResult {
          * Creates a new builder.
          * <p>Mandatory parameter</p>
          * <ol>
-         *     <li>response</li>
-         *     <li>status</li>
+         *     <li>get</li>
          * </ol>
          * <p>Optional parameter (and their default values)</p>
          * <ul>
@@ -80,12 +82,10 @@ public class OperationResult {
          *     <li>pretty (false)</li>
          * </ul>
          *
-         * @param response
-         * @param status
+         * @param get
          */
-        public Builder(final ModelNode response, final int status) {
-            this.response = response;
-            this.status = status;
+        public Builder(final boolean get) {
+            this.get = get;
             this.maxAge = 0;
             this.lastModified = null;
             this.encode = false;
@@ -102,11 +102,6 @@ public class OperationResult {
             return this;
         }
 
-        public Builder response(ModelNode response) {
-            this.response = response;
-            return this;
-        }
-
         public Builder encode(boolean encode) {
             this.encode = encode;
             return this;
@@ -117,8 +112,8 @@ public class OperationResult {
             return this;
         }
 
-        public OperationResult build() {
-            return new OperationResult(this);
+        public OperationParameter build() {
+            return new OperationParameter(this);
         }
     }
 }

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/OperationResult.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/OperationResult.java
@@ -1,0 +1,124 @@
+package org.jboss.as.domain.http.server;
+
+import java.util.Date;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Value class for describing the result of an operation against the {@link DomainApiHandler}.
+ * Used by {@link DomainUtil#writeResponse(io.undertow.server.HttpServerExchange, OperationResult)}
+ *
+ * @author Harald Pehl
+ * @date 05/14/2013
+ */
+public class OperationResult {
+    private final ModelNode response;
+    private final int status;
+    private final int maxAge;
+    private final Date lastModified;
+    private final boolean encode;
+    private final boolean pretty;
+
+    private OperationResult(Builder builder) {
+        this.response = builder.response;
+        this.status = builder.status;
+        this.maxAge = builder.maxAge;
+        this.lastModified = builder.lastModified;
+        this.encode = builder.encode;
+        this.pretty = builder.pretty;
+    }
+
+    public ModelNode getResponse() {
+        return response;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public int getMaxAge() {
+        return maxAge;
+    }
+
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    public boolean isEncode() {
+        return encode;
+    }
+
+    public boolean isPretty() {
+        return pretty;
+    }
+
+    /**
+     * Builder for {@link OperationResult}.
+     */
+    public static class Builder {
+        private final int status;
+        // mandatory
+        private ModelNode response;
+        // optional
+        private int maxAge;
+        private Date lastModified;
+        private boolean pretty;
+        private boolean encode;
+
+        /**
+         * Creates a new builder.
+         * <p>Mandatory parameter</p>
+         * <ol>
+         *     <li>response</li>
+         *     <li>status</li>
+         * </ol>
+         * <p>Optional parameter (and their default values)</p>
+         * <ul>
+         *     <li>maxAge (0)</li>
+         *     <li>lastModified (null)</li>
+         *     <li>encode (false)</li>
+         *     <li>pretty (false)</li>
+         * </ul>
+         *
+         * @param response
+         * @param status
+         */
+        public Builder(final ModelNode response, final int status) {
+            this.response = response;
+            this.status = status;
+            this.maxAge = 0;
+            this.lastModified = null;
+            this.encode = false;
+            this.pretty = false;
+        }
+
+        public Builder maxAge(int maxAge) {
+            this.maxAge = maxAge;
+            return this;
+        }
+
+        public Builder lastModified(Date lastModified) {
+            this.lastModified = lastModified;
+            return this;
+        }
+
+        public Builder response(ModelNode response) {
+            this.response = response;
+            return this;
+        }
+
+        public Builder encode(boolean encode) {
+            this.encode = encode;
+            return this;
+        }
+
+        public Builder pretty(boolean pretty) {
+            this.pretty = pretty;
+            return this;
+        }
+
+        public OperationResult build() {
+            return new OperationResult(this);
+        }
+    }
+}

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/security/DmrFailureReadinessHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/security/DmrFailureReadinessHandler.java
@@ -34,6 +34,7 @@ import io.undertow.server.HttpServerExchange;
 
 import java.io.IOException;
 
+import org.jboss.as.domain.http.server.OperationResult;
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.dmr.ModelNode;
 
@@ -52,7 +53,7 @@ public class DmrFailureReadinessHandler extends RealmReadinessHandler {
     }
 
     /**
-     * @see org.jboss.as.domain.http.server.RealmReadinessHandler#rejectRequest(org.jboss.com.sun.net.httpserver.HttpExchange)
+     * @see org.jboss.as.domain.http.server.security.RealmReadinessHandler#rejectRequest(io.undertow.server.HttpServerExchange)
      */
     @Override
     void rejectRequest(HttpServerExchange exchange) throws IOException {
@@ -62,7 +63,11 @@ public class DmrFailureReadinessHandler extends RealmReadinessHandler {
         rejection.get(ROLLED_BACK).set(Boolean.TRUE.toString());
 
         // Keep the response visible so it can easily be seen in network traces.
-        writeResponse(exchange, false, true, rejection, 403, false);
+        OperationResult operationResult = new OperationResult.Builder(rejection, 403)
+                .encode(false)
+                .pretty(true)
+                .build();
+        writeResponse(exchange, operationResult);
     }
 
 }

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/security/DmrFailureReadinessHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/security/DmrFailureReadinessHandler.java
@@ -34,7 +34,8 @@ import io.undertow.server.HttpServerExchange;
 
 import java.io.IOException;
 
-import org.jboss.as.domain.http.server.OperationResult;
+import io.undertow.util.Methods;
+import org.jboss.as.domain.http.server.OperationParameter;
 import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.dmr.ModelNode;
 
@@ -63,11 +64,11 @@ public class DmrFailureReadinessHandler extends RealmReadinessHandler {
         rejection.get(ROLLED_BACK).set(Boolean.TRUE.toString());
 
         // Keep the response visible so it can easily be seen in network traces.
-        OperationResult operationResult = new OperationResult.Builder(rejection, 403)
+        boolean get = exchange.getRequestMethod().equals(Methods.GET);
+        OperationParameter operationParameter = new OperationParameter.Builder(get)
                 .encode(false)
                 .pretty(true)
                 .build();
-        writeResponse(exchange, operationResult);
+        writeResponse(exchange, 403, rejection, operationParameter);
     }
-
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
@@ -40,7 +40,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -87,7 +86,6 @@ public class HttpGetMgmtOpsTestCase {
         String cmd = recursive ? "/subsystem/undertow/server/default-server?operation=resource&recursive=true" : "/subsystem/undertow/server/default-server?operation=resource";
 
         ModelNode node = httpMgmt.sendGetCommand(cmd);
-        node = assertPayload(node);
 
         assertTrue(node.has("host"));
         ModelNode vServer = node.get("host");
@@ -108,7 +106,6 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=attribute&name=default-servlet-container");
-        node = assertPayload(node);
 
         // check that a boolean is returned
         assertTrue(node.getType() == ModelType.STRING);
@@ -123,7 +120,6 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=resource-description");
-        node = assertPayload(node);
 
         assertTrue(node.has("description"));
         assertTrue(node.has("attributes"));
@@ -136,7 +132,6 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=operation-names");
-        node = assertPayload(node);
 
         List<ModelNode> names = node.asList();
 
@@ -163,18 +158,9 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=operation-description&name=add");
-        node = assertPayload(node);
 
         assertTrue(node.has("operation-name"));
         assertTrue(node.has("description"));
         assertTrue(node.has("request-properties"));
-    }
-
-    private ModelNode assertPayload(ModelNode node)
-    {
-        assertTrue(node.hasDefined("outcome"));
-        assertEquals(node.get("outcome").asString(), "success");
-        assertTrue(node.hasDefined("result"));
-        return node.get("result");
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/http/HttpGetMgmtOpsTestCase.java
@@ -40,6 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -86,6 +87,7 @@ public class HttpGetMgmtOpsTestCase {
         String cmd = recursive ? "/subsystem/undertow/server/default-server?operation=resource&recursive=true" : "/subsystem/undertow/server/default-server?operation=resource";
 
         ModelNode node = httpMgmt.sendGetCommand(cmd);
+        node = assertPayload(node);
 
         assertTrue(node.has("host"));
         ModelNode vServer = node.get("host");
@@ -106,6 +108,7 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=attribute&name=default-servlet-container");
+        node = assertPayload(node);
 
         // check that a boolean is returned
         assertTrue(node.getType() == ModelType.STRING);
@@ -120,7 +123,7 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=resource-description");
-
+        node = assertPayload(node);
 
         assertTrue(node.has("description"));
         assertTrue(node.has("attributes"));
@@ -133,6 +136,7 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=operation-names");
+        node = assertPayload(node);
 
         List<ModelNode> names = node.asList();
 
@@ -159,9 +163,18 @@ public class HttpGetMgmtOpsTestCase {
         HttpMgmtProxy httpMgmt = new HttpMgmtProxy(mgmtURL);
 
         ModelNode node = httpMgmt.sendGetCommand("/subsystem/undertow?operation=operation-description&name=add");
+        node = assertPayload(node);
 
         assertTrue(node.has("operation-name"));
         assertTrue(node.has("description"));
         assertTrue(node.has("request-properties"));
+    }
+
+    private ModelNode assertPayload(ModelNode node)
+    {
+        assertTrue(node.hasDefined("outcome"));
+        assertEquals(node.get("outcome").asString(), "success");
+        assertTrue(node.hasDefined("result"));
+        return node.get("result");
     }
 }


### PR DESCRIPTION
The HTTP interface supports now cachable GET requests for distinct operations. Caching is done using last modified header and the server start as the reference date.
