### PR TITLE
[JBQA-8022] External JNDI context binding tests - tests against an actua...

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
@@ -22,14 +22,36 @@
 
 package org.jboss.as.test.integration.naming;
 
+import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.InitialDirContext;
 
+import com.sun.jndi.ldap.LdapCtx;
+import com.sun.jndi.ldap.LdapCtxFactory;
+
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.AnnotationUtils;
+import org.apache.directory.server.core.annotations.ContextEntry;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.factory.DSAnnotationProcessor;
+import org.apache.directory.server.factory.ServerAnnotationProcessor;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.shared.ldap.model.entry.DefaultEntry;
+import org.apache.directory.shared.ldap.model.ldif.LdifEntry;
+import org.apache.directory.shared.ldap.model.ldif.LdifReader;
+import org.apache.directory.shared.ldap.model.schema.SchemaManager;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.naming.subsystem.NamingExtension;
+import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
+import org.jboss.as.test.integration.security.common.ManagedCreateTransport;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,6 +64,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
@@ -49,25 +72,31 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING_TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.CACHE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.CLASS;
+import static org.jboss.as.naming.subsystem.NamingSubsystemModel.ENVIRONMENT;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.EXTERNAL_CONTEXT;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.MODULE;
 
 /**
- * Simple test for external context binding. We just bind a new initial context, more tests are needed
- * with actual LDAP contexts
+ * Test for external context binding. There are tests which use a usual InitialContext and treat it
+ * as an external context and tests which connect to an actual external LDAP server.
+ * @author Stuart Douglas, Jan Martiska
  */
 @RunWith(Arquillian.class)
-@ServerSetup(ExternalContextBindingTestCase.ObjectFactoryWithEnvironmentBindingTestCaseServerSetup.class)
+@ServerSetup({ExternalContextBindingTestCase.ObjectFactoryWithEnvironmentBindingTestCaseServerSetup.class,
+        ExternalContextBindingTestCase.PrepareExternalLDAPServerSetup.class})
 public class ExternalContextBindingTestCase {
 
     private static Logger LOGGER = Logger.getLogger(ExternalContextBindingTestCase.class);
 
     private static final String MODULE_NAME = "org.jboss.as.naming";
 
+    public static final int LDAP_PORT = 10389;
+
     static class ObjectFactoryWithEnvironmentBindingTestCaseServerSetup implements ServerSetupTask {
 
         @Override
-        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        public void setup(final ManagementClient managementClient, final String containerId)
+                throws Exception {
 
             // bind the object factory
             ModelNode address = createAddress("nocache");
@@ -78,7 +107,8 @@ public class ExternalContextBindingTestCase {
             bindingAdd.get(MODULE).set(MODULE_NAME);
             bindingAdd.get(CLASS).set(InitialContext.class.getName());
             ModelNode addResult = managementClient.getControllerClient().execute(bindingAdd);
-            Assert.assertFalse(addResult.get(FAILURE_DESCRIPTION).toString(), addResult.get(FAILURE_DESCRIPTION).isDefined());
+            Assert.assertFalse(addResult.get(FAILURE_DESCRIPTION).toString(),
+                    addResult.get(FAILURE_DESCRIPTION).isDefined());
             LOGGER.info("Object factory bound.");
 
             address = createAddress("cache");
@@ -90,8 +120,46 @@ public class ExternalContextBindingTestCase {
             bindingAdd.get(CACHE).set(true);
             bindingAdd.get(CLASS).set(InitialContext.class.getName());
             addResult = managementClient.getControllerClient().execute(bindingAdd);
-            Assert.assertFalse(addResult.get(FAILURE_DESCRIPTION).toString(), addResult.get(FAILURE_DESCRIPTION).isDefined());
+            Assert.assertFalse(addResult.get(FAILURE_DESCRIPTION).toString(),
+                    addResult.get(FAILURE_DESCRIPTION).isDefined());
             LOGGER.info("Object factory bound.");
+
+            address = createAddress("ldap");
+            bindingAdd = new ModelNode();
+            bindingAdd.get(OP).set(ADD);
+            bindingAdd.get(OP_ADDR).set(address);
+            bindingAdd.get(BINDING_TYPE).set(EXTERNAL_CONTEXT);
+            bindingAdd.get(MODULE).set(MODULE_NAME);
+            bindingAdd.get(CLASS).set(InitialDirContext.class.getName());
+            bindingAdd.get(ENVIRONMENT).add("java.naming.provider.url", "ldap://"+managementClient.getMgmtAddress()+":"+
+                    ExternalContextBindingTestCase.LDAP_PORT);
+            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", LdapCtxFactory.class.getName());
+            bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_AUTHENTICATION, "simple");
+            bindingAdd.get(ENVIRONMENT)
+                    .add(Context.SECURITY_PRINCIPAL, "uid=jduke,ou=People,dc=jboss,dc=org");
+            bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_CREDENTIALS, "theduke");
+            addResult = managementClient.getControllerClient().execute(bindingAdd);
+            Assert.assertFalse(addResult.get(FAILURE_DESCRIPTION).toString(),
+                    addResult.get(FAILURE_DESCRIPTION).isDefined());
+
+            address = createAddress("ldap-cache");
+            bindingAdd = new ModelNode();
+            bindingAdd.get(OP).set(ADD);
+            bindingAdd.get(OP_ADDR).set(address);
+            bindingAdd.get(BINDING_TYPE).set(EXTERNAL_CONTEXT);
+            bindingAdd.get(MODULE).set(MODULE_NAME);
+            bindingAdd.get(CLASS).set(InitialDirContext.class.getName());
+            bindingAdd.get(CACHE).set(true);
+            bindingAdd.get(ENVIRONMENT).add("java.naming.provider.url", "ldap://"+managementClient.getMgmtAddress()+":"+
+                    ExternalContextBindingTestCase.LDAP_PORT);
+            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", LdapCtxFactory.class.getName());
+            bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_AUTHENTICATION, "simple");
+            bindingAdd.get(ENVIRONMENT)
+                    .add(Context.SECURITY_PRINCIPAL, "uid=jduke,ou=People,dc=jboss,dc=org");
+            bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_CREDENTIALS, "theduke");
+            addResult = managementClient.getControllerClient().execute(bindingAdd);
+            Assert.assertFalse(addResult.get(FAILURE_DESCRIPTION).toString(),
+                    addResult.get(FAILURE_DESCRIPTION).isDefined());
 
         }
 
@@ -103,28 +171,121 @@ public class ExternalContextBindingTestCase {
         }
 
         @Override
-        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        public void tearDown(final ManagementClient managementClient, final String containerId)
+                throws Exception {
             // unbind the object factorys
             ModelNode bindingRemove = new ModelNode();
             bindingRemove.get(OP).set(REMOVE);
             bindingRemove.get(OP_ADDR).set(createAddress("nocache"));
-            bindingRemove.get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            bindingRemove.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
             ModelNode removeResult = managementClient.getControllerClient().execute(bindingRemove);
-            Assert.assertFalse(removeResult.get(FAILURE_DESCRIPTION).toString(), removeResult.get(FAILURE_DESCRIPTION)
-                    .isDefined());
-            LOGGER.info("Object factory unbound.");
+            Assert.assertFalse(removeResult.get(FAILURE_DESCRIPTION).toString(),
+                    removeResult.get(FAILURE_DESCRIPTION)
+                            .isDefined());
+            LOGGER.info("Object factory with uncached InitialContext unbound.");
 
             bindingRemove = new ModelNode();
             bindingRemove.get(OP).set(REMOVE);
             bindingRemove.get(OP_ADDR).set(createAddress("cache"));
-            bindingRemove.get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            bindingRemove.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
             removeResult = managementClient.getControllerClient().execute(bindingRemove);
-            Assert.assertFalse(removeResult.get(FAILURE_DESCRIPTION).toString(), removeResult.get(FAILURE_DESCRIPTION)
-                    .isDefined());
-            LOGGER.info("Object factory unbound.");
+            Assert.assertFalse(removeResult.get(FAILURE_DESCRIPTION).toString(),
+                    removeResult.get(FAILURE_DESCRIPTION)
+                            .isDefined());
+            LOGGER.info("Object factory with cached InitialContext unbound.");
+
+            bindingRemove = new ModelNode();
+            bindingRemove.get(OP).set(REMOVE);
+            bindingRemove.get(OP_ADDR).set(createAddress("ldap"));
+            bindingRemove.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            removeResult = managementClient.getControllerClient().execute(bindingRemove);
+            Assert.assertFalse(removeResult.get(FAILURE_DESCRIPTION).toString(),
+                    removeResult.get(FAILURE_DESCRIPTION)
+                            .isDefined());
+            LOGGER.info("Object factory with uncached InitialDirContext unbound.");
+
+            bindingRemove = new ModelNode();
+            bindingRemove.get(OP).set(REMOVE);
+            bindingRemove.get(OP_ADDR).set(createAddress("ldap-cache"));
+            bindingRemove.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            removeResult = managementClient.getControllerClient().execute(bindingRemove);
+            Assert.assertFalse(removeResult.get(FAILURE_DESCRIPTION).toString(),
+                    removeResult.get(FAILURE_DESCRIPTION)
+                            .isDefined());
+            LOGGER.info("Object factory with cached InitialDirContext unbound.");
         }
     }
 
+
+
+    //@formatter:off
+    @CreateDS(
+            name = "JBossDS",
+            partitions =
+                    {
+                            @CreatePartition(
+                                    name = "jboss",
+                                    suffix = "dc=jboss,dc=org",
+                                    contextEntry = @ContextEntry(
+                                            entryLdif =
+                                                    "dn: dc=jboss,dc=org\n" +
+                                                            "dc: jboss\n" +
+                                                            "objectClass: top\n" +
+                                                            "objectClass: domain\n\n"))
+                    })
+    @CreateLdapServer(
+            transports =
+                    {
+                            @CreateTransport(protocol = "LDAP",
+                                    port = ExternalContextBindingTestCase.LDAP_PORT)
+                    })
+    //@formatter:on
+    static class PrepareExternalLDAPServerSetup implements ServerSetupTask {
+
+        private DirectoryService directoryService;
+        private LdapServer ldapServer;
+
+        public void fixTransportAddress(ManagedCreateLdapServer createLdapServer, String address) {
+            final CreateTransport[] createTransports = createLdapServer.transports();
+            for (int i = 0; i < createTransports.length; i++) {
+                final ManagedCreateTransport mgCreateTransport = new ManagedCreateTransport(
+                        createTransports[i]);
+                mgCreateTransport.setAddress(address);
+                createTransports[i] = mgCreateTransport;
+            }
+        }
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            directoryService = DSAnnotationProcessor.getDirectoryService();
+            final SchemaManager schemaManager = directoryService.getSchemaManager();
+
+            try {
+                for (LdifEntry ldifEntry : new LdifReader(
+                        ExternalContextBindingTestCase.class
+                                .getResourceAsStream(ExternalContextBindingTestCase.class.getSimpleName()
+                                        + ".ldif"))) {
+                    directoryService.getAdminSession()
+                            .add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
+
+            final ManagedCreateLdapServer createLdapServer = new ManagedCreateLdapServer(
+                    (CreateLdapServer)AnnotationUtils.getInstance(CreateLdapServer.class));
+            fixTransportAddress(createLdapServer, managementClient.getMgmtAddress());
+            ldapServer = ServerAnnotationProcessor.instantiateLdapServer(createLdapServer, directoryService);
+            ldapServer.start();
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            ldapServer.stop();
+            directoryService.shutdown();
+        }
+    }
 
     @Deployment
     public static JavaArchive deploy() {
@@ -133,7 +294,7 @@ public class ExternalContextBindingTestCase {
     }
 
     @Test
-    public void testWithoutCache() throws Exception {
+    public void testBasicWithoutCache() throws Exception {
         InitialContext context = new InitialContext();
         InitialContext lookupContext = (InitialContext) context.lookup("java:global/nocache");
         Assert.assertNotNull(lookupContext);
@@ -145,7 +306,7 @@ public class ExternalContextBindingTestCase {
     }
 
     @Test
-    public void testWithCache() throws Exception {
+    public void testBasicWithCache() throws Exception {
         InitialContext context = new InitialContext();
         InitialContext lookupContext = (InitialContext) context.lookup("java:global/cache");
         Assert.assertNotNull(lookupContext);
@@ -160,4 +321,67 @@ public class ExternalContextBindingTestCase {
         Assert.assertNotNull(ejb);
         Assert.assertNotSame(InitialContext.class, lookupContext.getClass());
     }
+
+    @Test
+    public void testWithActualLDAPContextWithoutCache() throws Exception {
+        InitialContext ctx = null;
+        InitialDirContext ldapContext1 = null;
+        InitialDirContext ldapContext2 = null;
+        try {
+            ctx = new InitialContext();
+            LOGGER.info("looking up java:global/ldap ....");
+            ldapContext1 = (InitialDirContext)ctx.lookup("java:global/ldap");
+            ldapContext2 = (InitialDirContext)ctx.lookup("java:global/ldap");
+            Assert.assertNotNull(ldapContext1);
+            Assert.assertNotNull(ldapContext2);
+            Assert.assertNotSame(ldapContext1, ldapContext2);
+            LOGGER.info("acquired external LDAP context: " + ldapContext1.toString());
+            LdapCtx c = (LdapCtx)ldapContext1.lookup("dc=jboss,dc=org");
+            c = (LdapCtx)c.lookup("ou=People");
+            Attributes attributes = c.getAttributes("uid=jduke");
+            Assert.assertTrue(attributes.get("description").contains("awesome"));
+        } finally {
+            if (ctx != null) {
+                ctx.close();
+            }
+            if(ldapContext1 != null) {
+                ldapContext1.close();
+            }
+            if(ldapContext2 != null) {
+                ldapContext2.close();
+            }
+        }
+    }
+
+    @Test
+    public void testWithActualLDAPContextWithCache() throws Exception {
+        InitialContext ctx = null;
+        InitialDirContext ldapContext1 = null;
+        InitialDirContext ldapContext2 = null;
+        try {
+            ctx = new InitialContext();
+            LOGGER.info("looking up java:global/ldap-cache ....");
+            ldapContext1 = (InitialDirContext)ctx.lookup("java:global/ldap-cache");
+            ldapContext2 = (InitialDirContext)ctx.lookup("java:global/ldap-cache");
+            Assert.assertNotNull(ldapContext1);
+            Assert.assertNotNull(ldapContext2);
+            Assert.assertSame(ldapContext1, ldapContext2);
+            LOGGER.info("acquired external LDAP context: " + ldapContext1.toString());
+            LdapCtx c = (LdapCtx)ldapContext1.lookup("dc=jboss,dc=org");
+            c = (LdapCtx)c.lookup("ou=People");
+            Attributes attributes = c.getAttributes("uid=jduke");
+            Assert.assertTrue(attributes.get("description").contains("awesome"));
+        } finally {
+            if (ctx != null) {
+                ctx.close();
+            }
+            if(ldapContext1 != null) {
+                ldapContext1.close();
+            }
+            if(ldapContext2 != null) {
+                ldapContext2.close();
+            }
+        }
+    }
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.ldif
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.ldif
@@ -1,0 +1,14 @@
+dn: ou=People,dc=jboss,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: People
+
+dn: uid=jduke,ou=People,dc=jboss,dc=org
+objectclass: top
+objectclass: uidObject
+objectclass: person
+uid: jduke
+cn: Java Duke
+sn: Duke
+userPassword: theduke
+description: awesome


### PR DESCRIPTION
...l LDAP server

New tests for external JNDI federation using an actual LDAP server instance run as part of the testsuite.
