### PR TITLE
[WFLY-1464] Add support for Digest authentication where backed by a realm.

### DIFF
--- a/security/src/main/java/org/jboss/as/security/DigestCredential.java
+++ b/security/src/main/java/org/jboss/as/security/DigestCredential.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security;
+
+/**
+ * A Credential to allow for JAAS verification of digest requests.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface DigestCredential {
+
+    boolean verifyHA1(final byte[] ha1);
+
+    String getRealm();
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/DigestCredentialImpl.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/DigestCredentialImpl.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow.security;
+
+import java.util.UUID;
+
+import org.jboss.as.security.DigestCredential;
+
+/**
+ * Implementation to map from the Undertow variant to the WildFly variant.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+final class DigestCredentialImpl implements DigestCredential {
+
+    private final String uniqueValue = UUID.randomUUID().toString();
+    private final io.undertow.security.idm.DigestCredential wrapped;
+
+    DigestCredentialImpl(final io.undertow.security.idm.DigestCredential wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public boolean verifyHA1(byte[] ha1) {
+        return wrapped.verifyHA1(ha1);
+    }
+
+    @Override
+    public String getRealm() {
+        return wrapped.getRealm();
+    }
+
+    @Override
+    public String toString() {
+        // Not actually used for validation in a correctly configured installation, however a randomly generated UUID is
+        // returned for bad configurations.
+        return uniqueValue;
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/JAASIdentityManagerImpl.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/JAASIdentityManagerImpl.java
@@ -35,6 +35,7 @@ import javax.security.auth.Subject;
 
 import io.undertow.security.idm.Account;
 import io.undertow.security.idm.Credential;
+import io.undertow.security.idm.DigestCredential;
 import io.undertow.security.idm.IdentityManager;
 import io.undertow.security.idm.PasswordCredential;
 import io.undertow.security.idm.X509CertificateCredential;
@@ -79,11 +80,14 @@ public class JAASIdentityManagerImpl implements IdentityManager {
     @Override
     public Account verify(String id, Credential credential) {
         Account account = getAccount(id);
-        final char[] password = ((PasswordCredential) credential).getPassword();
-        // The original array may be cleared, this integration relies on it being cached for use later.
-        final char[] duplicate = Arrays.copyOf(password, password.length);
-        return verifyCredential(account, duplicate);
-
+        if (credential instanceof DigestCredential) {
+            return verifyCredential(account, new DigestCredentialImpl((DigestCredential) credential));
+        } else {
+            final char[] password = ((PasswordCredential) credential).getPassword();
+            // The original array may be cleared, this integration relies on it being cached for use later.
+            final char[] duplicate = Arrays.copyOf(password, password.length);
+            return verifyCredential(account, duplicate);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is an intermediate change to enable Digest authentication with Undertow where a security domain is backed by a domain.

Longer term this will be replaced with PicketLink IDM.
