### PR TITLE
[WFLY-1634] Make the HTTP Upgrade attribute parsing specific to version 2.0 of the schema.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -462,8 +462,14 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                         case DOMAIN_1_0:
                             parseNativeManagementInterface1_0(reader, address, list);
                             break;
-                        default:
+                        case DOMAIN_1_1:
+                        case DOMAIN_1_2:
+                        case DOMAIN_1_3:
+                        case DOMAIN_1_4:
                             parseManagementInterface1_1(reader, address, false, expectedNs, list);
+                            break;
+                        default:
+                            parseManagementInterface2_0(reader, address, false, expectedNs, list);
                     }
                     break;
                 }
@@ -472,8 +478,14 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
                         case DOMAIN_1_0:
                             parseHttpManagementInterface1_0(reader, address, list);
                             break;
-                        default:
+                        case DOMAIN_1_1:
+                        case DOMAIN_1_2:
+                        case DOMAIN_1_3:
+                        case DOMAIN_1_4:
                             parseManagementInterface1_1(reader, address, true, expectedNs, list);
+                            break;
+                        default:
+                            parseManagementInterface2_0(reader, address, true, expectedNs, list);
                     }
                     break;
                 }
@@ -658,6 +670,86 @@ public class HostXml extends CommonXml implements ManagementXml.Delegate {
         list.add(addOp);
     }
 
+    private void parseHttpManagementInterfaceAttributes2_0(XMLExtendedStreamReader reader, ModelNode addOp) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final String value = reader.getAttributeValue(i);
+            if (!isNoNamespaceAttribute(reader, i)) {
+                throw unexpectedAttribute(reader, i);
+            } else {
+                final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+                switch (attribute) {
+                    case SECURITY_REALM: {
+                        HttpManagementResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, addOp, reader);
+                        break;
+                    }
+                    case CONSOLE_ENABLED: {
+                        HttpManagementResourceDefinition.CONSOLE_ENABLED.parseAndSetParameter(value, addOp, reader);
+                        break;
+                    }
+                    case HTTP_UPGRADE_ENABLED: {
+                        HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.parseAndSetParameter(value, addOp, reader);
+                        break;
+                    }
+                    default:
+                        throw unexpectedAttribute(reader, i);
+                }
+            }
+        }
+    }
+
+    private void parseNativeManagementInterfaceAttributes2_0(XMLExtendedStreamReader reader, ModelNode addOp) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            final String value = reader.getAttributeValue(i);
+            if (!isNoNamespaceAttribute(reader, i)) {
+                throw unexpectedAttribute(reader, i);
+            } else {
+                final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+                switch (attribute) {
+                    case SECURITY_REALM: {
+                        NativeManagementResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, addOp, reader);
+                        break;
+                    }
+                    default:
+                        throw unexpectedAttribute(reader, i);
+                }
+            }
+        }
+    }
+
+    private void parseManagementInterface2_0(XMLExtendedStreamReader reader, ModelNode address, boolean http, Namespace expectedNs, List<ModelNode> list)  throws XMLStreamException {
+
+        final ModelNode operationAddress = address.clone();
+        operationAddress.add(MANAGEMENT_INTERFACE, http ? HTTP_INTERFACE : NATIVE_INTERFACE);
+        final ModelNode addOp = Util.getEmptyOperation(ADD, operationAddress);
+
+        // Handle attributes
+        if (http) {
+            parseHttpManagementInterfaceAttributes2_0(reader, addOp);
+        } else {
+            parseNativeManagementInterfaceAttributes2_0(reader, addOp);
+        }
+
+        // Handle elements
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            requireNamespace(reader, expectedNs);
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case SOCKET:
+                    if (http) {
+                        parseHttpManagementSocket(reader, addOp);
+                    } else {
+                        parseNativeManagementSocket(reader, addOp);
+                    }
+                    break;
+                default:
+                    throw unexpectedElement(reader);
+            }
+        }
+
+        list.add(addOp);
+    }
     private void parseNativeManagementSocket(XMLExtendedStreamReader reader, ModelNode addOp) throws XMLStreamException {
         // Handle attributes
         boolean hasInterface = false;


### PR DESCRIPTION
Also for version 2.0 split out the attribute parsing for http and native interfaces, trying to handle both in the same place was also becomming inconsistant.
