### PR TITLE
[WFLY-1583] Remove org.jboss.as.logging dependency from the org.jboss.logmanager module

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
@@ -29,6 +29,5 @@
 
     <dependencies>
         <module name="org.jboss.modules"/>
-        <module name="org.jboss.as.logging" services="import"/>
     </dependencies>
 </module>

--- a/logging/src/main/resources/META-INF/services/org.jboss.logmanager.Configurator
+++ b/logging/src/main/resources/META-INF/services/org.jboss.logmanager.Configurator
@@ -1,1 +1,0 @@
-org.jboss.as.logging.logmanager.ConfigurationPersistence

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/operations/SyslogHandlerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/operations/SyslogHandlerTestCase.java
@@ -54,6 +54,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.productivity.java.syslog4j.server.SyslogServer;
@@ -63,11 +64,12 @@ import org.productivity.java.syslog4j.server.impl.event.printstream.FileSyslogSe
 
 /**
  * A SyslogHandlerTestCase for testing that logs are logged to syslog
- * 
+ *
  * @author Ondrej Lukas
  */
 @RunWith(Arquillian.class)
 @ServerSetup(SyslogHandlerTestCase.SyslogHandlerTestCaseSetup.class)
+@Ignore("WFLY-1584 - Events may not be getting fired before the file read is done.")
 public class SyslogHandlerTestCase {
 
     private static final Logger LOGGER = Logger.getLogger(SyslogHandlerTestCase.class.getPackage().getName());


### PR DESCRIPTION
Remove `org.jboss.as.logging` dependency from the `org.jboss.logmanager` module. Use the default configurator in the logmanager rather than one defined in the logging subsystem.

Also a commit to disable a test that seems to have temporary failures. A [JIRA](https://issues.jboss.org/browse/WFLY-1584) has been filed to fix, but the test should be disabled until it is fixed.

Lastly lock the `logging.properties` file during writes.
