### PR TITLE
[WFLY-924] Evacuate stacktraces from WARN to DEBUG in EE subsystem.

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/EeLogger.java
@@ -115,22 +115,20 @@ public interface EeLogger extends BasicLogger {
     /**
      * Logs a warning message indicating a failure to destroy the component instance.
      *
-     * @param cause     the cause of the error.
      * @param component the component instance.
      */
     @LogMessage(level = WARN)
     @Message(id = 11005, value = "Failed to destroy component instance %s")
-    void componentDestroyFailure(@Cause Throwable cause, ComponentInstance component);
+    void componentDestroyFailure(ComponentInstance component);
 
     /**
      * Logs a warning message indicating the component is not being installed due to an exception.
      *
-     * @param cause the cause of the error.
      * @param name  the name of the component.
      */
     @LogMessage(level = WARN)
     @Message(id = 11006, value = "Not installing optional component %s due to exception")
-    void componentInstallationFailure(@Cause Throwable cause, String name);
+    void componentInstallationFailure(String name);
 
     /**
      * Logs a warning message indicating the property, represented by the {@code name} parameter, is be ignored due to
@@ -171,12 +169,11 @@ public interface EeLogger extends BasicLogger {
      * Logs a warning message indicating an exception occurred while invoking the pre-destroy on the interceptor
      * component class, represented by the {@code component} parameter.
      *
-     * @param cause     the cause of the error.
      * @param component the component.
      */
     @LogMessage(level = WARN)
     @Message(id = 11010, value = "Exception while invoking pre-destroy interceptor for component class: %s")
-    void preDestroyInterceptorFailure(@Cause Throwable cause, Class<?> component);
+    void preDestroyInterceptorFailure(Class<?> component);
 
     /**
      * Logs a warning message indicating the transaction datasource, represented by the {@code className} parameter,

--- a/ee/src/main/java/org/jboss/as/ee/component/BasicComponentInstance.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/BasicComponentInstance.java
@@ -123,7 +123,8 @@ public class BasicComponentInstance implements ComponentInstance {
                 preDestroy.processInvocation(interceptorContext);
             }
         } catch (Exception e) {
-            ROOT_LOGGER.componentDestroyFailure(e, this);
+            ROOT_LOGGER.componentDestroyFailure(this);
+            ROOT_LOGGER.debug(this, e);
         } finally {
             component.finishDestroy();
         }

--- a/ee/src/main/java/org/jboss/as/ee/component/ViewService.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ViewService.java
@@ -289,7 +289,8 @@ public final class ViewService implements Service<ComponentView> {
                         interceptorContext.putPrivateData(Component.class, component);
                         clientPreDestroyInterceptor.processInvocation(interceptorContext);
                     } catch (Exception e) {
-                        ROOT_LOGGER.preDestroyInterceptorFailure(e, component.getComponentClass());
+                        ROOT_LOGGER.preDestroyInterceptorFailure(component.getComponentClass());
+                        ROOT_LOGGER.debug(component.getComponentClass(), e);
                     }
                 }
 

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleConfigurationProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleConfigurationProcessor.java
@@ -83,7 +83,8 @@ public class EEModuleConfigurationProcessor implements DeploymentUnitProcessor {
                     moduleConfiguration.addComponentConfiguration(componentConfiguration);
                 } catch (Exception e) {
                     if (componentDescription.isOptional()) {
-                        ROOT_LOGGER.componentInstallationFailure(e, componentDescription.getComponentName());
+                        ROOT_LOGGER.componentInstallationFailure(componentDescription.getComponentName());
+                        ROOT_LOGGER.debug(componentDescription.getComponentName(), e);
                         failed.add(componentDescription.getStartServiceName());
                         failed.add(componentDescription.getCreateServiceName());
                         failed.add(componentDescription.getServiceName());


### PR DESCRIPTION
Extreme popular frameworks like Spring Web and Apache CXF generate a stacktrace in a WARN level log when deploying and a user asks us about it everytime.  The stacktrace is harmless and move it to DEBUG level to save our time.
