### PR TITLE
Restore original module name for mod_cluster extension in default configuration files.

### DIFF
--- a/build/src/main/resources/configuration/subsystems/mod_cluster.xml
+++ b/build/src/main/resources/configuration/subsystems/mod_cluster.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
-    <extension-module>org.wildfly.extension.mod_cluster</extension-module>
+    <extension-module>org.jboss.as.modcluster</extension-module>
     <subsystem xmlns="urn:jboss:domain:modcluster:1.1">
-        <mod-cluster-config advertise-socket="mod_cluster" connector="ajp">
+        <mod-cluster-config advertise-socket="modcluster" connector="ajp">
             <dynamic-load-provider>
                 <load-metric type="busyness"/>
             </dynamic-load-provider>
         </mod-cluster-config>
     </subsystem>
-    <socket-binding name="mod_cluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
+    <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
 </config>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -37,7 +37,7 @@
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.mail"/>
         <extension module="org.jboss.as.messaging"/>
-        <extension module="org.wildfly.extension.mod_cluster"/>
+        <extension module="org.jboss.as.modcluster"/>
         <extension module="org.jboss.as.naming"/>
         <extension module="org.jboss.as.osgi"/>
         <extension module="org.jboss.as.remoting"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mod_cluster/ModClusterSubsystemAddTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mod_cluster/ModClusterSubsystemAddTestCase.java
@@ -61,7 +61,7 @@ public class ModClusterSubsystemAddTestCase {
             ctx.connectController();
 
             // Add the mod_cluster extension first (not in this profile by default)
-            ModelNode request = ctx.buildRequest("/extension=org.wildfly.extension.mod_cluster:add");
+            ModelNode request = ctx.buildRequest("/extension=org.jboss.as.modcluster:add");
             ModelNode response = controllerClient.execute(request);
             String outcome = response.get("outcome").asString();
             Assert.assertEquals("Adding mod_cluster extension failed! " + request.toJSONString(false), "success", outcome);
@@ -69,9 +69,9 @@ public class ModClusterSubsystemAddTestCase {
             // Now lets execute subsystem add operation but we need to specify a connector
             ctx.getBatchManager().activateNewBatch();
             Batch b = ctx.getBatchManager().getActiveBatch();
-            b.add(ctx.toBatchedCommand("/socket-binding-group=standard-sockets/socket-binding=mod_cluster:add(multicast-port=23364, multicast-address=224.0.1.105)"));
+            b.add(ctx.toBatchedCommand("/socket-binding-group=standard-sockets/socket-binding=modcluster:add(multicast-port=23364, multicast-address=224.0.1.105)"));
             b.add(ctx.toBatchedCommand("/subsystem=modcluster:add"));
-            b.add(ctx.toBatchedCommand("/subsystem=modcluster/mod-cluster-config=configuration:add(connector=http,advertise-socket=mod_cluster)"));
+            b.add(ctx.toBatchedCommand("/subsystem=modcluster/mod-cluster-config=configuration:add(connector=http,advertise-socket=modcluster)"));
             request = b.toRequest();
             b.clear();
             ctx.getBatchManager().discardActiveBatch();
@@ -100,13 +100,13 @@ public class ModClusterSubsystemAddTestCase {
             Assert.assertEquals("Removing mod_cluster subsystem failed! " + request.toJSONString(false), "success", outcome);
 
             // Cleanup socket binding
-            request = ctx.buildRequest("/socket-binding-group=standard-sockets/socket-binding=mod_cluster:remove");
+            request = ctx.buildRequest("/socket-binding-group=standard-sockets/socket-binding=modcluster:remove");
             response = controllerClient.execute(request);
             outcome = response.get("outcome").asString();
             Assert.assertEquals("Removing socket binding failed! " + request.toJSONString(false), "success", outcome);
 
             // Cleanup and remove the extension
-            request = ctx.buildRequest("/extension=org.wildfly.extension.mod_cluster:remove");
+            request = ctx.buildRequest("/extension=org.jboss.as.modcluster:remove");
             response = controllerClient.execute(request);
             outcome = response.get("outcome").asString();
             Assert.assertEquals("Removing mod_cluster extension failed! " + request.toJSONString(false), "success", outcome);


### PR DESCRIPTION
Revert attempt to address https://issues.jboss.org/browse/WFLY-689 per discussion/rant here:
https://github.com/wildfly/wildfly/pull/4691
