### PR TITLE
AS7-5728 fixed double call of ssoClusterManager.logout(ssoId);

### DIFF
--- a/web/src/main/java/org/jboss/as/web/sso/ClusteredSingleSignOn.java
+++ b/web/src/main/java/org/jboss/as/web/sso/ClusteredSingleSignOn.java
@@ -550,10 +550,6 @@ public class ClusteredSingleSignOn extends org.apache.catalina.authenticator.Sin
      */
     protected void logout(String ssoId) {
         deregister(ssoId);
-        // broadcast logout to any cluster
-        if (ssoClusterManager != null) {
-            ssoClusterManager.logout(ssoId);
-        }
     }
 
     /**


### PR DESCRIPTION
Removed `logout(String)` method lines, which are already included in the `deregister(String)` method.
(see also https://github.com/wildfly/wildfly/pull/3229)
