### PR TITLE
update mvn script to run on Mac OS X

### DIFF
--- a/tools/maven/bin/mvn
+++ b/tools/maven/bin/mvn
@@ -54,11 +54,8 @@ case "`uname`" in
   CYGWIN*) cygwin=true ;;
   MINGW*) mingw=true;;
   Darwin*) darwin=true 
-           if [ -z "$JAVA_VERSION" ] ; then
-             JAVA_VERSION="CurrentJDK"
-           fi
            if [ -z "$JAVA_HOME" ] ; then
-             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+             JAVA_HOME=`/usr/libexec/java_home`
            fi
            ;;
 esac


### PR DESCRIPTION
- fix the way to find JAVA_HOME on Darwin (Mac OS X)
  to be able to use JDK 1.7
