### PR TITLE
[WFLY-1513] remove messages when JMS destination is removed

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueRemove.java
@@ -24,12 +24,17 @@ package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import org.hornetq.api.core.management.ResourceNames;
+import org.hornetq.api.jms.management.JMSQueueControl;
+import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -43,10 +48,24 @@ public class JMSQueueRemove extends AbstractRemoveStepHandler {
 
     public static final JMSQueueRemove INSTANCE = new JMSQueueRemove();
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
+
+        ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
+        HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
+        // on queue removal, all the messages held by the queue are removed.
+        JMSQueueControl control = JMSQueueControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_QUEUE + name));
+        if (control != null) {
+            try {
+                control.removeMessages(null);
+            } catch (Exception e) {
+                throw new OperationFailedException(e);
+            }
+        }
+
         context.removeService(JMSServices.getJmsQueueBaseServiceName(hqServiceName).append(name));
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicRemove.java
@@ -24,12 +24,17 @@ package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import org.hornetq.api.core.management.ResourceNames;
+import org.hornetq.api.jms.management.TopicControl;
+import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -43,10 +48,23 @@ public class JMSTopicRemove extends AbstractRemoveStepHandler {
 
     public static final JMSTopicRemove INSTANCE = new JMSTopicRemove();
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         final ServiceName hqServiceName = MessagingServices.getHornetQServiceName(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String name = address.getLastElement().getValue();
+
+        ServiceController<?> hqService = context.getServiceRegistry(false).getService(hqServiceName);
+        HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
+        // on queue removal, all the messages held by the queue are removed.
+        TopicControl control = TopicControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_TOPIC + name));
+        if (control != null) {
+            try {
+                control.removeMessages(null);
+            } catch (Exception e) {
+                throw new OperationFailedException(e);
+            }
+        }
+
         context.removeService(JMSServices.getJmsTopicBaseServiceName(hqServiceName).append(name));
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSQueueManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSQueueManagementTestCase.java
@@ -406,6 +406,24 @@ public class JMSQueueManagementTestCase {
         }
     }
 
+    @Test
+    public void removeJMSQueueRemovesAllMessages() throws Exception {
+        MessageProducer producer = session.createProducer(queue);
+        producer.send(session.createTextMessage("A"));
+
+        ModelNode result = execute(getQueueOperation("count-messages"), true);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertEquals(1, result.asInt());
+
+        // remove and add the queue
+        adminSupport.removeJmsQueue(getQueueName());
+        adminSupport.createJmsQueue(getQueueName(), getQueueJndiName());
+
+        result = execute(getQueueOperation("count-messages"), true);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertEquals(0, result.asInt());
+    }
+
     private String getQueueName() {
         return getClass().getSimpleName() + count;
     }


### PR DESCRIPTION
when a JMS destination (queue or topic) is removed, removes all the
messages from the destination. This will ensure that removal of a JMS
destination leaves the server in a clean state. If a destination with
the same name is adder later, it will not hold any messages from the
previous destination.
