### PR TITLE
WFLY-507 EJB 3.2 - Allow TimerService#getAllTimers() to be functional from stateful beans

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -2482,6 +2482,9 @@ public interface EjbMessages {
     @Message(id = 14586, value = "Transaction '%s' is in unexpected state (%s)")
     EJBException transactionInUnexpectedState(Transaction tx, String txStatus);
 
+    @Message(id = 14587, value = "Timerservice API is not allowed on stateful session bean %s")
+    String timerServiceMethodNotAllowedForSFSB(final String ejbComponent);
+
 
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -398,4 +398,28 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
     public void setPassivationApplicable(final boolean passivationApplicable) {
         this.passivationApplicable = passivationApplicable;
     }
+
+    /**
+     * EJB 3.2 spec allows the TimeService to be injected/looked up/accessed from the stateful bean so as to allow access to the {@link javax.ejb.TimerService#getAllTimers()}
+     * method from a stateful bean. Hence we make timerservice applicable for stateful beans too. However, we return <code>false</code> in {@link #isTimerServiceRequired()} so that a {@link org.jboss.as.ejb3.timerservice.NonFunctionalTimerService}
+     * is made available for the stateful bean. The {@link org.jboss.as.ejb3.timerservice.NonFunctionalTimerService} only allows access to {@link javax.ejb.TimerService#getAllTimers()} and {@link javax.ejb.TimerService#getTimers()}
+     * methods and throws an {@link IllegalStateException} for all othre methods on the timerservice and that's exactly how we want it to behave for stateful beans
+     *
+     * @return
+     * @see {@link #isTimerServiceRequired()}
+     */
+    @Override
+    public boolean isTimerServiceApplicable() {
+        return true;
+    }
+
+    /**
+     * Timeout methods and auto timer methods aren't applicable for stateful beans, hence we return false.
+     * @return
+     * @see {@link #isTimerServiceApplicable()}
+     */
+    @Override
+    public boolean isTimerServiceRequired() {
+        return false;
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
@@ -98,6 +98,8 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
      */
     private final Set<Object> serialiableInterceptorContextKeys;
 
+    private final TimerService timerService;
+
     /**
      * Construct a new instance.
      *
@@ -120,6 +122,7 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
         this.currentMarshallingVersion = ejbComponentCreateService.getCurrentMarshallingVersion();
         this.marshallingConfigurations = ejbComponentCreateService.getMarshallingConfigurations();
         this.serialiableInterceptorContextKeys = ejbComponentCreateService.getSerializableInterceptorContextKeys();
+        this.timerService = ejbComponentCreateService.getTimerService();
 
         String beanName = ejbComponentCreateService.getComponentClass().getName();
         StatefulObjectFactory<StatefulSessionComponentInstance> factory = new TransactionAwareObjectFactory<StatefulSessionComponentInstance>(this, this.getTransactionManager());
@@ -206,7 +209,7 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
 
     @Override
     public TimerService getTimerService() throws IllegalStateException {
-        throw MESSAGES.timerServiceNotSupportedForSFSB(this.getComponentName());
+        return this.timerService;
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/TimerServiceJndiBindingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/TimerServiceJndiBindingProcessor.java
@@ -28,7 +28,6 @@ import org.jboss.as.ee.component.ComponentNamingMode;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.component.deployers.AbstractComponentConfigProcessor;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
-import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.ejb3.timerservice.TimerServiceBindingSource;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -39,9 +38,7 @@ import org.jboss.as.server.deployment.annotation.CompositeIndex;
  * Deployment processor responsible for detecting EJB components and adding a {@link BindingConfiguration} for the
  * java:comp/TimerService entry.
  * <p/>
- * Note that the java:comp/TimerService *isn't* added for Stateful session beans, since TimerService isn't supported for
- * stateful session EJBs.
- * <p/>
+ *
  * User: Jaikiran Pai
  */
 public class TimerServiceJndiBindingProcessor extends AbstractComponentConfigProcessor {
@@ -51,18 +48,15 @@ public class TimerServiceJndiBindingProcessor extends AbstractComponentConfigPro
         if (!(componentDescription instanceof EJBComponentDescription)) {
             return;  // Only process EJBs
         }
-        if (componentDescription instanceof StatefulComponentDescription) {
-            return; // TimerService isn't supported for Stateful session beans
-        }
         // if the EJB is packaged in a .war, then we need to bind the java:comp/TimerService only once for the entire module
         if (componentDescription.getNamingMode() != ComponentNamingMode.CREATE) {
             // get the module description
             final EEModuleDescription moduleDescription = componentDescription.getModuleDescription();
             // the java:module/TimerService binding configuration
-                    // Note that we bind to java:module/TimerService since it's a .war. End users can still lookup java:comp/TimerService
-                    // and that will internally get translated to  java:module/TimerService for .war, since java:comp == java:module in
-                    // a web ENC. So binding to java:module/TimerService is OK.
-                    final BindingConfiguration timerServiceBinding = new BindingConfiguration("java:module/TimerService", new TimerServiceBindingSource());
+            // Note that we bind to java:module/TimerService since it's a .war. End users can still lookup java:comp/TimerService
+            // and that will internally get translated to  java:module/TimerService for .war, since java:comp == java:module in
+            // a web ENC. So binding to java:module/TimerService is OK.
+            final BindingConfiguration timerServiceBinding = new BindingConfiguration("java:module/TimerService", new TimerServiceBindingSource());
             moduleDescription.getBindingConfigurations().add(timerServiceBinding);
         } else { // EJB packaged outside of a .war. So process normally.
             // add the binding configuration to the component description

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/ActiveTimerServiceCountTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/ActiveTimerServiceCountTestCase.java
@@ -1,5 +1,11 @@
 package org.jboss.as.test.integration.ejb.timerservice.count;
 
+import java.io.Serializable;
+import java.util.Collection;
+
+import javax.ejb.Timer;
+import javax.naming.InitialContext;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -9,11 +15,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.ejb.Timer;
-import javax.naming.InitialContext;
-import java.io.Serializable;
-import java.util.Collection;
 
 /**
  * Testcase for the {@link javax.ejb.TimerService#getAllTimers()} API introduced in EJB 3.2 spec
@@ -30,7 +31,7 @@ public class ActiveTimerServiceCountTestCase {
     @Deployment
     public static Archive createDeployment() {
         final JavaArchive ejbJarOne = ShrinkWrap.create(JavaArchive.class, MODULE_ONE_NAME + ".jar");
-        ejbJarOne.addClasses(ActiveTimerServiceCountTestCase.class, SimpleTimerBean.class, OtherTimerBeanInSameModule.class);
+        ejbJarOne.addClasses(ActiveTimerServiceCountTestCase.class, SimpleTimerBean.class, OtherTimerBeanInSameModule.class, StatefulBean.class);
 
         final JavaArchive ejbJarTwo = ShrinkWrap.create(JavaArchive.class, MODULE_TWO_NAME + ".jar");
         ejbJarTwo.addClasses(TimerBeanInOtherModule.class);
@@ -81,7 +82,29 @@ public class ActiveTimerServiceCountTestCase {
             Assert.assertNotEquals("Unexpectedly found a timer from other EJB module " + MODULE_TWO_NAME, infoForTimerBeanInOtherModule.equals(remainingTimer.getInfo()));
         }
 
+        // Now fetch the same info, this time from the SFSB. We expect the same number of active timers in the module.
+        final StatefulBean statefulBean = InitialContext.doLookup("java:module/" + StatefulBean.class.getSimpleName() + "!" + StatefulBean.class.getName());
+        final Collection<Timer> activeTimersReturnedFromSFSB = statefulBean.getAllActiveTimersInEJBModule();
+
+        Assert.assertFalse("No active timers found in EJB module " + MODULE_ONE_NAME + " when queried from a stateful bean", activeTimersReturnedFromSFSB.isEmpty());
+
+        // now make sure that the active timers are indeed the one we expected
+        Assert.assertTrue("@Schedule timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers when queried from a stateful bean", this.removeSheduleOneTimerOfSimpleTimerBean(activeTimersReturnedFromSFSB));
+        Assert.assertTrue("@Schedule timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers when queried from a stateful bean", this.removeSheduleTwoTimerOfSimpleTimerBean(activeTimersReturnedFromSFSB));
+        Assert.assertTrue("@Schedule timer on " + OtherTimerBeanInSameModule.class.getSimpleName() + " not found in active timers when queried from a stateful bean", this.removeSheduleOneTimerOfOtherTimerBean(activeTimersReturnedFromSFSB));
+        Assert.assertTrue("Programmatic timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers when queried from a stateful bean", this.removeProgramaticTimer(activeTimersReturnedFromSFSB, infoOne, false));
+        Assert.assertTrue("Programmatic timer on " + SimpleTimerBean.class.getSimpleName() + " not found in active timers when queried from a stateful bean", this.removeProgramaticTimer(activeTimersReturnedFromSFSB, infoTwo, true));
+        Assert.assertTrue("Programmatic timer on " + OtherTimerBeanInSameModule.class.getSimpleName() + " not found in active timers when queried from a stateful bean", this.removeProgramaticTimer(activeTimersReturnedFromSFSB, infoThree, false));
+
+        // make sure there isn't an unexpected timer in the active timers
+        for (final Timer remainingTimer : activeTimersReturnedFromSFSB) {
+            Assert.assertNotEquals("Unexpectedly found a timer from other EJB module " + MODULE_TWO_NAME + " when queried from a stateful bean", TimerBeanInOtherModule.SCHEDULE_ONE_INFO.equals(remainingTimer.getInfo()));
+            Assert.assertNotEquals("Unexpectedly found a timer from other EJB module " + MODULE_TWO_NAME + " when queried from a stateful bean", infoForTimerBeanInOtherModule.equals(remainingTimer.getInfo()));
+        }
+
     }
+
+
 
     private boolean removeSheduleOneTimerOfSimpleTimerBean(final Collection<Timer> timers) {
         for (final Timer activeTimer : timers) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/StatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/count/StatefulBean.java
@@ -1,0 +1,24 @@
+package org.jboss.as.test.integration.ejb.timerservice.count;
+
+import java.util.Collection;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.Stateful;
+import javax.ejb.Timer;
+import javax.ejb.TimerService;
+
+/**
+ * @author: Jaikiran Pai
+ */
+@Stateful
+@LocalBean
+public class StatefulBean {
+
+    @Resource // we inject timerservice in a stateful bean so as to use (only) the TimerService.getAllTimers() method from the SFSB
+    private TimerService timerService;
+
+    public Collection<Timer> getAllActiveTimersInEJBModule() {
+        return this.timerService.getAllTimers();
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-507. The commit here is related to adding EJB 3.2 support in WildFly. 

This commit now allows stateful EJBs to invoke the (new) Timerservice#getAllTimers() method from within the stateful bean. The commit also includes a test to verify this functionality.
