### PR TITLE
WFLY-381 rework Host to register Deployment instances instead of DeploymentInfo only

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AbstractUndertowEventListener.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AbstractUndertowEventListener.java
@@ -21,7 +21,7 @@
  */
 package org.wildfly.extension.undertow;
 
-import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.Deployment;
 
 /**
  * Implementers of the listener API through {@link UndertowEventListener} should extend this class to maintain
@@ -37,11 +37,11 @@ public abstract class AbstractUndertowEventListener implements UndertowEventList
     }
 
     @Override
-    public void onDeploymentStart(DeploymentInfo deploymentInfo, Host host) {
+    public void onDeploymentStart(Deployment deployment, Host host) {
     }
 
     @Override
-    public void onDeploymentStop(DeploymentInfo deploymentInfo, Host host) {
+    public void onDeploymentStop(Deployment deployment, Host host) {
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowEventListener.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowEventListener.java
@@ -21,7 +21,7 @@
  */
 package org.wildfly.extension.undertow;
 
-import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.Deployment;
 
 /**
  * Implementers of {@link UndertowEventListener} should extend {@link AbstractUndertowEventListener} to maintai
@@ -37,9 +37,9 @@ public interface UndertowEventListener {
 
     //void onDeploymentAdd(DeploymentInfo deploymentInfo, Host host);
 
-    void onDeploymentStart(DeploymentInfo deploymentInfo, Host host);
+    void onDeploymentStart(Deployment deployment, Host host);
 
-    void onDeploymentStop(DeploymentInfo deploymentInfo, Host host);
+    void onDeploymentStop(Deployment deployment, Host host);
 
     //void onDeploymentRemove(DeploymentInfo deploymentInfo, Host host);
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentService.java
@@ -75,7 +75,8 @@ public class UndertowDeploymentService implements Service<UndertowDeploymentServ
             deploymentManager.deploy();
             try {
                 HttpHandler handler = deploymentManager.start();
-                host.getValue().registerDeployment(deploymentInfo, handler);
+                Deployment deployment = deploymentManager.getDeployment();
+                host.getValue().registerDeployment(deployment, handler);
             } catch (ServletException e) {
                 throw new StartException(e);
             }
@@ -86,13 +87,14 @@ public class UndertowDeploymentService implements Service<UndertowDeploymentServ
 
     @Override
     public void stop(final StopContext stopContext) {
+        Deployment deployment = deploymentManager.getDeployment();
         try {
             deploymentManager.stop();
         } catch (ServletException e) {
             throw new RuntimeException(e);
         }
         deploymentManager.undeploy();
-        host.getValue().unregisterDeployment(deploymentInfoInjectedValue.getValue());
+        host.getValue().unregisterDeployment(deployment);
     }
 
     @Override


### PR DESCRIPTION
DeploymentInfo itself is pretty useless if you want to act upon the listener events.
