### PR TITLE
Wfly 1667

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/BasicTests.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/BasicTests.java
@@ -21,6 +21,10 @@
  */
 package org.jboss.as.test.integration.ws.basic;
 
+import java.util.Iterator;
+import javax.xml.namespace.QName;
+import javax.xml.soap.SOAPFault;
+import javax.xml.ws.soap.SOAPFaultException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,20 +33,20 @@ import org.junit.Test;
  * @author <a href="mailto:rsvoboda@redhat.com">Rostislav Svoboda</a>
  */
 public class BasicTests {
-    
+
     protected EndpointIface proxy;
 
     @Test
     public void testHelloString() {
         Assert.assertEquals("Hello World!", proxy.helloString("World"));
     }
-    
+
     @Test
     public void testHelloBean() {
         HelloObject helloObject = new HelloObject("Kermit");
         Assert.assertEquals("Hello Kermit!", proxy.helloBean(helloObject).getMessage());
     }
-    
+
     @Test
     public void testHelloArray() {
         HelloObject[] query = new HelloObject[3];
@@ -54,5 +58,21 @@ public class BasicTests {
             Assert.assertEquals("Hello " + query[i].getMessage() + "!", reply[i].getMessage());
         }
     }
-    
+
+    @Test
+    public void testHelloError() {
+        try {
+            proxy.helloError("Fault for test purpose");
+            Assert.fail("This should throw a SOAPFaultException");
+        } catch (SOAPFaultException ex) {
+             SOAPFault fault = ex.getFault();
+             Assert.assertEquals("Fault for test purpose", fault.getFaultString());
+             Iterator iter = fault.getFaultSubcodes();
+             Assert.assertTrue(iter != null);
+             Assert.assertTrue(iter.hasNext());
+             QName subcode = (QName) iter.next();
+             Assert.assertEquals( new QName("http://ws.gss.redhat.com/", "NullPointerException"), subcode);
+        }
+    }
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpoint.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpoint.java
@@ -23,6 +23,13 @@ package org.jboss.as.test.integration.ws.basic;
 
 import javax.ejb.Stateless;
 import javax.jws.WebService;
+import javax.xml.namespace.QName;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFactory;
+import javax.xml.soap.SOAPFault;
+import javax.xml.ws.BindingType;
+import javax.xml.ws.soap.SOAPFaultException;
 import org.jboss.ws.api.annotation.WebContext;
 
 /**
@@ -39,6 +46,7 @@ import org.jboss.ws.api.annotation.WebContext;
         urlPattern = "/EJB3Service",
         contextRoot = "/jaxws-basic-ejb3"
 )
+@BindingType(javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
 @Stateless
 public class EJBEndpoint implements EndpointIface {
 
@@ -57,5 +65,19 @@ public class EJBEndpoint implements EndpointIface {
         }
         return reply;
     }
-    
+
+     public String helloError(String input) {
+        try {
+            SOAPFault fault = SOAPFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL).createFault(input,
+                    SOAPConstants.SOAP_VERSIONMISMATCH_FAULT);
+            fault.setFaultActor("mr.actor");
+            fault.addDetail().addChildElement("test");
+            fault.appendFaultSubcode(new QName("http://ws.gss.redhat.com/", "NullPointerException"));
+            fault.appendFaultSubcode(new QName("http://ws.gss.redhat.com/", "OperatorNotFound"));
+            throw new SOAPFaultException(fault);
+        } catch (SOAPException ex) {
+            ex.printStackTrace();
+        }
+        return "Failure!";
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,13 +40,12 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("AS7-6319")
 public class EJBEndpointTestCase extends BasicTests {
 
     @ArquillianResource
     URL baseUrl;
-    
-    @Deployment( testable=false )
+
+    @Deployment(testable = false)
     public static Archive<?> deployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jaxws-basic-ejb.jar")
                 .addClasses(EndpointIface.class, EJBEndpoint.class, HelloObject.class);
@@ -62,5 +60,5 @@ public class EJBEndpointTestCase extends BasicTests {
         Service service = Service.create(wsdlURL, serviceName);
         proxy = service.getPort(EndpointIface.class);
     }
-    
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/EndpointIface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/EndpointIface.java
@@ -35,4 +35,6 @@ public interface EndpointIface {
     public HelloObject helloBean(HelloObject input);
 
     public HelloObject[] helloArray(HelloObject[] input);
+
+    public String helloError(String input);
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/PojoEndpoint.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/PojoEndpoint.java
@@ -22,6 +22,13 @@
 package org.jboss.as.test.integration.ws.basic;
 
 import javax.jws.WebService;
+import javax.xml.namespace.QName;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFactory;
+import javax.xml.soap.SOAPFault;
+import javax.xml.ws.BindingType;
+import javax.xml.ws.soap.SOAPFaultException;
 
 /**
  * Simple POJO endpoint
@@ -32,7 +39,8 @@ import javax.jws.WebService;
         serviceName = "POJOService",
         targetNamespace = "http://jbossws.org/basic",
         endpointInterface = "org.jboss.as.test.integration.ws.basic.EndpointIface"
-)
+        )
+@BindingType(javax.xml.ws.soap.SOAPBinding.SOAP12HTTP_BINDING)
 public class PojoEndpoint implements EndpointIface {
 
     public String helloString(String input) {
@@ -49,5 +57,19 @@ public class PojoEndpoint implements EndpointIface {
             reply[n] = helloBean(input[n]);
         }
         return reply;
+    }
+
+    public String helloError(String input) {
+        try {
+            SOAPFault fault = SOAPFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL).createFault(input,
+                    SOAPConstants.SOAP_VERSIONMISMATCH_FAULT);
+            fault.setFaultActor("mr.actor");
+            fault.addDetail().addChildElement("test");
+            fault.appendFaultSubcode(new QName("http://ws.gss.redhat.com/", "NullPointerException"));
+            throw new SOAPFaultException(fault);
+        } catch (SOAPException ex) {
+            ex.printStackTrace();
+        }
+        return "Failure!";
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/PojoEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/basic/PojoEndpointTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 /**
@@ -41,13 +40,12 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("AS7-6319")
 public class PojoEndpointTestCase extends BasicTests {
 
     @ArquillianResource
     URL baseUrl;
-    
-    @Deployment( testable=false )
+
+    @Deployment(testable = false)
     public static Archive<?> deployment() {
         WebArchive pojoWar = ShrinkWrap.create(WebArchive.class, "jaxws-basic-pojo.war")
                 .addClasses(EndpointIface.class, PojoEndpoint.class, HelloObject.class);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/invocation/AbstractInvocationHandler.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/invocation/AbstractInvocationHandler.java
@@ -31,6 +31,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.util.Collection;
 
 import javax.management.MBeanException;
+import javax.xml.ws.soap.SOAPFaultException;
 
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentView;
@@ -149,6 +150,10 @@ abstract class AbstractInvocationHandler extends org.jboss.ws.common.invocation.
          if (t instanceof InvocationTargetException) {
             throw (Exception) t;
          } else {
+            SOAPFaultException ex = findSoapFaultException(t);
+            if(ex != null) {
+                 throw new InvocationTargetException(ex);
+            }
             throw new InvocationTargetException(t);
          }
       }
@@ -157,6 +162,16 @@ abstract class AbstractInvocationHandler extends org.jboss.ws.common.invocation.
       }
       throw new UndeclaredThrowableException(t);
    }
+
+   protected SOAPFaultException findSoapFaultException(Throwable ex) {
+        if (ex instanceof SOAPFaultException) {
+            return (SOAPFaultException)ex;
+        }
+        if (ex.getCause() != null) {
+            return findSoapFaultException(ex.getCause());
+        }
+        return null;
+    }
 
    /**
     * Compares two methods if they are identical.


### PR DESCRIPTION
- Adding some integration test code to check that WFLY-1667 can be closed.
- **When using an EJB endpoint**, the SoapFaultException is nested inside an EJBException which breaks the propagation of Fault subcodes in **CXF** `org.apache.cxf.jaxws.interceptors.WebFaultOutInterceptor` which only check the direct cause and not the whole exception stack. This was fixed in the webservice integration class : `org.jboss.as.webservices.invocation.AbstractInvocationHandler` by setting the SoapFaultException as the cause of the InvocationTargetException.
