### PR TITLE
WFLY-924 Only log a summarized WARN message when an optional component installation fails

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/EeLogger.java
@@ -125,12 +125,11 @@ public interface EeLogger extends BasicLogger {
     /**
      * Logs a warning message indicating the component is not being installed due to an exception.
      *
-     * @param cause the cause of the error.
      * @param name  the name of the component.
      */
     @LogMessage(level = WARN)
-    @Message(id = 11006, value = "Not installing optional component %s due to exception")
-    void componentInstallationFailure(@Cause Throwable cause, String name);
+    @Message(id = 11006, value = "Not installing optional component %s due to an exception (enable DEBUG log level to see the cause)")
+    void componentInstallationFailure(String name);
 
     /**
      * Logs a warning message indicating the property, represented by the {@code name} parameter, is be ignored due to

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleConfigurationProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleConfigurationProcessor.java
@@ -83,7 +83,10 @@ public class EEModuleConfigurationProcessor implements DeploymentUnitProcessor {
                     moduleConfiguration.addComponentConfiguration(componentConfiguration);
                 } catch (Exception e) {
                     if (componentDescription.isOptional()) {
-                        ROOT_LOGGER.componentInstallationFailure(e, componentDescription.getComponentName());
+                        // https://issues.jboss.org/browse/WFLY-924 Just log a WARN summary of which component failed and then log the cause at DEBUG level
+                        ROOT_LOGGER.componentInstallationFailure(componentDescription.getComponentName());
+                        ROOT_LOGGER.debugf(e, "Not installing optional component %s due to an exception", componentDescription.getComponentName());
+                        // keep track of failed optional components
                         failed.add(componentDescription.getStartServiceName());
                         failed.add(componentDescription.getCreateServiceName());
                         failed.add(componentDescription.getServiceName());


### PR DESCRIPTION
After discussions about https://issues.jboss.org/browse/WFLY-924, Stuart and Osamu suggested that we log the optional component installation failure at WARN level but without the exception stacktrace. The exception stacktrace will be logged at DEBUG level and the WARN message will have a note about it.
