### PR TITLE
WFLY-471 - Updating Hibernate Validator and RESTeasy integration

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1195,10 +1195,6 @@
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-crypto"/>
         </module-def>
 
-        <module-def name="org.jboss.resteasy.resteasy-hibernatevalidator-provider">
-            <maven-resource group="org.jboss.resteasy" artifact="resteasy-hibernatevalidator-provider"/>
-        </module-def>
-
         <module-def name="org.jboss.resteasy.resteasy-jackson-provider">
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-jackson-provider"/>
         </module-def>
@@ -1222,6 +1218,10 @@
 
         <module-def name="org.jboss.resteasy.resteasy-multipart-provider">
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-multipart-provider"/>
+        </module-def>
+
+        <module-def name="org.jboss.resteasy.resteasy-validator-provider-11">
+            <maven-resource group="org.jboss.resteasy" artifact="resteasy-validator-provider-11"/>
         </module-def>
 
         <module-def name="org.jboss.resteasy.resteasy-yaml-provider">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1541,11 +1541,6 @@
 
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-hibernatevalidator-provider</artifactId>
-                </dependency>
-
-                <dependency>
-                    <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jackson-provider</artifactId>
                 </dependency>
 
@@ -1567,6 +1562,11 @@
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-multipart-provider</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-validator-provider-11</artifactId>
                 </dependency>
 
                 <dependency>
@@ -2153,13 +2153,13 @@
                                         <include>org.jboss.resteasy:async-http-servlet-3.0</include>
                                         <include>org.jboss.resteasy:jaxrs-api</include>
                                         <include>org.jboss.resteasy:resteasy-atom-provider</include>
-                                        <include>org.jboss.resteasy:resteasy-hibernatevalidator-provider</include>
                                         <include>org.jboss.resteasy:resteasy-jackson-provider</include>
                                         <include>org.jboss.resteasy:resteasy-jaxb-provider</include>
                                         <include>org.jboss.resteasy:resteasy-jaxrs</include>
                                         <include>org.jboss.resteasy:resteasy-jettison-provider</include>
                                         <include>org.jboss.resteasy:resteasy-jsapi</include>
                                         <include>org.jboss.resteasy:resteasy-multipart-provider</include>
+                                        <include>org.jboss.resteasy:resteasy-validator-provider-11</include>
                                         <include>org.jboss.sasl:jboss-sasl</include>
                                         <include>org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec</include>
                                         <include>org.jboss.spec.javax.ejb:jboss-ejb-api_3.2_spec</include>
@@ -3279,10 +3279,6 @@
                                             <packages>org.jboss.resteasy.cdi</packages>
                                         </group>
                                         <group>
-                                            <title>Module org.jboss.resteasy.resteasy-hibernatevalidator-provider</title>
-                                            <packages>org.jboss.resteasy.plugins.validation.hibernate</packages>
-                                        </group>
-                                        <group>
                                             <title>Module org.jboss.resteasy.resteasy-jackson-provider</title>
                                             <packages>org.jboss.resteasy.annotations.providers:org.jboss.resteasy.plugins.providers.jackson</packages>
                                         </group>
@@ -3305,6 +3301,10 @@
                                         <group>
                                             <title>Module org.jboss.resteasy.resteasy-multipart-provider</title>
                                             <packages>org.jboss.resteasy.annotations.providers.multipart:org.jboss.resteasy.plugins.providers.multipart</packages>
+                                        </group>
+                                        <group>
+                                            <title>Module org.jboss.resteasy.resteasy-validator-provider-11</title>
+                                            <packages>org.jboss.resteasy.plugins.validation</packages>
                                         </group>
                                         <group>
                                             <title>Module org.jboss.security.negotiation</title>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/classmate/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/classmate/main/module.xml
@@ -31,4 +31,3 @@
         <!-- Insert resources here -->
     </resources>
 </module>
-

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -23,18 +23,22 @@
   -->
 
 <module xmlns="urn:jboss:module:1.1" name="org.hibernate.validator">
+
+  <exports>
+    <exclude path="org/hibernate/validator/internal/**"/>
+  </exports>
+
   <resources>
     <!-- Insert resources here -->
   </resources>
 
   <dependencies>
-    <module name="javax.api"/>
+    <module name="com.fasterxml.classmate"/>
     <module name="javax.persistence.api"/>
     <module name="javax.validation.api"/>
-    <module name="javax.persistence.api"/>
     <module name="javax.xml.bind.api"/>
+    <module name="org.glassfish.javax.el"/>
     <module name="org.jboss.logging"/>
-    <module name="org.jboss.common-core"/>
     <module name="org.joda.time"/>
     <module name="org.jsoup"/>
     <module name="org.slf4j"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -37,7 +37,7 @@
         <module name="javax.transaction.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.validation.api"/>
-        <module name="org.hibernate.validator"/>
+        <module name="org.hibernate.validator" services="import"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.server" />

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -37,7 +37,7 @@
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
         <module name="javax.xml.ws.api" optional="true"/>
-        <module name="org.hibernate.validator" optional="true"/>
+        <module name="org.hibernate.validator" optional="true" services="import"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming" optional="true"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -50,13 +50,13 @@
         <module name="org.jboss.resteasy.resteasy-atom-provider"/>
         <module name="org.jboss.resteasy.resteasy-cdi"/>
         <module name="org.jboss.resteasy.resteasy-crypto"/>
-        <module name="org.jboss.resteasy.resteasy-hibernatevalidator-provider"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
         <module name="org.jboss.resteasy.resteasy-jackson-provider"/>
         <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
         <module name="org.jboss.resteasy.resteasy-jsapi"/>
         <module name="org.jboss.resteasy.resteasy-multipart-provider"/>
+        <module name="org.jboss.resteasy.resteasy-validator-provider-11"/>
         <module name="org.jboss.resteasy.resteasy-yaml-provider"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider-11/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider-11/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,22 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-hibernatevalidator-provider">
-
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-validator-provider-11">
     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
-        <module name="com.sun.xml.bind"/>
-        <module name="javax.xml.bind.api"/>
-        <module name="javax.api"/>
-        <module name="javax.enterprise.api"/>
-        <module name="javax.servlet.api"/>
-        <module name="javax.validation.api"/>
         <module name="javax.ws.rs.api"/>
-        <module name="org.hibernate.validator"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
-        <module name="org.jboss.resteasy.resteasy-jaxb-provider"/>
+        <module name="javax.validation.api"/>
+        <module name="org.hibernate.validator"/>
+        <module name="com.fasterxml.classmate"/>
+        <module name="javax.persistence.api"/>
     </dependencies>
 </module>

--- a/connector/src/main/java/org/jboss/as/connector/util/WildFlyProviderResolver.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/WildFlyProviderResolver.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.connector.util;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import javax.validation.ValidationProviderResolver;
+import javax.validation.spi.ValidationProvider;
+
+import org.hibernate.validator.HibernateValidator;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * A {@link ValidationProviderResolver} to be used within WildFly. If several BV providers are available,
+ * {@code HibernateValidator} will be the first element of the returned provider list.
+ * <p/>
+ * The providers are loaded via the current thread's context class loader; If no providers are found, the loader of this class
+ * will be tried as fallback.
+ * </p>
+ * Note: This class is a copy of {@code org.jboss.as.ee.beanvalidation.WildFlyProviderResolver}.
+ *
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ */
+public class WildFlyProviderResolver implements ValidationProviderResolver {
+
+    /**
+     * Returns a list with all {@link ValidationProvider} validation providers.
+     *
+     * @return a list with all {@link ValidationProvider} validation providers
+     */
+    @Override
+    public List<ValidationProvider<?>> getValidationProviders() {
+        // first try the TCCL
+        List<ValidationProvider<?>> providers = loadProviders(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+
+        if (providers != null && !providers.isEmpty()) {
+            return providers;
+        }
+        // otherwise use the loader of this class
+        else {
+            return loadProviders(WildFlySecurityManager.getClassLoaderPrivileged(WildFlyProviderResolver.class));
+        }
+    }
+
+    /**
+     * Retrieves the providers from the given loader, using the service loader mechanism.
+     *
+     * @param classLoader the class loader to use
+     * @return a list with providers retrieved via the given loader. May be empty but never {@code null}
+     */
+    private List<ValidationProvider<?>> loadProviders(ClassLoader classLoader) {
+        @SuppressWarnings("rawtypes")
+        Iterator<ValidationProvider> providerIterator = ServiceLoader.load(ValidationProvider.class, classLoader).iterator();
+        LinkedList<ValidationProvider<?>> providers = new LinkedList<ValidationProvider<?>>();
+
+        while (providerIterator.hasNext()) {
+            try {
+                ValidationProvider<?> provider = providerIterator.next();
+
+                // put Hibernate Validator to the beginning of the list
+                if (provider.getClass().getName().equals(HibernateValidator.class.getName())) {
+                    providers.addFirst(provider);
+                } else {
+                    providers.add(provider);
+                }
+            } catch (ServiceConfigurationError e) {
+                // ignore, because it can happen when multiple
+                // providers are present and some of them are not class loader
+                // compatible with our API.
+            }
+        }
+
+        return providers;
+    }
+}

--- a/ee/src/main/java/org/jboss/as/ee/beanvalidation/LazyValidatorFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/beanvalidation/LazyValidatorFactory.java
@@ -21,32 +21,21 @@
  */
 package org.jboss.as.ee.beanvalidation;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 import javax.validation.Configuration;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.Validation;
-import javax.validation.ValidationProviderResolver;
 import javax.validation.Validator;
 import javax.validation.ValidatorContext;
 import javax.validation.ValidatorFactory;
-import javax.validation.spi.ValidationProvider;
-
-import org.hibernate.validator.HibernateValidator;
-import org.hibernate.validator.HibernateValidatorConfiguration;
-import org.hibernate.validator.cfg.ConstraintMapping;
 
 /**
- * This class lazily initialize the ValidatorFactory on the first usage
- * One benefit is that no domain class is loaded until the
- * ValidatorFactory is really needed.
- * Useful to avoid loading classes before JPA is initialized
- * and has enhanced its classes.
+ * This class lazily initialize the ValidatorFactory on the first usage One benefit is that no domain class is loaded until the
+ * ValidatorFactory is really needed. Useful to avoid loading classes before JPA is initialized and has enhanced its classes.
  *
  * @author Emmanuel Bernard
  * @author Stuart Douglas
@@ -56,7 +45,7 @@ public class LazyValidatorFactory implements ValidatorFactory {
     private final Configuration<?> configuration;
     private final ClassLoader classLoader;
 
-    private volatile ValidatorFactory delegate; //use as a barrier
+    private volatile ValidatorFactory delegate; // use as a barrier
 
     /**
      * Use the default ValidatorFactory creation routine
@@ -83,6 +72,7 @@ public class LazyValidatorFactory implements ValidatorFactory {
         return result;
     }
 
+    @Override
     public Validator getValidator() {
         return getDelegate().getValidator();
     }
@@ -92,11 +82,8 @@ public class LazyValidatorFactory implements ValidatorFactory {
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
             if (configuration == null) {
-                ConstraintMapping mapping = new ConstraintMapping();
-                HibernateValidatorConfiguration config = Validation.byProvider(HibernateValidator.class).providerResolver(new JbossProviderResolver()).configure();
-                config.addMapping(mapping);
-                ValidatorFactory factory = config.buildValidatorFactory();
-                return factory;
+                return Validation.byDefaultProvider().providerResolver(new WildFlyProviderResolver()).configure()
+                        .buildValidatorFactory();
 
             } else {
                 return configuration.buildValidatorFactory();
@@ -106,31 +93,38 @@ public class LazyValidatorFactory implements ValidatorFactory {
         }
     }
 
+    @Override
     public ValidatorContext usingContext() {
         return getDelegate().usingContext();
     }
 
+    @Override
     public MessageInterpolator getMessageInterpolator() {
         return getDelegate().getMessageInterpolator();
     }
 
+    @Override
     public TraversableResolver getTraversableResolver() {
         return getDelegate().getTraversableResolver();
     }
 
+    @Override
     public ConstraintValidatorFactory getConstraintValidatorFactory() {
         return getDelegate().getConstraintValidatorFactory();
     }
 
+    @Override
+    public ParameterNameProvider getParameterNameProvider() {
+        return getDelegate().getParameterNameProvider();
+    }
+
+    @Override
     public <T> T unwrap(Class<T> clazz) {
         return getDelegate().unwrap(clazz);
     }
 
-    private static final class JbossProviderResolver implements ValidationProviderResolver {
-
-        @Override
-        public List<ValidationProvider<?>> getValidationProviders() {
-            return Collections.<ValidationProvider<?>>singletonList(new HibernateValidator());
-        }
+    @Override
+    public void close() {
+        getDelegate().close();
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/beanvalidation/WildFlyProviderResolver.java
+++ b/ee/src/main/java/org/jboss/as/ee/beanvalidation/WildFlyProviderResolver.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import javax.validation.ValidationProviderResolver;
+import javax.validation.spi.ValidationProvider;
+
+import org.hibernate.validator.HibernateValidator;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * A {@link ValidationProviderResolver} to be used within WildFly. If several BV providers are available,
+ * {@code HibernateValidator} will be the first element of the returned provider list.
+ * <p/>
+ * The providers are loaded via the current thread's context class loader; If no providers are found, the loader of this class
+ * will be tried as fallback.
+ *
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ */
+public class WildFlyProviderResolver implements ValidationProviderResolver {
+
+    /**
+     * Returns a list with all {@link ValidationProvider} validation providers.
+     *
+     * @return a list with all {@link ValidationProvider} validation providers
+     */
+    @Override
+    public List<ValidationProvider<?>> getValidationProviders() {
+        // first try the TCCL
+        List<ValidationProvider<?>> providers = loadProviders(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+
+        if (providers != null && !providers.isEmpty()) {
+            return providers;
+        }
+        // otherwise use the loader of this class
+        else {
+            return loadProviders(WildFlySecurityManager.getClassLoaderPrivileged(WildFlyProviderResolver.class));
+        }
+    }
+
+    /**
+     * Retrieves the providers from the given loader, using the service loader mechanism.
+     *
+     * @param classLoader the class loader to use
+     * @return a list with providers retrieved via the given loader. May be empty but never {@code null}
+     */
+    private List<ValidationProvider<?>> loadProviders(ClassLoader classLoader) {
+        @SuppressWarnings("rawtypes")
+        Iterator<ValidationProvider> providerIterator = ServiceLoader.load(ValidationProvider.class, classLoader).iterator();
+        LinkedList<ValidationProvider<?>> providers = new LinkedList<ValidationProvider<?>>();
+
+        while (providerIterator.hasNext()) {
+            try {
+                ValidationProvider<?> provider = providerIterator.next();
+
+                // put Hibernate Validator to the beginning of the list
+                if (provider.getClass().getName().equals(HibernateValidator.class.getName())) {
+                    providers.addFirst(provider);
+                } else {
+                    providers.add(provider);
+                }
+            } catch (ServiceConfigurationError e) {
+                // ignore, because it can happen when multiple
+                // providers are present and some of them are not class loader
+                // compatible with our API.
+            }
+        }
+
+        return providers;
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/LazyValidatorFactoryTestCase.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/LazyValidatorFactoryTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.hibernate.validator.HibernateValidatorFactory;
+import org.jboss.as.ee.beanvalidation.testprovider.MyValidatorImpl;
+import org.jboss.as.ee.beanvalidation.testutil.WithContextClassLoader;
+import org.jboss.as.ee.beanvalidation.testutil.ContextClassLoaderRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Unit test for {@link LazyValidatorFactory}.
+ *
+ * @author Gunnar Morling
+ */
+public class LazyValidatorFactoryTestCase {
+
+    @Rule
+    public final ContextClassLoaderRule contextClassLoaderRule = new ContextClassLoaderRule();
+
+    private ValidatorFactory validatorFactory;
+
+    @Before
+    public void setupValidatorFactory() {
+        validatorFactory = new LazyValidatorFactory(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+    }
+
+    @Test
+    public void testHibernateValidatorIsUsedAsProviderByDefault() {
+        HibernateValidatorFactory hibernateValidatorFactory = validatorFactory.unwrap(HibernateValidatorFactory.class);
+        assertNotNull("LazyValidatorFactory should delegate to the HV factory by default", hibernateValidatorFactory);
+
+        Validator validator = validatorFactory.getValidator();
+        assertNotNull("LazyValidatorFactory should provide a validator", validator);
+    }
+
+    @Test
+    @WithContextClassLoader(TestClassLoader.class)
+    public void testSpecificProviderCanBeConfiguredInValidationXml() {
+        Validator validator = validatorFactory.getValidator();
+        assertNotNull("LazyValidatorFactory should provide a validator", validator);
+        assertTrue("Validator should be of type created by XML-configured provider", validator instanceof MyValidatorImpl);
+    }
+
+    /**
+     * A class loader which makes the file {@code custom-default-validation-provider-validation.xml} available as
+     * {@code META-INF/validation.xml}.
+     *
+     * @author Gunnar Morling
+     */
+    public final static class TestClassLoader extends ClassLoader {
+
+        public TestClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (name.equals("META-INF/validation.xml")) {
+                return LazyValidatorFactoryTestCase.class.getResourceAsStream("custom-default-validation-provider-validation.xml");
+            }
+
+            return super.getResourceAsStream(name);
+        }
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/WildFlyProviderResolverTestCase.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/WildFlyProviderResolverTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import javax.validation.ValidationProviderResolver;
+import javax.validation.spi.ValidationProvider;
+
+import org.hibernate.validator.HibernateValidator;
+import org.jboss.as.ee.beanvalidation.testprovider.MyValidationProvider;
+import org.jboss.as.ee.beanvalidation.testutil.ContextClassLoaderRule;
+import org.jboss.as.ee.beanvalidation.testutil.WithContextClassLoader;
+import org.jboss.as.ee.beanvalidation.testutil.WithContextClassLoader.NullClassLoader;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test for {@link WildFlyProviderResolver}.
+ *
+ * @author Gunnar Morling
+ */
+public class WildFlyProviderResolverTestCase {
+
+    @Rule
+    public final ContextClassLoaderRule contextClassLoaderRule = new ContextClassLoaderRule();
+
+    private ValidationProviderResolver providerResolver;
+
+    @Before
+    public void setupProviderResolver() {
+        providerResolver = new WildFlyProviderResolver();
+    }
+
+    @Test
+    public void testHibernateValidatorIsFirstProviderInList() {
+        List<ValidationProvider<?>> validationProviders = providerResolver.getValidationProviders();
+
+        assertEquals(2, validationProviders.size());
+        assertEquals(HibernateValidator.class.getName(), validationProviders.get(0).getClass().getName());
+        assertEquals(MyValidationProvider.class.getName(), validationProviders.get(1).getClass().getName());
+    }
+
+    @Test
+    @WithContextClassLoader(NullClassLoader.class)
+    public void testValidationProvidersCanBeLoadedIfContextLoaderIsNull() {
+        List<ValidationProvider<?>> validationProviders = providerResolver.getValidationProviders();
+
+        assertEquals(2, validationProviders.size());
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/AnotherValidationProvider.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/AnotherValidationProvider.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testprovider;
+
+import javax.validation.Configuration;
+import javax.validation.ValidatorFactory;
+import javax.validation.spi.BootstrapState;
+import javax.validation.spi.ConfigurationState;
+import javax.validation.spi.ValidationProvider;
+
+/**
+ * A {@link ValidationProvider} implementation for testing purposes.
+ *
+ * @author Gunnar Morling
+ */
+public class AnotherValidationProvider implements ValidationProvider<MyConfiguration> {
+
+    @Override
+    public MyConfiguration createSpecializedConfiguration(BootstrapState state) {
+        return new MyConfiguration();
+    }
+
+    @Override
+    public Configuration<?> createGenericConfiguration(BootstrapState state) {
+        return new MyConfiguration();
+    }
+
+    @Override
+    public ValidatorFactory buildValidatorFactory(ConfigurationState configurationState) {
+        return new MyValidatorFactoryImpl();
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyConfiguration.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyConfiguration.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testprovider;
+
+import java.io.InputStream;
+
+import javax.validation.BootstrapConfiguration;
+import javax.validation.Configuration;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.TraversableResolver;
+import javax.validation.ValidatorFactory;
+
+/**
+ * A {@link Configuration} implementation for testing purposes.
+ *
+ * @author Gunnar Morling
+ */
+public class MyConfiguration implements Configuration<MyConfiguration> {
+
+    @Override
+    public MyConfiguration ignoreXmlConfiguration() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MyConfiguration messageInterpolator(MessageInterpolator interpolator) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MyConfiguration traversableResolver(TraversableResolver resolver) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MyConfiguration constraintValidatorFactory(ConstraintValidatorFactory constraintValidatorFactory) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MyConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MyConfiguration addMapping(InputStream stream) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MyConfiguration addProperty(String name, String value) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MessageInterpolator getDefaultMessageInterpolator() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public TraversableResolver getDefaultTraversableResolver() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ConstraintValidatorFactory getDefaultConstraintValidatorFactory() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ParameterNameProvider getDefaultParameterNameProvider() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public BootstrapConfiguration getBootstrapConfiguration() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ValidatorFactory buildValidatorFactory() {
+        return new MyValidatorFactoryImpl();
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyValidationProvider.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyValidationProvider.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testprovider;
+
+import javax.validation.Configuration;
+import javax.validation.ValidatorFactory;
+import javax.validation.spi.BootstrapState;
+import javax.validation.spi.ConfigurationState;
+import javax.validation.spi.ValidationProvider;
+
+/**
+ * A {@link ValidationProvider} implementation for testing purposes.
+ *
+ * @author Gunnar Morling
+ */
+public class MyValidationProvider implements ValidationProvider<MyConfiguration> {
+
+    @Override
+    public MyConfiguration createSpecializedConfiguration(BootstrapState state) {
+        return new MyConfiguration();
+    }
+
+    @Override
+    public Configuration<?> createGenericConfiguration(BootstrapState state) {
+        return new MyConfiguration();
+    }
+
+    @Override
+    public ValidatorFactory buildValidatorFactory(ConfigurationState configurationState) {
+        return new MyValidatorFactoryImpl();
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyValidatorFactoryImpl.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyValidatorFactoryImpl.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testprovider;
+
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.TraversableResolver;
+import javax.validation.Validator;
+import javax.validation.ValidatorContext;
+import javax.validation.ValidatorFactory;
+
+/**
+ * A {@link ValidatorFactory} implementation for testing purposes.
+ *
+ * @author Gunnar Morling
+ */
+public class MyValidatorFactoryImpl implements ValidatorFactory {
+
+    @Override
+    public Validator getValidator() {
+        return new MyValidatorImpl();
+    }
+
+    @Override
+    public ValidatorContext usingContext() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public MessageInterpolator getMessageInterpolator() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public TraversableResolver getTraversableResolver() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ConstraintValidatorFactory getConstraintValidatorFactory() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ParameterNameProvider getParameterNameProvider() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyValidatorImpl.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testprovider/MyValidatorImpl.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testprovider;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.executable.ExecutableValidator;
+import javax.validation.metadata.BeanDescriptor;
+
+/**
+ * A {@link Validator} implementation for testing purposes.
+ *
+ * @author Gunnar Morling
+ */
+public class MyValidatorImpl implements Validator {
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validate(T object, Class<?>... groups) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateProperty(T object, String propertyName, Class<?>... groups) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateValue(Class<T> beanType, String propertyName, Object value,
+            Class<?>... groups) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public BeanDescriptor getConstraintsForClass(Class<?> clazz) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> type) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ExecutableValidator forExecutables() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testutil/ContextClassLoaderRule.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testutil/ContextClassLoaderRule.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testutil;
+
+import static java.security.AccessController.doPrivileged;
+
+import java.security.PrivilegedAction;
+
+import org.jboss.as.ee.beanvalidation.testutil.WithContextClassLoader.NullClassLoader;
+import org.wildfly.security.manager.GetContextClassLoaderAction;
+import org.wildfly.security.manager.SetContextClassLoaderAction;
+import org.wildfly.security.manager.WildFlySecurityManager;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+/**
+ * A JUnit rule which allows to use a specific class loader as context class loader by annotating the concerned test method with
+ * {@link WithContextClassLoader}. The previous context class loader will be set after test execution.
+ *
+ * @author Gunnar Morling
+ */
+public class ContextClassLoaderRule extends TestWatcher {
+    private ClassLoader previousContextClassLoader;
+
+    @Override
+    protected void starting(Description description) {
+        final WithContextClassLoader validationXml = description.getAnnotation(WithContextClassLoader.class);
+        if (validationXml == null) {
+            return;
+        }
+
+        previousContextClassLoader = getContextClassLoader();
+
+        setContextClassLoader(validationXml.value() == NullClassLoader.class ? null : newClassLoaderInstance(
+                validationXml.value(), previousContextClassLoader));
+    }
+
+    @Override
+    protected void finished(Description description) {
+        if (previousContextClassLoader != null) {
+            setContextClassLoader(previousContextClassLoader);
+        }
+    }
+
+    private ClassLoader getContextClassLoader() {
+        return run(GetContextClassLoaderAction.getInstance());
+    }
+
+    private void setContextClassLoader(ClassLoader classLoader) {
+        run(new SetContextClassLoaderAction(classLoader));
+    }
+
+    private <T extends ClassLoader> T newClassLoaderInstance(Class<T> clazz, ClassLoader parent) {
+        return run(new NewClassLoaderInstanceAction<T>(clazz, parent));
+    }
+
+    private <T> T run(PrivilegedAction<T> action) {
+        return ! WildFlySecurityManager.isChecking() ? action.run() : doPrivileged(action);
+    }
+
+    private final static class NewClassLoaderInstanceAction<T extends ClassLoader> implements PrivilegedAction<T> {
+
+        private final Class<T> clazz;
+        private final ClassLoader parent;
+
+        private NewClassLoaderInstanceAction(Class<T> clazz, ClassLoader parent) {
+            this.clazz = clazz;
+            this.parent = parent;
+        }
+
+        @Override
+        public T run() {
+            try {
+                return clazz.getConstructor(ClassLoader.class).newInstance(parent);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/ee/src/test/java/org/jboss/as/ee/beanvalidation/testutil/WithContextClassLoader.java
+++ b/ee/src/test/java/org/jboss/as/ee/beanvalidation/testutil/WithContextClassLoader.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.ee.beanvalidation.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the context class loader to use for a given test.
+ *
+ * @author Gunnar Morling
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface WithContextClassLoader {
+
+    /**
+     * The context class loader to use for a given test.
+     *
+     * @return the context class loader to use for a given test
+     */
+    Class<? extends ClassLoader> value();
+
+    /**
+     * A marker type for setting the context class loader to {@code null}.
+     *
+     * @author Gunnar Morling
+     */
+    public static class NullClassLoader extends ClassLoader {
+    }
+}

--- a/ee/src/test/resources/META-INF/services/javax.validation.spi.ValidationProvider
+++ b/ee/src/test/resources/META-INF/services/javax.validation.spi.ValidationProvider
@@ -1,0 +1,1 @@
+org.jboss.as.ee.beanvalidation.testprovider.MyValidationProvider

--- a/ee/src/test/resources/org/jboss/as/ee/beanvalidation/custom-default-validation-provider-validation.xml
+++ b/ee/src/test/resources/org/jboss/as/ee/beanvalidation/custom-default-validation-provider-validation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<validation-config
+    xmlns="http://jboss.org/xml/ns/javax/validation/configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/configuration validation-configuration-1.1.xsd"
+    version="1.1">
+
+    <default-provider>org.jboss.as.ee.beanvalidation.testprovider.MyValidationProvider</default-provider>
+</validation-config>

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java
@@ -44,7 +44,7 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
     public static final ModuleIdentifier RESTEASY_ATOM = ModuleIdentifier.create("org.jboss.resteasy.resteasy-atom-provider");
     public static final ModuleIdentifier RESTEASY_CDI = ModuleIdentifier.create("org.jboss.resteasy.resteasy-cdi");
     public static final ModuleIdentifier RESTEASY_CRYPTO = ModuleIdentifier.create("org.jboss.resteasy.resteasy-crypto");
-    public static final ModuleIdentifier RESTEASY_HIBERNATE_VALIDATOR = ModuleIdentifier.create("org.jboss.resteasy.resteasy-hibernatevalidator-provider");
+    public static final ModuleIdentifier RESTEASY_VALIDATOR_11 = ModuleIdentifier.create("org.jboss.resteasy.resteasy-validator-provider-11");
     public static final ModuleIdentifier RESTEASY_JAXRS = ModuleIdentifier.create("org.jboss.resteasy.resteasy-jaxrs");
     public static final ModuleIdentifier RESTEASY_JAXB = ModuleIdentifier.create("org.jboss.resteasy.resteasy-jaxb-provider");
     public static final ModuleIdentifier RESTEASY_JACKSON = ModuleIdentifier.create("org.jboss.resteasy.resteasy-jackson-provider");
@@ -72,7 +72,7 @@ public class JaxrsDependencyProcessor implements DeploymentUnitProcessor {
             return;
         }
         addDependency(moduleSpecification, moduleLoader, RESTEASY_ATOM);
-        addDependency(moduleSpecification, moduleLoader, RESTEASY_HIBERNATE_VALIDATOR);
+        addDependency(moduleSpecification, moduleLoader, RESTEASY_VALIDATOR_11);
         addDependency(moduleSpecification, moduleLoader, RESTEASY_JAXRS);
         addDependency(moduleSpecification, moduleLoader, RESTEASY_JAXB);
         addDependency(moduleSpecification, moduleLoader, RESTEASY_JACKSON);

--- a/jpa/core/src/main/java/org/jboss/as/jpa/validator/SerializableValidatorFactory.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/validator/SerializableValidatorFactory.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.Validator;
 import javax.validation.ValidatorContext;
@@ -66,6 +67,9 @@ public class SerializableValidatorFactory implements ValidatorFactory, Serializa
         return delegate.getMessageInterpolator();
     }
 
+    public ParameterNameProvider getParameterNameProvider() {
+        return delegate.getParameterNameProvider();
+    }
 
     /**
      * Get the validator
@@ -93,6 +97,10 @@ public class SerializableValidatorFactory implements ValidatorFactory, Serializa
      */
     public <T> T unwrap(Class<T> type) {
         return delegate.unwrap(type);
+    }
+
+    public void close() {
+        delegate.close();
     }
 
     /**

--- a/jpa/core/src/main/java/org/jboss/as/jpa/validator/WildFlyProviderResolver.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/validator/WildFlyProviderResolver.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.jpa.validator;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+import javax.validation.ValidationProviderResolver;
+import javax.validation.spi.ValidationProvider;
+
+import org.hibernate.validator.HibernateValidator;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * A {@link ValidationProviderResolver} to be used within WildFly. If several BV providers are available,
+ * {@code HibernateValidator} will be the first element of the returned provider list.
+ * <p/>
+ * The providers are loaded via the current thread's context class loader; If no providers are found, the loader of this class
+ * will be tried as fallback.
+ * </p>
+ * Note: This class is a copy of {@code org.jboss.as.ee.beanvalidation.WildFlyProviderResolver}.
+ *
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ */
+public class WildFlyProviderResolver implements ValidationProviderResolver {
+
+    /**
+     * Returns a list with all {@link ValidationProvider} validation providers.
+     *
+     * @return a list with all {@link ValidationProvider} validation providers
+     */
+    @Override
+    public List<ValidationProvider<?>> getValidationProviders() {
+        // first try the TCCL
+        List<ValidationProvider<?>> providers = loadProviders(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+
+        if (providers != null && !providers.isEmpty()) {
+            return providers;
+        }
+        // otherwise use the loader of this class
+        else {
+            return loadProviders(WildFlySecurityManager.getClassLoaderPrivileged(WildFlyProviderResolver.class));
+        }
+    }
+
+    /**
+     * Retrieves the providers from the given loader, using the service loader mechanism.
+     *
+     * @param classLoader the class loader to use
+     * @return a list with providers retrieved via the given loader. May be empty but never {@code null}
+     */
+    private List<ValidationProvider<?>> loadProviders(ClassLoader classLoader) {
+        @SuppressWarnings("rawtypes")
+        Iterator<ValidationProvider> providerIterator = ServiceLoader.load(ValidationProvider.class, classLoader).iterator();
+        LinkedList<ValidationProvider<?>> providers = new LinkedList<ValidationProvider<?>>();
+
+        while (providerIterator.hasNext()) {
+            try {
+                ValidationProvider<?> provider = providerIterator.next();
+
+                // put Hibernate Validator to the beginning of the list
+                if (provider.getClass().getName().equals(HibernateValidator.class.getName())) {
+                    providers.addFirst(provider);
+                } else {
+                    providers.add(provider);
+                }
+            } catch (ServiceConfigurationError e) {
+                // ignore, because it can happen when multiple
+                // providers are present and some of them are not class loader
+                // compatible with our API.
+            }
+        }
+
+        return providers;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <version.javax.json-api>1.0</version.javax.json-api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.5.0-b01</version.javax.mail>
-        <version.javax.validation>1.0.0.GA</version.javax.validation>
+        <version.javax.validation>1.1.0.Final</version.javax.validation>
         <version.org.jboss.spec.javax.websockets>1.0.0.Beta1</version.org.jboss.spec.javax.websockets>
         <version.jaxen>1.1.3</version.jaxen>
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
@@ -150,7 +150,7 @@
         <version.org.hibernate>4.3.0.Beta3</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
-        <version.org.hibernate.validator>4.3.1.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>5.0.1.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Draft-16</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate3>3.6.6.Final</version.org.hibernate3>
         <version.org.hibernate3.commons.annotations>3.2.0.Final</version.org.hibernate3.commons.annotations>

--- a/pom.xml
+++ b/pom.xml
@@ -5044,7 +5044,7 @@
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>resteasy-hibernatevalidator-provider</artifactId>
+                <artifactId>resteasy-validator-provider-11</artifactId>
                 <version>${version.org.jboss.resteasy}</version>
             </dependency>
 

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -84,18 +84,17 @@
             <version>${version.apacheds.shared}</version>
             <scope>test</scope>
         </dependency>
-
- 	<dependency>
+        <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-core-jndi</artifactId>
             <version>${version.apacheds}</version>
             <scope>test</scope>
         </dependency>
-	<dependency>
-	    <groupId>org.syslog4j</groupId>
-	    <artifactId>syslog4j</artifactId>
-	    <version>0.9.30</version>
-	</dependency>
+        <dependency>
+            <groupId>org.syslog4j</groupId>
+            <artifactId>syslog4j</artifactId>
+            <version>0.9.30</version>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -290,7 +289,7 @@
                                         <jboss.inst>${basedir}/target/jbossas</jboss.inst>
                                         <org.jboss.model.test.cache.root>${org.jboss.model.test.cache.root}</org.jboss.model.test.cache.root>
                                         <org.jboss.model.test.classpath.cache>${org.jboss.model.test.classpath.cache}</org.jboss.model.test.classpath.cache>
-																				<org.jboss.model.test.maven.repository.urls>${org.jboss.model.test.maven.repository.urls}</org.jboss.model.test.maven.repository.urls>
+                                        <org.jboss.model.test.maven.repository.urls>${org.jboss.model.test.maven.repository.urls}</org.jboss.model.test.maven.repository.urls>
                                     </systemPropertyVariables>
 
                                     <additionalClasspathElements>
@@ -344,10 +343,10 @@
                     </plugin>
 
                     <plugin>
-                    	<groupId>org.apache.felix</groupId>
-                    	<artifactId>maven-bundle-plugin</artifactId>
-                    	<inherited>true</inherited>
-                    	<extensions>true</extensions>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>maven-bundle-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <extensions>true</extensions>
                     </plugin>
 
                 </plugins>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
-			<!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
-			     In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
+            <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
+                 In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/BootStrapValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/BootStrapValidationTestCase.java
@@ -1,16 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Set;
+
 import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-import javax.validation.constraints.NotNull;
 
-import org.junit.Assert;
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.HibernateValidatorFactory;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -19,14 +44,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.hibernate.validator.HibernateValidator;
-import org.hibernate.validator.HibernateValidatorConfiguration;
-import org.hibernate.validator.HibernateValidatorFactory;
-import org.hibernate.validator.internal.constraintvalidators.NotNullValidator;
-import org.hibernate.validator.internal.engine.ConstraintValidatorFactoryImpl;
-
 /**
- * Tests that bootstrapping works correctly for hibernate validator
+ * Tests that bootstrapping works correctly for Hibernate Validator.
  *
  * @author Madhumita Sadhukhan
  */
@@ -38,20 +57,18 @@ public class BootStrapValidationTestCase {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testbootstrapvalidation.war");
         war.addPackage(BootStrapValidationTestCase.class.getPackage());
         return war;
-
     }
 
     @Test
     public void testBootstrapAsServiceDefault() {
         HibernateValidatorFactory factory = (HibernateValidatorFactory) Validation.buildDefaultValidatorFactory();
-        Assert.assertNotNull(factory);
+        assertNotNull(factory);
     }
 
     @Test
     public void testCustomConstraintValidatorFactory() {
-
         HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class).configure();
-        Assert.assertNotNull(configuration);
+        assertNotNull(configuration);
 
         ValidatorFactory factory = configuration.buildValidatorFactory();
         Validator validator = factory.getValidator();
@@ -64,25 +81,18 @@ public class BootStrapValidationTestCase {
         emp.setEmail("madhu@redhat.com");
 
         Set<ConstraintViolation<Employee>> constraintViolations = validator.validate(emp);
-        Assert.assertEquals("Wrong number of constraints", constraintViolations.size(), 0);
+        assertEquals("Wrong number of constraints", constraintViolations.size(), 1);
+        assertEquals("Created by default factory", constraintViolations.iterator().next().getMessage());
 
         // get a new factory using a custom configuration
-        configuration = (HibernateValidatorConfiguration) Validation.byDefaultProvider().configure();
-        configuration.constraintValidatorFactory(new ConstraintValidatorFactory() {
-
-            @Override
-            public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
-                if (key == NotNullValidator.class) {
-                    return (T) new ErroneousNotNullValidator();
-                }
-                return new ConstraintValidatorFactoryImpl().getInstance(key);
-            }
-        });
+        configuration.constraintValidatorFactory(new CustomConstraintValidatorFactory(configuration
+                .getDefaultConstraintValidatorFactory()));
 
         factory = configuration.buildValidatorFactory();
         validator = factory.getValidator();
         constraintViolations = validator.validate(emp);
-        Assert.assertEquals("Wrong number of constraints", constraintViolations.size(), 1);
+        assertEquals("Wrong number of constraints", constraintViolations.size(), 1);
+        assertEquals("Created by custom factory", constraintViolations.iterator().next().getMessage());
     }
 
     /**
@@ -90,49 +100,47 @@ public class BootStrapValidationTestCase {
      */
     @Test
     public void testSafeHTML() {
-
         HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class).configure();
-        Assert.assertNotNull(configuration);
+        assertNotNull(configuration);
 
         ValidatorFactory factory = configuration.buildValidatorFactory();
         Validator validator = factory.getValidator();
 
         Employee emp = new Employee();
         // create employee
-        emp.setEmpId("M1234");
         emp.setFirstName("Joe");
         emp.setLastName("Cocker");
         emp.setEmail("none@jboss.org");
         emp.setWebsite("<script> Cross-site scripting http://en.wikipedia.org/wiki/Joe_Cocker <script/>.");
 
         Set<ConstraintViolation<Employee>> constraintViolations = validator.validate(emp);
-        Assert.assertEquals("Wrong number of constraints", constraintViolations.size(), 1);
-
+        assertEquals("Wrong number of constraints", constraintViolations.size(), 1);
     }
 
-    class ErroneousNotNullValidator implements ConstraintValidator<NotNull,Object> {
+    /**
+     * A custom constraint validator factory.
+     */
+    private static class CustomConstraintValidatorFactory implements ConstraintValidatorFactory {
+
+        private final ConstraintValidatorFactory delegate;
+
+        public CustomConstraintValidatorFactory(ConstraintValidatorFactory delegate) {
+            this.delegate = delegate;
+        }
+
         @Override
-        public void initialize(NotNull parameters) {
-           }
-        @Override
-        public boolean isValid(Object obj, ConstraintValidatorContext constraintValidatorContext) {
-
-            if (obj != null) {
-                String var = ((String) obj);
-
-                if (var.length() > 0 && var.length() < 10 && var.matches("^[0-9]+$")) {
-
-                    return true;
-                } else {
-
-                    return false;
-
-                }
-            } else {
-
-                return false;
-
+        @SuppressWarnings("unchecked")
+        public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+            if (key == CustomConstraint.Validator.class) {
+                return (T) new CustomConstraint.Validator("Created by custom factory");
             }
+
+            return delegate.getInstance(key);
+        }
+
+        @Override
+        public void releaseInstance(ConstraintValidator<?, ?> instance) {
+            delegate.releaseInstance(instance);
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/CarGroupSequenceProvider.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/CarGroupSequenceProvider.java
@@ -24,13 +24,12 @@ package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.validator.group.DefaultGroupSequenceProvider;
+import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 
 /**
  * 
  * @author Madhumita Sadhukhan
  */
-
 public class CarGroupSequenceProvider implements DefaultGroupSequenceProvider<Car> {
 
     List<Class<?>> defaultGroupSequence = new ArrayList<Class<?>>();
@@ -41,14 +40,11 @@ public class CarGroupSequenceProvider implements DefaultGroupSequenceProvider<Ca
         defaultGroupSequence.add(Car.class);
         defaultGroupSequence.add(CarChecks.class);
 
-        System.out.println("car.inspectionCompleted()::--" + car.inspectionCompleted());
-
         if (car != null && car.inspectionCompleted()) {
             defaultGroupSequence.add(FinalInspection.class);
 
         }
 
         return defaultGroupSequence;
-
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ConstraintValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ConstraintValidationTestCase.java
@@ -21,7 +21,9 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
-import java.sql.SQLException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -37,14 +39,12 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * 
  * Tests that hibernate validator works correctly for WAR(Web Applications)
- * 
  * 
  * @author Madhumita Sadhukhan
  */
@@ -56,36 +56,33 @@ public class ConstraintValidationTestCase {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testconstraintvalidation.war");
         war.addPackage(ConstraintValidationTestCase.class.getPackage());
         return war;
-
     }
 
     @Test
-    public void testConstraintValidation() throws NamingException, SQLException {
+    public void testConstraintValidation() throws NamingException {
         Validator validator = (Validator) new InitialContext().lookup("java:comp/Validator");
         UserBean user1 = new UserBean("MADHUMITA", "");
         user1.setEmail("madhumita_gmail");
         user1.setAddress("");
         final Set<ConstraintViolation<UserBean>> result = validator.validate(user1);
 
-        Object[] resultArray = result.toArray();
-        Iterator it = result.iterator();
+        Iterator<ConstraintViolation<UserBean>> it = result.iterator();
         String message = "";
 
         while (it.hasNext()) {
-            ConstraintViolation<UserBean> cts = (ConstraintViolation<UserBean>) it.next();
+            ConstraintViolation<UserBean> cts = it.next();
             String mess = cts.getMessage();
 
             if (mess.contains("Please get a valid address"))
                 message = mess;
-
         }
 
-        Assert.assertEquals(3, result.size());
-        Assert.assertTrue(message.contains("Please get a valid address"));
+        assertEquals(3, result.size());
+        assertTrue(message.contains("Please get a valid address"));
     }
 
     @Test
-    public void testObjectGraphValidation() throws NamingException, SQLException {
+    public void testObjectGraphValidation() throws NamingException {
         Validator validator = (Validator) new InitialContext().lookup("java:comp/Validator");
 
         // create first passenger
@@ -107,20 +104,18 @@ public class ConstraintValidationTestCase {
 
         final Set<ConstraintViolation<Car>> errorresult = validator.validate(car);
 
-        Object[] resultArray = errorresult.toArray();
-        Iterator it1 = errorresult.iterator();
+        Iterator<ConstraintViolation<Car>> it1 = errorresult.iterator();
         String message = "";
 
         while (it1.hasNext()) {
-            ConstraintViolation<Car> cts = (ConstraintViolation<Car>) it1.next();
+            ConstraintViolation<Car> cts = it1.next();
             String mess = cts.getMessage();
 
             if (mess.contains("Please get a valid address"))
                 message = mess;
-
         }
 
-        Assert.assertEquals(2, errorresult.size());
-        Assert.assertTrue(message.contains("Please get a valid address"));
+        assertEquals(2, errorresult.size());
+        assertTrue(message.contains("Please get a valid address"));
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/CustomConstraint.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/CustomConstraint.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+/**
+ * A custom constraint which expects a custom constraint validator factory.
+ *
+ * @author Gunnar Morling
+ */
+@Constraint(validatedBy = CustomConstraint.Validator.class)
+@Documented
+@Target(FIELD)
+@Retention(RUNTIME)
+public @interface CustomConstraint {
+
+    String message() default "my custom constraint";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    public class Validator implements ConstraintValidator<CustomConstraint, String> {
+
+        private final String message;
+
+        public Validator() {
+            this.message = "Created by default factory";
+        }
+
+        public Validator(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public void initialize(CustomConstraint parameters) {
+        }
+
+        @Override
+        public boolean isValid(String object, ConstraintValidatorContext constraintValidatorContext) {
+            if (object == null) {
+                return true;
+            }
+
+            constraintValidatorContext.disableDefaultConstraintViolation();
+            constraintValidatorContext.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+
+            return false;
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/Employee.java
@@ -21,10 +21,6 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
-import java.lang.String;
-
-import javax.validation.constraints.NotNull;
-
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.SafeHtml;
 
@@ -34,7 +30,7 @@ import org.hibernate.validator.constraints.SafeHtml;
  */
 public class Employee {
 
-    @NotNull
+    @CustomConstraint
     private String empId;
 
     private String firstName;
@@ -50,7 +46,6 @@ public class Employee {
     public String getEmpId() {
         return empId;
     }
-
 
     public void setEmpId(String empId) {
         this.empId = empId;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ExpressionLanguageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ExpressionLanguageTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.Size;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that Unified EL expressions can be used in Bean Violation messages as supported since BV 1.1.
+ *
+ * @author Gunnar Morling
+ */
+@RunWith(Arquillian.class)
+public class ExpressionLanguageTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "expression-language-validation.war").addClass(
+                ExpressionLanguageTestCase.class);
+    }
+
+    @Test
+    public void testValidationUsingExpressionLanguage() {
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Set<ConstraintViolation<TestBean>> violations = validator.validate(new TestBean());
+
+        assertEquals(1, violations.size());
+        assertEquals("'Bob' is too short, it should at least be 5 characters long.", violations.iterator().next().getMessage());
+    }
+
+    private static class TestBean {
+
+        @Size(min = 5, message = "'${validatedValue}' is too short, it should at least be {min} characters long.")
+        private final String name = "Bob";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/GroupandGroupSequenceValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/GroupandGroupSequenceValidationTestCase.java
@@ -21,7 +21,8 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
-import java.sql.SQLException;
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -36,14 +37,11 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * 
- * Tests GroupSequenceProvider feature in  hibernate validator
- * 
+ * Tests GroupSequenceProvider feature in Hibernate Validator.
  * 
  * @author Madhumita Sadhukhan
  */
@@ -59,7 +57,7 @@ public class GroupandGroupSequenceValidationTestCase {
     }
 
     @Test
-    public void testGroupValidation() throws NamingException, SQLException {
+    public void testGroupValidation() throws NamingException {
         Validator validator = (Validator) new InitialContext().lookup("java:comp/Validator");
 
         // create first passenger
@@ -82,35 +80,35 @@ public class GroupandGroupSequenceValidationTestCase {
 
         // validate Car with default group as per GroupSequenceProvider
         Set<ConstraintViolation<Car>> result = validator.validate(car);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals("The Car has to pass the fuel test and inspection test before being driven", result.iterator()
-                .next().getMessage());
+        assertEquals(1, result.size());
+        assertEquals("The Car has to pass the fuel test and inspection test before being driven", result.iterator().next()
+                .getMessage());
 
         Driver driver = new Driver("Sebastian", "Vettel");
         driver.setAge(25);
         driver.setAddress("ABC");
 
         result = validator.validate(car);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals("The Car has to pass the fuel test and inspection test before being driven", result.iterator()
-                .next().getMessage());
+        assertEquals(1, result.size());
+        assertEquals("The Car has to pass the fuel test and inspection test before being driven", result.iterator().next()
+                .getMessage());
         car.setPassedVehicleInspection(true);
 
         result = validator.validate(car);
         // New group set in defaultsequence for Car as per CarGroupSequenceProvider should be implemented now
-        Assert.assertEquals(2, result.size());
+        assertEquals(2, result.size());
 
         car.setDriver(driver);
         // implementing validation for group associated with associated objects of Car(in this case Driver)
         Set<ConstraintViolation<Car>> driverResult = validator.validate(car, DriverChecks.class);
-        Assert.assertEquals(1, driverResult.size());
+        assertEquals(1, driverResult.size());
         driver.setHasValidDrivingLicense(true);
-        Assert.assertEquals(0, validator.validate(car, DriverChecks.class).size());
+        assertEquals(0, validator.validate(car, DriverChecks.class).size());
 
         car.setSeats(5);
         car.setHasBeenPaid(true);
 
-        Assert.assertEquals(0, validator.validate(car).size());
+        assertEquals(0, validator.validate(car).size());
 
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/AnotherValidatorResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/AnotherValidatorResource.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -28,13 +28,17 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-@Path("validate/{id}")
+@Path("another-validate/{id}")
 @Produces("text/plain")
-public class ValidatorResource {
+public class AnotherValidatorResource {
+
+    @PathParam("id")
+    @Min(value = 4)
+    private int id;
 
     @Valid
     @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
+    public ValidatorModel getValidatorModel() {
         return new ValidatorModel(id);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationConfiguredGloballyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationConfiguredGloballyTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jaxrs.validator;
+
+import java.net.URL;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for JAX-RS taking the global Bean Validation configuration into account (META-INF/validation.xml).
+ *
+ * @author Gunnar Morling
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class BeanValidationConfiguredGloballyTestCase {
+
+    @ApplicationPath("/myjaxrs")
+    public static class TestApplication extends Application {
+    }
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "jaxrsnoap.war")
+            .addPackage(HttpRequest.class.getPackage())
+            .addClasses(
+                BeanValidationConfiguredGloballyTestCase.class,
+                ValidatorModel.class,
+                GloballyConfiguredValidatorResource.class
+            )
+            .addAsManifestResource(new StringAsset(
+                "<validation-config version=\"1.1\" xmlns=\"http://jboss.org/xml/ns/javax/validation/configuration\">\n" +
+                    "<executable-validation>\n" +
+                        "<default-validated-executable-types>\n" +
+                            "<executable-type>NONE</executable-type>\n" +
+                        "</default-validated-executable-types>\n" +
+                    "</executable-validation>\n" +
+                "</validation-config>"), "validation.xml"
+            );
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void testInvalidRequestsAreAcceptedDependingOnGlobalValidationConfiguration() throws Exception {
+        DefaultHttpClient client = new DefaultHttpClient(new PoolingClientConnectionManager());
+
+        HttpGet get = new HttpGet(url + "myjaxrs/globally-configured-validate/3/disabled");
+        HttpResponse result = client.execute(get);
+
+        Assert.assertEquals("No constraint violated", 200, result.getStatusLine().getStatusCode());
+        EntityUtils.consume(result.getEntity());
+
+        get = new HttpGet(url + "myjaxrs/globally-configured-validate/3/enabled");
+        result = client.execute(get);
+        Assert.assertEquals("Parameter constraint violated", 400, result.getStatusLine().getStatusCode());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/BeanValidationIntegrationTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jaxrs.validator;
+
+import java.net.URL;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.PoolingClientConnectionManager;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for the integration of JAX-RS and Bean Validation.
+ *
+ * @author Stuart Douglas
+ * @author Gunnar Morling
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class BeanValidationIntegrationTestCase {
+
+    @ApplicationPath("/myjaxrs")
+    public static class TestApplication extends Application {
+    }
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "jaxrsnoap.war")
+            .addPackage(HttpRequest.class.getPackage())
+            .addClasses(
+                BeanValidationIntegrationTestCase.class,
+                ValidatorModel.class,
+                ValidatorResource.class,
+                AnotherValidatorResource.class,
+                YetAnotherValidatorResource.class
+            );
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void testValidRequest() throws Exception {
+        DefaultHttpClient client = new DefaultHttpClient(new PoolingClientConnectionManager());
+
+        HttpGet get = new HttpGet(url + "myjaxrs/validate/5");
+        HttpResponse result = client.execute(get);
+
+        Assert.assertEquals(200, result.getStatusLine().getStatusCode());
+        Assert.assertEquals("ValidatorModel{id=5}", EntityUtils.toString(result.getEntity()));
+    }
+
+    @Test
+    public void testInvalidRequest() throws Exception {
+        DefaultHttpClient client = new DefaultHttpClient(new PoolingClientConnectionManager());
+
+        HttpGet get = new HttpGet(url + "myjaxrs/validate/3");
+        HttpResponse result = client.execute(get);
+        result = client.execute(get);
+
+        Assert.assertEquals("Parameter constraint violated", 400, result.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testInvalidRequestCausingPropertyConstraintViolation() throws Exception {
+        DefaultHttpClient client = new DefaultHttpClient(new PoolingClientConnectionManager());
+
+        HttpGet get = new HttpGet(url + "myjaxrs/another-validate/3");
+        HttpResponse result = client.execute(get);
+        result = client.execute(get);
+
+        Assert.assertEquals("Property constraint violated", 400, result.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testInvalidRequestsAreAcceptedDependingOnValidationConfiguration() throws Exception {
+        DefaultHttpClient client = new DefaultHttpClient(new PoolingClientConnectionManager());
+
+        HttpGet get = new HttpGet(url + "myjaxrs/yet-another-validate/3/disabled");
+        HttpResponse result = client.execute(get);
+
+        Assert.assertEquals("No constraint violated", 200, result.getStatusLine().getStatusCode());
+        EntityUtils.consume(result.getEntity());
+
+        get = new HttpGet(url + "myjaxrs/yet-another-validate/3/enabled");
+        result = client.execute(get);
+
+        Assert.assertEquals("Parameter constraint violated", 400, result.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testInvalidResponse() throws Exception {
+        DefaultHttpClient client = new DefaultHttpClient(new PoolingClientConnectionManager());
+
+        HttpGet get = new HttpGet(url + "myjaxrs/validate/11");
+        HttpResponse result = client.execute(get);
+        result = client.execute(get);
+
+        Assert.assertEquals("Return value constraint violated", 500, result.getStatusLine().getStatusCode());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/GloballyConfiguredValidatorResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/GloballyConfiguredValidatorResource.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -21,20 +21,28 @@
  */
 package org.jboss.as.test.integration.jaxrs.validator;
 
-import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-@Path("validate/{id}")
+@Path("globally-configured-validate/{id}")
 @Produces("text/plain")
-public class ValidatorResource {
+public class GloballyConfiguredValidatorResource {
 
-    @Valid
     @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
+    @Path("disabled")
+    public ValidatorModel getWithoutValidation(@PathParam("id") @Min(value = 4) int id) {
+        return new ValidatorModel(id);
+    }
+
+    @GET
+    @Path("enabled")
+    @ValidateOnExecution(type = ExecutableType.NON_GETTER_METHODS)
+    public ValidatorModel getWithValidation(@PathParam("id") @Min(value = 4) int id) {
         return new ValidatorModel(id);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/ValidatorModel.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/ValidatorModel.java
@@ -21,12 +21,14 @@
  */
 package org.jboss.as.test.integration.jaxrs.validator;
 
+import javax.validation.constraints.Max;
+
 /**
  * @author Stuart Douglas
  */
-
 public class ValidatorModel {
 
+    @Max(10)
     private int id;
 
     public ValidatorModel(final int id) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/YetAnotherValidatorResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/YetAnotherValidatorResource.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -21,20 +21,29 @@
  */
 package org.jboss.as.test.integration.jaxrs.validator;
 
-import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-@Path("validate/{id}")
+@Path("yet-another-validate/{id}")
 @Produces("text/plain")
-public class ValidatorResource {
+public class YetAnotherValidatorResource {
 
-    @Valid
     @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
+    @Path("disabled")
+    @ValidateOnExecution(type = ExecutableType.NONE)
+    public ValidatorModel getWithoutValidation(@PathParam("id") @Min(value = 4) int id) {
+        return new ValidatorModel(id);
+    }
+
+    @GET
+    @Path("enabled")
+    @ValidateOnExecution(type = ExecutableType.NON_GETTER_METHODS)
+    public ValidatorModel getWithValidation(@PathParam("id") @Min(value = 4) int id) {
         return new ValidatorModel(id);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/CustomMax.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/CustomMax.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jaxrs.validator.cdi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Custom constraint using CDI in its validator class.
+ *
+ * @author Gunnar Morling
+ */
+@Constraint(validatedBy = CustomMaxValidator.class)
+@Documented
+@Target({ METHOD, FIELD, TYPE, PARAMETER })
+@Retention(RUNTIME)
+public @interface CustomMax {
+    String message() default "my custom constraint";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/CustomMaxValidator.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/CustomMaxValidator.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -19,22 +19,32 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.jaxrs.validator;
+package org.jboss.as.test.integration.jaxrs.validator.cdi;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.inject.Inject;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
 
-@Path("validate/{id}")
-@Produces("text/plain")
-public class ValidatorResource {
+/**
+ * A validator which makes use of constructor injection.
+ *
+ * @author Gunnar Morling
+ */
+public class CustomMaxValidator implements ConstraintValidator<CustomMax, Integer> {
 
-    @Valid
-    @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
-        return new ValidatorModel(id);
+    private final MaximumValueProvider maximumValueProvider;
+
+    @Inject
+    public CustomMaxValidator(MaximumValueProvider maximumValueProvider) {
+        this.maximumValueProvider = maximumValueProvider;
+    }
+
+    @Override
+    public void initialize(CustomMax constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return value <= maximumValueProvider.getMax();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/MaximumValueProvider.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/MaximumValueProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -19,22 +19,19 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.jaxrs.validator;
+package org.jboss.as.test.integration.jaxrs.validator.cdi;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.enterprise.context.ApplicationScoped;
 
-@Path("validate/{id}")
-@Produces("text/plain")
-public class ValidatorResource {
+/**
+ * A test CDI bean.
+ *
+ * @author Gunnar Morling
+ */
+@ApplicationScoped
+public class MaximumValueProvider {
 
-    @Valid
-    @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
-        return new ValidatorModel(id);
+    public int getMax() {
+        return 10;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/OrderModel.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/OrderModel.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * Copyright 2013, Red Hat Inc., and individual contributors as indicated
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -19,22 +19,31 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.jaxrs.validator;
+package org.jboss.as.test.integration.jaxrs.validator.cdi;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+/**
+ * An order.
+ *
+ * @author Gunnar Morling
+ */
+public class OrderModel {
 
-@Path("validate/{id}")
-@Produces("text/plain")
-public class ValidatorResource {
+    private int id;
 
-    @Valid
-    @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
-        return new ValidatorModel(id);
+    public OrderModel(final int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "OrderModel{" + "id=" + id + "}";
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/OrderResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/validator/cdi/OrderResource.java
@@ -19,22 +19,19 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.jaxrs.validator;
+package org.jboss.as.test.integration.jaxrs.validator.cdi;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Min;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
-@Path("validate/{id}")
 @Produces("text/plain")
-public class ValidatorResource {
+@Path("order/{id}")
+public class OrderResource {
 
-    @Valid
     @GET
-    public ValidatorModel get(@PathParam("id") @Min(value=4) int id) {
-        return new ValidatorModel(id);
+    public OrderModel get(@PathParam("id") @CustomMax int id) {
+        return new OrderModel(id);
     }
 }

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -293,7 +293,7 @@
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
-						<type>pom</type>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Updated to Hibernate Validator 5.0.1
- Updated RESTEasy Bean Validation integration to "resteasy-validator-provider-11" (BV 1.1 support)
- Added tests for the integration of JAX-RS and Bean Validation
