### PR TITLE
WFLY-1407, Correct test methods dependency in EjbMethodInterceptorTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/method/EjbMethodInterceptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/method/EjbMethodInterceptorTestCase.java
@@ -26,7 +26,6 @@ import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,11 +48,12 @@ public class EjbMethodInterceptorTestCase {
     }
 
     @Test
-    @InSequence(1)
     public void testMethodLevelInterceptors() throws NamingException {
         final InitialContext ctx = new InitialContext();
         final ClassifiedBean bean = (ClassifiedBean) ctx.lookup("java:module/" + ClassifiedBean.class.getSimpleName());
 
+        TopSecretInterceptor.called = false;
+        SecretInterceptor.called = false;
         final String secret = bean.secretMethod();
         Assert.assertEquals("Secret", secret);
         Assert.assertTrue(SecretInterceptor.called);
@@ -69,7 +69,6 @@ public class EjbMethodInterceptorTestCase {
     }
 
     @Test
-    @InSequence(2)
     public void testMethodOverloaded() throws NamingException {
         final InitialContext ctx = new InitialContext();
         final ClassifiedBean bean = (ClassifiedBean) ctx.lookup("java:module/" + ClassifiedBean.class.getSimpleName());
@@ -90,7 +89,6 @@ public class EjbMethodInterceptorTestCase {
     }
 
     @Test
-    @InSequence(3)
     public void testAroundInvokeOverridedByXmlDescriptor() throws NamingException {
         InitialContext ctx = new InitialContext();
         AroundInvokeBean bean = (AroundInvokeBean) ctx.lookup("java:module/" + AroundInvokeBean.class.getSimpleName());


### PR DESCRIPTION
WFLY-1407, avoid variables 'TopSecretInterceptor' and 'SecretInterceptor' dependency between testMethodLevelInterceptors() and testMethodOverloaded(), not using @InSequence to force test running order.

https://issues.jboss.org/browse/WFLY-1407
