### PR TITLE
Use daemon threads for remoting endpoint in CLI

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -78,7 +78,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
         executorService.allowCoreThreadTimeOut(true);
 
         try {
-            endpoint = Remoting.createEndpoint("cli-client", OptionMap.EMPTY);
+            endpoint = Remoting.createEndpoint("cli-client", OptionMap.create(Options.THREAD_DAEMON, true));
             endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
             endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
             endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));


### PR DESCRIPTION
The commit here fixes the CLI shutdown problem reported here https://community.jboss.org/message/819992#819992
