### PR TITLE
WFLY-1590, Add missing cache statistics in EJB3 deployment metrics.

### DIFF
--- a/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanBackingCacheEntryStore.java
+++ b/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanBackingCacheEntryStore.java
@@ -35,6 +35,8 @@ import org.infinispan.affinity.KeyGenerator;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.DataLocality;
 import org.infinispan.distribution.DistributionManager;
+import org.infinispan.loaders.CacheLoaderException;
+import org.infinispan.loaders.CacheLoaderManager;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryActivated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryPassivated;
@@ -335,4 +337,20 @@ public class InfinispanBackingCacheEntryStore<K extends Serializable, V extends 
             this.log.tracef(message, args);
         }
     }
+
+    @Override
+    public int getStoreSize() {
+        return this.cache.size();
+    }
+
+    @Override
+    public int getPassivatedCount() {
+        try {
+            return this.cache.getAdvancedCache().getComponentRegistry().getComponent(CacheLoaderManager.class).getCacheStore()
+                    .loadAll().size();
+        } catch (CacheLoaderException e) {
+            throw InfinispanEjbMessages.MESSAGES.CacheLoaderFailure(e);
+        }
+    }
+
 }

--- a/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanEjbMessages.java
+++ b/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanEjbMessages.java
@@ -52,4 +52,7 @@ public interface InfinispanEjbMessages {
 
     @Message(id = 10363, value = "Interrupted while acquiring ownership of %s")
     RuntimeException lockAcquisitionInterruption(@Cause Throwable cause, Object key);
+
+    @Message(id = 10364, value = "Failed to load infinispan cache store")
+    RuntimeException CacheLoaderFailure(@Cause Throwable cause);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
@@ -77,4 +77,10 @@ public interface Cache<K extends Serializable, V extends Identifiable<K>> extend
      * Stop the cache.
      */
     void stop();
+
+    int getCacheSize();
+
+    int getPassivatedCount();
+
+    int getTotalSize();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/NonPassivatingBackingCacheImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/NonPassivatingBackingCacheImpl.java
@@ -212,4 +212,19 @@ public class NonPassivatingBackingCacheImpl<K extends Serializable, V extends Ca
             }
         }
     }
+
+    @Override
+    public int getCacheSize() {
+        return this.cache.size();
+    }
+
+    @Override
+    public int getPassivatedCount() {
+        return 0;
+    }
+
+    @Override
+    public int getTotalSize() {
+        return this.cache.size();
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/PassivatingBackingCacheImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/PassivatingBackingCacheImpl.java
@@ -354,4 +354,19 @@ public class PassivatingBackingCacheImpl<K extends Serializable, V extends Cache
             log.tracef(pattern, args);
         }
     }
+
+    @Override
+    public int getCacheSize() {
+        return this.store.getStoreSize();
+    }
+
+    @Override
+    public int getPassivatedCount() {
+         return this.store.getPassivatedCount();
+    }
+
+    @Override
+    public int getTotalSize() {
+         return this.getCacheSize() + this.getPassivatedCount();
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupMemberContainer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupMemberContainer.java
@@ -341,4 +341,15 @@ public class SerializationGroupMemberContainer<K extends Serializable, V extends
     public boolean isCompatibleWith(GroupCompatibilityChecker other) {
         return store.isCompatibleWith(other);
     }
+
+    @Override
+    public int getStoreSize() {
+        return store.getStoreSize();
+    }
+
+    @Override
+    public int getPassivatedCount() {
+        return store.getPassivatedCount();
+    }
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SimpleBackingCacheEntryStore.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SimpleBackingCacheEntryStore.java
@@ -220,4 +220,14 @@ public class SimpleBackingCacheEntryStore<K extends Serializable, V extends Cach
             this.timestamp = timestamp;
         }
     }
+
+    @Override
+    public int getStoreSize() {
+        return this.cache.size();
+    }
+
+    @Override
+    public int getPassivatedCount() {
+        return this.store.getStoreSize();
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCache.java
@@ -128,4 +128,10 @@ public interface BackingCache<K extends Serializable, V extends Cacheable<K>, E 
      * @param listener the listener. Cannot be <code>null</code>.
      */
     void removeLifecycleListener(BackingCacheLifecycleListener listener);
+
+    int getCacheSize();
+
+    int getPassivatedCount();
+
+    int getTotalSize();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCacheEntryStore.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/BackingCacheEntryStore.java
@@ -110,4 +110,8 @@ public interface BackingCacheEntryStore<K extends Serializable, V extends Cachea
     BackingCacheEntryStoreConfig getConfig();
 
     StatefulTimeoutInfo getTimeout();
+
+    int getStoreSize();
+
+    int getPassivatedCount();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/PersistentObjectStore.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/PersistentObjectStore.java
@@ -54,4 +54,6 @@ public interface PersistentObjectStore<K, V extends Identifiable<K>> {
      * Perform any shutdown work.
      */
     void stop();
+
+    int getStoreSize();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/impl/AbstractCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/spi/impl/AbstractCache.java
@@ -132,4 +132,19 @@ public abstract class AbstractCache<K extends Serializable, V extends Cacheable<
     public boolean hasAffinity(K key) {
         return this.backingCache.hasAffinity(key);
     }
+
+    @Override
+    public int getCacheSize() {
+        return this.backingCache.getCacheSize();
+    }
+
+    @Override
+    public int getPassivatedCount() {
+        return this.backingCache.getPassivatedCount();
+    }
+
+    @Override
+    public int getTotalSize() {
+        return this.backingCache.getTotalSize();
+    }
 }

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -174,6 +174,9 @@ stateful-session-bean.methods.invocations=Number of invocations processed.
 stateful-session-bean.methods.wait-time=Time spend waiting to obtain an instance.
 stateful-session-bean.peak-concurrent-invocations=Peak concurrent invocations.
 stateful-session-bean.wait-time=Time spend waiting to obtain an instance.
+stateful-session-bean.cache-size=Cache size.
+stateful-session-bean.passivated-count=Passivated count.
+stateful-session-bean.total-size=Total size.
 
 stateless-session-bean=Stateless session bean component included in the deployment.
 stateless-session-bean.component-class-name=The component's class name.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/AbstractManagedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/AbstractManagedBean.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.ejb.management.deployments;
 
+import javax.ejb.Remove;
+
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
@@ -31,5 +33,9 @@ public abstract class AbstractManagedBean implements BusinessInterface {
             Thread.sleep(50);
         } catch (InterruptedException e) {
         }
+    }
+
+    @Remove
+    public void remove() {
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/BusinessInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/BusinessInterface.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.integration.ejb.management.deployments;
 
 import javax.ejb.Remote;
+import javax.ejb.Remove;
 
 /**
  * Dummy interface for session beans in this class.
@@ -33,4 +34,7 @@ import javax.ejb.Remote;
 public interface BusinessInterface {
 
     void doIt();
+
+    void remove();
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/EjbInvocationStatisticsTestCaseSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/EjbInvocationStatisticsTestCaseSetup.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.management.deployments;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+
+/**
+ * @author Stuart Douglas, Ondrej Chaloupka
+ * @author wangchao
+ */
+public class EjbInvocationStatisticsTestCaseSetup implements ServerSetupTask {
+
+    private static final Logger log = Logger.getLogger(EjbInvocationStatisticsTestCaseSetup.class);
+
+    private static ModelNode getAddress() {
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "ejb3");
+        address.add("file-passivation-store", "file");
+        address.protect();
+        return address;
+    }
+
+    @Override
+    public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        ModelNode address = getAddress();
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("write-attribute");
+        operation.get(OP_ADDR).set(address);
+        operation.get("name").set("idle-timeout");
+        operation.get("value").set(2);
+        ModelNode result = managementClient.getControllerClient().execute(operation);
+        log.info("modelnode operation write-attribute idle-timeout=1: " + result);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+
+    }
+
+    @Override
+    public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+        ModelNode address = getAddress();
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("undefine-attribute");
+        operation.get(OP_ADDR).set(address);
+        operation.get("name").set("idle-timeout");
+        ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/ManagedStatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/ManagedStatefulBean.java
@@ -26,6 +26,7 @@ import javax.annotation.security.DeclareRoles;
 import javax.annotation.security.RunAs;
 import javax.ejb.Stateful;
 
+import org.jboss.ejb3.annotation.Cache;
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
@@ -37,5 +38,6 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @SecurityDomain("other")
 @DeclareRoles(value = {"Role1", "Role2", "Role3"})
 @RunAs("Role3")
+@Cache("passivating")
 public class ManagedStatefulBean extends AbstractManagedBean implements BusinessInterface {
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerSingletonBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerSingletonBean.java
@@ -41,6 +41,11 @@ public class NoTimerSingletonBean implements BusinessInterface {
 
     @Override
     public void doIt() {
-        //no-op;
+        // no-op;
+    }
+
+    @Override
+    public void remove() {
+        // no-op;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerStatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerStatelessBean.java
@@ -41,6 +41,11 @@ public class NoTimerStatelessBean implements BusinessInterface {
 
     @Override
     public void doIt() {
-        //no-op;
+        // no-op;
+    }
+
+    @Override
+    public void remove() {
+        // no-op;
     }
 }


### PR DESCRIPTION
WFLY issue link: https://issues.jboss.org/browse/WFLY-1590

Add following cache statistics:
Cache Size - Cache Size
Passivated Count - Passivated Count
Total Size - Total Size
