### PR TITLE
WFLY-239: new concurrent module, containing jsr 236 impl + extensive uni...

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1354,6 +1354,10 @@
             <maven-resource group="org.yaml" artifact="snakeyaml"/>
         </module-def>
 
+        <module-def name="org.wildfly.concurrent">
+            <maven-resource group="org.wildfly" artifact="wildfly-concurrent"/>
+        </module-def>
+        
         <module-def name="javax.wsdl4j.api">
             <maven-resource group="wsdl4j" artifact="wsdl4j"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -942,6 +942,11 @@
 
                 <dependency>
                     <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-concurrent</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.wildfly</groupId>
                     <artifactId>wildfly-configadmin</artifactId>
                 </dependency>
 

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/concurrent/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/concurrent/main/module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.wildfly.concurrent">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="javax.enterprise.concurrent.api"/>
+        <module name="org.jboss.logging"/>
+        <module name="sun.jdk"/>        
+    </dependencies>
+
+</module>

--- a/concurrent/pom.xml
+++ b/concurrent/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <version>8.0.0.Alpha2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-concurrent</artifactId>
+
+    <name>WildFly: Concurrent</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <enableAssertions>true</enableAssertions>
+                    <systemPropertyVariables>
+                        <org.jboss.model.test.cache.root>${org.jboss.model.test.cache.root}
+                        </org.jboss.model.test.cache.root>
+                        <org.jboss.model.test.classpath.cache>${org.jboss.model.test.classpath.cache}
+                        </org.jboss.model.test.classpath.cache>
+                        <org.jboss.model.test.maven.repository.urls>${org.jboss.model.test.maven.repository.urls}
+                        </org.jboss.model.test.maven.repository.urls>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+            <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ConcurrentLogger.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ConcurrentLogger.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+import static org.jboss.logging.Logger.Level.DEBUG;
+
+/**
+ * This module is using message IDs in the range ?-?.
+ * <p/>
+ * This file is using the subset ?-? for logger messages.
+ * <p/>
+ * See <a href="http://community.jboss.org/docs/DOC-16810">http://community.jboss.org/docs/DOC-16810</a> for the full
+ * list of currently reserved WFLY message id blocks.
+ * <p/>
+ *
+ * @author Eduardo Martins
+ */
+@MessageLogger(projectCode = "WFLY")
+public interface ConcurrentLogger extends BasicLogger {
+
+    /**
+     * A logger with a category of the package name.
+     */
+    ConcurrentLogger ROOT_LOGGER = Logger.getMessageLogger(ConcurrentLogger.class, ConcurrentLogger.class.getPackage().getName());
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 99800, value = "Failure in taskSubmitted() callback.")
+    void failureInTaskSubmittedCallback(@Cause Throwable t);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 99801, value = "Failure in taskStarting() callback.")
+    void failureInTaskStartingCallback(@Cause Throwable t);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 99802, value = "Failure in taskDone() callback.")
+    void failureInTaskDoneCallback(@Cause Throwable t);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 99803, value = "Task never submitted, since Trigger's first invocation of getNextRunTime() returned null.")
+    void triggerTaskNeverSubmittedDueToNullGetNextRunTime();
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 99804, value = "Task never submitted, since first schedule of a run failed.")
+    void triggerTaskNeverSubmittedDueToFailureWhenSchedulingNextRun();
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 99805, value = "Failure when scheduling next runtime.")
+    void failureWhenSchedulingNextRun(@Cause Throwable e);
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ConcurrentMessages.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ConcurrentMessages.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
+
+import java.lang.reflect.InvocationHandler;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * This module is using message IDs in the range ?-?.
+ * <p/>
+ * This file is using the subset ?-? for non-logger messages.
+ * <p/>
+ * See <a href="http://community.jboss.org/docs/DOC-16810">http://community.jboss.org/docs/DOC-16810</a> for the full
+ * list of currently reserved WFLY message id blocks.
+ * <p/>
+ *
+ * @author Eduardo Martins
+ */
+@MessageBundle(projectCode = "WFLY")
+public interface ConcurrentMessages {
+
+    /**
+     * The messages.
+     */
+    ConcurrentMessages MESSAGES = Messages.getBundle(ConcurrentMessages.class);
+
+    @Message(id = 99900, value = "The lifecycle of a ManagedExecutorService is done by the application server.")
+    IllegalStateException lifecycleOfManagedExecutorServiceIsDoneByTheApplicationServer();
+
+    @Message(id = 99901, value = "The ManagedExecutorService is shutdown.")
+    RejectedExecutionException managedExecutorServiceShutdown();
+
+    @Message(id = 99902, value = "Unexpected InvocationHandler type: %s")
+    IllegalArgumentException unexpectedInvocationHandlerType(InvocationHandler invocationHandler);
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ContextServiceImpl.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ContextServiceImpl.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.Context;
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+import org.wildfly.as.concurrent.context.ContextualProxyInvocationHandler;
+
+import javax.enterprise.concurrent.ContextService;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+/**
+ * Impl for {@link ContextService}
+ *
+ * @author Eduardo Martins
+ */
+public class ContextServiceImpl implements ContextService {
+
+    private final ContextConfiguration contextConfiguration;
+
+    public ContextServiceImpl(ContextConfiguration contextConfiguration) {
+        this.contextConfiguration = contextConfiguration;
+    }
+
+    @Override
+    public Object createContextualProperty(Object instance, Class<?>... interfaces) throws IllegalArgumentException {
+        return createContextualProperty(instance, null, interfaces);
+    }
+
+    @Override
+    public Object createContextualProperty(Object instance, Map<String, String> executionProperties, Class<?>... interfaces) throws IllegalArgumentException {
+        return Proxy.newProxyInstance(instance.getClass().getClassLoader(), interfaces, new ContextualProxyInvocationHandler(executionProperties, newContextualProxyContext(instance), instance));
+    }
+
+    private Context newContextualProxyContext(Object instance) {
+        return contextConfiguration != null ? contextConfiguration.newContextualProxyContext(instance) : null;
+    }
+
+    @Override
+    public <T> T createContextualProperty(T instance, Class<T> _interface) throws IllegalArgumentException {
+        return createContextualProperty(instance, null, _interface);
+    }
+
+    @Override
+    public <T> T createContextualProperty(T instance, Map<String, String> executionProperties, Class<T> _interface) throws IllegalArgumentException {
+        return (T) Proxy.newProxyInstance(instance.getClass().getClassLoader(), new Class[]{_interface}, new ContextualProxyInvocationHandler(executionProperties, newContextualProxyContext(instance), instance));
+    }
+
+    @Override
+    public Map<String, String> getExecutionProperties(Object contextualProxy) throws IllegalArgumentException {
+        InvocationHandler invocationHandler = Proxy.getInvocationHandler(contextualProxy);
+        if (invocationHandler instanceof ContextualProxyInvocationHandler) {
+            return ((ContextualProxyInvocationHandler) invocationHandler).getExecutionProperties();
+        }
+        throw ConcurrentMessages.MESSAGES.unexpectedInvocationHandlerType(invocationHandler);
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ManageableThreadImpl.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ManageableThreadImpl.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.Context;
+import org.wildfly.as.concurrent.context.Utils;
+
+import javax.enterprise.concurrent.ManageableThread;
+
+/**
+ * @author Eduardo Martins
+ */
+class ManageableThreadImpl extends Thread implements ManageableThread {
+
+    private final Context context;
+    private final ManagedThreadFactoryImpl parent;
+    private volatile boolean shutdown;
+
+    ManageableThreadImpl(Context context, ManagedThreadFactoryImpl parent) {
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(Runnable target, Context context, ManagedThreadFactoryImpl parent) {
+        super(target);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(ThreadGroup group, Runnable target, Context context, ManagedThreadFactoryImpl parent) {
+        super(group, target);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(String name, Context context, ManagedThreadFactoryImpl parent) {
+        super(name);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(ThreadGroup group, String name, Context context, ManagedThreadFactoryImpl parent) {
+        super(group, name);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(Runnable target, String name, Context context, ManagedThreadFactoryImpl parent) {
+        super(target, name);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(ThreadGroup group, Runnable target, String name, Context context, ManagedThreadFactoryImpl parent) {
+        super(group, target, name);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    ManageableThreadImpl(ThreadGroup group, Runnable target, String name, long stackSize, Context context, ManagedThreadFactoryImpl parent) {
+        super(group, target, name, stackSize);
+        this.context = context;
+        this.parent = parent;
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return shutdown;
+    }
+
+    void shutdown() {
+        this.shutdown = true;
+    }
+
+    @Override
+    public void run() {
+        try {
+            if (shutdown) {
+                this.interrupt();
+            }
+            if (context == null) {
+                super.run();
+            } else {
+                final Context previousContext = Utils.setContext(context);
+                try {
+                    super.run();
+                } finally {
+                    Utils.setContext(previousContext);
+                }
+            }
+        } finally {
+            parent.remove(this);
+        }
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ManagedExecutorServiceImpl.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ManagedExecutorServiceImpl.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.component.ComponentManagedExecutorService;
+import org.wildfly.as.concurrent.component.ComponentManagedExecutorServiceShutdownHandler;
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerExecutorService;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A ManagedExecutorService for an EE component, which on internalShutdown cancels/interrupts all submitted tasks.
+ *
+ * @author Eduardo Martins
+ */
+public class ManagedExecutorServiceImpl extends ContextualManagedExecutorService implements ComponentManagedExecutorService {
+
+    /**
+     * component ManagedExecutorService are required to cancel all tasks on shutdown, this handler is responsible for managing that.
+     */
+    private final ComponentManagedExecutorServiceShutdownHandler shutdownHandler;
+
+    public ManagedExecutorServiceImpl(TaskListenerExecutorService executor, ContextConfiguration contextConfiguration) {
+        super(executor, contextConfiguration);
+        this.shutdownHandler = new ComponentManagedExecutorServiceShutdownHandler();
+    }
+
+    @Override
+    public void internalShutdown() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        shutdownHandler.internalShutdown();
+    }
+
+    @Override
+    public void shutdown() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        shutdownHandler.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    protected Runnable wrap(Runnable task) {
+        return shutdownHandler.wrap(super.wrap(task));
+    }
+
+    @Override
+    protected <V> Callable<V> wrap(Callable<V> task) {
+        return shutdownHandler.wrap(super.wrap(task));
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImpl.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImpl.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.component.ComponentManagedExecutorServiceShutdownHandler;
+import org.wildfly.as.concurrent.component.ComponentManagedScheduledExecutorService;
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+import org.wildfly.as.concurrent.context.ContextualManagedScheduledExecutorService;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerScheduledExecutorService;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A ManagedScheduledExecutorService for a specific EE component, which on internalShutdown cancels/interrupts all submitted/scheduled tasks.
+ *
+ * @author Eduardo Martins
+ */
+public class ManagedScheduledExecutorServiceImpl extends ContextualManagedScheduledExecutorService implements ComponentManagedScheduledExecutorService {
+
+    /**
+     * component ManagedExecutorService are required to cancel all tasks on shutdown, this handler is responsible for managing that.
+     */
+    private final ComponentManagedExecutorServiceShutdownHandler shutdownHandler;
+
+    /**
+     * @param executor
+     * @param contextConfiguration
+     */
+    public ManagedScheduledExecutorServiceImpl(TaskListenerScheduledExecutorService executor, ContextConfiguration contextConfiguration) {
+        super(executor, contextConfiguration);
+        this.shutdownHandler = new ComponentManagedExecutorServiceShutdownHandler();
+    }
+
+    @Override
+    public void internalShutdown() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        shutdownHandler.internalShutdown();
+    }
+
+    @Override
+    public void shutdown() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        shutdownHandler.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        // all lifecycle related methods are delegated to the shutdown handler
+        return shutdownHandler.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    protected Runnable wrap(Runnable task) {
+        // use the shutdown handler to wrap the task, so it becomes managed
+        return shutdownHandler.wrap(super.wrap(task));
+    }
+
+    @Override
+    protected <V> Callable<V> wrap(Callable<V> task) {
+        // use the shutdown handler to wrap the task, so it becomes managed
+        return shutdownHandler.wrap(super.wrap(task));
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/ManagedThreadFactoryImpl.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/ManagedThreadFactoryImpl.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.Context;
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+
+import javax.enterprise.concurrent.ManagedThreadFactory;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * @author Eduardo Martins
+ */
+public class ManagedThreadFactoryImpl implements ManagedThreadFactory {
+
+    private final ContextConfiguration contextConfiguration;
+    private final ReentrantLock lock;
+    private final Set<ManageableThreadImpl> threads;
+    private volatile boolean shutdown;
+
+    public ManagedThreadFactoryImpl(ContextConfiguration contextConfiguration) {
+        // TODO add thread groups, thread name prefix, priority, etc
+        this.contextConfiguration = contextConfiguration;
+        this.threads = new HashSet<>();
+        this.lock = new ReentrantLock();
+    }
+
+    @Override
+    public Thread newThread(final Runnable r) {
+        lock.lock();
+        if (shutdown) {
+            throw new IllegalStateException();
+        }
+        try {
+            final ManageableThreadImpl t;
+            if (System.getSecurityManager() == null) {
+                t = newManageableThread(r);
+            } else {
+                t = AccessController.doPrivileged(
+                        new PrivilegedAction<ManageableThreadImpl>() {
+                            @Override
+                            public ManageableThreadImpl run() {
+                                return newManageableThread(r);
+                            }
+                        });
+            }
+            t.setDaemon(true);
+            threads.add(t);
+            return t;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    ManageableThreadImpl newManageableThread(Runnable r) {
+        final Context context = contextConfiguration != null ? contextConfiguration.newManageableThreadContext(r) : null;
+        return new ManageableThreadImpl(r, context, this);
+    }
+
+    void remove(Thread thread) {
+        lock.lock();
+        try {
+            threads.remove(thread);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @return true if the factory is shutdown
+     */
+    public boolean isShutdown() {
+        return shutdown;
+    }
+
+    /**
+     * Initiates an orderly shutdown in which existent threads continue to run, but no new threads will be created.
+     * Invocation has no additional effect if already shut down.
+     */
+    public void shutdown() {
+        lock.lock();
+        try {
+            if (isShutdown()) {
+                return;
+            }
+            // change state of the factory
+            shutdown = true;
+            // warn managedtask about shutdown
+            for (ManageableThreadImpl thread : threads) {
+                thread.shutdown();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    List<? extends Thread> getThreads() {
+        lock.lock();
+        try {
+            return new ArrayList<>(this.threads);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Besides the orderly shutdown, this method attempts to stop all existent threads, through interrupt calls.
+     */
+    public List<? extends Thread> shutdownNow() {
+        lock.lock();
+        try {
+            if (isShutdown()) {
+                return null;
+            }
+            // changes state and warns threads
+            shutdown();
+            // interrupt threads
+            List<? extends Thread> result = getThreads();
+            for (Thread thread : result) {
+                try {
+                    thread.interrupt();
+                } catch (Throwable e) {
+                    // ignore
+                }
+            }
+            return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/component/ComponentManagedExecutorService.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/component/ComponentManagedExecutorService.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.component;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+
+/**
+ * A {@link javax.enterprise.concurrent.ManagedExecutorService} for an EE component, adds the {@link org.wildfly.as.concurrent.component.ComponentManagedScheduledExecutorService#internalShutdown()} method to shutdown the executor, since by the spec all executor lifecycle related methods throw IllegalStateException.
+ *
+ * @author Eduardo Martins
+ */
+public interface ComponentManagedExecutorService extends ManagedExecutorService {
+
+    /**
+     * Use to shutdown the executor service. Will cancel all submitted tasks, interrupting the thread if required.
+     */
+    void internalShutdown();
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/component/ComponentManagedExecutorServiceShutdownHandler.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/component/ComponentManagedExecutorServiceShutdownHandler.java
@@ -1,0 +1,263 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.component;
+
+import org.wildfly.as.concurrent.ConcurrentMessages;
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Handler for all lifecycle related {@link ComponentManagedExecutorService} methods, does book keeping of tasks being executed throw wrapping original tasks.
+ *
+ * @author Eduardo Martins
+ */
+public class ComponentManagedExecutorServiceShutdownHandler {
+
+    private final Set<Future> futures;
+    private volatile boolean internalShutdown;
+    private final ReentrantLock lock;
+
+    /**
+     *
+     */
+    public ComponentManagedExecutorServiceShutdownHandler() {
+        this.futures = new HashSet<>();
+        this.lock = new ReentrantLock();
+    }
+
+    /**
+     * @see org.wildfly.as.concurrent.component.ComponentManagedExecutorService#internalShutdown()
+     */
+    public void internalShutdown() {
+        lock.lock();
+        try {
+            if (internalShutdown) {
+                return;
+            }
+            internalShutdown = true;
+            for (Future future : futures) {
+                try {
+                    future.cancel(true);
+                } catch (Throwable throwable) {
+                    // ignore
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @see org.wildfly.as.concurrent.component.ComponentManagedExecutorService#shutdown()
+     */
+    public void shutdown() {
+        throw ConcurrentMessages.MESSAGES.lifecycleOfManagedExecutorServiceIsDoneByTheApplicationServer();
+    }
+
+    /**
+     * @return
+     * @see org.wildfly.as.concurrent.component.ComponentManagedExecutorService#shutdownNow()
+     */
+    public List<Runnable> shutdownNow() {
+        throw ConcurrentMessages.MESSAGES.lifecycleOfManagedExecutorServiceIsDoneByTheApplicationServer();
+    }
+
+    /**
+     * @return
+     * @see org.wildfly.as.concurrent.component.ComponentManagedExecutorService#isShutdown()
+     */
+    public boolean isShutdown() {
+        return false;
+    }
+
+    /**
+     * @return
+     * @see org.wildfly.as.concurrent.component.ComponentManagedExecutorService#isTerminated()
+     */
+    public boolean isTerminated() {
+        return false;
+    }
+
+    /**
+     * @param timeout
+     * @param unit
+     * @return
+     * @throws InterruptedException * @see org.wildfly.as.concurrent.component.ComponentManagedExecutorService#awaitTermination()
+     */
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        throw ConcurrentMessages.MESSAGES.lifecycleOfManagedExecutorServiceIsDoneByTheApplicationServer();
+    }
+
+    /**
+     * Wraps the task as a {@link ShutdownHandlerTaskListener}.
+     *
+     * @param task
+     * @return
+     */
+    public Runnable wrap(Runnable task) {
+        if (internalShutdown) {
+            throw ConcurrentMessages.MESSAGES.managedExecutorServiceShutdown();
+        }
+        return new ShutdownHandlerTaskListenerRunnable(task);
+    }
+
+    /**
+     * Wraps the task as a {@link ShutdownHandlerTaskListener}.
+     *
+     * @param task
+     * @param <V>
+     * @return
+     */
+    public <V> Callable<V> wrap(Callable<V> task) {
+        if (internalShutdown) {
+            throw ConcurrentMessages.MESSAGES.managedExecutorServiceShutdown();
+        }
+        // wrap to get notified about task status
+        return new ShutdownHandlerTaskListenerCallable<>(task);
+    }
+
+    /**
+     * Task wrapping as a {@link TaskListener}, so this executor gets notified when task is submit and done, and know which tasks to cancel on shutdown
+     */
+    abstract class ShutdownHandlerTaskListener implements TaskListener {
+
+        private final TaskListener taskListener;
+        private Future<?> future;
+
+        /**
+         * @param task
+         */
+        ShutdownHandlerTaskListener(Object task) {
+            this.taskListener = task instanceof TaskListener ? (TaskListener) task : null;
+        }
+
+        @Override
+        public void taskSubmitted(Future<?> future) {
+            lock.lock();
+            try {
+                this.future = future;
+                try {
+                    if (taskListener != null) {
+                        taskListener.taskSubmitted(future);
+                    }
+                } finally {
+                    if (internalShutdown) {
+                        try {
+                            future.cancel(true);
+                        } catch (Throwable throwable) {
+                            // ignore
+                        }
+                    } else {
+                        futures.add(future);
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
+
+        }
+
+        @Override
+        public void taskStarting() {
+            if (taskListener != null) {
+                taskListener.taskStarting();
+            }
+        }
+
+        @Override
+        public void taskDone(Throwable exception) {
+            lock.lock();
+            try {
+                try {
+                    if (taskListener != null) {
+                        taskListener.taskDone(exception);
+                    }
+                } finally {
+                    if (!internalShutdown) {
+                        futures.remove(future);
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
+
+        }
+    }
+
+    /**
+     * A {@link Runnable} {@link ShutdownHandlerTaskListener}.
+     */
+    class ShutdownHandlerTaskListenerRunnable extends ShutdownHandlerTaskListener implements Runnable {
+
+        private final Runnable task;
+
+        ShutdownHandlerTaskListenerRunnable(Runnable task) {
+            super(task);
+            this.task = task;
+        }
+
+        @Override
+        public void run() {
+            task.run();
+        }
+
+        @Override
+        public String toString() {
+            // propagates identity name
+            return task.toString();
+        }
+    }
+
+    /**
+     * A {@link Callable} {@link ShutdownHandlerTaskListener}.
+     *
+     * @param <V>
+     */
+    class ShutdownHandlerTaskListenerCallable<V> extends ShutdownHandlerTaskListener implements Callable<V> {
+
+        private final Callable<V> task;
+
+        ShutdownHandlerTaskListenerCallable(Callable<V> task) {
+            super(task);
+            this.task = task;
+        }
+
+        @Override
+        public V call() throws Exception {
+            return task.call();
+        }
+
+        @Override
+        public String toString() {
+            // propagates identity name
+            return task.toString();
+        }
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/component/ComponentManagedScheduledExecutorService.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/component/ComponentManagedScheduledExecutorService.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.component;
+
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+
+/**
+ * A {@link ManagedScheduledExecutorService} for an EE component, adds the {@link org.wildfly.as.concurrent.component.ComponentManagedScheduledExecutorService#internalShutdown()} method to shutdown the executor, since by the spec all executor lifecycle related methods throw IllegalStateException.
+ *
+ * @author Eduardo Martins
+ */
+public interface ComponentManagedScheduledExecutorService extends ComponentManagedExecutorService, ManagedScheduledExecutorService {
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/Context.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/Context.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+/**
+ * The context to be set when invoking an object.
+ *
+ * @author Eduardo Martins
+ */
+public interface Context {
+
+    /**
+     * Sets this context.
+     *
+     * @return the context previously set
+     */
+    Context set();
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextConfiguration.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedTaskListener;
+
+/**
+ * A ContextConfiguration can be used to create new Context instances, for different objects.
+ *
+ * @author Eduardo Martins
+ */
+public interface ContextConfiguration {
+
+    /**
+     * Creates a new Context for the specified task.
+     *
+     * @param task
+     * @return
+     */
+    Context newTaskContext(Object task);
+
+    /**
+     * Creates a new Context for the specified listener.
+     *
+     * @param listener
+     * @return
+     */
+    Context newManagedTaskListenerContext(ManagedTaskListener listener);
+
+    /**
+     * Creates a new Context for the specified object instance, to be used by a reflection proxy.
+     *
+     * @param instance
+     * @return
+     */
+    Context newContextualProxyContext(Object instance);
+
+    /**
+     * Creates a new Context for the specified  task, to be used by a manageable thread.
+     *
+     * @param task
+     * @return
+     */
+    Context newManageableThreadContext(Runnable task);
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualManagedExecutorService.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualManagedExecutorService.java
@@ -1,0 +1,129 @@
+package org.wildfly.as.concurrent.context;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListenerExecutorService;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A {@link ManagedExecutorService} which wraps tasks so these get invoked with a specific context set, and delegates executions into a {@link TaskListenerExecutorService}.
+ *
+ * @author Eduardo Martins
+ */
+public class ContextualManagedExecutorService implements ManagedExecutorService {
+
+    private final TaskListenerExecutorService taskListenerExecutorService;
+    private final ContextConfiguration contextConfiguration;
+
+    public ContextualManagedExecutorService(TaskListenerExecutorService taskListenerExecutorService, ContextConfiguration contextConfiguration) {
+        this.taskListenerExecutorService = taskListenerExecutorService;
+        this.contextConfiguration = contextConfiguration;
+    }
+
+    public ContextConfiguration getContextConfiguration() {
+        return contextConfiguration;
+    }
+
+    public TaskListenerExecutorService getTaskListenerExecutorService() {
+        return taskListenerExecutorService;
+    }
+
+    // ExecutorService delegation
+
+    @Override
+    public void shutdown() {
+        taskListenerExecutorService.shutdown();
+    }
+
+    @Override
+    public List<java.lang.Runnable> shutdownNow() {
+        return taskListenerExecutorService.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return taskListenerExecutorService.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return taskListenerExecutorService.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return taskListenerExecutorService.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return taskListenerExecutorService.submit(wrap(task));
+    }
+
+    @Override
+    public <T> Future<T> submit(java.lang.Runnable task, T result) {
+        return taskListenerExecutorService.submit(wrap(task), result);
+    }
+
+    @Override
+    public Future<?> submit(java.lang.Runnable task) {
+        return taskListenerExecutorService.submit(wrap(task));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return taskListenerExecutorService.invokeAll(wrap(tasks));
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return taskListenerExecutorService.invokeAll(wrap(tasks), timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return taskListenerExecutorService.invokeAny(wrap(tasks));
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return taskListenerExecutorService.invokeAny(wrap(tasks), timeout, unit);
+    }
+
+    @Override
+    public void execute(java.lang.Runnable task) {
+        taskListenerExecutorService.execute(wrap(task));
+    }
+
+    // task wrapping
+
+    protected Runnable wrap(Runnable task) {
+        if (task instanceof ContextualTask) {
+            return task;
+        }
+        return new ContextualTaskRunnable(task, contextConfiguration, this);
+    }
+
+    protected <V> Callable<V> wrap(Callable<V> task) {
+        if (task instanceof ContextualTask) {
+            return task;
+        }
+        return new ContextualTaskCallable<>(task, contextConfiguration, this);
+    }
+
+    protected <T> Collection<? extends Callable<T>> wrap(Collection<? extends Callable<T>> tasks) {
+        final List<Callable<T>> wrappedTasks = new ArrayList<>();
+        for (Callable<T> callable : tasks) {
+            wrappedTasks.add(wrap(callable));
+        }
+        return wrappedTasks;
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualManagedScheduledExecutorService.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualManagedScheduledExecutorService.java
@@ -1,0 +1,59 @@
+package org.wildfly.as.concurrent.context;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListenerScheduledExecutorService;
+
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.Trigger;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link ManagedScheduledExecutorService} which wraps tasks so these get invoked with a specific context set, and delegates executions into a {@link TaskListenerScheduledExecutorService}.
+ *
+ * @author Eduardo Martins
+ */
+public class ContextualManagedScheduledExecutorService extends ContextualManagedExecutorService implements ManagedScheduledExecutorService {
+
+    private final TaskListenerScheduledExecutorService scheduledExecutorService;
+
+    public ContextualManagedScheduledExecutorService(TaskListenerScheduledExecutorService scheduledExecutorService, ContextConfiguration contextConfiguration) {
+        super(scheduledExecutorService, contextConfiguration);
+        this.scheduledExecutorService = scheduledExecutorService;
+    }
+
+    // ScheduledExecutorService delegation
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
+        return scheduledExecutorService.schedule(wrap(task), delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
+        return scheduledExecutorService.schedule(wrap(task), delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
+        return scheduledExecutorService.scheduleAtFixedRate(wrap(task), initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
+        return scheduledExecutorService.scheduleWithFixedDelay(wrap(task), initialDelay, delay, unit);
+    }
+
+    // ManagedScheduledExecutorService impl
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> task, Trigger trigger) {
+        return new TriggerScheduledFuture<>(task, trigger, this);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
+        return new TriggerScheduledFuture<>(task, trigger, this);
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualManagedTaskListener.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualManagedTaskListener.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+import java.util.concurrent.Future;
+
+/**
+ * A {@link ManagedTaskListener} which invocations are done with a specific {@link Context} set.
+ *
+ * @author Eduardo Martins
+ */
+public class ContextualManagedTaskListener implements ManagedTaskListener {
+
+    private final Context context;
+    private final ManagedTaskListener listener;
+
+    /**
+     * @param context
+     * @param listener
+     */
+    public ContextualManagedTaskListener(Context context, ManagedTaskListener listener) {
+        this.context = context;
+        this.listener = listener;
+    }
+
+    @Override
+    public void taskAborted(Future<?> future, ManagedExecutorService executor, Throwable exception) {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            listener.taskAborted(future, executor, exception);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+    @Override
+    public void taskDone(Future<?> future, ManagedExecutorService executor, Throwable exception) {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            listener.taskDone(future, executor, exception);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+    @Override
+    public void taskStarting(Future<?> future, ManagedExecutorService executor) {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            listener.taskStarting(future, executor);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+    @Override
+    public void taskSubmitted(Future<?> future, ManagedExecutorService executor) {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            listener.taskSubmitted(future, executor);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+    /**
+     * Retrieves a contextual {@link ManagedTaskListener} for the specified {@link ContextConfiguration}, but only if the specified {@link ManagedTaskConfiguration} indicates that.
+     *
+     * @param managedTaskConfiguration
+     * @param contextConfiguration
+     * @return
+     */
+    public static ManagedTaskListener getContextualManagedTaskListener(ManagedTaskConfiguration managedTaskConfiguration, ContextConfiguration contextConfiguration) {
+        final ManagedTask managedTask = managedTaskConfiguration.getManagedTask();
+        final ManagedTaskListener managedTaskListener = managedTask.getManagedTaskListener();
+        if (managedTaskListener == null || contextConfiguration == null) {
+            return managedTaskListener;
+        }
+        if (managedTaskConfiguration.isManagedTaskWithContextualCallbacks()) {
+            return new ContextualManagedTaskListener(contextConfiguration.newManagedTaskListenerContext(managedTaskListener), managedTaskListener);
+        } else {
+            return managedTaskListener;
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualProxyInvocationHandler.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualProxyInvocationHandler.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * A {@link InvocationHandler} which invocations are done with a specific {@link Context} set.
+ *
+ * @author Eduardo Martins
+ */
+public class ContextualProxyInvocationHandler implements InvocationHandler {
+
+    private final Map<String, String> executionProperties;
+    private final Context context;
+    private final Object instance;
+
+    public ContextualProxyInvocationHandler(Map<String, String> executionProperties, Context context, Object instance) {
+        this.executionProperties = executionProperties;
+        this.context = context;
+        this.instance = instance;
+    }
+
+    public Map<String, String> getExecutionProperties() {
+        return executionProperties;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (method.getDeclaringClass() == java.lang.Object.class) {
+            // Object methods are invoked without any context
+            return method.invoke(instance, args);
+        }
+        final Context previousContext = Utils.setContext(context);
+        try {
+            return method.invoke(instance, args);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTask.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTask.java
@@ -1,0 +1,83 @@
+package org.wildfly.as.concurrent.context;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+
+import javax.enterprise.concurrent.AbortedException;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+import javax.enterprise.concurrent.SkippedException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+
+/**
+ * The base for a contextual task, adapted into a {@link TaskListener}, to be executed at {@link org.wildfly.as.concurrent.tasklistener.TaskListenerExecutorService}s.
+ *
+ * @author Eduardo Martins
+ */
+abstract class ContextualTask implements TaskListener {
+
+    private final ManagedTaskListener managedTaskListener;
+    private final String identityName;
+    private final ManagedExecutorService executor;
+    private Future<?> future;
+
+    /**
+     * @param task
+     * @param contextConfiguration
+     * @param executor
+     */
+    ContextualTask(Object task, ContextConfiguration contextConfiguration, ManagedExecutorService executor) {
+        if (task instanceof ManagedTask) {
+            final ManagedTask managedTask = (ManagedTask) task;
+            ManagedTaskConfiguration managedTaskConfiguration = new ManagedTaskConfiguration(managedTask);
+            this.managedTaskListener = ContextualManagedTaskListener.getContextualManagedTaskListener(managedTaskConfiguration, contextConfiguration);
+            this.identityName = managedTaskConfiguration.getIdentityName();
+        } else {
+            this.managedTaskListener = null;
+            this.identityName = task.toString();
+        }
+        this.executor = executor;
+    }
+
+    /**
+     * @return
+     */
+    String getIdentityName() {
+        return identityName;
+    }
+
+    @Override
+    public void taskSubmitted(Future<?> future) {
+        this.future = future;
+        if (managedTaskListener != null) {
+            managedTaskListener.taskSubmitted(future, executor);
+        }
+    }
+
+    @Override
+    public void taskStarting() {
+        if (managedTaskListener != null) {
+            managedTaskListener.taskStarting(future, executor);
+        }
+    }
+
+    @Override
+    public void taskDone(Throwable exception) {
+        if (managedTaskListener != null) {
+            if (exception != null) {
+                if (!(exception instanceof SkippedException) && !(exception instanceof CancellationException)) {
+                    exception = new AbortedException(exception);
+                }
+                managedTaskListener.taskAborted(future, executor, exception);
+            }
+            managedTaskListener.taskDone(future, executor, exception);
+        }
+    }
+
+    @Override
+    public String toString() {
+        // do not change this, specs define task.toString() as fallback to obtain task identity name, here we ensure the fallback is consistent with wrapped task, in case it's a spec ManagedTask
+        return identityName;
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTaskCallable.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTaskCallable.java
@@ -1,0 +1,32 @@
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+import java.util.concurrent.Callable;
+
+/**
+ * A {@link Callable} {@link ContextualTask}.
+ *
+ * @author Eduardo Martins
+ */
+class ContextualTaskCallable<V> extends ContextualTask implements Callable<V> {
+
+    private final Context context;
+    private final Callable<V> task;
+
+    ContextualTaskCallable(Callable<V> task, ContextConfiguration contextConfiguration, ManagedExecutorService executor) {
+        super(task, contextConfiguration, executor);
+        this.task = task;
+        this.context = contextConfiguration != null ? contextConfiguration.newTaskContext(task) : null;
+    }
+
+    @Override
+    public V call() throws Exception {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            return task.call();
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTaskRunnable.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTaskRunnable.java
@@ -1,0 +1,31 @@
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedExecutorService;
+
+/**
+ * A {@link Runnable} {@link ContextualTask}.
+ *
+ * @author Eduardo Martins
+ */
+class ContextualTaskRunnable extends ContextualTask implements Runnable {
+
+    private final Context context;
+    private final Runnable task;
+
+    ContextualTaskRunnable(Runnable task, ContextConfiguration contextConfiguration, ManagedExecutorService executor) {
+        super(task, contextConfiguration, executor);
+        this.task = task;
+        this.context = contextConfiguration != null ? contextConfiguration.newTaskContext(task) : null;
+    }
+
+    @Override
+    public void run() {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            task.run();
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTrigger.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ContextualTrigger.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.Trigger;
+import java.util.Date;
+
+/**
+ * A {@link Trigger} which invocations are done with a specific {@link Context} set.
+ *
+ * @author Eduardo Martins
+ */
+public class ContextualTrigger implements Trigger {
+
+    private final Trigger trigger;
+    private final Context context;
+
+    /**
+     * @param trigger
+     * @param context
+     */
+    public ContextualTrigger(Trigger trigger, Context context) {
+        this.trigger = trigger;
+        this.context = context;
+    }
+
+    @Override
+    public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            return trigger.getNextRunTime(lastExecutionInfo, taskScheduledTime);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+
+    @Override
+    public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+        final Context previousContext = Utils.setContext(context);
+        try {
+            return trigger.skipRun(lastExecutionInfo, scheduledRunTime);
+        } finally {
+            Utils.setContext(previousContext);
+        }
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/LastExecutionImpl.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/LastExecutionImpl.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.LastExecution;
+import java.util.Date;
+
+/**
+ * A simple POJO kind impl for {@link LastExecution}.
+ *
+ * @author Eduardo Martins
+ */
+public class LastExecutionImpl implements LastExecution {
+
+    private String identityName;
+    private Object result;
+    private Date runEnd;
+    private Date runStart;
+    private Date scheduledStart;
+    private boolean skipped;
+
+    @Override
+    public String getIdentityName() {
+        return identityName;
+    }
+
+    /**
+     * @param identityName
+     */
+    public void setIdentityName(String identityName) {
+        this.identityName = identityName;
+    }
+
+    @Override
+    public Object getResult() {
+        return result;
+    }
+
+    /**
+     * @param result
+     */
+    public void setResult(Object result) {
+        this.result = result;
+    }
+
+    @Override
+    public Date getRunEnd() {
+        return runEnd;
+    }
+
+    /**
+     * @param runEnd
+     */
+    public void setRunEnd(Date runEnd) {
+        this.runEnd = runEnd;
+    }
+
+    @Override
+    public Date getRunStart() {
+        return runStart;
+    }
+
+    /**
+     * @param runStart
+     */
+    public void setRunStart(Date runStart) {
+        this.runStart = runStart;
+    }
+
+    @Override
+    public Date getScheduledStart() {
+        return scheduledStart;
+    }
+
+    /**
+     * @param scheduledStart
+     */
+    public void setScheduledStart(Date scheduledStart) {
+        this.scheduledStart = scheduledStart;
+    }
+
+    /**
+     * @return
+     */
+    public boolean isSkipped() {
+        return skipped;
+    }
+
+    /**
+     * @param skipped
+     */
+    public void setSkipped(boolean skipped) {
+        this.skipped = skipped;
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/ManagedTaskConfiguration.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/ManagedTaskConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedTask;
+import java.util.Map;
+
+/**
+ * A {@link ManagedTask} configuration object.
+ *
+ * @author Eduardo Martins
+ */
+public class ManagedTaskConfiguration {
+
+    private final ManagedTask managedTask;
+    private final String identityName;
+    private final boolean contextualCallbacks;
+
+    /**
+     * @param managedTask
+     */
+    public ManagedTaskConfiguration(ManagedTask managedTask) {
+        this.managedTask = managedTask;
+        final Map<String, String> executionProperties = managedTask.getExecutionProperties();
+        // task identity name
+        String propertiesIdentityName = null;
+        if (executionProperties != null) {
+            propertiesIdentityName = executionProperties.get("javax.enterprise.ee.IDENTITY_NAME");
+        }
+        if (propertiesIdentityName == null) {
+            identityName = managedTask.toString();
+        } else {
+            identityName = propertiesIdentityName;
+        }
+        // contextual callbacks
+        boolean contextualCallbacks = false;
+        if (executionProperties != null) {
+            final String contextualCallbackHintProperty = executionProperties.get("javax.enterprise.ee.CONTEXTUAL_CALLBACK_HINT");
+            if (contextualCallbackHintProperty != null) {
+                contextualCallbacks = Boolean.valueOf(contextualCallbackHintProperty);
+            }
+        }
+        this.contextualCallbacks = contextualCallbacks;
+    }
+
+    /**
+     * @return
+     */
+    public boolean isManagedTaskWithContextualCallbacks() {
+        return contextualCallbacks;
+    }
+
+    /**
+     * @return
+     */
+    public String getIdentityName() {
+        return identityName;
+    }
+
+    /**
+     * @return
+     */
+    public ManagedTask getManagedTask() {
+        return managedTask;
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerContextualTask.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerContextualTask.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.SkippedException;
+import java.util.Date;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * The {@link ContextualTask}s created by a {@link TriggerScheduledFuture}, and responsible for the original task scheduling and execution.
+ *
+ * @author Eduardo Martins
+ */
+public abstract class TriggerContextualTask<V> extends ContextualTask {
+
+    protected final TriggerScheduledFuture<V> parent;
+    protected final ManagedScheduledExecutorService scheduler;
+
+    private LastExecution lastExecution;
+    private Date scheduledStart;
+    private LastExecutionImpl currentExecution;
+
+    /**
+     * @param task
+     * @param scheduler
+     * @param parent
+     */
+    public TriggerContextualTask(Object task, ContextualManagedScheduledExecutorService scheduler, TriggerScheduledFuture<V> parent) {
+        super(task, scheduler.getContextConfiguration(), scheduler);
+        this.scheduler = scheduler;
+        this.parent = parent;
+        this.scheduledStart = new Date();
+    }
+
+    /**
+     * @return
+     */
+    protected LastExecutionImpl getCurrentExecution() {
+        return currentExecution;
+    }
+
+    @Override
+    public void taskSubmitted(Future<?> future) {
+        final ScheduledFutureWrapper<V> futureWrapper = new ScheduledFutureWrapper<>((ScheduledFuture<V>) future);
+        super.taskSubmitted(futureWrapper);
+        parent.runTaskSubmitted(futureWrapper);
+    }
+
+    @Override
+    public void taskStarting() {
+        currentExecution.setRunStart(new Date());
+        currentExecution.setSkipped(parent.getTrigger().skipRun(lastExecution, scheduledStart));
+        super.taskStarting();
+    }
+
+    @Override
+    public void taskDone(Throwable exception) {
+        if (exception == null && currentExecution.isSkipped()) {
+            exception = new SkippedException();
+        }
+        super.taskDone(exception);
+        if (exception == null) {
+            currentExecution.setRunEnd(new Date());
+        }
+        parent.runTaskDone(currentExecution);
+    }
+
+    /**
+     * @param lastExecution
+     * @param nextRuntime
+     */
+    protected void scheduleNextRun(LastExecution lastExecution, Date nextRuntime) {
+        this.currentExecution = new LastExecutionImpl();
+        this.currentExecution.setIdentityName(getIdentityName());
+        this.lastExecution = lastExecution;
+        this.scheduledStart = nextRuntime;
+        this.currentExecution.setScheduledStart(scheduledStart);
+        long delay = nextRuntime.getTime() - System.currentTimeMillis();
+        if (delay < 0L) {
+            delay = 0L;
+        }
+        scheduleTask(delay, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * @param delay
+     * @param timeUnit
+     */
+    protected abstract void scheduleTask(long delay, TimeUnit timeUnit);
+
+    /**
+     * A wrapper for {@link ScheduledFuture}, which intercepts get() methods and throws the spec SkippedException when required.
+     *
+     * @param <V>
+     */
+    private class ScheduledFutureWrapper<V> implements ScheduledFuture<V> {
+
+        private final ScheduledFuture<V> future;
+
+        private ScheduledFutureWrapper(ScheduledFuture<V> future) {
+            this.future = future;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return future.getDelay(unit);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            return future.compareTo(o);
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return future.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return future.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return future.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            final V v = future.get();
+            if (currentExecution.isSkipped()) {
+                throw new SkippedException();
+            }
+            return v;
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            final V v = future.get(timeout, unit);
+            if (currentExecution.isSkipped()) {
+                throw new SkippedException();
+            }
+            return v;
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerContextualTaskCallable.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerContextualTaskCallable.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link Callable} {@link TriggerContextualTask}.
+ *
+ * @author Eduardo Martins
+ */
+public class TriggerContextualTaskCallable<V> extends TriggerContextualTask<V> implements Callable<V> {
+
+    private final Context context;
+    private final Callable<V> task;
+
+    /**
+     * @param task
+     * @param executor
+     * @param parent
+     */
+    protected TriggerContextualTaskCallable(Callable<V> task, ContextualManagedScheduledExecutorService executor, TriggerScheduledFuture<V> parent) {
+        super(task, executor, parent);
+        this.task = task;
+        context = executor.getContextConfiguration() != null ? executor.getContextConfiguration().newTaskContext(task) : null;
+    }
+
+    /**
+     * @return
+     */
+    protected Context getContext() {
+        return context;
+    }
+
+    @Override
+    public V call() throws Exception {
+        if (!getCurrentExecution().isSkipped()) {
+            final Context previousContext = Utils.setContext(context);
+            try {
+                final V v = task.call();
+                getCurrentExecution().setResult(v);
+                return v;
+            } finally {
+                Utils.setContext(previousContext);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    protected void scheduleTask(long delay, TimeUnit timeUnit) {
+        scheduler.schedule(this, delay, timeUnit);
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerContextualTaskRunnable.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerContextualTaskRunnable.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link Runnable} {@link TriggerContextualTask}.
+ *
+ * @author Eduardo Martins
+ */
+public class TriggerContextualTaskRunnable<V> extends TriggerContextualTask<V> implements Runnable {
+
+    private final Context context;
+    private final Runnable task;
+
+    /**
+     * @param task
+     * @param executor
+     * @param parent
+     */
+    protected TriggerContextualTaskRunnable(Runnable task, ContextualManagedScheduledExecutorService executor, TriggerScheduledFuture<V> parent) {
+        super(task, executor, parent);
+        this.task = task;
+        context = executor.getContextConfiguration() != null ? executor.getContextConfiguration().newTaskContext(task) : null;
+    }
+
+    /**
+     * @return
+     */
+    protected Context getContext() {
+        return context;
+    }
+
+    @Override
+    public void run() {
+        if (!getCurrentExecution().isSkipped()) {
+            final Context previousContext = Utils.setContext(context);
+            try {
+                task.run();
+            } finally {
+                Utils.setContext(previousContext);
+            }
+        }
+    }
+
+    @Override
+    protected void scheduleTask(long delay, TimeUnit timeUnit) {
+        scheduler.schedule(this, delay, timeUnit);
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerScheduledFuture.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/TriggerScheduledFuture.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+import org.wildfly.as.concurrent.ConcurrentLogger;
+
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.Trigger;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The future which controls a trigger task execution.
+ *
+ * @author Eduardo Martins
+ */
+class TriggerScheduledFuture<V> implements ScheduledFuture<V> {
+
+    private final TriggerContextualTask<V> task;
+    private final Trigger trigger;
+    private final ContextualManagedScheduledExecutorService executorService;
+
+    private final Date scheduledStart = new Date();
+    private ScheduledFuture<V> currentFuture;
+
+    private final AtomicBoolean done = new AtomicBoolean(false);
+
+    /**
+     * @param runnable
+     * @param trigger
+     * @param executorService
+     */
+    TriggerScheduledFuture(Runnable runnable, Trigger trigger, ContextualManagedScheduledExecutorService executorService) {
+        final TriggerContextualTaskRunnable<V> rTask = new TriggerContextualTaskRunnable<V>(runnable, executorService, this);
+        this.task = rTask;
+        this.trigger = rTask.getContext() != null ? new ContextualTrigger(trigger, rTask.getContext()) : trigger;
+        this.executorService = executorService;
+        scheduleNextRun(null);
+    }
+
+    /**
+     * @param callable
+     * @param trigger
+     * @param executorService
+     */
+    TriggerScheduledFuture(Callable<V> callable, Trigger trigger, ContextualManagedScheduledExecutorService executorService) {
+        final TriggerContextualTaskCallable<V> cTask = new TriggerContextualTaskCallable<>(callable, executorService, this);
+        this.task = cTask;
+        this.trigger = cTask.getContext() != null ? new ContextualTrigger(trigger, cTask.getContext()) : trigger;
+        this.executorService = executorService;
+        scheduleNextRun(null);
+    }
+
+    /**
+     * @return
+     */
+    Trigger getTrigger() {
+        return trigger;
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return currentFuture == null ? 0L : currentFuture.getDelay(unit);
+    }
+
+    @Override
+    public int compareTo(Delayed other) {
+        if (other == this) {
+            return 0;
+        }
+        final long delayDiff = this.getDelay(TimeUnit.NANOSECONDS) - other.getDelay(TimeUnit.NANOSECONDS);
+        if (delayDiff == 0) {
+            return 0;
+        }
+        return delayDiff < 0 ? -1 : 1;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (done.compareAndSet(false, true)) {
+            return currentFuture.cancel(mayInterruptIfRunning);
+        } else {
+            // task already done
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return currentFuture == null ? false : currentFuture.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return done.get();
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        return currentFuture == null ? null : currentFuture.get();
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return currentFuture == null ? null : currentFuture.get(timeout, unit);
+    }
+
+    /**
+     * @param lastExecution
+     */
+    void scheduleNextRun(LastExecution lastExecution) {
+        final Date nextRuntime = trigger.getNextRunTime(lastExecution, scheduledStart);
+        if (nextRuntime == null) {
+            // task done
+            if (done.compareAndSet(false, true)) {
+                if (currentFuture == null) {
+                    ConcurrentLogger.ROOT_LOGGER.triggerTaskNeverSubmittedDueToNullGetNextRunTime();
+                }
+            }
+        } else {
+            if (!isDone()) {
+                try {
+                    task.scheduleNextRun(lastExecution, nextRuntime);
+                } catch (Throwable e) {
+                    ConcurrentLogger.ROOT_LOGGER.failureWhenSchedulingNextRun(e);
+                    if (done.compareAndSet(false, true)) {
+                        if (currentFuture == null) {
+                            ConcurrentLogger.ROOT_LOGGER.triggerTaskNeverSubmittedDueToFailureWhenSchedulingNextRun();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param future
+     */
+    void runTaskSubmitted(ScheduledFuture<V> future) {
+        currentFuture = future;
+    }
+
+    /**
+     * @param lastExecution
+     */
+    void runTaskDone(LastExecution lastExecution) {
+        scheduleNextRun(lastExecution);
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/context/Utils.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/context/Utils.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent.context;
+
+/**
+ * @author Eduardo Martins
+ */
+public class Utils {
+
+    private Utils() {
+    }
+
+    /**
+     * Sets the specified context, and returns the one previously set. If the specified context is null this invocation is ignored.
+     *
+     * @param context
+     * @return the context previously set
+     */
+    public static Context setContext(Context context) {
+        return context != null ? context.set() : null;
+    }
+
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/TaskListener.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/TaskListener.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import java.util.concurrent.Future;
+
+/**
+ * <p>Listener for callbacks with respect to task execution.</p>
+ * <p>Possible scenarios:</p>
+ * <ul>
+ * <li>Task submit failed to complete - taskSubmitted, taskDone(Throwable which aborted the submit)</li>
+ * <li>Task execution aborted - taskSubmitted, taskStarting, taskDone(Throwable which aborted execution)</li>
+ * <li>Task cancellation before execution - taskSubmitted, taskDone(CancellationException)</li>
+ * <li>Task cancellation during execution - taskSubmitted, taskStarting, taskDone(CancellationException)</li>
+ * <li>Task successfully executed - taskSubmitted, taskStarting, taskDone(null)</li>
+ * </ul>
+ * <p>Periodic tasks will produce one scenario per run.</p>
+ *
+ * @author Eduardo Martins
+ */
+public interface TaskListener {
+
+    /**
+     * Callback which indicates the task has been submitted.
+     *
+     * @param future
+     */
+    void taskSubmitted(Future<?> future);
+
+    /**
+     * Callback which indicates the task execution is starting.
+     */
+    void taskStarting();
+
+    /**
+     * Callback which indicates the task is done.
+     *
+     * @param exception null if the task executed successfully; CancellationException if the task has been cancelled; any other non null Throwable is related to an aborted task submit or execution.
+     */
+    void taskDone(Throwable exception);
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/TaskListenerExecutorService.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/TaskListenerExecutorService.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A type used to mark an {@link ExecutorService} with support for {@link TaskListener} task execution.
+ *
+ * @author Eduardo Martins
+ */
+public interface TaskListenerExecutorService extends ExecutorService {
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/TaskListenerScheduledExecutorService.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/TaskListenerScheduledExecutorService.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * A type used to mark an {@link java.util.concurrent.ScheduledExecutorService} with support for {@link TaskListener} task execution and scheduling.
+ *
+ * @author Eduardo Martins
+ */
+public interface TaskListenerScheduledExecutorService extends ScheduledExecutorService, TaskListenerExecutorService {
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/RunnableFutureWrapper.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/RunnableFutureWrapper.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Wrapper for {@link RunnableFuture}, responsible for doing the {@link TaskListenerWrapper#taskSubmitted(java.util.concurrent.Future)} callback on instance creation, and {@link org.wildfly.as.concurrent.tasklistener.impl.TaskListenerWrapper#taskCancelled()} callbacks on successful cancels.
+ *
+ * @author Eduardo Martins
+ */
+class RunnableFutureWrapper<V> implements RunnableFuture<V> {
+
+    private final RunnableFuture<V> runnableFuture;
+    private final TaskListenerWrapper taskListenerWrapper;
+
+    RunnableFutureWrapper(RunnableFuture<V> runnableFuture, TaskListenerWrapper taskListenerWrapper) {
+        this.runnableFuture = runnableFuture;
+        this.taskListenerWrapper = taskListenerWrapper;
+        taskListenerWrapper.taskSubmitted(this);
+    }
+
+    @Override
+    public void run() {
+        runnableFuture.run();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (runnableFuture.cancel(mayInterruptIfRunning)) {
+            taskListenerWrapper.taskCancelled();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return runnableFuture.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return runnableFuture.isDone();
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        return runnableFuture.get();
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return runnableFuture.get(timeout, unit);
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/RunnableScheduledFutureWrapper.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/RunnableScheduledFutureWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Wrapper for {@link java.util.concurrent.RunnableScheduledFuture}, responsible for doing the {@link TaskListenerWrapper#taskSubmitted(java.util.concurrent.Future)} callback on instance creation, and {@link org.wildfly.as.concurrent.tasklistener.impl.TaskListenerWrapper#taskCancelled()} callbacks on successful cancels.
+ *
+ * @author Eduardo Martins
+ */
+class RunnableScheduledFutureWrapper<V> implements RunnableScheduledFuture<V> {
+
+    final RunnableScheduledFuture<V> runnableScheduledFuture;
+    final TaskListenerWrapper taskListenerWrapper;
+
+    RunnableScheduledFutureWrapper(RunnableScheduledFuture<V> runnableScheduledFuture, TaskListenerWrapper taskListenerWrapper) {
+        this.runnableScheduledFuture = runnableScheduledFuture;
+        this.taskListenerWrapper = taskListenerWrapper;
+        taskListenerWrapper.taskSubmitted(this);
+    }
+
+    @Override
+    public boolean isPeriodic() {
+        return runnableScheduledFuture.isPeriodic();
+    }
+
+    @Override
+    public void run() {
+        runnableScheduledFuture.run();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (runnableScheduledFuture.cancel(mayInterruptIfRunning)) {
+            taskListenerWrapper.taskCancelled();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return runnableScheduledFuture.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return runnableScheduledFuture.isDone();
+    }
+
+    @Override
+    public V get() throws InterruptedException, ExecutionException {
+        return runnableScheduledFuture.get();
+    }
+
+    @Override
+    public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return runnableScheduledFuture.get(timeout, unit);
+    }
+
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return runnableScheduledFuture.getDelay(unit);
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return runnableScheduledFuture.compareTo(o);
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerScheduledThreadPoolExecutor.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerScheduledThreadPoolExecutor.java
@@ -1,0 +1,311 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerScheduledExecutorService;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A {@link ScheduledThreadPoolExecutor} with {@link TaskListener} support, i.e. upon execution of tasks that implement {@link TaskListener}, the executor will be do the callbacks.
+ *
+ * @author Eduardo Martins
+ */
+public class TaskListenerScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor implements TaskListenerScheduledExecutorService {
+
+    /**
+     * @param corePoolSize
+     * @see java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledThreadPoolExecutor(int)
+     */
+    public TaskListenerScheduledThreadPoolExecutor(int corePoolSize) {
+        super(corePoolSize);
+    }
+
+    /**
+     * @param corePoolSize
+     * @param threadFactory
+     * @see java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledThreadPoolExecutor(int, java.util.concurrent.ThreadFactory)
+     */
+    public TaskListenerScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory) {
+        super(corePoolSize, threadFactory);
+    }
+
+    /**
+     * @param corePoolSize
+     * @param handler
+     * @see java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledThreadPoolExecutor(int, java.util.concurrent.RejectedExecutionHandler)
+     */
+    public TaskListenerScheduledThreadPoolExecutor(int corePoolSize, RejectedExecutionHandler handler) {
+        super(corePoolSize, handler);
+    }
+
+    /**
+     * @param corePoolSize
+     * @param threadFactory
+     * @param handler
+     * @see java.util.concurrent.ScheduledThreadPoolExecutor#ScheduledThreadPoolExecutor(int, java.util.concurrent.ThreadFactory, java.util.concurrent.RejectedExecutionHandler)
+     */
+    public TaskListenerScheduledThreadPoolExecutor(int corePoolSize, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+        super(corePoolSize, threadFactory, handler);
+    }
+
+    // note: all submit and execute methods delegate to schedule, no need to override these
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable task, long delay, TimeUnit unit) {
+        Throwable t = null;
+        task = TaskListenerWrapperRunnable.wrap(task, false);
+        try {
+            return super.schedule(task, delay, unit);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> task, long delay, TimeUnit unit) {
+        Throwable t = null;
+        task = TaskListenerWrapperCallable.wrap(task, false);
+        try {
+            return super.schedule(task, delay, unit);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long initialDelay, long period, TimeUnit unit) {
+        Throwable t = null;
+        task = TaskListenerWrapperRunnable.wrap(task, true);
+        try {
+            return super.scheduleAtFixedRate(task, initialDelay, period, unit);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long initialDelay, long delay, TimeUnit unit) {
+        Throwable t = null;
+        task = TaskListenerWrapperRunnable.wrap(task, true);
+        try {
+            return super.scheduleWithFixedDelay(task, initialDelay, delay, unit);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    // future makers
+
+    @Override
+    protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable, RunnableScheduledFuture<V> task) {
+        if (callable instanceof TaskListenerWrapper) {
+            task = new RunnableScheduledFutureWrapper<>(task, (TaskListenerWrapper) callable);
+        }
+        return task;
+    }
+
+    @Override
+    protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable, RunnableScheduledFuture<V> task) {
+        if (runnable instanceof TaskListenerWrapper) {
+            task = new RunnableScheduledFutureWrapper<>(task, (TaskListenerWrapper) runnable);
+        } else if (runnable instanceof RunnableScheduledFutureWrapper) {
+            // this may happen due to newTaskFor() usage by invokeAll()
+            task = (RunnableScheduledFuture<V>) runnable;
+        }
+        return task;
+    }
+
+    // fixes for two issues with super impl
+
+    // 1. fixing forgotten (by super) invokeAll()
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Callable<T> task) {
+        // invokeAll is not overwritten by ScheduledThreadPoolExecutor, i.e. uses AbstractExecutorService logic, and that relies on this method to create the futures returned
+        boolean isTaskListener = task instanceof TaskListener;
+        if (isTaskListener) {
+            task = new TaskListenerWrapperCallable<>(task, false);
+        }
+        RunnableFuture<T> runnableFuture = super.newTaskFor(task);
+        if (isTaskListener) {
+            runnableFuture = decorateTask(task, new RunnableFutureAdapter<>(runnableFuture));
+        }
+        return runnableFuture;
+    }
+
+    /**
+     * A class which adapts a RunnableFuture to RunnableScheduledFuture.
+     *
+     * @author Eduardo Martins
+     */
+    private static final class RunnableFutureAdapter<V> implements RunnableScheduledFuture<V> {
+
+        final RunnableFuture<V> runnableFuture;
+
+        RunnableFutureAdapter(RunnableFuture<V> runnableFuture) {
+            this.runnableFuture = runnableFuture;
+        }
+
+        @Override
+        public void run() {
+            runnableFuture.run();
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return runnableFuture.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return runnableFuture.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return runnableFuture.isDone();
+        }
+
+        @Override
+        public V get() throws InterruptedException, ExecutionException {
+            return runnableFuture.get();
+        }
+
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return runnableFuture.get(timeout, unit);
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return 0L;
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            if (other == this)
+                return 0;
+            long d = -other.getDelay(TimeUnit.NANOSECONDS);
+            return (d == 0) ? 0 : ((d < 0) ? -1 : 1);
+        }
+
+        @Override
+        public boolean isPeriodic() {
+            return false;
+        }
+    }
+
+    // 2. usage of Executors.callable(Runnable task, T result) on submit(Runnable task, T result), hides impl of TaskListener by the Runnable
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        if (task instanceof TaskListener) {
+            return submit(new TaskListenerRunnableAdapter<>(task, result));
+        } else {
+            return super.submit(task, result);
+        }
+    }
+
+    /**
+     * A callable that runs given task and returns given result, but also implements TaskListener
+     */
+    static final class TaskListenerRunnableAdapter<T> implements Callable<T>, TaskListener {
+
+        final Runnable task;
+        final TaskListener taskListener;
+        final T result;
+
+        TaskListenerRunnableAdapter(Runnable task, T result) {
+            this.task = task;
+            this.taskListener = (TaskListener) task;
+            this.result = result;
+        }
+
+        @Override
+        public T call() throws Exception {
+            task.run();
+            return result;
+        }
+
+        @Override
+        public void taskSubmitted(Future<?> future) {
+            taskListener.taskSubmitted(future);
+        }
+
+        @Override
+        public void taskStarting() {
+            taskListener.taskStarting();
+        }
+
+        @Override
+        public void taskDone(Throwable exception) {
+            taskListener.taskDone(exception);
+        }
+    }
+
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerThreadPoolExecutor.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerThreadPoolExecutor.java
@@ -1,0 +1,206 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerExecutorService;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link java.util.concurrent.ThreadPoolExecutor} with {@link TaskListener} support, i.e. upon execution of tasks that implement {@link TaskListener}, the executor will be do the callbacks.
+ *
+ * @author Eduardo Martins
+ */
+public class TaskListenerThreadPoolExecutor extends ThreadPoolExecutor implements TaskListenerExecutorService {
+
+    /**
+     * @param corePoolSize
+     * @param maximumPoolSize
+     * @param keepAliveTime
+     * @param unit
+     * @param workQueue
+     * @see java.util.concurrent.ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue)
+     */
+    public TaskListenerThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    /**
+     * @param corePoolSize
+     * @param maximumPoolSize
+     * @param keepAliveTime
+     * @param unit
+     * @param workQueue
+     * @param threadFactory
+     * @see java.util.concurrent.ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue, java.util.concurrent.ThreadFactory)
+     */
+    public TaskListenerThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    }
+
+    /**
+     * @param corePoolSize
+     * @param maximumPoolSize
+     * @param keepAliveTime
+     * @param unit
+     * @param workQueue
+     * @param handler
+     * @see java.util.concurrent.ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue, java.util.concurrent.RejectedExecutionHandler)
+     */
+    public TaskListenerThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    }
+
+    /**
+     * @param corePoolSize
+     * @param maximumPoolSize
+     * @param keepAliveTime
+     * @param unit
+     * @param workQueue
+     * @param threadFactory
+     * @param handler
+     * @see java.util.concurrent.ThreadPoolExecutor#ThreadPoolExecutor(int, int, long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue, java.util.concurrent.ThreadFactory, java.util.concurrent.RejectedExecutionHandler)
+     */
+    public TaskListenerThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    // override submit and execute methods to abort task listeners if the operation does not succeeds
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        task = TaskListenerWrapperRunnable.wrap(task, false);
+        Throwable t = null;
+        try {
+            return super.submit(task);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        task = TaskListenerWrapperRunnable.wrap(task, false);
+        Throwable t = null;
+        try {
+            return super.submit(task, result);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        task = TaskListenerWrapperCallable.wrap(task, false);
+        Throwable t = null;
+        try {
+            return super.submit(task);
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            if (t != null && task instanceof TaskListenerWrapper) {
+                ((TaskListenerWrapper) task).taskSubmitFailed(t);
+            }
+        }
+    }
+
+    @Override
+    public void execute(Runnable task) {
+        if (!(task instanceof TaskListener)) {
+            super.execute(task);
+        } else {
+            Throwable t = null;
+            task = TaskListenerWrapperRunnable.wrap(task, false);
+            try {
+                super.execute(newTaskFor(task, null));
+            } catch (RuntimeException e) {
+                t = e;
+                throw e;
+            } catch (Error e) {
+                t = e;
+                throw e;
+            } finally {
+                if (t != null) {
+                    ((TaskListenerWrapper) task).taskSubmitFailed(t);
+                }
+            }
+        }
+    }
+
+    // override future maker methods, in case it's a task listener wrap both the task and future
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Callable<T> task) {
+        if (task instanceof TaskListenerWrapper) {
+            return new RunnableFutureWrapper<>(super.newTaskFor(task), (TaskListenerWrapper) task);
+        } else if (task instanceof TaskListener) {
+            final TaskListenerWrapperCallable<T> taskWrapper = new TaskListenerWrapperCallable<>(task, false);
+            return new RunnableFutureWrapper<>(super.newTaskFor(taskWrapper), taskWrapper);
+        } else {
+            return super.newTaskFor(task);
+        }
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable task, T value) {
+        if (task instanceof TaskListenerWrapper) {
+            return new RunnableFutureWrapper<>(super.newTaskFor(task, value), (TaskListenerWrapper) task);
+        } else if (task instanceof TaskListener) {
+            final TaskListenerWrapperRunnable taskWrapper = new TaskListenerWrapperRunnable(task, false);
+            return new RunnableFutureWrapper<>(super.newTaskFor(taskWrapper, value), taskWrapper);
+        } else {
+            return super.newTaskFor(task, value);
+        }
+    }
+
+}
+
+

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerWrapper.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerWrapper.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import org.wildfly.as.concurrent.ConcurrentLogger;
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Wrapper for {@link TaskListener}, responsible for doing the callbacks.
+ *
+ * @author Eduardo Martins
+ */
+abstract class TaskListenerWrapper {
+
+    private TaskListener taskListener;
+    private final boolean periodic;
+    private Future<?> future;
+
+    private final CallbacksLock callbacksLock = new CallbacksLock();
+
+    TaskListenerWrapper(TaskListener taskListener, boolean periodic) {
+        this.taskListener = taskListener;
+        this.periodic = periodic;
+    }
+
+    void taskSubmitted(Future<?> future) {
+        if (callbacksLock.lock()) {
+            this.future = future;
+            try {
+                taskListener.taskSubmitted(future);
+            } catch (Throwable t) {
+                ConcurrentLogger.ROOT_LOGGER.failureInTaskSubmittedCallback(t);
+            }
+            callbacksLock.unlock();
+            if (future.isCancelled()) {
+                // a concurrent cancel may have not obtained the callbacks lock...
+                taskCancelled();
+            }
+        }
+    }
+
+    void beforeExecution() {
+        if (callbacksLock.lock()) {
+            try {
+                taskListener.taskStarting();
+            } catch (Throwable t) {
+                ConcurrentLogger.ROOT_LOGGER.failureInTaskStartingCallback(t);
+            }
+            callbacksLock.unlock();
+            if (future.isCancelled()) {
+                // a concurrent cancel may have not obtained the callbacks lock...
+                taskCancelled();
+            }
+        }
+    }
+
+    void afterExecution(Throwable throwable) {
+        if (callbacksLock.lock()) {
+            if (future.isCancelled()) {
+                try {
+                    taskListener.taskDone(new CancellationException());
+                } catch (Throwable t) {
+                    ConcurrentLogger.ROOT_LOGGER.failureInTaskDoneCallback(t);
+                }
+                // do not unlock callbacks to avoid possible concurrent callbacks
+            } else {
+                try {
+                    taskListener.taskDone(throwable);
+                } catch (Throwable t) {
+                    ConcurrentLogger.ROOT_LOGGER.failureInTaskDoneCallback(t);
+                }
+                if (throwable == null && periodic) {
+                    // only unlock callbacks if there is another run
+                    callbacksLock.unlock();
+                    taskSubmitted(future);
+                }
+            }
+        }
+    }
+
+    void taskCancelled() {
+        if (callbacksLock.lock()) {
+            if (future != null) {
+                try {
+                    taskListener.taskDone(new CancellationException());
+                } catch (Throwable t) {
+                    ConcurrentLogger.ROOT_LOGGER.failureInTaskDoneCallback(t);
+                }
+            }
+            // do not unlock callbacks to avoid possible concurrent callbacks
+        }
+    }
+
+    void taskSubmitFailed(Throwable throwable) {
+        if (callbacksLock.lock()) {
+            if (future != null) {
+                try {
+                    taskListener.taskDone(throwable);
+                } catch (Throwable t) {
+                    ConcurrentLogger.ROOT_LOGGER.failureInTaskDoneCallback(t);
+                }
+            }
+            // do not unlock callbacks to avoid possible concurrent callbacks
+        }
+    }
+
+    /**
+     * A lock to avoid issues with concurrent callbacks
+     */
+    private static class CallbacksLock {
+
+        private final AtomicBoolean lock = new AtomicBoolean(false);
+
+        private boolean lock() {
+            return lock.compareAndSet(false, true);
+        }
+
+        private void unlock() {
+            lock.set(false);
+        }
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerWrapperCallable.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerWrapperCallable.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A {@link Callable} {@link TaskListenerWrapper}.
+ *
+ * @author Eduardo Martins
+ */
+class TaskListenerWrapperCallable<V> extends TaskListenerWrapper implements Callable<V> {
+
+    private final Callable<V> task;
+
+    TaskListenerWrapperCallable(Callable<V> task, boolean periodic) {
+        super((TaskListener) task, periodic);
+        this.task = task;
+    }
+
+    @Override
+    public V call() throws Exception {
+        Throwable t = null;
+        try {
+            beforeExecution();
+            return task.call();
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } catch (Exception e) {
+            t = e;
+            throw e;
+        } finally {
+            afterExecution(t);
+        }
+    }
+
+    /**
+     * Wraps the task, but only if the task is a TaskListener
+     *
+     * @param task
+     * @param periodic
+     * @return
+     */
+    static <V> Callable<V> wrap(Callable<V> task, boolean periodic) {
+        return task instanceof TaskListener ? new TaskListenerWrapperCallable<>(task, periodic) : task;
+    }
+}

--- a/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerWrapperRunnable.java
+++ b/concurrent/src/main/java/org/wildfly/as/concurrent/tasklistener/impl/TaskListenerWrapperRunnable.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener.impl;
+
+import org.wildfly.as.concurrent.tasklistener.TaskListener;
+
+/**
+ * * A {@link Runnable} {@link TaskListenerWrapper}.
+ *
+ * @author Eduardo Martins
+ */
+class TaskListenerWrapperRunnable extends TaskListenerWrapper implements Runnable {
+
+    private final Runnable task;
+
+    TaskListenerWrapperRunnable(Runnable task, boolean periodic) {
+        super((TaskListener) task, periodic);
+        this.task = task;
+    }
+
+    @Override
+    public void run() {
+        Throwable t = null;
+        try {
+            beforeExecution();
+            task.run();
+        } catch (RuntimeException e) {
+            t = e;
+            throw e;
+        } catch (Error e) {
+            t = e;
+            throw e;
+        } finally {
+            afterExecution(t);
+        }
+    }
+
+    /**
+     * Wraps the task, but only if the task is a TaskListener
+     *
+     * @param task
+     * @param periodic
+     * @return
+     */
+    static Runnable wrap(Runnable task, boolean periodic) {
+        return task instanceof TaskListener ? new TaskListenerWrapperRunnable(task, periodic) : task;
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ContextServiceImplTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ContextServiceImplTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+import org.wildfly.as.concurrent.context.TestContext;
+import org.wildfly.as.concurrent.context.TestContextConfiguration;
+import org.wildfly.as.concurrent.context.TestRunnable;
+
+/**
+ *
+ */
+public class ContextServiceImplTestCase {
+
+    protected ContextServiceImpl contextService;
+
+    protected ContextServiceImpl newContextService(ContextConfiguration contextConfiguration) {
+        return new ContextServiceImpl(contextConfiguration);
+    }
+
+    @Before
+    public void beforeTest() {
+        final TestContextConfiguration contextConfiguration = new TestContextConfiguration();
+        contextService = newContextService(contextConfiguration);
+        Assert.assertTrue(TestContext.allContexts.isEmpty());
+    }
+
+    @Test
+    public void testNonObjectInvocation() throws Exception {
+        final TestRunnable testRunnable = new TestRunnable();
+        Runnable runnable = contextService.createContextualProperty(testRunnable, Runnable.class);
+        testRunnable.assertContextIsNotSet();
+        runnable.run();
+        testRunnable.assertContextWasSet();
+        testRunnable.assertContextWasReset();
+    }
+
+    @Test
+    public void testObjectInvocation() throws Exception {
+        final TestRunnable testRunnable = new TestRunnable();
+        Runnable runnable = contextService.createContextualProperty(testRunnable, Runnable.class);
+        testRunnable.assertContextIsNotSet();
+        runnable.hashCode();
+        testRunnable.assertContextIsNotSet();
+    }
+
+    @After
+    public void afterTest() {
+        Assert.assertTrue(TestContext.allContexts.isEmpty());
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedExecutorServiceImplAbortedTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedExecutorServiceImplAbortedTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.context.ManagedExecutorServiceAbortedTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedExecutorServiceImplAbortedTestCase extends ManagedExecutorServiceAbortedTestCase {
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestExecutors.newComponentManagedExecutorService();
+    }
+
+    protected ManagedExecutorServiceImpl componentExecutor;
+
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        componentExecutor = (ManagedExecutorServiceImpl) executor;
+    }
+
+    @Override
+    protected void shutdownExecutor() throws Exception {
+        componentExecutor.internalShutdown();
+        componentExecutor.getTaskListenerExecutorService().shutdown();
+        if (!componentExecutor.getTaskListenerExecutorService().awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedExecutorServiceImplCancellationTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedExecutorServiceImplCancellationTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.context.ManagedExecutorServiceCancellationTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedExecutorServiceImplCancellationTestCase extends ManagedExecutorServiceCancellationTestCase {
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestExecutors.newComponentManagedExecutorService();
+    }
+
+    protected ManagedExecutorServiceImpl componentExecutor;
+
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        componentExecutor = (ManagedExecutorServiceImpl) executor;
+    }
+
+    @Override
+    protected void shutdownExecutor() throws Exception {
+        componentExecutor.internalShutdown();
+        componentExecutor.getTaskListenerExecutorService().shutdown();
+        if (!componentExecutor.getTaskListenerExecutorService().awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedExecutorServiceImplStandardTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedExecutorServiceImplStandardTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.context.ManagedExecutorServiceStandardTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedExecutorServiceImplStandardTestCase extends ManagedExecutorServiceStandardTestCase {
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestExecutors.newComponentManagedExecutorService();
+    }
+
+    protected ManagedExecutorServiceImpl componentExecutor;
+
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        componentExecutor = (ManagedExecutorServiceImpl) executor;
+    }
+
+    @Override
+    protected void shutdownExecutor() throws Exception {
+        componentExecutor.internalShutdown();
+        componentExecutor.getTaskListenerExecutorService().shutdown();
+        if (!componentExecutor.getTaskListenerExecutorService().awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImplAbortedTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImplAbortedTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.context.ManagedScheduledExecutorServiceAbortedTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedScheduledExecutorServiceImplAbortedTestCase extends ManagedScheduledExecutorServiceAbortedTestCase {
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestExecutors.newComponentManagedScheduledExecutorService();
+    }
+
+    protected ManagedScheduledExecutorServiceImpl componentExecutor;
+
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        componentExecutor = (ManagedScheduledExecutorServiceImpl) executor;
+    }
+
+    @Override
+    protected void shutdownExecutor() throws Exception {
+        componentExecutor.internalShutdown();
+        componentExecutor.getTaskListenerExecutorService().shutdown();
+        if (!componentExecutor.getTaskListenerExecutorService().awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImplCancellationTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImplCancellationTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.context.ManagedScheduledExecutorServiceCancellationTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedScheduledExecutorServiceImplCancellationTestCase extends ManagedScheduledExecutorServiceCancellationTestCase {
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestExecutors.newComponentManagedScheduledExecutorService();
+    }
+
+    protected ManagedScheduledExecutorServiceImpl componentExecutor;
+
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        componentExecutor = (ManagedScheduledExecutorServiceImpl) executor;
+    }
+
+    @Override
+    protected void shutdownExecutor() throws Exception {
+        componentExecutor.internalShutdown();
+        componentExecutor.getTaskListenerExecutorService().shutdown();
+        if (!componentExecutor.getTaskListenerExecutorService().awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImplStandardTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedScheduledExecutorServiceImplStandardTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextualManagedExecutorService;
+import org.wildfly.as.concurrent.context.ManagedScheduledExecutorServiceStandardTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedScheduledExecutorServiceImplStandardTestCase extends ManagedScheduledExecutorServiceStandardTestCase {
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestExecutors.newComponentManagedScheduledExecutorService();
+    }
+
+    protected ManagedScheduledExecutorServiceImpl componentExecutor;
+
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        componentExecutor = (ManagedScheduledExecutorServiceImpl) executor;
+    }
+
+    @Override
+    protected void shutdownExecutor() throws Exception {
+        componentExecutor.internalShutdown();
+        componentExecutor.getTaskListenerExecutorService().shutdown();
+        if (!componentExecutor.getTaskListenerExecutorService().awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedThreadFactoryImplTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/ManagedThreadFactoryImplTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.as.concurrent;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+import org.wildfly.as.concurrent.context.TestContext;
+import org.wildfly.as.concurrent.context.TestContextConfiguration;
+import org.wildfly.as.concurrent.context.TestRunnable;
+
+import javax.enterprise.concurrent.ManageableThread;
+
+/**
+ *
+ */
+public class ManagedThreadFactoryImplTestCase {
+
+    protected ManagedThreadFactoryImpl threadFactory;
+
+    protected ManagedThreadFactoryImpl newManagedThreadFactory(ContextConfiguration contextConfiguration) {
+        return new ManagedThreadFactoryImpl(contextConfiguration);
+    }
+
+    @Before
+    public void beforeTest() {
+        final TestContextConfiguration contextConfiguration = new TestContextConfiguration();
+        threadFactory = newManagedThreadFactory(contextConfiguration);
+        Assert.assertFalse(threadFactory.isShutdown());
+        Assert.assertTrue(threadFactory.getThreads().isEmpty());
+        Assert.assertTrue(TestContext.allContexts.isEmpty());
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        TestRunnable runnable = new TestRunnable();
+        runnable.assertContextIsNotSet();
+        Thread thread = threadFactory.newThread(runnable);
+        Assert.assertFalse(((ManageableThread) thread).isShutdown());
+        Assert.assertEquals(1, threadFactory.getThreads().size());
+        Assert.assertEquals(thread, threadFactory.getThreads().get(0));
+        thread.start();
+        runnable.assertContextWasSet();
+        runnable.assertContextWasReset();
+    }
+
+    @Test
+    public void testInterrupt() throws Exception {
+        TestRunnable runnable = new TestRunnable();
+        runnable.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    // ignore
+                }
+            }
+        };
+        runnable.assertContextIsNotSet();
+        Thread thread = threadFactory.newThread(runnable);
+        Assert.assertFalse(((ManageableThread) thread).isShutdown());
+        Assert.assertEquals(1, threadFactory.getThreads().size());
+        Assert.assertEquals(thread, threadFactory.getThreads().get(0));
+        thread.start();
+        try {
+            Thread.sleep(1000);
+            thread.interrupt();
+        } catch (InterruptedException e) {
+            // ignore
+        }
+        runnable.assertContextWasSet();
+        runnable.assertContextWasReset();
+    }
+
+    @After
+    public void afterTest() {
+        threadFactory.shutdown();
+        Assert.assertTrue(threadFactory.isShutdown());
+        Assert.assertTrue(threadFactory.getThreads().isEmpty());
+        Assert.assertTrue(TestContext.allContexts.isEmpty());
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/SharedManagedTaskThreadPoolExecutorTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/SharedManagedTaskThreadPoolExecutorTestCase.java
@@ -1,0 +1,231 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.as.concurrent.component.ComponentManagedExecutorService;
+import org.wildfly.as.concurrent.context.TestCallable;
+import org.wildfly.as.concurrent.context.TestManagedCallable;
+import org.wildfly.as.concurrent.context.TestManagedRunnable;
+import org.wildfly.as.concurrent.context.TestManagedTaskListener;
+import org.wildfly.as.concurrent.context.TestRunnable;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerExecutorService;
+import org.wildfly.as.concurrent.tasklistener.TestTaskListenerExecutors;
+import org.wildfly.as.concurrent.tasklistener.impl.TaskListenerThreadPoolExecutor;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class SharedManagedTaskThreadPoolExecutorTestCase {
+
+    protected ComponentManagedExecutorService componentExecutor1;
+    protected ComponentManagedExecutorService componentExecutor2;
+    protected ComponentManagedExecutorService componentExecutor3;
+    protected TaskListenerExecutorService taskListenerExecutorService;
+
+    protected void createExecutors() {
+        createThreadPoolExecutor();
+        componentExecutor1 = createServerManagedExecutorService();
+        componentExecutor2 = createServerManagedExecutorService();
+    }
+
+    protected void createThreadPoolExecutor() {
+        taskListenerExecutorService = TestTaskListenerExecutors.newExecutor();
+    }
+
+    protected ComponentManagedExecutorService createServerManagedExecutorService() {
+        return TestExecutors.newComponentManagedExecutorService((TaskListenerThreadPoolExecutor) taskListenerExecutorService);
+    }
+
+    @Before
+    public void beforeTest() {
+        createExecutors();
+    }
+
+    @Test
+    public void testSubmitThreadPoolExecutorSharing() throws Exception {
+
+        // submit a few tasks which blocks on execution to executor 1
+        final ReentrantLock lock11 = new ReentrantLock();
+        lock11.lock();
+        final TestRunnable task11 = new TestRunnable();
+        final Runnable innerTask11 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock11.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task11.setInnerTask(innerTask11);
+        Future future11 = componentExecutor1.submit(task11);
+        while (!lock11.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        final ReentrantLock lock12 = new ReentrantLock();
+        lock12.lock();
+        TestCallable task12 = new TestCallable();
+        Runnable innerTask12 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock12.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task12.setInnerTask(innerTask12);
+        final Future future12 = componentExecutor1.submit(task12);
+        while (!lock12.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        final ReentrantLock lock13 = new ReentrantLock();
+        lock13.lock();
+        final TestManagedRunnable task13 = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        final Runnable innerTask13 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock13.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task13.setInnerTask(innerTask13);
+        final Future future13 = componentExecutor1.submit(task13);
+        // wait till the task is blocked
+        while (!lock13.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        // submit another task that blocks on execution, but to executor 2
+        final ReentrantLock lock2 = new ReentrantLock();
+        lock2.lock();
+        final TestManagedCallable task2 = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length);
+        final Runnable runnable2 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock2.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task2.setInnerTask(runnable2);
+        final Future future2 = componentExecutor2.submit(task2);
+        // wait till the task is blocked
+        while (!lock2.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        // shutdown executor 1, this should cancel all 1x tasks
+        shutdownServerManagedExecutorService(componentExecutor1);
+
+        // assert tasks 1x status
+        Assert.assertTrue(future11.isCancelled());
+        Assert.assertTrue(future11.isDone());
+        task11.assertContextWasSet();
+        task11.assertContextWasReset();
+        Assert.assertTrue(future12.isCancelled());
+        Assert.assertTrue(future12.isDone());
+        task12.assertContextWasSet();
+        task12.assertContextWasReset();
+        Assert.assertTrue(future13.isCancelled());
+        Assert.assertTrue(future13.isDone());
+        task13.assertContextWasSet();
+        task13.assertContextWasReset();
+        final TestManagedTaskListener listener13 = task13.getTestManagedTaskListener();
+        listener13.assertListenerDone();
+        listener13.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+
+        // ensure task 2 was not cancelled
+        Assert.assertFalse(future2.isCancelled());
+        Assert.assertFalse(future2.isDone());
+
+        // unlock task2 so it completes its execution
+        lock2.unlock();
+        future2.get();
+        task2.assertContextWasSet();
+        task2.assertContextWasReset();
+        final TestManagedTaskListener listener2 = task2.getTestManagedTaskListener();
+        listener2.assertListenerDone();
+        listener2.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+
+        // shutdown executor 2
+        shutdownServerManagedExecutorService(componentExecutor2);
+
+        // ensure shared thread pool is alive
+        Assert.assertFalse(taskListenerExecutorService.isShutdown());
+
+        // create a 3rd executor and execute a task
+        componentExecutor3 = createServerManagedExecutorService();
+        final TestRunnable task3 = new TestRunnable();
+        componentExecutor3.submit(task3).get();
+        task3.assertContextWasSet();
+        task3.assertContextWasReset();
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        shutdownExecutors();
+    }
+
+    protected void shutdownExecutors() throws Exception {
+        shutdownServerManagedExecutorService(componentExecutor1);
+        shutdownServerManagedExecutorService(componentExecutor2);
+        shutdownServerManagedExecutorService(componentExecutor3);
+        shutdownThreadPoolExecutor();
+    }
+
+    protected void shutdownServerManagedExecutorService(ComponentManagedExecutorService executorService) throws Exception {
+        if (executorService != null) {
+            executorService.internalShutdown();
+        }
+    }
+
+    protected void shutdownThreadPoolExecutor() throws Exception {
+        if (taskListenerExecutorService != null) {
+            taskListenerExecutorService.shutdown();
+            if (!taskListenerExecutorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                fail();
+            }
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/SharedTaskListenerExecutorServiceTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/SharedTaskListenerExecutorServiceTestCase.java
@@ -1,0 +1,178 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.as.concurrent.component.ComponentManagedExecutorService;
+import org.wildfly.as.concurrent.component.ComponentManagedScheduledExecutorService;
+import org.wildfly.as.concurrent.context.TestCallable;
+import org.wildfly.as.concurrent.context.TestManagedCallable;
+import org.wildfly.as.concurrent.context.TestManagedRunnable;
+import org.wildfly.as.concurrent.context.TestManagedTaskListener;
+import org.wildfly.as.concurrent.context.TestRunnable;
+import org.wildfly.as.concurrent.tasklistener.TestTaskListenerExecutors;
+import org.wildfly.as.concurrent.tasklistener.impl.TaskListenerScheduledThreadPoolExecutor;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ *
+ */
+public class SharedTaskListenerExecutorServiceTestCase extends SharedManagedTaskThreadPoolExecutorTestCase {
+
+    protected ComponentManagedScheduledExecutorService componentScheduler1;
+    protected ComponentManagedScheduledExecutorService componentScheduler2;
+    protected ComponentManagedScheduledExecutorService componentScheduler3;
+
+    protected void createExecutors() {
+        super.createExecutors();
+        componentScheduler1 = (ComponentManagedScheduledExecutorService) componentExecutor1;
+        componentScheduler2 = (ComponentManagedScheduledExecutorService) componentExecutor2;
+    }
+
+    protected void createThreadPoolExecutor() {
+        taskListenerExecutorService = TestTaskListenerExecutors.newScheduledExecutor();
+    }
+
+    protected ComponentManagedExecutorService createServerManagedExecutorService() {
+        return TestExecutors.newComponentManagedScheduledExecutorService((TaskListenerScheduledThreadPoolExecutor) taskListenerExecutorService);
+    }
+
+    @Test
+    public void testScheduleThreadPoolExecutorSharing() throws Exception {
+
+        // schedule a few tasks to executor 1, some which blocks on execution, other with long delay for execution
+        final ReentrantLock lock11 = new ReentrantLock();
+        lock11.lock();
+        final TestRunnable task11 = new TestRunnable();
+        final Runnable innerTask11 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock11.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task11.setInnerTask(innerTask11);
+        Future future11 = componentScheduler1.schedule(task11, 10, TimeUnit.NANOSECONDS);
+        while (!lock11.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        TestCallable task12 = new TestCallable();
+        final Future future12 = componentScheduler1.schedule(task12, 10, TimeUnit.HOURS);
+
+
+        final ReentrantLock lock13 = new ReentrantLock();
+        lock13.lock();
+        final TestManagedRunnable task13 = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        final Runnable innerTask13 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock13.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task13.setInnerTask(innerTask13);
+        final Future future13 = componentScheduler1.schedule(task13, 10, TimeUnit.NANOSECONDS);
+        // wait till the task is blocked
+        while (!lock13.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        // schedule another task that blocks on execution, but to executor 2
+        final ReentrantLock lock2 = new ReentrantLock();
+        lock2.lock();
+        final TestManagedCallable task2 = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length);
+        final Runnable runnable2 = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock2.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task2.setInnerTask(runnable2);
+        final Future future2 = componentScheduler2.schedule(task2, 10, TimeUnit.NANOSECONDS);
+        // wait till the task is blocked
+        while (!lock2.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+
+        // shutdown executor 1, this should cancel all 1x tasks
+        shutdownServerManagedExecutorService(componentScheduler1);
+
+        // assert tasks 1x status
+        Assert.assertTrue(future11.isCancelled());
+        Assert.assertTrue(future11.isDone());
+        task11.assertContextWasSet();
+        task11.assertContextWasReset();
+        Assert.assertTrue(future12.isCancelled());
+        Assert.assertTrue(future12.isDone());
+        Assert.assertTrue(future13.isCancelled());
+        Assert.assertTrue(future13.isDone());
+        task13.assertContextWasSet();
+        task13.assertContextWasReset();
+        final TestManagedTaskListener listener13 = task13.getTestManagedTaskListener();
+        listener13.assertListenerDone();
+        listener13.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+
+        // ensure task 2 was not cancelled
+        Assert.assertFalse(future2.isCancelled());
+        Assert.assertFalse(future2.isDone());
+
+        // unlock task2 so it completes its execution
+        lock2.unlock();
+        future2.get();
+        task2.assertContextWasSet();
+        task2.assertContextWasReset();
+        final TestManagedTaskListener listener2 = task2.getTestManagedTaskListener();
+        listener2.assertListenerDone();
+        listener2.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+
+        // shutdown executor 2
+        shutdownServerManagedExecutorService(componentScheduler2);
+
+        // ensure shared thread pool is alive
+        Assert.assertFalse(taskListenerExecutorService.isShutdown());
+
+        // create a 3rd executor and execute a task
+        componentScheduler3 = (ComponentManagedScheduledExecutorService) createServerManagedExecutorService();
+        final TestRunnable task3 = new TestRunnable();
+        componentScheduler3.schedule(task3, 10, TimeUnit.NANOSECONDS).get();
+        task3.assertContextWasSet();
+        task3.assertContextWasReset();
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/TestExecutors.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/TestExecutors.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent;
+
+import org.wildfly.as.concurrent.context.ContextConfiguration;
+import org.wildfly.as.concurrent.context.TestContextExecutors;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerExecutorService;
+import org.wildfly.as.concurrent.tasklistener.TaskListenerScheduledExecutorService;
+import org.wildfly.as.concurrent.tasklistener.TestTaskListenerExecutors;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestExecutors {
+
+    private TestExecutors() {
+    }
+
+    public static ManagedExecutorServiceImpl newComponentManagedExecutorService() {
+        return newComponentManagedExecutorService(TestTaskListenerExecutors.newExecutor());
+    }
+
+    public static ManagedExecutorServiceImpl newComponentManagedExecutorService(TaskListenerExecutorService taskListenerExecutorService) {
+        return new ManagedExecutorServiceImpl(taskListenerExecutorService, newContextConfiguration());
+    }
+
+    public static ManagedScheduledExecutorServiceImpl newComponentManagedScheduledExecutorService() {
+        return newComponentManagedScheduledExecutorService(TestTaskListenerExecutors.newScheduledExecutor());
+    }
+
+    public static ManagedScheduledExecutorServiceImpl newComponentManagedScheduledExecutorService(TaskListenerScheduledExecutorService taskListenerScheduledExecutorService) {
+        return new ManagedScheduledExecutorServiceImpl(taskListenerScheduledExecutorService, newContextConfiguration());
+    }
+
+    public static ContextConfiguration newContextConfiguration() {
+        return TestContextExecutors.newContextConfiguration();
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/AbstractManagedExecutorServiceTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/AbstractManagedExecutorServiceTestCase.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public abstract class AbstractManagedExecutorServiceTestCase {
+
+    protected ContextualManagedExecutorService executor;
+
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestContextExecutors.newContextualManagedExecutorService();
+    }
+
+    protected void shutdownExecutor() throws Exception {
+        executor.shutdown();
+        if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+    @Before
+    public void beforeTest() {
+        executor = newExecutor();
+        Assert.assertTrue(TestContext.allContexts.isEmpty());
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        shutdownExecutor();
+        Assert.assertTrue(TestContext.allContexts.isEmpty());
+    }
+
+    protected void assertFutureTermination(Future future, boolean cancelled) {
+        Assert.assertNotNull(future);
+        Assert.assertTrue(future.isDone());
+        Assert.assertEquals(cancelled, future.isCancelled());
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedExecutorServiceAbortedTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedExecutorServiceAbortedTestCase.java
@@ -1,0 +1,202 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedExecutorServiceAbortedTestCase extends AbstractManagedExecutorServiceTestCase {
+
+    // execute
+
+    @Test
+    public void testExecuteRunnableAborted() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        executor.execute(task);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testExecuteManagedRunnableAborted() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        executor.execute(task);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution);
+    }
+
+    // submit
+
+    @Test
+    public void testSubmitRunnableAborted() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            executor.submit(task).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitRunnableWithValueAborted() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            executor.submit(task, new Object()).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitCallableAborted() throws Exception {
+        TestCallable task = new TestCallable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            executor.submit(task).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitManagedRunnableAborted() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            executor.submit(task).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution);
+    }
+
+    @Test
+    public void testSubmitManagedRunnableWithValueAborted() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            executor.submit(task, new Object()).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution);
+    }
+
+    @Test
+    public void testSubmitManagedCallableAborted() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            executor.submit(task).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedExecutorServiceCancellationTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedExecutorServiceCancellationTestCase.java
@@ -1,0 +1,234 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Test;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedExecutorServiceCancellationTestCase extends AbstractManagedExecutorServiceTestCase {
+
+    // submit
+
+    @Test
+    public void testSubmitRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = executor.submit(task);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitRunnableWithValueCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = executor.submit(task, new Object());
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitCallableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestCallable task = new TestCallable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = executor.submit(task);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitManagedRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = executor.submit(task);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+    @Test
+    public void testSubmitManagedRunnableWithValueCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = executor.submit(task, new Object());
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+    @Test
+    public void testSubmitManagedCallableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = executor.submit(task);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener managedTaskListener = task.getTestManagedTaskListener();
+        managedTaskListener.assertListenerDone();
+        managedTaskListener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedExecutorServiceStandardTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedExecutorServiceStandardTestCase.java
@@ -1,0 +1,196 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+/**
+ *
+ */
+public class ManagedExecutorServiceStandardTestCase extends AbstractManagedExecutorServiceTestCase {
+
+    // execute
+
+    @Test
+    public void testExecuteRunnable() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.assertContextIsNotSet();
+        executor.execute(task);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testExecuteManagedRunnable() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length, false);
+        task.assertContextIsNotSet();
+        executor.execute(task);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+    }
+
+    // submit
+
+    @Test
+    public void testSubmitRunnable() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.assertContextIsNotSet();
+        executor.submit(task).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitRunnableWithValue() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.assertContextIsNotSet();
+        executor.submit(task, new Object()).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitCallable() throws Exception {
+        TestCallable task = new TestCallable();
+        task.assertContextIsNotSet();
+        executor.submit(task).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testSubmitManagedRunnable() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length);
+        task.assertContextIsNotSet();
+        executor.submit(task).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+    }
+
+    @Test
+    public void testSubmitManagedRunnableWithValue() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length, false);
+        task.assertContextIsNotSet();
+        executor.submit(task, new Object()).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+    }
+
+    @Test
+    public void testSubmitManagedCallable() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length);
+        task.assertContextIsNotSet();
+        executor.submit(task).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+    }
+
+    // invoke all
+
+    @Test
+    public void testInvokeAllCallable() throws Exception {
+        Set<TestCallable<Object>> taskSet = new HashSet<>();
+        taskSet.add(new TestCallable());
+        taskSet.add(new TestCallable());
+        taskSet.add(new TestCallable());
+        for (TestCallable task : taskSet) {
+            task.assertContextIsNotSet();
+        }
+        List<Future<Object>> futures = executor.invokeAll(taskSet);
+        for (Future future : futures) {
+            future.get();
+        }
+        for (TestCallable callable : taskSet) {
+            callable.assertContextWasSet();
+            callable.assertContextWasReset();
+        }
+    }
+
+    @Test
+    public void testInvokeAllManagedCallable() throws Exception {
+        Set<TestManagedCallable<Object>> taskSet = new HashSet<>();
+        taskSet.add(new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length, false));
+        taskSet.add(new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length, true));
+        taskSet.add(new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length, false));
+        for (TestManagedCallable task : taskSet) {
+            task.assertContextIsNotSet();
+        }
+        List<Future<Object>> futures = executor.invokeAll(taskSet);
+        for (Future future : futures) {
+            future.get();
+        }
+        for (TestManagedCallable managedCallable : taskSet) {
+            managedCallable.assertContextWasSet();
+            managedCallable.assertContextWasReset();
+            TestManagedTaskListener listener = managedCallable.getTestManagedTaskListener();
+            listener.assertListenerDone();
+            listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+        }
+    }
+
+    // invoke any 
+
+    @Test
+    public void testInvokeAnyCallable() throws Exception {
+        Set<TestCallable<Object>> taskSet = new HashSet<>();
+        taskSet.add(new TestCallable());
+        taskSet.add(new TestCallable());
+        taskSet.add(new TestCallable());
+        for (TestCallable task : taskSet) {
+            task.assertContextIsNotSet();
+        }
+        executor.invokeAny(taskSet);
+        // TODO ensure any was truly invoked with success
+    }
+
+    @Test
+    public void testInvokeAnyManagedCallable() throws Exception {
+        Set<TestManagedCallable<Object>> taskSet = new HashSet<>();
+        taskSet.add(new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length));
+        taskSet.add(new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length));
+        taskSet.add(new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length));
+        for (TestManagedCallable task : taskSet) {
+            task.assertContextIsNotSet();
+        }
+        executor.invokeAny(taskSet);
+        // TODO ensure any was truly invoked with success
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedScheduledExecutorServiceAbortedTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedScheduledExecutorServiceAbortedTestCase.java
@@ -1,0 +1,410 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedScheduledExecutorServiceAbortedTestCase extends ManagedExecutorServiceAbortedTestCase {
+
+    protected ContextualManagedScheduledExecutorService scheduledExecutor;
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestContextExecutors.newContextualManagedScheduledExecutorService();
+    }
+
+    @Before
+    public void beforeTest() {
+        super.beforeTest();
+        scheduledExecutor = (ContextualManagedScheduledExecutorService) executor;
+    }
+
+    // schedule
+
+    @Test
+    public void testScheduleRunnableAborted() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleCallableAborted() throws Exception {
+        TestCallable task = new TestCallable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleManagedRunnableAborted() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution);
+    }
+
+    @Test
+    public void testSubmitManagedCallableAborted() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        task.assertContextIsNotSet();
+        try {
+            scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForAbortedExecution);
+    }
+
+    // periodic - at fixed rate
+
+    @Test
+    public void testScheduleAtFixedRateRunnableAborted() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    throw new RuntimeException();
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (executions.get() < 1) {
+            Thread.sleep(50);
+        }
+        try {
+            future.get();
+            fail("task should have been aborted");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleAtFixedRateManagedRunnableAborted() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedCallbacksForTwoExecutionsAborted.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    throw new RuntimeException();
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (executions.get() < 1) {
+            Thread.sleep(50);
+        }
+        try {
+            future.get();
+            fail("task should have been aborted");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedCallbacksForTwoExecutionsAborted);
+    }
+
+    // periodic - with fixed delay
+
+    @Test
+    public void testScheduleWithFixedDelayRunnableAborted() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    throw new RuntimeException();
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (executions.get() < 1) {
+            Thread.sleep(50);
+        }
+        try {
+            future.get();
+            fail("task should have been aborted");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayManagedRunnableAborted() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedCallbacksForTwoExecutionsAborted.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    throw new RuntimeException();
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (executions.get() < 1) {
+            Thread.sleep(50);
+        }
+        try {
+            future.get();
+            fail("task should have been aborted");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedCallbacksForTwoExecutionsAborted);
+    }
+
+    // trigger
+
+    @Test
+    public void testScheduleTriggerRunnableAborted() throws Exception {
+        TestRunnable task = new TestRunnable(2);
+        TestTrigger trigger = new TestTrigger(task.toString(), false, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerCallableAborted() throws Exception {
+        TestCallable task = new TestCallable(2);
+        TestTrigger trigger = new TestTrigger(task.toString(), false, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedRunnableAborted() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(2, TestManagedTaskListener.expectedListenerCallbacksForTriggerWithAbortExecution.length);
+        TestTrigger trigger = new TestTrigger(task.toString(), false, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerWithAbortExecution);
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedCallableAborted() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(2, TestManagedTaskListener.expectedListenerCallbacksForTriggerWithAbortExecution.length);
+        task.identityName = UUID.randomUUID().toString();
+        TestTrigger trigger = new TestTrigger(task.identityName, false, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerWithAbortExecution);
+        trigger.assertResults();
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerRunnableSkippedAndAborted() throws Exception {
+        TestRunnable task = new TestRunnable(1);
+        TestTrigger trigger = new TestTrigger(task.toString(), true, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerCallableSkippedAndAborted() throws Exception {
+        TestCallable task = new TestCallable(1);
+        TestTrigger trigger = new TestTrigger(task.toString(), true, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedRunnableSkippedAndAborted() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(1, TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipAndAbortExecution.length);
+        task.identityName = UUID.randomUUID().toString();
+        TestTrigger trigger = new TestTrigger(task.identityName, true, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipAndAbortExecution);
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedCallableSkippedAndAborted() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(1, TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipAndAbortExecution.length);
+        TestTrigger trigger = new TestTrigger(task.toString(), true, true);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipAndAbortExecution);
+        try {
+            future.get();
+            fail();
+        } catch (Throwable e) {
+            // expected
+        }
+        assertFutureTermination(future, false);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedScheduledExecutorServiceCancellationTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedScheduledExecutorServiceCancellationTestCase.java
@@ -1,0 +1,778 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.Trigger;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class ManagedScheduledExecutorServiceCancellationTestCase extends ManagedExecutorServiceCancellationTestCase {
+
+    protected ContextualManagedScheduledExecutorService scheduledExecutor;
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestContextExecutors.newContextualManagedScheduledExecutorService();
+    }
+
+    @Before
+    public void beforeTest() {
+        super.beforeTest();
+        scheduledExecutor = (ContextualManagedScheduledExecutorService) executor;
+    }
+
+    // schedule
+
+    @Test
+    public void testScheduleRunnableCancellationBeforeExecution() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.SECONDS);
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextIsNotSet();
+    }
+
+    @Test
+    public void testScheduleCallableCancellationBeforeExecution() throws Exception {
+        TestCallable task = new TestCallable();
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.SECONDS);
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextIsNotSet();
+    }
+
+    @Test
+    public void testScheduleManagedRunnableCancellationBeforeExecution() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution.length);
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.SECONDS);
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextIsNotSet();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleManagedCallableCancellationBeforeExecution() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution.length);
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.SECONDS);
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextIsNotSet();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+
+    @Test
+    public void testScheduleCallableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestCallable task = new TestCallable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleManagedRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+    @Test
+    public void testScheduleManagedRunnableWithValueCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        task.assertContextIsNotSet();
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+    // periodic - at fixed rate
+
+    @Test
+    public void testScheduleAtFixedRateRunnableCancellationDuringExecution() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    try {
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleAtFixedRateManagedRunnableCancellationDuringExecution() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    try {
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution);
+    }
+
+    @Test
+    public void testScheduleAtFixedRateRunnableCancellationBeforeExecution() throws Exception {
+        final CountDownLatch done = new CountDownLatch(1);
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                done.countDown();
+            }
+        };
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10000, TimeUnit.MILLISECONDS);
+        if (!done.await(1, TimeUnit.SECONDS)) {
+            fail("task should have been executed");
+        }
+        // give it time to reschedule
+        Thread.sleep(100);
+        // and cancel
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleAtFixedRateManagedRunnableCancellationBeforeExecution() throws Exception {
+        final CountDownLatch done = new CountDownLatch(1);
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                done.countDown();
+            }
+        };
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10000, TimeUnit.MILLISECONDS);
+        if (!done.await(1, TimeUnit.SECONDS)) {
+            fail("task should have been executed");
+        }
+        // give it time to reschedule
+        Thread.sleep(100);
+        // and cancel
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution);
+    }
+
+    // periodic - with fixed delay
+
+    @Test
+    public void testScheduleWithFixedDelayRunnableCancellationDuringExecution() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    try {
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayManagedRunnableCancellationDuringExecution() throws Exception {
+        final AtomicInteger executions = new AtomicInteger(0);
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                if (executions.incrementAndGet() > 1) {
+                    try {
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution);
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayRunnableCancellationBeforeExecution() throws Exception {
+        final CountDownLatch done = new CountDownLatch(1);
+        final TestRunnable task = new TestRunnable();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                done.countDown();
+            }
+        };
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10000, TimeUnit.MILLISECONDS);
+        if (!done.await(1, TimeUnit.SECONDS)) {
+            fail("task should have been executed");
+        }
+        // give it time to reschedule
+        Thread.sleep(100);
+        // and cancel
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayManagedRunnableCancellationBeforeExecution() throws Exception {
+        final CountDownLatch done = new CountDownLatch(1);
+        final TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution.length);
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                done.countDown();
+            }
+        };
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10000, TimeUnit.MILLISECONDS);
+        if (!done.await(1, TimeUnit.SECONDS)) {
+            fail("task should have been executed");
+        }
+        // give it time to reschedule
+        Thread.sleep(100);
+        // and cancel
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution);
+    }
+
+    // trigger
+
+    @Test
+    public void testScheduleTriggerRunnableCancellationBeforeExecution() throws Exception {
+        TestRunnable task = new TestRunnable();
+        task.assertContextIsNotSet();
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 5000L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        scheduledExecutor.schedule(task, trigger).cancel(false);
+        task.assertContextIsNotSet();
+    }
+
+    @Test
+    public void testScheduleTriggerCallableCancellationBeforeExecution() throws Exception {
+        TestCallable task = new TestCallable();
+        task.assertContextIsNotSet();
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 5000L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        scheduledExecutor.schedule(task, trigger).cancel(false);
+        task.assertContextIsNotSet();
+    }
+
+    @Test
+    public void testScheduleTriggerManagedRunnableCancellationBeforeExecution() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution.length);
+        task.assertContextIsNotSet();
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 5000L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        scheduledExecutor.schedule(task, trigger).cancel(false);
+        task.assertContextIsNotSet();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedCallableCancellationBeforeExecution() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution.length);
+        task.assertContextIsNotSet();
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 5000L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        scheduledExecutor.schedule(task, trigger).cancel(false);
+        task.assertContextIsNotSet();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleTriggerRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        TestRunnable task = new TestRunnable();
+        task.assertContextIsNotSet();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        // create trigger to schedule task for 10ms delay
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 10L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        Future future = scheduledExecutor.schedule(task, trigger);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleTriggerCallableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        TestCallable task = new TestCallable();
+        task.assertContextIsNotSet();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        // create trigger to schedule task for 10ms delay
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 10L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        Future future = scheduledExecutor.schedule(task, trigger);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleTriggerManagedRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.assertContextIsNotSet();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        // create trigger to schedule task for 10ms delay
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 10L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        Future future = scheduledExecutor.schedule(task, trigger);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedCallableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution.length);
+        task.assertContextIsNotSet();
+        task.innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        // create trigger to schedule task for 10ms delay
+        final Trigger trigger = new Trigger() {
+            @Override
+            public Date getNextRunTime(LastExecution lastExecutionInfo, Date taskScheduledTime) {
+                return new Date(System.currentTimeMillis() + 10L);
+            }
+
+            @Override
+            public boolean skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime) {
+                return false;
+            }
+        };
+        Future future = scheduledExecutor.schedule(task, trigger);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForCancellationDuringExecution);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedScheduledExecutorServiceStandardTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/ManagedScheduledExecutorServiceStandardTestCase.java
@@ -1,0 +1,202 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ */
+public class ManagedScheduledExecutorServiceStandardTestCase extends ManagedExecutorServiceStandardTestCase {
+
+    protected ContextualManagedScheduledExecutorService scheduledExecutor;
+
+    @Override
+    protected ContextualManagedExecutorService newExecutor() {
+        return TestContextExecutors.newContextualManagedScheduledExecutorService();
+    }
+
+    @Before
+    public void beforeTest() {
+        super.beforeTest();
+        scheduledExecutor = (ContextualManagedScheduledExecutorService) executor;
+    }
+
+    // schedule
+
+    @Test
+    public void testScheduleRunnable() throws Exception {
+        TestRunnable task = new TestRunnable();
+        scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleCallable() throws Exception {
+        TestCallable task = new TestCallable();
+        scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+    }
+
+    @Test
+    public void testScheduleManagedRunnable() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length);
+        scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+    }
+
+    @Test
+    public void testScheduleManagedCallable() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution.length);
+        scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForNormalExecution);
+    }
+
+    // trigger
+
+    @Test
+    public void testScheduleTriggerRunnable() throws Exception {
+        TestRunnable task = new TestRunnable(3);
+        TestTrigger trigger = new TestTrigger(task.toString(), false, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerCallable() throws Exception {
+        TestCallable task = new TestCallable(3);
+        TestTrigger trigger = new TestTrigger(task.toString(), false, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedRunnable() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(3, TestManagedTaskListener.expectedListenerCallbacksForTriggerExecution.length);
+        TestTrigger trigger = new TestTrigger(task.toString(), false, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerExecution);
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedCallable() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(3, TestManagedTaskListener.expectedListenerCallbacksForTriggerExecution.length);
+        task.identityName = UUID.randomUUID().toString();
+        TestTrigger trigger = new TestTrigger(task.identityName, false, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerExecution);
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerRunnableSkipped() throws Exception {
+        TestRunnable task = new TestRunnable(2);
+        TestTrigger trigger = new TestTrigger(task.toString(), true, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerCallableSkipped() throws Exception {
+        TestCallable task = new TestCallable(2);
+        TestTrigger trigger = new TestTrigger(task.toString(), true, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedRunnableSkipped() throws Exception {
+        TestManagedRunnable task = new TestManagedRunnable(2, TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipExecution.length);
+        task.identityName = UUID.randomUUID().toString();
+        TestTrigger trigger = new TestTrigger(task.identityName, true, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipExecution);
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+    @Test
+    public void testScheduleTriggerManagedCallableSkipped() throws Exception {
+        TestManagedCallable task = new TestManagedCallable(2, TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipExecution.length);
+        TestTrigger trigger = new TestTrigger(task.toString(), true, false);
+        ScheduledFuture future = scheduledExecutor.schedule(task, trigger);
+        task.assertContextWasSet();
+        task.assertContextWasReset();
+        trigger.assertResults();
+        TestManagedTaskListener listener = task.getTestManagedTaskListener();
+        listener.assertListenerDone();
+        listener.assertListenerGotExpectedCallbacks(TestManagedTaskListener.expectedListenerCallbacksForTriggerWithSkipExecution);
+        future.get();
+        assertFutureTermination(future, false);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestCallable.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestCallable.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestCallable<V> extends TestTask implements Callable<V> {
+
+    public TestCallable() {
+        super();
+    }
+
+    public TestCallable(int executions) {
+        super(executions);
+    }
+
+    @Override
+    public V call() throws Exception {
+        super.execute();
+        return null;
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestContext.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestContext.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestContext implements Context {
+
+    public static final ConcurrentHashMap<SetData, Boolean> allContexts = new ConcurrentHashMap<>();
+    static final ThreadLocal<SetData> threadLocal = new ThreadLocal<>();
+
+    private final Object object;
+
+    public TestContext(Object object) {
+        this.object = object;
+    }
+
+    static SetData getCurrent() {
+        return threadLocal.get();
+    }
+
+    @Override
+    public Context set() {
+        SetData previous = getCurrent();
+        SetData current = new SetData();
+        current.testContext = this;
+        current.countDownLatch = new CountDownLatch(1);
+        allContexts.put(current, Boolean.TRUE);
+        threadLocal.set(current);
+        ResetContext resetContext = new ResetContext();
+        resetContext.context = this;
+        resetContext.previous = previous;
+        resetContext.current = current;
+        return resetContext;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+    static class SetData {
+        TestContext testContext;
+        CountDownLatch countDownLatch;
+    }
+
+    static class ResetContext implements Context {
+
+        TestContext context;
+        SetData previous;
+        SetData current;
+
+        @Override
+        public Context set() {
+            if (threadLocal.get() != current) {
+                throw new IllegalStateException();
+            }
+            threadLocal.set(previous);
+            allContexts.remove(current);
+            current.countDownLatch.countDown();
+            return context;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TestContext that = (TestContext) o;
+
+        if (!object.equals(that.object)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return object.hashCode();
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestContextConfiguration.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestContextConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedTaskListener;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestContextConfiguration implements ContextConfiguration {
+
+    @Override
+    public Context newTaskContext(Object task) {
+        return new TestContext(task);
+    }
+
+    @Override
+    public Context newManagedTaskListenerContext(ManagedTaskListener listener) {
+        return new TestContext(listener);
+    }
+
+    @Override
+    public Context newContextualProxyContext(Object instance) {
+        return new TestContext(instance);
+    }
+
+    @Override
+    public Context newManageableThreadContext(Runnable task) {
+        return new TestContext(task);
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestContextExecutors.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestContextExecutors.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.wildfly.as.concurrent.tasklistener.TestTaskListenerExecutors;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestContextExecutors {
+
+    private TestContextExecutors() {
+    }
+
+    public static ContextualManagedExecutorService newContextualManagedExecutorService() {
+        return new ContextualManagedExecutorService(TestTaskListenerExecutors.newExecutor(), newContextConfiguration());
+    }
+
+    public static ContextualManagedExecutorService newContextualManagedScheduledExecutorService() {
+        return new ContextualManagedScheduledExecutorService(TestTaskListenerExecutors.newScheduledExecutor(), newContextConfiguration());
+    }
+
+    public static ContextConfiguration newContextConfiguration() {
+        return new TestContextConfiguration();
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedCallable.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedCallable.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestManagedCallable<V> extends TestManagedTask implements Callable<V> {
+
+    public TestManagedCallable(int expectedCallbacks) {
+        this(1, expectedCallbacks);
+    }
+
+    public TestManagedCallable(int expectedCallbacks, boolean contextualListener) {
+        this(1, expectedCallbacks, contextualListener);
+    }
+
+    public TestManagedCallable(int executions, int expectedCallbacks) {
+        this(executions, expectedCallbacks, true);
+    }
+
+    public TestManagedCallable(int executions, int expectedCallbacks, boolean contextualListener) {
+        super(executions, expectedCallbacks, contextualListener);
+    }
+
+    @Override
+    public V call() throws Exception {
+        super.execute();
+        return null;
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedRunnable.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedRunnable.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestManagedRunnable extends TestManagedTask implements Runnable {
+
+    public TestManagedRunnable(int expectedCallbacks) {
+        this(1, expectedCallbacks);
+    }
+
+    public TestManagedRunnable(int expectedCallbacks, boolean contextualListener) {
+        this(1, expectedCallbacks, contextualListener);
+    }
+
+    public TestManagedRunnable(int executions, int expectedCallbacks) {
+        this(executions, expectedCallbacks, true);
+    }
+
+    public TestManagedRunnable(int executions, int expectedCallbacks, boolean contextualListener) {
+        super(executions, expectedCallbacks, contextualListener);
+    }
+
+    @Override
+    public void run() {
+        super.execute();
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedTask.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedTask.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestManagedTask extends TestTask implements ManagedTask {
+
+    private final TestManagedTaskListener listener;
+    String identityName = null;
+    final boolean contextualListener;
+
+    public TestManagedTask(int executions, int expectedCallbacks) {
+        this(executions, expectedCallbacks, true);
+    }
+
+    public TestManagedTask(int executions, int expectedCallbacks, boolean contextualListener) {
+        super(executions);
+        listener = new TestManagedTaskListener(expectedCallbacks, contextualListener);
+        this.contextualListener = contextualListener;
+    }
+
+    public TestManagedTaskListener getTestManagedTaskListener() {
+        return listener;
+    }
+
+    @Override
+    public Map<String, String> getExecutionProperties() {
+        Map<String, String> executionProperties = new HashMap<>();
+        executionProperties.put("javax.enterprise.ee.CONTEXTUAL_CALLBACK_HINT", Boolean.toString(contextualListener));
+        if (identityName != null) {
+            executionProperties.put("javax.enterprise.ee.IDENTITY_NAME", identityName);
+        }
+        return executionProperties;
+    }
+
+    @Override
+    public ManagedTaskListener getManagedTaskListener() {
+        return getTestManagedTaskListener();
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedTaskListener.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestManagedTaskListener.java
@@ -1,0 +1,156 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Assert;
+
+import javax.enterprise.concurrent.AbortedException;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedTaskListener;
+import javax.enterprise.concurrent.SkippedException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestManagedTaskListener implements ManagedTaskListener {
+
+    public enum CallbackType {aborted, cancelled, skipped, done, starting, submitted, unexpected}
+
+    public static final CallbackType[] expectedListenerCallbacksForNormalExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForAbortedExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.aborted, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForCancellationBeforeExecution = {CallbackType.submitted, CallbackType.cancelled, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForCancellationDuringExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.cancelled, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForTriggerExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForTriggerWithSkipExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.skipped, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForTriggerWithAbortExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.aborted, CallbackType.done};
+    public static final CallbackType[] expectedListenerCallbacksForTriggerWithSkipAndAbortExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.skipped, CallbackType.done, CallbackType.submitted, CallbackType.aborted, CallbackType.done};
+
+    public static final CallbackType[] expectedCallbacksForTwoExecutionsAborted = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.aborted, CallbackType.done};
+    public static final CallbackType[] expectedCallbacksForTwoExecutionsCancelledBeforeExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.cancelled, CallbackType.done};
+    public static final CallbackType[] expectedCallbacksForTwoExecutionsCancelledDuringExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.cancelled, CallbackType.done};
+
+    private final ArrayList<CallbackType> callbacks = new ArrayList<>();
+    private final CountDownLatch done;
+    private final boolean contextual;
+    private boolean expectedContext = true;
+
+
+    public TestManagedTaskListener(int expectedCallbacks, boolean contextual) {
+        this.contextual = contextual;
+        this.done = new CountDownLatch(expectedCallbacks);
+
+    }
+
+    public ArrayList<CallbackType> getCallbacks() {
+        return callbacks;
+    }
+
+    public boolean waitForExpectedCallbacks(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return done.await(timeout, timeUnit);
+    }
+
+    private synchronized void addCallback(CallbackType callbackType) {
+        if (expectedContext) {
+            TestContext.SetData contextSetData = TestContext.getCurrent();
+            if (contextual) {
+                expectedContext = contextSetData != null && contextSetData.testContext.getObject() == this;
+            } else {
+                expectedContext = contextSetData == null || contextSetData.testContext.getObject() != this;
+            }
+            if (!expectedContext) {
+                throw new RuntimeException("unexpected context for " + contextSetData + " set on " + (contextual ? "" : "non") + " contextual listener callback " + callbackType);
+            }
+        }
+        callbacks.add(callbackType);
+        if (done.getCount() == 0) {
+            throw new RuntimeException();
+        }
+        done.countDown();
+    }
+
+    @Override
+    public void taskAborted(Future<?> future, ManagedExecutorService executor, Throwable exception) {
+        if (exception instanceof AbortedException) {
+            addCallback(CallbackType.aborted);
+        } else if (exception instanceof CancellationException) {
+            addCallback(CallbackType.cancelled);
+        } else if (exception instanceof SkippedException) {
+            addCallback(CallbackType.skipped);
+        } else {
+            addCallback(CallbackType.unexpected);
+        }
+    }
+
+    @Override
+    public void taskDone(Future<?> future, ManagedExecutorService executor, Throwable exception) {
+        addCallback(CallbackType.done);
+    }
+
+    @Override
+    public void taskStarting(Future<?> future, ManagedExecutorService executor) {
+        addCallback(CallbackType.starting);
+    }
+
+    @Override
+    public void taskSubmitted(Future<?> future, ManagedExecutorService executor) {
+        addCallback(CallbackType.submitted);
+    }
+
+    public void assertListenerDone() throws InterruptedException {
+        assertListenerDone(5);
+    }
+
+    public void assertListenerDone(int seconds) throws InterruptedException {
+        if (!this.waitForExpectedCallbacks(seconds, TimeUnit.SECONDS)) {
+            fail("Callbacks: " + callbacks);
+        }
+        assertExpectedContextOnCallbacks();
+    }
+
+    public void assertListenerGotExpectedCallbacks(CallbackType[] expectedCallbacks) throws InterruptedException {
+        assertListenerGotExpectedCallbacks(expectedCallbacks, true);
+    }
+
+    public void assertListenerGotExpectedCallbacks(CallbackType[] expectedCallbacks, boolean assertSameLength) throws InterruptedException {
+        List<CallbackType> listenerCallbacks = this.getCallbacks();
+        if (assertSameLength) {
+            Assert.assertEquals("Unexpected listener callbacks size. Listener callbacks: " + listenerCallbacks + ". Expected callbacks: " + Arrays.asList(expectedCallbacks), expectedCallbacks.length, listenerCallbacks.size());
+        }
+        for (int i = 0; i < expectedCallbacks.length; i++) {
+            Assert.assertEquals(expectedCallbacks[i], listenerCallbacks.get(i));
+        }
+    }
+
+    public void assertExpectedContextOnCallbacks() {
+        Assert.assertTrue(expectedContext);
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestRunnable.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestRunnable.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestRunnable extends TestTask implements Runnable {
+
+    public TestRunnable() {
+        super();
+    }
+
+    public TestRunnable(int executions) {
+        super(executions);
+    }
+
+    @Override
+    public void run() {
+        super.execute();
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestTask.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestTask.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Assert;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestTask {
+
+    public TestTask() {
+        this(1);
+    }
+
+    public TestTask(int executions) {
+        done = new CountDownLatch(executions);
+    }
+
+    TestContext.SetData setData;
+    final CountDownLatch done;
+    public Runnable innerTask;
+
+    public void setInnerTask(Runnable innerTask) {
+        this.innerTask = innerTask;
+    }
+
+    public void execute() {
+        setData = TestContext.getCurrent();
+        try {
+            if (innerTask != null) {
+                innerTask.run();
+            }
+        } finally {
+            if (done.getCount() != 0) {
+                done.countDown();
+            } else {
+                throw new RuntimeException();
+            }
+        }
+    }
+
+    public void assertContextIsNotSet() {
+        for (TestContext.SetData setData : TestContext.allContexts.keySet()) {
+            if (setData.testContext.getObject() == this) {
+                fail();
+            }
+        }
+    }
+
+    public void assertContextWasSet() throws InterruptedException {
+        assertContextWasSet(true);
+    }
+
+    public void assertContextWasSet(boolean wait) throws InterruptedException {
+        if (wait) {
+            if (!this.done.await(10, TimeUnit.SECONDS)) {
+                fail();
+            }
+        }
+        Assert.assertTrue(this.setData != null && this.setData.testContext.getObject() == this);
+    }
+
+    public void assertContextWasReset() throws InterruptedException {
+        if (!this.setData.countDownLatch.await(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestTrigger.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/context/TestTrigger.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.context;
+
+import org.junit.Assert;
+
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.Trigger;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestTrigger implements Trigger {
+
+    final CountDownLatch done = new CountDownLatch(1);
+
+    private final String identityName;
+    private final boolean skip;
+    private final boolean abort;
+
+    int nextRunTimeRuns = 0;
+    int skipRuns = 0;
+    LastExecution nextRuntimeLastExecution1;
+    LastExecution nextRuntimeLastExecution2;
+    LastExecution nextRuntimeLastExecution3;
+    LastExecution nextRuntimeLastExecution4;
+    Date nextRuntimeDate1;
+    Date nextRuntimeDate2;
+    Date nextRuntimeDate3;
+    Date scheduledRunTime1;
+    Date scheduledRunTime2;
+    Date scheduledRunTime3;
+    LastExecution skipRunLastExecution1;
+    LastExecution skipRunLastExecution2;
+    LastExecution skipRunLastExecution3;
+
+    public TestTrigger(String identityName, boolean skip, boolean abort) {
+        this.skip = skip;
+        this.abort = abort;
+        this.identityName = identityName;
+    }
+
+    @Override
+    public Date getNextRunTime(LastExecution lastExecution, Date taskScheduledTime) {
+        System.out.println("trigger nextRunTimeRuns" + nextRunTimeRuns);
+        if (nextRunTimeRuns == 0) {
+            nextRuntimeLastExecution1 = lastExecution;
+            nextRunTimeRuns++;
+            nextRuntimeDate1 = new Date(System.currentTimeMillis() + (nextRunTimeRuns * 100));
+            return nextRuntimeDate1;
+        }
+        if (nextRunTimeRuns == 1) {
+            nextRuntimeLastExecution2 = lastExecution;
+            nextRunTimeRuns++;
+            nextRuntimeDate2 = new Date(System.currentTimeMillis() + (nextRunTimeRuns * 100));
+            return nextRuntimeDate2;
+        }
+        if (nextRunTimeRuns == 2) {
+            nextRuntimeLastExecution3 = lastExecution;
+            nextRunTimeRuns++;
+            nextRuntimeDate3 = new Date(System.currentTimeMillis() + (nextRunTimeRuns * 100));
+            return nextRuntimeDate3;
+        }
+        if (nextRunTimeRuns == 3) {
+            nextRunTimeRuns++;
+            nextRuntimeLastExecution4 = lastExecution;
+            // return null to signal task done
+            try {
+                return null;
+            } finally {
+                done.countDown();
+            }
+        }
+        // too many runs already
+        throw new RuntimeException();
+    }
+
+    @Override
+    public boolean skipRun(LastExecution lastExecution, Date scheduledRunTime) {
+        System.out.println("trigger skipRuns" + skipRuns);
+        if (skipRuns == 0) {
+            skipRunLastExecution1 = lastExecution;
+            scheduledRunTime1 = scheduledRunTime;
+            skipRuns++;
+            return false;
+        }
+        if (skipRuns == 1) {
+            skipRunLastExecution2 = lastExecution;
+            scheduledRunTime2 = scheduledRunTime;
+            skipRuns++;
+            return skip;
+        }
+        if (skipRuns == 2) {
+            skipRunLastExecution3 = lastExecution;
+            scheduledRunTime3 = scheduledRunTime;
+            skipRuns++;
+            if (!abort) {
+                return false;
+            } else {
+                throw new RuntimeException();
+            }
+        }
+        // too many runs already
+        throw new RuntimeException();
+    }
+
+    void assertResults() throws Exception {
+
+        assertIsDone();
+
+        Assert.assertEquals(4, nextRunTimeRuns);
+        Assert.assertEquals(3, skipRuns);
+
+        Assert.assertNull(nextRuntimeLastExecution1);
+        Assert.assertNull(skipRunLastExecution1);
+        Assert.assertNotNull(nextRuntimeDate1);
+        Assert.assertNotNull(scheduledRunTime1);
+        Assert.assertEquals(nextRuntimeDate1, scheduledRunTime1);
+
+        Assert.assertNotNull(nextRuntimeLastExecution2);
+        Assert.assertNotNull(skipRunLastExecution2);
+        Assert.assertNotNull(nextRuntimeDate2);
+        Assert.assertNotNull(scheduledRunTime2);
+        Assert.assertEquals(nextRuntimeDate2, scheduledRunTime2);
+        Assert.assertEquals(identityName, nextRuntimeLastExecution2.getIdentityName());
+        Assert.assertEquals(identityName, skipRunLastExecution2.getIdentityName());
+
+
+        Assert.assertNotNull(nextRuntimeLastExecution3);
+        if (skip) {
+            Assert.assertNotNull(nextRuntimeLastExecution3.getRunStart());
+            Assert.assertNull(nextRuntimeLastExecution3.getRunEnd());
+        }
+        Assert.assertNotNull(skipRunLastExecution3);
+        if (skip) {
+            Assert.assertNotNull(skipRunLastExecution3.getRunStart());
+            Assert.assertNull(skipRunLastExecution3.getRunEnd());
+        }
+        Assert.assertNotNull(nextRuntimeDate3);
+        Assert.assertNotNull(scheduledRunTime3);
+        Assert.assertEquals(nextRuntimeDate3, scheduledRunTime3);
+        Assert.assertEquals(identityName, nextRuntimeLastExecution3.getIdentityName());
+        Assert.assertEquals(identityName, skipRunLastExecution3.getIdentityName());
+
+        Assert.assertNotNull(nextRuntimeLastExecution4);
+        if (abort) {
+            Assert.assertNotNull(nextRuntimeLastExecution4.getRunStart());
+            Assert.assertNull(nextRuntimeLastExecution4.getRunEnd());
+        }
+        Assert.assertEquals(identityName, nextRuntimeLastExecution4.getIdentityName());
+    }
+
+    void assertIsDone() throws InterruptedException {
+        assertIsDone(5);
+    }
+
+    void assertIsDone(int seconds) throws InterruptedException {
+        if (!done.await(seconds, TimeUnit.SECONDS)) {
+            Assert.fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TaskListenerScheduledThreadPoolExecutorTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TaskListenerScheduledThreadPoolExecutorTestCase.java
@@ -1,0 +1,313 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class TaskListenerScheduledThreadPoolExecutorTestCase extends TaskListenerThreadPoolExecutorTestCase {
+
+    protected TaskListenerScheduledExecutorService scheduledExecutor;
+
+    protected TaskListenerExecutorService newExecutor() {
+        return TestTaskListenerExecutors.newScheduledExecutor();
+    }
+
+    @Before
+    public void beforeTest() {
+        super.beforeTest();
+        scheduledExecutor = (TaskListenerScheduledExecutorService) executor;
+    }
+
+    @Test
+    public void testScheduleRunnable() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null);
+        scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+    }
+
+    @Test
+    public void testScheduleCallable() throws Exception {
+        TestTaskListenerCallable task = new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null);
+        scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+    }
+
+    @Test
+    public void testScheduleRunnableAborted() throws Exception {
+        final Runnable innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionAborted.length, innerTask);
+        try {
+            scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionAborted);
+    }
+
+    @Test
+    public void testScheduleCallableAborted() throws Exception {
+        final Callable<Object> innerTask = new Callable() {
+            @Override
+            public Object call() throws Exception {
+                throw new RuntimeException();
+            }
+        };
+        TestTaskListenerCallable task = new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionAborted.length, innerTask);
+        try {
+            scheduledExecutor.schedule(task, 10, TimeUnit.MILLISECONDS).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionAborted);
+    }
+
+    @Test
+    public void testScheduleRunnableCancellationBeforeExecution() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionCancelledBeforeExecution.length, null);
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.SECONDS);
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionCancelledBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleCallableCancellationBeforeExecution() throws Exception {
+        TestTaskListenerCallable task = new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionCancelledBeforeExecution.length, null);
+        Future future = scheduledExecutor.schedule(task, 10, TimeUnit.SECONDS);
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionCancelledBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleAtFixedRateAborted() throws Exception {
+        final Runnable innerTask = new Runnable() {
+            int executions = 0;
+
+            @Override
+            public void run() {
+                if (executions > 0) {
+                    throw new RuntimeException();
+                }
+                executions++;
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForTwoExecutionsAborted.length, innerTask);
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (task.getExecutions() < 1) {
+            Thread.sleep(50);
+        }
+        try {
+            future.get();
+            fail("task should have been aborted");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForTwoExecutionsAborted);
+
+    }
+
+    @Test
+    public void testScheduleAtFixedRateCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final Runnable innerTask = new Runnable() {
+            int executions = 0;
+
+            @Override
+            public void run() {
+                if (executions > 0) {
+                    try {
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                executions++;
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution.length, innerTask);
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution);
+    }
+
+    @Test
+    public void testScheduleAtFixedRateCancellationBeforeExecution() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution.length, null);
+        Future future = scheduledExecutor.scheduleAtFixedRate(task, 10, 10000, TimeUnit.MILLISECONDS);
+        while (task.getExecutions() != 1) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution);
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayAborted() throws Exception {
+        final Runnable innerTask = new Runnable() {
+            int executions = 0;
+
+            @Override
+            public void run() {
+                if (executions > 0) {
+                    throw new RuntimeException();
+                }
+                executions++;
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForTwoExecutionsAborted.length, innerTask);
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (task.getExecutions() < 1) {
+            Thread.sleep(50);
+        }
+        try {
+            future.get();
+            fail("task should have been aborted");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForTwoExecutionsAborted);
+
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final Runnable innerTask = new Runnable() {
+            int executions = 0;
+
+            @Override
+            public void run() {
+                if (executions > 0) {
+                    try {
+                        lock.lockInterruptibly();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                executions++;
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution.length, innerTask);
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10, TimeUnit.MILLISECONDS);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledDuringExecution);
+    }
+
+    @Test
+    public void testScheduleWithFixedDelayCancellationBeforeExecution() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution.length, null);
+        Future future = scheduledExecutor.scheduleWithFixedDelay(task, 10, 10000, TimeUnit.MILLISECONDS);
+        while (task.getExecutions() != 1) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForTwoExecutionsCancelledBeforeExecution);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TaskListenerThreadPoolExecutorTestCase.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TaskListenerThreadPoolExecutorTestCase.java
@@ -1,0 +1,291 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.Assert.fail;
+
+/**
+ *
+ */
+public class TaskListenerThreadPoolExecutorTestCase {
+
+    protected TaskListenerExecutorService executor;
+
+    protected TaskListenerExecutorService newExecutor() {
+        return TestTaskListenerExecutors.newExecutor();
+    }
+
+    @Before
+    public void beforeTest() {
+        executor = newExecutor();
+    }
+
+    @Test
+    public void testSubmitRunnable() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null);
+        executor.submit(task).get();
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+    }
+
+    @Test
+    public void testSubmitRunnableWithValue() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null);
+        executor.submit(task, new Object()).get();
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+    }
+
+    @Test
+    public void testSubmitCallable() throws Exception {
+        TestTaskListenerCallable task = new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null);
+        executor.submit(task).get();
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+    }
+
+    @Test
+    public void testSubmitRunnableAborted() throws Exception {
+        final Runnable innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionAborted.length, innerTask);
+        try {
+            executor.submit(task).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionAborted);
+    }
+
+    @Test
+    public void testSubmitRunnableWithValueAborted() throws Exception {
+        final Runnable innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionAborted.length, innerTask);
+        try {
+            executor.submit(task, new Object()).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionAborted);
+    }
+
+    @Test
+    public void testSubmitCallableAborted() throws Exception {
+        final Callable<Object> innerTask = new Callable() {
+            @Override
+            public Object call() throws Exception {
+                throw new RuntimeException();
+            }
+        };
+        TestTaskListenerCallable task = new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionAborted.length, innerTask);
+        try {
+            executor.submit(task).get();
+            fail("task execution should have failed due to runtime exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionAborted);
+    }
+
+    @Test
+    public void testExecute() throws Exception {
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null);
+        executor.execute(task);
+        task.assertDone(10);
+        task.assertExecutions(1);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+    }
+
+    @Test
+    public void testExecuteAborted() throws Exception {
+        final Runnable innerTask = new Runnable() {
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionAborted.length, innerTask);
+        executor.execute(task);
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionAborted);
+    }
+
+    @Test
+    public void testSubmitRunnableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final Runnable innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionCancelledDuringExecution.length, innerTask);
+        Future future = executor.submit(task);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionCancelledDuringExecution);
+    }
+
+    @Test
+    public void testSubmitRunnableWithValueCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final Runnable innerTask = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    lock.lockInterruptibly();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        TestTaskListenerRunnable task = new TestTaskListenerRunnable(TestTaskListener.expectedCallbacksForSingleExecutionCancelledDuringExecution.length, innerTask);
+        Future future = executor.submit(task, new Object());
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionCancelledDuringExecution);
+    }
+
+    @Test
+    public void testSubmitCallableCancellationDuringExecution() throws Exception {
+        final ReentrantLock lock = new ReentrantLock();
+        lock.lock();
+        final Callable<Object> innerTask = new Callable() {
+            @Override
+            public Object call() throws Exception {
+                lock.lockInterruptibly();
+                return new Object();
+            }
+        };
+        TestTaskListenerCallable task = new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionCancelledDuringExecution.length, innerTask);
+        Future future = executor.submit(task);
+        while (!lock.hasQueuedThreads()) {
+            Thread.sleep(10);
+        }
+        future.cancel(true);
+        try {
+            future.get();
+            fail("task should have been cancelled");
+        } catch (Throwable e) {
+            // expected
+        }
+        task.assertDone(10);
+        task.assertExecutions(0);
+        task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionCancelledDuringExecution);
+    }
+
+    @Test
+    public void testInvokeAll() throws Exception {
+        Set<TestTaskListenerCallable<Object>> taskSet = new HashSet<>();
+        taskSet.add(new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null));
+        taskSet.add(new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null));
+        taskSet.add(new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null));
+        List<Future<Object>> futures = executor.invokeAll(taskSet);
+        for (Future future : futures) {
+            future.get();
+        }
+        for (TestTaskListenerCallable task : taskSet) {
+            task.assertDone(10);
+            task.assertExecutions(1);
+            task.assertExpectedCallbacks(TestTaskListener.expectedCallbacksForSingleExecutionNormal);
+        }
+    }
+
+    @Test
+    public void testInvokeAny() throws Exception {
+        Set<TestTaskListenerCallable<Object>> taskSet = new HashSet<>();
+        taskSet.add(new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null));
+        taskSet.add(new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null));
+        taskSet.add(new TestTaskListenerCallable(TestTaskListener.expectedCallbacksForSingleExecutionNormal.length, null));
+        executor.invokeAny(taskSet);
+    }
+
+    @After
+    public void afterTest() throws InterruptedException {
+        executor.shutdown();
+        if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListener.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListener.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Eduardo Martins
+ */
+public abstract class TestTaskListener implements TaskListener {
+
+    enum CallbackType {aborted, cancelled, done, starting, submitted}
+
+    public static final CallbackType[] expectedCallbacksForSingleExecutionNormal = {CallbackType.submitted, CallbackType.starting, CallbackType.done};
+    public static final CallbackType[] expectedCallbacksForSingleExecutionAborted = {CallbackType.submitted, CallbackType.starting, CallbackType.aborted};
+    public static final CallbackType[] expectedCallbacksForSingleExecutionCancelledBeforeExecution = {CallbackType.submitted, CallbackType.cancelled};
+    public static final CallbackType[] expectedCallbacksForSingleExecutionCancelledDuringExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.cancelled};
+
+    public static final CallbackType[] expectedCallbacksForTwoExecutionsAborted = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.aborted};
+    public static final CallbackType[] expectedCallbacksForTwoExecutionsCancelledBeforeExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.cancelled};
+    public static final CallbackType[] expectedCallbacksForTwoExecutionsCancelledDuringExecution = {CallbackType.submitted, CallbackType.starting, CallbackType.done, CallbackType.submitted, CallbackType.starting, CallbackType.cancelled};
+
+    private final ArrayList<CallbackType> callbacks = new ArrayList<>();
+    private final CountDownLatch done;
+    protected AtomicInteger executions = new AtomicInteger(0);
+
+    public TestTaskListener(int expectedCallbacks) {
+        this.done = new CountDownLatch(expectedCallbacks);
+    }
+
+    public ArrayList<CallbackType> getCallbacks() {
+        return callbacks;
+    }
+
+    public int getExecutions() {
+        return executions.get();
+    }
+
+    private synchronized void addCallback(CallbackType callbackType) {
+        callbacks.add(callbackType);
+        if (done.getCount() == 0) {
+            throw new RuntimeException();
+        }
+        done.countDown();
+    }
+
+    @Override
+    public void taskSubmitted(Future<?> future) {
+        addCallback(CallbackType.submitted);
+        Assert.assertNotNull(future);
+    }
+
+    @Override
+    public void taskStarting() {
+        addCallback(CallbackType.starting);
+    }
+
+    @Override
+    public void taskDone(Throwable exception) {
+        if (exception == null) {
+            addCallback(CallbackType.done);
+        } else if (exception instanceof CancellationException) {
+            addCallback(CallbackType.cancelled);
+        } else {
+            addCallback(CallbackType.aborted);
+        }
+    }
+
+    protected void assertDone(int seconds) throws InterruptedException {
+        if (!this.waitForExpectedCallbacks(seconds, TimeUnit.SECONDS)) {
+            fail("Callbacks: " + callbacks);
+        }
+    }
+
+    public boolean waitForExpectedCallbacks(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return done.await(timeout, timeUnit);
+    }
+
+    protected void assertExecutions(int expectedExecutions) throws InterruptedException {
+        Assert.assertEquals(expectedExecutions, getExecutions());
+    }
+
+    protected void assertExpectedCallbacks(CallbackType[] expectedCallbacks) throws InterruptedException {
+        List<CallbackType> listenerCallbacks = this.getCallbacks();
+        Assert.assertEquals("Unexpected callbacks size. Listener callbacks: " + listenerCallbacks + ". Expected callbacks: " + Arrays.asList(expectedCallbacks), expectedCallbacks.length, listenerCallbacks.size());
+        for (int i = 0; i < expectedCallbacks.length; i++) {
+            Assert.assertEquals(expectedCallbacks[i], listenerCallbacks.get(i));
+        }
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListenerCallable.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListenerCallable.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestTaskListenerCallable<V> extends TestTaskListener implements Callable<V> {
+
+    private final Callable<V> task;
+
+    public TestTaskListenerCallable(int expectedCallbacks, Callable<V> task) {
+        super(expectedCallbacks);
+        this.task = task;
+    }
+
+    @Override
+    public V call() throws Exception {
+        final V v;
+        if (task != null) {
+            v = task.call();
+        } else {
+            v = null;
+        }
+        executions.incrementAndGet();
+        return v;
+    }
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListenerExecutors.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListenerExecutors.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+import org.wildfly.as.concurrent.tasklistener.impl.TaskListenerScheduledThreadPoolExecutor;
+import org.wildfly.as.concurrent.tasklistener.impl.TaskListenerThreadPoolExecutor;
+
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestTaskListenerExecutors {
+
+    private TestTaskListenerExecutors() {
+    }
+
+    public static TaskListenerExecutorService newExecutor() {
+        return new TaskListenerThreadPoolExecutor(0, Integer.MAX_VALUE,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>());
+    }
+
+    public static TaskListenerScheduledExecutorService newScheduledExecutor() {
+        return new TaskListenerScheduledThreadPoolExecutor(4);
+    }
+
+}

--- a/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListenerRunnable.java
+++ b/concurrent/src/test/java/org/wildfly/as/concurrent/tasklistener/TestTaskListenerRunnable.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.as.concurrent.tasklistener;
+
+/**
+ * @author Eduardo Martins
+ */
+public class TestTaskListenerRunnable extends TestTaskListener implements Runnable {
+
+    private final Runnable task;
+
+    public TestTaskListenerRunnable(int expectedCallbacks, Runnable task) {
+        super(expectedCallbacks);
+        this.task = task;
+    }
+
+    @Override
+    public void run() {
+        if (task != null) {
+            task.run();
+        }
+        executions.incrementAndGet();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@
         <module>build</module>
         <module>build-config</module>
         <module>build-modular</module>
+        <module>concurrent</module>
         <module>controller</module>
         <module>controller-client</module>
         <module>deployment-repository</module>
@@ -1020,6 +1021,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-concurrent</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        
             <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-core-model-test</artifactId>
@@ -6341,10 +6348,10 @@
                 <module>osgi</module>
                 <module>pojo</module>
                 <module>remoting-test</module>
-                <module>system-jmx</module>
                 <module>sar</module>
                 <module>security</module>
                 <module>spec-api</module>
+                <module>system-jmx</module>
                 <module>transactions</module>
                 <module>undertow</module>
                 <module>web-common</module>


### PR DESCRIPTION
...t testsuite

For the bigger picture, wrt https://issues.jboss.org/browse/WFLY-236 , threads subsystem will be used to manage the TaskListener thread pools, and needed for our JSR 236 ManagedExecutorService impls, similar to the already existent thread pools in that subsystem, while EE subsystem will include the MSC Services that bound the default managed executor services, context service and thread factories into jndi. 
