### PR TITLE
WFLY-1373 Fix dependency on sun.jdk to allow Javascript engine to be found

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/scriptassert/ScriptAssertTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/scriptassert/ScriptAssertTestCase.java
@@ -21,40 +21,52 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.scriptassert;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.sql.SQLException;
+import java.util.Set;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
-import java.sql.SQLException;
-import java.util.Set;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * AS7-1110
- *
+ * <p/>
  * Tests that hibernate validator @ScriptAssert works correctly
- *
+ * <p/>
  * This is a non-standard extension provided by hibernate validator
  *
  * @author Stuart Douglas
  */
-@Ignore("AS7-2166 - Fails on OpenJDK due to missing JavaScript engine")
 @RunWith(Arquillian.class)
 public class ScriptAssertTestCase {
 
+    private static final Logger logger = Logger.getLogger(ScriptAssertTestCase.class);
+
+    @Before
+    public void runOnlyAgainstSunJDK() {
+        // Since this test apparently fails (https://issues.jboss.org/browse/AS7-2166) against OpenJDK, due to missing Javascript engine, let's just enable this test against Sun/Oracle JDK (which is known/expected to pass).
+        // If a org.junit.Assume fails, then the @Test(s) are ignored http://stackoverflow.com/questions/1689242/conditionally-ignoring-tests-in-junit-4
+        final boolean compatibleJRE = isCompatibleJRE();
+        logger.info("Current JRE is " + (compatibleJRE ? "compatible, running " : "incompatible, skipping ") + " tests in " + ScriptAssertTestCase.class.getSimpleName());
+        Assume.assumeTrue(compatibleJRE);
+    }
+
     @Deployment
     public static Archive<?> deploy() {
-        final WebArchive war = ShrinkWrap.create(WebArchive.class,"testscriptassert.war");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "testscriptassert.war");
         war.addPackage(ScriptAssertTestCase.class.getPackage());
         return war;
 
@@ -66,5 +78,18 @@ public class ScriptAssertTestCase {
         Validator validator = (Validator) new InitialContext().lookup("java:comp/Validator");
         final Set<ConstraintViolation<ScriptAssertBean>> result = validator.validate(new ScriptAssertBean());
         Assert.assertEquals(1, result.size());
+    }
+
+    /**
+     * Returns true if this testcase is expected to pass against the current Java runtime. Else returns false.
+     *
+     * @return
+     */
+    private boolean isCompatibleJRE() {
+        final String javaRuntimeName = System.getProperty("java.runtime.name");
+        // The OpenJDK runtime has a value of "OpenJDK Runtime Environment" for the java.runtime.name system property. Since this test isn't passing against OpenJDK, we classify it as incompatible and return false
+        // if OpenJDK runtime is identified.
+        // Note, if this test is failing against other JREs (like IBM), add another check with the appropriate value for IBM here.
+        return !javaRuntimeName.contains("OpenJDK");
     }
 }


### PR DESCRIPTION
Related JIRA https://issues.jboss.org/browse/WFLY-1373

The commit here fixes the dependency on sun.jdk to "importServices" and allow the Javascript engine to be found. The commit also enables a @Ignored test to conditionally run against specific JREs so as to have this test enabled against Oracle JRE and disabled against OpenJDK JRE.
