### PR TITLE
WFLY-1397 parse jpa 2.1 persistence.xml version tag

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
@@ -88,10 +88,12 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
                 version = Version.JPA_1_0;
             } else if ("2.0".equals(versionString)) {
                 version = Version.JPA_2_0;
+            } else if ("2.1".equals(versionString)) {
+                version = Version.JPA_2_1;
             } else if ("2".equals(versionString)) {
                 version = Version.JPA_2_0;
             } else {
-                version = Version.JPA_2_0;
+                version = Version.JPA_2_1;
             }
         }
 
@@ -157,8 +159,10 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
         pu.setPersistenceProviderClassName(Configuration.PROVIDER_CLASS_DEFAULT);
         if (version.equals(Version.JPA_1_0)) {
             pu.setPersistenceXMLSchemaVersion("1.0");
-        } else {
+        } else if (version.equals(Version.JPA_2_0)) {
             pu.setPersistenceXMLSchemaVersion("2.0");
+        } else {
+            pu.setPersistenceXMLSchemaVersion("2.1");
         }
 
         final int count = reader.getAttributeCount();

--- a/jpa/core/src/main/java/org/jboss/as/jpa/puparser/Version.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/puparser/Version.java
@@ -32,7 +32,9 @@ public enum Version {
 
     UNKNOWN(null),
     JPA_1_0("http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"),
-    JPA_2_0("http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd");
+    JPA_2_0("http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"),
+    JPA_2_1("http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd");
+
 
     private static final Map<String, Version> bindings = new HashMap<String, Version>();
 


### PR DESCRIPTION
no actually changes, just a version increase to match the spec version.
