### PR TITLE
WFLY-1554 Cleanup the org.jboss.as.test.integration.management.api.web.DeploymentScannerTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/web/DeploymentScannerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/web/DeploymentScannerTestCase.java
@@ -23,54 +23,41 @@ package org.jboss.as.test.integration.management.api.web;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.SimpleServlet;
-import org.jboss.as.test.integration.management.util.WebUtil;
 import org.jboss.dmr.ModelNode;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
+import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 
 /**
+ * Tests that the deployment scanner can be added and removed using management APIs
+ *
  * @author Dominik Pospisil <dpospisi@redhat.com>
+ * @author Jaikiran Pai - Updated to fix intermittent failures as reported in https://issues.jboss.org/browse/WFLY-1554
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 public class DeploymentScannerTestCase extends ContainerResourceMgmtTestBase {
 
+    private static final Logger logger = Logger.getLogger(DeploymentScannerTestCase.class);
+
     private static final String tempDir = System.getProperty("java.io.tmpdir");
-    private static File warFile;
     private static File deployDir;
-
-    @ArquillianResource
-    private URL url;
-
-    @Deployment
-    public static Archive<?> getDeployment() {
-        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
-        ja.addClass(DeploymentScannerTestCase.class);
-        return ja;
-    }
 
     @Before
     public void before() throws IOException {
@@ -86,120 +73,137 @@ public class DeploymentScannerTestCase extends ContainerResourceMgmtTestBase {
         FileUtils.deleteDirectory(deployDir);
     }
 
+    /**
+     * 1) Executes a add operation for a test deployment scanner. This is expected to pass
+     * 2) Tests that the test deployment scanner resource added in step#1, exists
+     * 3) Finally, removes the test deployment scanner
+     *
+     * @throws Exception
+     */
     @Test
-    @InSequence(1)
     public void testAddRemove() throws Exception {
 
-        prepareDeployment();
         addDeploymentScanner();
-        removeDeploymentScanner();
+        try {
+            assertTestDeploymentScannerResourceExists();
+        } finally {
+            // now clean up
+            try {
+                removeDeploymentScanner();
+            } catch (Throwable t) {
+                // just log so that the any previous exception that might have failed this test will be propagated back
+                logger.info("Removing test deployment scanner failed with exception", t);
+            }
+        }
     }
 
+    /**
+     * Adds a deployment scanner (let's say "foo") which points to a non-existing deployment directory. This operation is expected to fail and the test asserts it.
+     * Later it adds a deployment scanner with the same name, but this time points to a correct/existing deployment directory. This operation is then expected to pass.
+     *
+     * @throws Exception
+     */
     @Test
-    @InSequence(2)
     public void testAddWrongPath() throws Exception {
 
-        prepareDeployment();
+        // add deployment scanner with non existing path
+        final ModelNode addScannerForNonExistentPath = createOpNode("subsystem=deployment-scanner/scanner=testScanner", "add");
+        addScannerForNonExistentPath.get("scan-interval").set(1000);
+        addScannerForNonExistentPath.get("path").set("/tmp/DeploymentScannerTestCase/nonExistingPath");
 
-        // add DS with non existing path
-        ModelNode op = createOpNode("subsystem=deployment-scanner/scanner=testScanner", "add");
-        op.get("scan-interval").set(1000);
-        op.get("path").set("/tmp/DeploymentScannerTestCase/nonExistingPath");
-
-        ModelNode ret = executeOperation(op, false);
+        final ModelNode result = executeOperation(addScannerForNonExistentPath, false);
         // check that it failed
-        assertTrue("failed".equals(ret.get("outcome").asString()));
+        assertEquals("Adding a deployment scanner for a non-existent path was expected to fail but it passed", "failed", result.get("outcome").asString());
 
-        // check that rollback was success and we can create propper one
+        // check that rollback was success and we can create proper deployment scanner with the same name that failed
         addDeploymentScanner();
-        removeDeploymentScanner();
-
+        try {
+            assertTestDeploymentScannerResourceExists();
+        } finally {
+            // now clean up
+            try {
+                removeDeploymentScanner();
+            } catch (Throwable t) {
+                // just log so that the any previous exception that might have failed this test will be propagated back
+                logger.info("Removing test deployment scanner failed with exception", t);
+            }
+        }
     }
 
+    /**
+     * 1) Triggers a composite operation, a step of which includes the add operation for the test deployment scanner.
+     * 2) #1 step is supposed to fail and the test deployment scanner is *not* expected to be present after that failure
+     * 3) After #2, executes an add operation which adds a test deployment scanner and that's supposed to pass
+     * 4) The presence of the deployment scanner added in #3 is asserted
+     * 5) Another composite operation is triggered and that's expected to rollback/fail
+     * 6) After #5 step the presence of the test deployment scanner added in #3 step is asserted. It should still exist
+     *
+     * @throws Exception
+     */
     @Test
-    @InSequence(3)
     public void testAddRemoveRollbacks() throws Exception {
 
-        prepareDeployment();
-
         // execute and rollback add deployment scanner
-        ModelNode addOp = getAddDSOp();
-        ModelNode ret = executeAndRollbackOperation(addOp);
-        assertTrue("failed".equals(ret.get("outcome").asString()));
-        //todo this is a bug, thread.sleep() is just workaround, WFLY-1554
-        Thread.sleep(3000);
-        // add deployment scanner
+        final ModelNode addOp = getAddDeploymentScannerOp();
+        final ModelNode resultOfRollback = executeAndRollbackOperation(addOp);
+        assertEquals("Unexpected result from invoking an operation which was supposed to fail", "failed", resultOfRollback.get("outcome").asString());
+
+        // add deployment scanner - this time it's supposed to be added successfully
         addDeploymentScanner();
+        try {
+            assertTestDeploymentScannerResourceExists();
+            // execute and rollback remove deployment scanner
+            final ModelNode removeOp = getRemoveDeploymentScannerOp();
+            final ModelNode resultOfRemoveRollback = executeAndRollbackOperation(removeOp);
+            assertEquals("Unexpected result from invoking an operation which was supposed to fail", "failed", resultOfRemoveRollback.get("outcome").asString());
 
-        // execute and rollback remove deployment scanner
-        ModelNode removeOp = getRemoveDSOp();
-        ret = executeAndRollbackOperation(removeOp);
-        assertTrue("failed".equals(ret.get("outcome").asString()));
-
-        // check that the ds is still present
-
-
-        // remove deployment scanner
-        removeDeploymentScanner();
+            // check that the deployment scanner is still present
+            assertTestDeploymentScannerResourceExists();
+        } finally {
+            // now clean up
+            try {
+                removeDeploymentScanner();
+            } catch (Throwable t) {
+                // just log so that the any previous exception that might have failed this test will be propagated back
+                logger.info("Removing test deployment scanner failed with exception", t);
+            }
+        }
     }
 
-    private void addDeploymentScanner() throws Exception {
-
+    private ModelNode addDeploymentScanner() throws Exception {
         // add deployment scanner
-        ModelNode op = getAddDSOp();
-        executeOperation(op);
-
-        // wait for deployment
-        Thread.sleep(2000);
-
-        // check that the app has been deployed
-        File marker = new File(deployDir.getAbsolutePath() + File.separator + "SimpleServlet.war.deployed");
-        assertTrue(marker.exists());
-
-        String response = HttpRequest.get(WebUtil.getBaseURL(url) + "SimpleServlet/SimpleServlet", 10, TimeUnit.SECONDS);
-        assertTrue("Invalid response: " + response, response.indexOf("SimpleServlet") >= 0);
-
+        final ModelNode op = getAddDeploymentScannerOp();
+        final ModelNode result = executeOperation(op, false);
+        assertEquals("Unexpected outcome of adding the test deployment scanner: " + op, ModelDescriptionConstants.SUCCESS, result.get("outcome").asString());
+        return result;
     }
 
-    private void removeDeploymentScanner() throws Exception {
+    private void assertTestDeploymentScannerResourceExists() throws Exception {
+        final ModelNode readResourceOp = Util.createOperation(ModelDescriptionConstants.READ_RESOURCE_OPERATION, getTestDeploymentScannerResourcePath());
+        final ModelNode result = executeOperation(readResourceOp, false);
+        assertEquals(readResourceOp + " was supposed to be successful but received " + result, ModelDescriptionConstants.SUCCESS, result.get("outcome").asString());
+    }
 
+    private ModelNode removeDeploymentScanner() throws Exception {
         // remove deployment scanner
-        executeOperation(getRemoveDSOp());
-
-        // delete deployment
-        assertTrue("Could not delete deployed file.", warFile.delete());
-
-        // wait for deployment
-        Thread.sleep(2000);
-
-        // check that the deployment is still live
-        String response = HttpRequest.get(WebUtil.getBaseURL(url) + "SimpleServlet/SimpleServlet", 10, TimeUnit.SECONDS);
-        assertTrue("Invalid response: " + response, response.indexOf("SimpleServlet") >= 0);
-
-        // undeploy
-        ModelNode op = createOpNode("deployment=SimpleServlet.war", "remove");
-        executeOperation(op);
-
+        final ModelNode op = getRemoveDeploymentScannerOp();
+        final ModelNode result = executeOperation(op, false);
+        assertEquals("Unexpected outcome of removing the test deployment scanner: " + op, ModelDescriptionConstants.SUCCESS, result.get("outcome").asString());
+        return result;
     }
 
-    private ModelNode getAddDSOp() {
-        String path = deployDir.getAbsolutePath();
-        path = path.replaceAll("\\\\", "/");
-
-        ModelNode op = createOpNode("subsystem=deployment-scanner/scanner=testScanner", "add");
+    private ModelNode getAddDeploymentScannerOp() {
+        final ModelNode op = Util.createAddOperation(getTestDeploymentScannerResourcePath());
         op.get("scan-interval").set(1000);
-        op.get("path").set(path);
+        op.get("path").set(deployDir.getAbsolutePath());
         return op;
     }
 
-    private ModelNode getRemoveDSOp() {
+    private ModelNode getRemoveDeploymentScannerOp() {
         return createOpNode("subsystem=deployment-scanner/scanner=testScanner", "remove");
     }
 
-    private void prepareDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "SimpleServlet.war");
-        war.addClass(SimpleServlet.class);
-        warFile = new File(deployDir.getAbsolutePath() + File.separator + "SimpleServlet.war");
-        new ZipExporterImpl(war).exportTo(warFile, true);
+    private PathAddress getTestDeploymentScannerResourcePath() {
+        return PathAddress.pathAddress(PathElement.pathElement("subsystem", "deployment-scanner"), PathElement.pathElement("scanner", "testScanner"));
     }
 }


### PR DESCRIPTION
The commit here cleans up the org.jboss.as.test.integration.management.api.web.DeploymentScannerTestCase to remove the Thread.sleep(s) and at the same time ensure that it doesn't run into intermittent failures. The real problem with this test was that it was doing this:

There are 3 test methods in that testcase one of the test methods did:

1) add deployment scanner which is expected to fail
2) test that it has failed
3) add a deployment scanner "foo" which is expected to pass
4) also add a valid .war which is expected to deploy fine
5) wait for 2 seconds for the deployed marker to be visible

If step 5 fails (which is what happens from what i have seen) then the "foo" deployment scanner which was added in step#3 is left around.

Now the other 2 test methods all add the "foo" deployment scanner themselves and since the first test method didn't clean itself after that failure, the other 2 test methods used to fail with duplicate resource for that "foo" scanner.

The commit here uses a different technique to ensure that the presence/absence of the deployment scanner instead of waiting for a random time to check for the presence of a deployment (marker).
