### PR TITLE
delete left-over test artifact jdr_...zip on windows and improve tests

### DIFF
--- a/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrTestCase.java
+++ b/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrTestCase.java
@@ -44,17 +44,22 @@ public class JdrTestCase {
         JdrEnvironment env = new JdrEnvironment();
         env.setJbossHome("/foo/bar/baz");
         env.setHostControllerName("host");
+        env.setOutputDirectory("target");
+        String name;
         JdrZipFile zf = new JdrZipFile(env);
-        String name = zf.name();
-
         try {
-            assertTrue(name.endsWith(".zip"));
-            assertTrue(name.contains("host"));
+            name = zf.name();
+            zf.close();
         }
         finally {
+            safeClose(zf);
             File f = new File(zf.name());
             f.delete();
         }
+
+        assertTrue(name.endsWith(".zip"));
+        assertTrue(name.contains("host"));
+        assertTrue(name.startsWith("target"));
     }
 
     @Test
@@ -133,4 +138,11 @@ public class JdrTestCase {
         assertFalse(filter.accepts(bad2));
         assertFalse(filter.accepts(winbad));
     }
+
+    private void safeClose(JdrZipFile zf) {
+        try {
+            zf.close();
+        } catch (Exception ignored) { }
+    }
+
 }


### PR DESCRIPTION
The JDR module will create a test ZIP file in the base directory, not close it but try to delete it.

The delete will fail on Windows: this patch is fixing it by adding a `close()`.
This is mainly to keep the GIT tree clean after a build.

This patch will also make sure the file is not created in a source control managed directory anyway by using `setOutputDirectory("target")`. This way the test can assert the relative output path name as well. 
