### PR TITLE
WFLY-1431 fix small issue in InterceptorLifecycleSFSBTestCase.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptorLifecycleSFSBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptorLifecycleSFSBTestCase.java
@@ -64,7 +64,7 @@ public class InterceptorLifecycleSFSBTestCase {
         InitialContext ctx = new InitialContext();
         InterceptedWithProceedSLSB bean = (InterceptedWithProceedSLSB)ctx.lookup("java:module/" + InterceptedWithProceedSLSB.class.getSimpleName());
         bean.doStuff();
-        Assert.assertTrue(LifecycleInterceptorNoProceed.postConstruct);
+        Assert.assertTrue(LifecycleInterceptorWithProceed.postConstruct);
         Assert.assertTrue(bean.isPostConstructCalled());
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-1431 

In the test testInterceptorPostConstructWithProceed(), it should use LifecycleInterceptorWithProceed instead of LifecycleInterceptorNoProceed. 
