### PR TITLE
Fix for WFLY-1601

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WebParsingDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WebParsingDeploymentProcessor.java
@@ -118,7 +118,7 @@ public class WebParsingDeploymentProcessor implements DeploymentUnitProcessor {
                 warMetaData.setWebMetaData(webMetaData);
 
             } catch (XMLStreamException e) {
-                throw new DeploymentUnitProcessingException(MESSAGES.failToParseXMLDescriptor(webXml, e.getLocation().getLineNumber(), e.getLocation().getColumnNumber()));
+                throw new DeploymentUnitProcessingException(MESSAGES.failToParseXMLDescriptor(webXml, e.getLocation().getLineNumber(), e.getLocation().getColumnNumber()), e);
             } catch (IOException e) {
                 throw new DeploymentUnitProcessingException(MESSAGES.failToParseXMLDescriptor(webXml), e);
             } finally {


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-1601 where the original exception was lost when throwing a DeploymentUnitProcessingException whenever there were problems parsing the web.xml
