### PR TITLE
WFLY-1401 Remove check for valid service names

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/ServerLogger.java
@@ -275,10 +275,6 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 15892, value = "Deployment unit processor %s unexpectedly threw an exception during undeploy phase %s of %s")
     void caughtExceptionUndeploying(@Cause Throwable cause, DeploymentUnitProcessor dup, Phase phase, DeploymentUnit unit);
 
-    @LogMessage(level = WARN)
-    @Message(id = 15893, value = "Encountered invalid class name '%s' for service type '%s'")
-    void invalidServiceClassName(String className, String type);
-
     @LogMessage(level = ERROR)
     @Message(id = 15894, value = "Module %s will not have it's annotations processed as no %s file was found in the deployment. Please generate this file using the Jandex ant task.")
     void noCompositeIndex(ModuleIdentifier identifier, String indexLocation);

--- a/server/src/main/java/org/jboss/as/server/deployment/ServiceLoaderProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ServiceLoaderProcessor.java
@@ -30,9 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
-import org.jboss.as.server.ServerLogger;
 import org.jboss.as.server.ServerMessages;
 import org.jboss.as.server.deployment.module.ModuleRootMarker;
 import org.jboss.as.server.deployment.module.ResourceRoot;
@@ -45,8 +43,6 @@ import org.jboss.vfs.VirtualFile;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class ServiceLoaderProcessor implements DeploymentUnitProcessor {
-
-    private static final Pattern VALID_NAME = Pattern.compile("(?:[a-zA-Z0-9_]+\\.)*[a-zA-Z0-9_]+");
 
     /**
      * {@inheritDoc}
@@ -71,7 +67,7 @@ public final class ServiceLoaderProcessor implements DeploymentUnitProcessor {
         final VirtualFile child = virtualFile.getChild("META-INF/services");
         for (VirtualFile serviceType : child.getChildren()) {
             final String name = serviceType.getName();
-            if (VALID_NAME.matcher(name).matches()) try {
+            try {
                 List<String> list = foundServices.get(name);
                 if (list == null) {
                     foundServices.put(name, list = new ArrayList<String>());
@@ -90,9 +86,6 @@ public final class ServiceLoaderProcessor implements DeploymentUnitProcessor {
                         }
                         if (className.length() == 0) {
                             continue;
-                        }
-                        if (!VALID_NAME.matcher(className).matches()) {
-                            ServerLogger.DEPLOYMENT_LOGGER.invalidServiceClassName(className, name);
                         }
                         list.add(className);
                     }


### PR DESCRIPTION
The JVM is actually much more lenient than the Java language
spec, and pretty much every time this warning has appered it
has been bogus.
