### PR TITLE
Web session clustering fix/optimization.

### DIFF
--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -169,6 +169,11 @@ public class InfinispanSessionManager<V, L> implements SessionManager<L>, KeyGen
     }
 
     @Override
+    public boolean containsSession(String id) {
+        return this.cache.containsKey(id);
+    }
+
+    @Override
     public Session<L> findSession(String id) {
         V value = this.factory.findValue(id);
         if (value == null) {

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
@@ -36,6 +36,8 @@ public interface SessionManager<L> extends SessionIdentifierFactory, RouteLocato
      */
     void stop();
 
+    boolean containsSession(String id);
+
     /**
      * Returns the session with the specified identifier, or null if none exists
      * @param id a session identifier

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/SessionManagerFacadeTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/SessionManagerFacadeTestCase.java
@@ -105,7 +105,7 @@ public class SessionManagerFacadeTestCase {
         String routingSessionId = "session.route";
         
         when(this.manager.createSessionId()).thenReturn(sessionId);
-        when(this.manager.findSession(sessionId)).thenReturn(null);
+        when(this.manager.containsSession(sessionId)).thenReturn(false);
         when(this.manager.createSession(sessionId)).thenReturn(session);
         when(this.manager.locate(sessionId)).thenReturn(route);
         when(this.manager.getBatcher()).thenReturn(batcher);
@@ -139,7 +139,7 @@ public class SessionManagerFacadeTestCase {
         String routingSessionId = "session.route";
         
         when(config.findSessionId(exchange)).thenReturn(requestedSessionId);
-        when(this.manager.findSession(sessionId)).thenReturn(null);
+        when(this.manager.containsSession(sessionId)).thenReturn(false);
         when(this.manager.createSession(sessionId)).thenReturn(session);
         when(this.manager.locate(sessionId)).thenReturn(route);
         when(this.manager.getBatcher()).thenReturn(batcher);
@@ -163,17 +163,12 @@ public class SessionManagerFacadeTestCase {
     @Test
     public void createSessionAlreadyExists() {
         HttpServerExchange exchange = new HttpServerExchange(null);
-        Batcher batcher = mock(Batcher.class);
         SessionConfig config = mock(SessionConfig.class);
-        @SuppressWarnings("unchecked")
-        Session<Void> session = mock(Session.class);
         String requestedSessionId = "session.route1";
         String sessionId = "session";
         
-        when(this.manager.getBatcher()).thenReturn(batcher);
-        when(batcher.startBatch()).thenReturn(true);
         when(config.findSessionId(exchange)).thenReturn(requestedSessionId);
-        when(this.manager.findSession(sessionId)).thenReturn(session);
+        when(this.manager.containsSession(sessionId)).thenReturn(true);
         
         IllegalStateException exception = null;
         try {
@@ -182,8 +177,6 @@ public class SessionManagerFacadeTestCase {
             exception = e;
         }
         assertNotNull(exception);
-        
-        verify(batcher).endBatch(false);
     }
 
     @Test


### PR DESCRIPTION
Make sure we rollback our batch if session creation/lookup fails.
Add SessionManager.containsSession(String), as a more efficient alternative than potentially creating a Session that we don't use.
