### PR TITLE
WFLY-1448 , for MultipleClientRemoteJndiTestCase and NestedRemoteContextTestCase, replace hardcoded 'localhost' by test.bind.address.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/CallEjbServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/CallEjbServlet.java
@@ -14,6 +14,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.jboss.as.network.NetworkUtils;
+
 @WebServlet(name = "CallEjbServlet", urlPatterns = {"/CallEjbServlet"})
 public class CallEjbServlet extends HttpServlet {
 	@EJB
@@ -23,7 +25,10 @@ public class CallEjbServlet extends HttpServlet {
 		Context ctx = null;
 		try {
 			Properties env = new Properties();
-			env.put(Context.PROVIDER_URL, "remote://localhost:4447");
+			String address = System.getProperty("node0", "localhost");
+			// format possible IPv6 address
+			address = NetworkUtils.formatPossibleIpv6Address(address);
+			env.put(Context.PROVIDER_URL, "remote://" + address + ":4447");
 			env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
 			ctx = new InitialContext(env);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MyEjbBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MyEjbBean.java
@@ -7,12 +7,17 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import org.jboss.as.network.NetworkUtils;
+
 @Stateless
 public class MyEjbBean implements MyEjb {
 	protected MyObject lookup() {
 		try {
 			Properties env = new Properties();
-			env.put(Context.PROVIDER_URL, "remote://localhost:4447");
+			String address = System.getProperty("node0", "localhost");
+			// format possible IPv6 address
+			address = NetworkUtils.formatPossibleIpv6Address(address);
+			env.put(Context.PROVIDER_URL, "remote://" + address + ":4447");
 			env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
 			Context ctx = new InitialContext(env);
 			try {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/RunRmiServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/RunRmiServlet.java
@@ -15,6 +15,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.jboss.as.network.NetworkUtils;
+
 @WebServlet(name = "RunRmiServlet", urlPatterns = {"/RunRmiServlet"})
 public class RunRmiServlet extends HttpServlet {
 	private List<Context> contexts = new ArrayList<Context>();
@@ -32,7 +34,10 @@ public class RunRmiServlet extends HttpServlet {
 	protected MyObject lookup() throws ServletException {
 		try {
 			Properties env = new Properties();
-			env.put(Context.PROVIDER_URL, "remote://localhost:4447");
+			String address = System.getProperty("node0", "localhost");
+			// format possible IPv6 address
+			address = NetworkUtils.formatPossibleIpv6Address(address);
+			env.put(Context.PROVIDER_URL, "remote://" + address + ":4447");
 			env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
 			Context ctx = new InitialContext(env);
 			try {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/ear-jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/ear-jboss-deployment-structure.xml
@@ -3,11 +3,13 @@
 	<sub-deployment name="web.war">
 		<dependencies>
 			<module name="org.jboss.remote-naming" />
+			<module name="org.jboss.as.network" />
 		</dependencies>
 	</sub-deployment>
 	<sub-deployment name="ejb.jar">
 		<dependencies>
 			<module name="org.jboss.remote-naming" />
+			<module name="org.jboss.as.network" />
 		</dependencies>
 	</sub-deployment>
 </jboss-deployment-structure>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/war-jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/war-jboss-deployment-structure.xml
@@ -3,6 +3,7 @@
 	<deployment>
 		<dependencies>
 			<module name="org.jboss.remote-naming" />
+			<module name="org.jboss.as.network" />
 		</dependencies>
 	</deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
Use system property test.bind.address to replace hardcoded localhost in case Jenkins configuration change to use other address than localhost.

wildfly: https://issues.jboss.org/browse/WFLY-1448
original bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=907542
