### PR TITLE
WFLY-507 More EJB 3.2 support

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/BusinessViewAnnotationProcessorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/BusinessViewAnnotationProcessorTestCase.java
@@ -21,21 +21,27 @@
  */
 package org.jboss.as.test.integration.ejb.view.basic;
 
-import static org.junit.Assert.assertNotNull;
+import java.io.Externalizable;
+import java.io.Serializable;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.NameNotFoundException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests the number of views exposed by EJBs are correct
  *
+ * @author Jaikiran Pai
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 @RunWith(Arquillian.class)
@@ -91,6 +97,76 @@ public class BusinessViewAnnotationProcessorTestCase {
 
         final ImplicitNoInterfaceBean noInterfaceBean = (ImplicitNoInterfaceBean) ctx.lookup("java:module/" + ImplicitNoInterfaceBean.class.getSimpleName() + "!" + ImplicitNoInterfaceBean.class.getName());
         assertNotNull("View " + MyInterface.class.getName() + " not found", noInterfaceBean);
+    }
+
+    /**
+     * Tests that if a bean has a {@link javax.ejb.Remote} annotation without any specific value and if the bean implements n (valid) interfaces, then all those n (valid) interfaces are considered
+     * as remote business interfaces
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEJB32MultipleRemoteViews() throws Exception {
+        final Context ctx = new InitialContext();
+
+        final One interfaceOne = (One) ctx.lookup("java:module/" + MultipleRemoteViewBean.class.getSimpleName() + "!" + One.class.getName());
+        assertNotNull("View " + One.class.getName() + " not found", interfaceOne);
+
+        final Two interfaceTwo = (Two) ctx.lookup("java:module/" + MultipleRemoteViewBean.class.getSimpleName() + "!" + Two.class.getName());
+        assertNotNull("View " + Two.class.getName() + " not found", interfaceTwo);
+
+
+        final Three interfaceThree = (Three) ctx.lookup("java:module/" + MultipleRemoteViewBean.class.getSimpleName() + "!" + Three.class.getName());
+        assertNotNull("View " + Three.class.getName() + " not found", interfaceThree);
+
+        try {
+            final Object view = ctx.lookup("java:module/" + MultipleRemoteViewBean.class.getSimpleName() + "!" + Serializable.class.getName());
+            Assert.fail("Unexpected view found: " + view + " for interface " + Serializable.class.getName());
+        } catch (NameNotFoundException nnfe) {
+            // expected
+        }
+
+        try {
+            final Object view = ctx.lookup("java:module/" + MultipleRemoteViewBean.class.getSimpleName() + "!" + Externalizable.class.getName());
+            Assert.fail("Unexpected view found: " + view + " for interface " + Externalizable.class.getName());
+        } catch (NameNotFoundException nnfe) {
+            // expected
+        }
+    }
+
+    /**
+     * Tests that if a bean has a {@link javax.ejb.Local} annotation without any specific value and if the bean implements n (valid) interfaces, then all those n (valid) interfaces are considered
+     * as local business interfaces
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEJB32MultipleLocalViews() throws Exception {
+        final Context ctx = new InitialContext();
+
+        final One interfaceOne = (One) ctx.lookup("java:module/" + MultipleLocalViewBean.class.getSimpleName() + "!" + One.class.getName());
+        assertNotNull("View " + One.class.getName() + " not found", interfaceOne);
+
+        final Two interfaceTwo = (Two) ctx.lookup("java:module/" + MultipleLocalViewBean.class.getSimpleName() + "!" + Two.class.getName());
+        assertNotNull("View " + Two.class.getName() + " not found", interfaceTwo);
+
+
+        final Three interfaceThree = (Three) ctx.lookup("java:module/" + MultipleLocalViewBean.class.getSimpleName() + "!" + Three.class.getName());
+        assertNotNull("View " + Three.class.getName() + " not found", interfaceThree);
+
+        try {
+            final Object view = ctx.lookup("java:module/" + MultipleLocalViewBean.class.getSimpleName() + "!" + Serializable.class.getName());
+            Assert.fail("Unexpected view found: " + view + " for interface " + Serializable.class.getName());
+        } catch (NameNotFoundException nnfe) {
+            // expected
+        }
+
+        try {
+            final Object view = ctx.lookup("java:module/" + MultipleLocalViewBean.class.getSimpleName() + "!" + Externalizable.class.getName());
+            Assert.fail("Unexpected view found: " + view + " for interface " + Externalizable.class.getName());
+        } catch (NameNotFoundException nnfe) {
+            // expected
+        }
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MultipleLocalViewBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MultipleLocalViewBean.java
@@ -1,0 +1,15 @@
+package org.jboss.as.test.integration.ejb.view.basic;
+
+import java.io.Externalizable;
+import java.io.Serializable;
+
+import javax.ejb.Local;
+import javax.ejb.Stateful;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateful
+@Local
+public class MultipleLocalViewBean extends MultipleRemoteViewBean implements One, Two, Three, Serializable, Externalizable {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MultipleRemoteViewBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/MultipleRemoteViewBean.java
@@ -1,0 +1,25 @@
+package org.jboss.as.test.integration.ejb.view.basic;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.Serializable;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateless
+@Remote
+public class MultipleRemoteViewBean implements One, Two, Three, Serializable, Externalizable {
+    @Override
+    public void writeExternal(ObjectOutput out) throws IOException {
+    }
+
+    @Override
+    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/One.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/One.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.view.basic;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public interface One {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/Three.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/Three.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.view.basic;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public interface Three {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/Two.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/basic/Two.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.view.basic;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public interface Two {
+}


### PR DESCRIPTION
The commit here adds support to the new relaxed requirement in EJB 3.2 spec which allows more than one interface to be considered as remote/local business view if the bean implementation class is annotated with an empty @Remote/@Local annotation.

For example:

```
public interface One {

}

public interface Two {

}

@Stateless
@Remote
public class BeanImpl implement One, Two {

}
```

Starting EJB 3.2 version, both One and Two will be considered as the remote business interfaces of the stateless bean.

The commit also includes tests to verify this behaviour.
