### PR TITLE
WFLY-1604 - Embed the chosen realm name within a comment in the properties file.

### DIFF
--- a/build/src/main/resources/domain/configuration/application-users.properties
+++ b/build/src/main/resources/domain/configuration/application-users.properties
@@ -17,6 +17,8 @@
 # - Windows
 #  bin\add-user.bat
 #
+#$REALM_NAME=ApplicationRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#
 # The following illustrates how an admin user could be defined, this
 # is for illustration only and does not correspond to a usable password.
 #

--- a/build/src/main/resources/domain/configuration/mgmt-users.properties
+++ b/build/src/main/resources/domain/configuration/mgmt-users.properties
@@ -16,10 +16,12 @@
 # - Windows
 #  bin\add-user.bat
 #
+#$REALM_NAME=ManagementRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#
 # On start-up the server will also automatically add a user $local - this user is specifically
 # for local tools running against this AS installation.
 #
 # The following illustrates how an admin user could be defined, this
-# is for illustration only an does not correspond to a usable password.
+# is for illustration only and does not correspond to a usable password.
 #
 #admin=2a0923285184943425d1f53ddd58ec7a

--- a/build/src/main/resources/standalone/configuration/application-users.properties
+++ b/build/src/main/resources/standalone/configuration/application-users.properties
@@ -17,6 +17,8 @@
 # - Windows
 #  bin\add-user.bat
 #
+#$REALM_NAME=ApplicationRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#
 # The following illustrates how an admin user could be defined, this
 # is for illustration only and does not correspond to a usable password.
 #

--- a/build/src/main/resources/standalone/configuration/mgmt-users.properties
+++ b/build/src/main/resources/standalone/configuration/mgmt-users.properties
@@ -1,5 +1,5 @@
 #
-# Properties declaration of users for the realm 'ManagementRealm' which is the default realm
+# Properties declaration of users for the realm 'ManagementRealm' which is the default realm 
 # for new AS 7.1 installations. Further authentication mechanism can be configured
 # as part of the <management /> in standalone.xml.
 #
@@ -15,7 +15,12 @@
 #
 # - Windows
 #  bin\add-user.bat
-
+#
+#$REALM_NAME=ManagementRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#
+# On start-up the server will also automatically add a user $local - this user is specifically
+# for local tools running against this AS installation.
+#
 # The following illustrates how an admin user could be defined, this
 # is for illustration only and does not correspond to a usable password.
 #

--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementLogger.java
@@ -67,9 +67,16 @@ public interface DomainManagementLogger extends BasicLogger {
     @Message(id = 15202, value = "The attribute 'password' is deprecated, 'keystore-password' should be used instead.")
     void passwordAttributeDeprecated();
 
+    /**
+     * Logs a message indicating that the name of the realm does not match the name used in the properties file.
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 15203, value = "The realm name of the defined security realm '%s' does not match the realm name within the properties file '%s'.")
+    void realmMisMatch(final String realmRealmName, final String fileRealmName);
+
     /*
-     * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementMessages
-     * also contains messages in this range commencing 15220.
+     * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementMessages also contains messages
+     * in this range commencing 15220.
      */
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -806,6 +806,13 @@ public interface DomainManagementMessages {
     @Message(id = Message.NONE, value = "Are you sure you want to set the realm to '%s'")
     String realmConfirmation(final String chosenRealm);
 
+    /**
+     * Parsing the user property file different realm names have been detected, the add-user utility requires the same realm
+     * name to be used across all propery files a user is being added to.
+     */
+    @Message(id = 15273, value = "Different realm names detected '%s', '%s' reading user property files, all realms must be equal.")
+    String multipleRealmsDetected(final String realmOne, final String realmTwo);
+
     /*
      * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementLogger also contains messages in
      * this range commencing 15200.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesCallbackHandler.java
@@ -47,6 +47,8 @@ import javax.security.sasl.RealmCallback;
 
 import org.jboss.as.domain.management.AuthMechanism;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
 import org.jboss.sasl.callback.DigestHashCallback;
 import org.jboss.sasl.callback.VerifyPasswordCallback;
 import org.jboss.sasl.util.UsernamePasswordHashUtil;
@@ -114,6 +116,19 @@ CallbackHandlerService, CallbackHandler {
         final String admin = "admin";
         if (properties.contains(admin) && admin.equals(properties.get(admin))) {
             ROOT_LOGGER.userAndPasswordWarning();
+        }
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        super.start(context);
+        try {
+            String fileRealm = getRealmName();
+            if (fileRealm != null && realm.equals(getRealmName()) == false) {
+                ROOT_LOGGER.realmMisMatch(realm, fileRealm);
+            }
+        } catch (IOException e) {
+            throw MESSAGES.unableToLoadProperties(e);
         }
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/AddUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/AddUser.java
@@ -68,6 +68,7 @@ public class AddUser extends UpdatePropertiesHandler implements State {
         UserPropertiesFileHandler propertiesHandler = new UserPropertiesFileHandler(file.getAbsolutePath());
         try {
             propertiesHandler.start(null);
+            propertiesHandler.setRealmName(stateValues.getRealm());
             Properties prob = propertiesHandler.getProperties();
             prob.setProperty(entry[0], entry[1]);
             propertiesHandler.persistProperties();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PromptRealmState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/PromptRealmState.java
@@ -60,19 +60,26 @@ public class PromptRealmState implements State {
          * Prompt for realm.
          */
         theConsole.printf(MESSAGES.realmPrompt(stateValues.getRealm()));
-        String temp = theConsole.readLine(" : ");
-        if (temp == null) {
-            /*
-             * This will return user to the command prompt so add a new line to ensure the command prompt is on the next line.
-             */
+        if (stateValues.isRealmAlreadyDefined()) {
+            theConsole.printf(" : ");
             theConsole.printf(NEW_LINE);
-            return null;
-        }
-        if (temp.length() > 0) {
-            stateValues.setRealm(temp);
-        }
+            return new PromptNewUserState(theConsole, stateValues);
+        } else {
+            String temp = theConsole.readLine(" : ");
+            if (temp == null) {
+                /*
+                 * This will return user to the command prompt so add a new line to ensure the command prompt is on the next
+                 * line.
+                 */
+                theConsole.printf(NEW_LINE);
+                return null;
+            }
+            if (temp.length() > 0) {
+                stateValues.setRealm(temp);
+            }
 
-        return new ValidateRealmState(theConsole, stateValues);
+            return new ValidateRealmState(theConsole, stateValues);
+        }
     }
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/StateValues.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/StateValues.java
@@ -37,13 +37,14 @@ import java.util.Set;
 */
 public class StateValues {
     private AddPropertiesUser.Interactiveness howInteractive = AddPropertiesUser.Interactiveness.INTERACTIVE;
+    private boolean realmAlreadyDefined;
     private String realm;
     private String userName;
     private char[] password;
     private boolean management;
     private String roles;
     private boolean existingUser = false;
-    private List<File> propertiesFiles;
+    private List<File> userFiles;
     private List<File> roleFiles;
     private Set<String> knownUsers;
     private Map<String,String> knownRoles;
@@ -82,6 +83,14 @@ public class StateValues {
         this.realm = realm;
     }
 
+    public boolean isRealmAlreadyDefined() {
+        return realmAlreadyDefined;
+    }
+
+    public void setRealmAlreadyDefined(boolean realmAlreadyDefined) {
+        this.realmAlreadyDefined = realmAlreadyDefined;
+    }
+
     public String getUserName() {
         return userName;
     }
@@ -114,12 +123,12 @@ public class StateValues {
         this.roles = roles;
     }
 
-    public List<File> getPropertiesFiles() {
-        return propertiesFiles;
+    public List<File> getUserFiles() {
+        return userFiles;
     }
 
-    public void setPropertiesFiles(List<File> propertiesFiles) {
-        this.propertiesFiles = propertiesFiles;
+    public void setUserFiles(List<File> userFiles) {
+        this.userFiles = userFiles;
     }
 
     public List<File> getRoleFiles() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/UpdatePropertiesHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/UpdatePropertiesHandler.java
@@ -78,7 +78,7 @@ public abstract class UpdatePropertiesHandler {
             return new ErrorState(theConsole, e.getMessage(), null, stateValues);
         }
 
-        for (File current : stateValues.getPropertiesFiles()) {
+        for (File current : stateValues.getUserFiles()) {
             try {
                 persist(entry, current);
                 if (stateValues.isSilent() == false) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/state/UpdateUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/state/UpdateUser.java
@@ -67,6 +67,7 @@ public class UpdateUser extends UpdatePropertiesHandler implements State {
         UserPropertiesFileHandler propertiesHandler = new UserPropertiesFileHandler(file.getAbsolutePath());
         try {
             propertiesHandler.start(null);
+            propertiesHandler.setRealmName(stateValues.getRealm());
             Properties prob = propertiesHandler.getProperties();
             prob.setProperty(entry[0], entry[1]);
             propertiesHandler.persistProperties();

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/AddUserTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/AddUserTestCase.java
@@ -44,7 +44,7 @@ public class AddUserTestCase extends PropertyTestHelper {
         AddUser addUserState = new AddUser(consoleMock, values);
 
         AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getPropertiesFiles().get(0).getCanonicalPath())).
+                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE).
                 expectedDisplayText(MESSAGES.addedRoles(values.getUserName(), values.getRoles(),values.getRoleFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE);

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/DuplicateUserCheckStateTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/DuplicateUserCheckStateTestCase.java
@@ -51,7 +51,7 @@ public class DuplicateUserCheckStateTestCase extends PropertyTestHelper {
                 expectedDisplayText(MESSAGES.isCorrectPrompt() + " " + MESSAGES.yes() + "/" + MESSAGES.no() + "?").
                 expectedDisplayText(" ").
                 expectedInput("yes").
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getPropertiesFiles().get(0).getCanonicalPath())).
+                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE).
                 expectedDisplayText(MESSAGES.addedRoles(values.getUserName(), values.getRoles(),values.getRoleFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE);
@@ -72,7 +72,7 @@ public class DuplicateUserCheckStateTestCase extends PropertyTestHelper {
         PreModificationState userCheckState = new PreModificationState(consoleMock, values);
 
         AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.updateUser(values.getUserName(), values.getPropertiesFiles().get(0).getCanonicalPath())).
+                expectedDisplayText(MESSAGES.updateUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE).
                 expectedDisplayText(MESSAGES.updatedRoles(values.getUserName(), values.getRoles(), values.getRoleFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE);

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyFileFinderTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyFileFinderTestCase.java
@@ -82,8 +82,8 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
         State nextState = propertyFileFinder.execute();
         assertTrue(nextState instanceof PromptRealmState);
         assertTrue("Expected to find the "+USER_NAME+" in the list of known users",values.getKnownUsers().contains(USER_NAME));
-        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile,values.getPropertiesFiles().contains(standaloneMgmtUserFile));
-        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile,values.getPropertiesFiles().contains(domainMgmtUserFile));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile,values.getUserFiles().contains(standaloneMgmtUserFile));
+        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile,values.getUserFiles().contains(domainMgmtUserFile));
     }
 
     @Test
@@ -103,8 +103,8 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
         State nextState = propertyFileFinder.execute();
         assertTrue(nextState instanceof PromptRealmState);
 
-        File locatedDomainPropertyFile = values.getPropertiesFiles().get(values.getPropertiesFiles().indexOf(domainUserFile));
-        File locatedStandalonePropertyFile = values.getPropertiesFiles().get(values.getPropertiesFiles().indexOf(standaloneUserFile));
+        File locatedDomainPropertyFile = values.getUserFiles().get(values.getUserFiles().indexOf(domainUserFile));
+        File locatedStandalonePropertyFile = values.getUserFiles().get(values.getUserFiles().indexOf(standaloneUserFile));
         UpdateUser updateUserState = new UpdateUser(consoleMock, values);
 
         AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyTestHelper.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/PropertyTestHelper.java
@@ -62,7 +62,7 @@ public class PropertyTestHelper {
         rolesPropertyFileList.add(rolesPropertyFile);
 
         values = new StateValues();
-        values.setPropertiesFiles(usersPropertyFileList);
+        values.setUserFiles(usersPropertyFileList);
         values.setRoleFiles(rolesPropertyFileList);
         values.setUserName(USER_NAME);
         values.setPassword("1sT%l<[pzD".toCharArray());
@@ -79,7 +79,7 @@ public class PropertyTestHelper {
     }
 
     protected void assertUserPropertyFile(String userName) throws StartException, IOException {
-        Properties properties = loadProperties(values.getPropertiesFiles().get(0).getAbsolutePath());
+        Properties properties = loadProperties(values.getUserFiles().get(0).getAbsolutePath());
         String password = (String) properties.get(userName);
         assertNotNull(password);
     }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/state/UpdateUserTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/state/UpdateUserTestCase.java
@@ -42,7 +42,7 @@ public class UpdateUserTestCase extends PropertyTestHelper {
         UpdateUser updateUserState = new UpdateUser(consoleMock, values);
 
         AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(updateUserState.consoleUserMessage(values.getPropertiesFiles().get(0).getCanonicalPath())).
+                expectedDisplayText(updateUserState.consoleUserMessage(values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE);
         consoleMock.setResponses(consoleBuilder);
         updateUserState.update(values);
@@ -57,7 +57,7 @@ public class UpdateUserTestCase extends PropertyTestHelper {
         values.setRoles(ROLES);
         UpdateUser updateUserState = new UpdateUser(consoleMock, values);
         AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(updateUserState.consoleUserMessage(values.getPropertiesFiles().get(0).getCanonicalPath())).
+                expectedDisplayText(updateUserState.consoleUserMessage(values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE).
                 expectedDisplayText(updateUserState.consoleRolesMessage(values.getRoleFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddPropertiesUser.NEW_LINE);


### PR DESCRIPTION
This eliminates a long standing issue with add-user where by users were asked for the name of the realm for each new user added even though different realms for different users was never an option.

This is also a pre-requisite change to allowing users to specify a custom name for their properties file, in that case we no longer know if this is for management for applications or for something else.  

This will also enable the implementation of another feature to allow every WildFly installation to have it's own custom realm name, this would mean that pre-prepared hashed from one installation would not be usable against another installation even if the same username and password was used as the realm name would make the hashes unique.
