### PR TITLE
[WFLY-1552] Add the LogContext to the LogContextSelector only if the figuration was successful

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingDeploymentUnitProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingDeploymentUnitProcessor.java
@@ -279,7 +279,6 @@ public class LoggingDeploymentUnitProcessor implements DeploymentUnitProcessor {
         InputStream configStream = null;
         try {
             LoggingLogger.ROOT_LOGGER.debugf("Found logging configuration file: %s", configFile);
-            LoggingExtension.CONTEXT_SELECTOR.registerLogContext(classLoader, logContext);
 
             // Get the filname and open the stream
             final String fileName = configFile.getName();
@@ -302,6 +301,7 @@ public class LoggingDeploymentUnitProcessor implements DeploymentUnitProcessor {
                     LoggingExtension.THREAD_LOCAL_CONTEXT_SELECTOR.getAndSet(CONTEXT_LOCK, old);
                     WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
                 }
+                LoggingExtension.CONTEXT_SELECTOR.registerLogContext(classLoader, logContext);
             } else {
                 // Create a properties file
                 final Properties properties = new Properties();
@@ -313,6 +313,7 @@ public class LoggingDeploymentUnitProcessor implements DeploymentUnitProcessor {
                     // Load non-log4j types
                     final PropertyConfigurator propertyConfigurator = new PropertyConfigurator(logContext);
                     propertyConfigurator.configure(properties);
+                    LoggingExtension.CONTEXT_SELECTOR.registerLogContext(classLoader, logContext);
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Moves where the `LogContext` was added to the `LogContextSelector` so that if a failure occurs during configuration the context is not added.
