### PR TITLE
Upgrade to 1.0.22.Final to EJB client library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.jboss-common-core>2.2.22.GA</version.org.jboss.jboss-common-core>
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
-        <version.org.jboss.ejb-client>1.0.21.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>1.0.22.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.0.0</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.0.Beta1</version.org.jboss.invocation>


### PR DESCRIPTION
The commit here upgrades EJB client project to 1.0.22.Final version. This is required to fix the intermittent failure reported in https://issues.jboss.org/browse/WFLY-1532
