### PR TITLE
Fix for WFLY-822

### DIFF
--- a/sar/src/main/java/org/jboss/as/service/AbstractService.java
+++ b/sar/src/main/java/org/jboss/as/service/AbstractService.java
@@ -40,15 +40,17 @@ abstract class AbstractService implements Service<Object> {
 
     private final Object mBeanInstance;
     private final ServiceName duServiceName;
+    private final ClassLoader mbeanContextClassLoader;
 
     /**
      *
      * @param mBeanInstance
      * @param duServiceName the deployment unit's service name
      */
-    protected AbstractService(final Object mBeanInstance, final ServiceName duServiceName) {
+    protected AbstractService(final Object mBeanInstance, final ServiceName duServiceName, final ClassLoader mbeanContextClassLoader) {
         this.mBeanInstance = mBeanInstance;
         this.duServiceName = duServiceName;
+        this.mbeanContextClassLoader = mbeanContextClassLoader;
     }
 
     /** {@inheritDoc} */
@@ -60,7 +62,7 @@ abstract class AbstractService implements Service<Object> {
         if (method != null) {
             WritableServiceBasedNamingStore.pushOwner(duServiceName);
             try {
-                final ClassLoader old = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(mBeanInstance.getClass().getClassLoader());
+                final ClassLoader old = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(this.mbeanContextClassLoader);
                 try {
                     method.invoke(mBeanInstance);
                 } finally {

--- a/sar/src/main/java/org/jboss/as/service/CreateDestroyService.java
+++ b/sar/src/main/java/org/jboss/as/service/CreateDestroyService.java
@@ -46,8 +46,9 @@ final class CreateDestroyService extends AbstractService {
     private final ServiceComponentInstantiator componentInstantiator;
     private ManagedReference managedReference;
 
-    CreateDestroyService(final Object mBeanInstance, final Method createMethod, final Method destroyMethod, ServiceComponentInstantiator componentInstantiator, final ServiceName duServiceName) {
-        super(mBeanInstance, duServiceName);
+    CreateDestroyService(final Object mBeanInstance, final Method createMethod, final Method destroyMethod, ServiceComponentInstantiator componentInstantiator,
+                         final ServiceName duServiceName, final ClassLoader mbeanContextClassLoader) {
+        super(mBeanInstance, duServiceName, mbeanContextClassLoader);
         this.createMethod = createMethod;
         this.destroyMethod = destroyMethod;
         this.componentInstantiator = componentInstantiator;

--- a/sar/src/main/java/org/jboss/as/service/MBeanServices.java
+++ b/sar/src/main/java/org/jboss/as/service/MBeanServices.java
@@ -74,7 +74,8 @@ final class MBeanServices {
      * @param componentInstantiator
      * @param duServiceName the deployment unit's service name
      */
-    MBeanServices(final String mBeanName, final Object mBeanInstance, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final ServiceTarget target,ServiceComponentInstantiator componentInstantiator, final ServiceName duServiceName) {
+    MBeanServices(final String mBeanName, final Object mBeanInstance, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final ServiceTarget target,ServiceComponentInstantiator componentInstantiator,
+                  final ServiceName duServiceName, final ClassLoader mbeanContextClassLoader) {
         if (mBeanClassHierarchy == null) {
             throw SarMessages.MESSAGES.nullVar("mBeanName");
         }
@@ -87,7 +88,7 @@ final class MBeanServices {
 
         final Method createMethod = ReflectionUtils.getMethod(mBeanClassHierarchy, CREATE_METHOD_NAME, NO_ARGS, false);
         final Method destroyMethod = ReflectionUtils.getMethod(mBeanClassHierarchy, DESTROY_METHOD_NAME, NO_ARGS, false);
-        createDestroyService = new CreateDestroyService(mBeanInstance, createMethod, destroyMethod,componentInstantiator, duServiceName);
+        createDestroyService = new CreateDestroyService(mBeanInstance, createMethod, destroyMethod,componentInstantiator, duServiceName, mbeanContextClassLoader);
         createDestroyServiceName = ServiceNameFactory.newCreateDestroy(mBeanName);
         createDestroyServiceBuilder = target.addService(createDestroyServiceName, createDestroyService);
         if(componentInstantiator != null) {
@@ -97,7 +98,7 @@ final class MBeanServices {
 
         final Method startMethod = ReflectionUtils.getMethod(mBeanClassHierarchy, START_METHOD_NAME, NO_ARGS, false);
         final Method stopMethod = ReflectionUtils.getMethod(mBeanClassHierarchy, STOP_METHOD_NAME, NO_ARGS, false);
-        startStopService = new StartStopService(mBeanInstance, startMethod, stopMethod, duServiceName);
+        startStopService = new StartStopService(mBeanInstance, startMethod, stopMethod, duServiceName, mbeanContextClassLoader);
         startStopServiceName = ServiceNameFactory.newStartStop(mBeanName);
         startStopServiceBuilder = target.addService(startStopServiceName, startStopService);
         startStopServiceBuilder.addDependency(createDestroyServiceName);

--- a/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
+++ b/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.service;
 
-import static org.jboss.msc.value.Values.cached;
-
 import java.beans.PropertyEditor;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -59,6 +57,9 @@ import org.jboss.msc.value.ImmediateValue;
 import org.jboss.msc.value.MethodValue;
 import org.jboss.msc.value.Value;
 import org.jboss.msc.value.Values;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+import static org.jboss.msc.value.Values.cached;
 
 /**
  * DeploymentUnit processor responsible for taking JBossServiceXmlDescriptor configuration and creating the
@@ -112,7 +113,7 @@ public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor
         final List<ClassReflectionIndex<?>> mBeanClassHierarchy = ReflectionUtils.getClassHierarchy(mBeanClassName, index, classLoader);
         final Object mBeanInstance = newInstance(mBeanConfig, mBeanClassHierarchy, classLoader);
         final String mBeanName = mBeanConfig.getName();
-        final MBeanServices mBeanServices = new MBeanServices(mBeanName, mBeanInstance, mBeanClassHierarchy, target, componentInstantiator, phaseContext.getDeploymentUnit().getServiceName());
+        final MBeanServices mBeanServices = new MBeanServices(mBeanName, mBeanInstance, mBeanClassHierarchy, target, componentInstantiator, phaseContext.getDeploymentUnit().getServiceName(), classLoader);
 
         final JBossServiceDependencyConfig[] dependencyConfigs = mBeanConfig.getDependencyConfigs();
         if (dependencyConfigs != null) {
@@ -189,25 +190,32 @@ public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor
         return new ImmediateValue<Object>(newValue(setterType, attributeConfig.getValue()));
     }
 
-    private static Object newInstance(final JBossServiceConfig serviceConfig, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final ClassLoader classLoader) throws DeploymentUnitProcessingException {
-        final JBossServiceConstructorConfig constructorConfig = serviceConfig.getConstructorConfig();
-        final int paramCount = constructorConfig != null ? constructorConfig.getArguments().length : 0;
-        final Class<?>[] types = new Class<?>[paramCount];
-        final Object[] params = new Object[paramCount];
+    private static Object newInstance(final JBossServiceConfig serviceConfig, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final ClassLoader deploymentClassLoader) throws DeploymentUnitProcessingException {
+        // set TCCL so that the MBean instantiation happens in the deployment's classloader
+        final ClassLoader oldTCCL = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(deploymentClassLoader);
+        try {
+            final JBossServiceConstructorConfig constructorConfig = serviceConfig.getConstructorConfig();
+            final int paramCount = constructorConfig != null ? constructorConfig.getArguments().length : 0;
+            final Class<?>[] types = new Class<?>[paramCount];
+            final Object[] params = new Object[paramCount];
 
-        if (constructorConfig != null) {
-            final Argument[] arguments = constructorConfig.getArguments();
-            for (int i = 0; i < paramCount; i++) {
-                final Argument argument = arguments[i];
-                types[i] = ReflectionUtils.getClass(argument.getType(), classLoader);
-                params[i] = newValue(ReflectionUtils.getClass(argument.getType(), classLoader), argument.getValue());
+            if (constructorConfig != null) {
+                final Argument[] arguments = constructorConfig.getArguments();
+                for (int i = 0; i < paramCount; i++) {
+                    final Argument argument = arguments[i];
+                    types[i] = ReflectionUtils.getClass(argument.getType(), deploymentClassLoader);
+                    params[i] = newValue(ReflectionUtils.getClass(argument.getType(), deploymentClassLoader), argument.getValue());
+                }
             }
+
+            final Constructor<?> constructor = mBeanClassHierarchy.get(0).getConstructor(types);
+            final Object mBeanInstance = ReflectionUtils.newInstance(constructor, params);
+
+            return mBeanInstance;
+        } finally {
+            // switch back the TCCL
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTCCL);
         }
-
-        final Constructor<?> constructor = mBeanClassHierarchy.get(0).getConstructor(types);
-        final Object mBeanInstance = ReflectionUtils.newInstance(constructor, params);
-
-        return mBeanInstance;
     }
 
     private static Injector<Object> getPropertyInjector(final String propertyName, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final Service<?> service, final Value<?> value) {

--- a/sar/src/main/java/org/jboss/as/service/SarModuleDependencyProcessor.java
+++ b/sar/src/main/java/org/jboss/as/service/SarModuleDependencyProcessor.java
@@ -40,8 +40,9 @@ import org.jboss.modules.ModuleIdentifier;
  */
 public class SarModuleDependencyProcessor implements DeploymentUnitProcessor {
 
-    private static ModuleIdentifier JBOSS_MODULES_ID = ModuleIdentifier.create("org.jboss.modules");
-    private static ModuleIdentifier JBOSS_AS_SYSTEM_JMX_ID = ModuleIdentifier.create("org.jboss.as.system-jmx");
+    private static final ModuleIdentifier JBOSS_MODULES_ID = ModuleIdentifier.create("org.jboss.modules");
+    private static final ModuleIdentifier JBOSS_AS_SYSTEM_JMX_ID = ModuleIdentifier.create("org.jboss.as.system-jmx");
+    private static final ModuleIdentifier PROPERTIES_EDITOR_MODULE_ID = ModuleIdentifier.create("org.jboss.common-beans");
 
     /**
      * Add dependencies for modules required for manged bean deployments, if managed bean configurations are attached
@@ -60,6 +61,8 @@ public class SarModuleDependencyProcessor implements DeploymentUnitProcessor {
 
         moduleSpecification.addSystemDependency(new ModuleDependency(Module.getBootModuleLoader(), JBOSS_MODULES_ID, false, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(Module.getBootModuleLoader(), JBOSS_AS_SYSTEM_JMX_ID, true, false, false, false));
+        // depend on Properties editor module which uses ServiceLoader approach to load the appropriate org.jboss.common.beans.property.finder.PropertyEditorFinder
+        moduleSpecification.addSystemDependency(new ModuleDependency(Module.getBootModuleLoader(), PROPERTIES_EDITOR_MODULE_ID, false, false, true, false));
     }
 
     public void undeploy(final DeploymentUnit context) {

--- a/sar/src/main/java/org/jboss/as/service/StartStopService.java
+++ b/sar/src/main/java/org/jboss/as/service/StartStopService.java
@@ -40,8 +40,8 @@ final class StartStopService extends AbstractService {
     private final Method startMethod;
     private final Method stopMethod;
 
-    StartStopService(final Object mBeanInstance, final Method startMethod, final Method stopMethod, final ServiceName duServiceName) {
-        super(mBeanInstance, duServiceName);
+    StartStopService(final Object mBeanInstance, final Method startMethod, final Method stopMethod, final ServiceName duServiceName, final ClassLoader mbeanContextClassLoader) {
+        super(mBeanInstance, duServiceName, mbeanContextClassLoader);
         this.startMethod = startMethod;
         this.stopMethod = stopMethod;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassAInSarDeployment.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassAInSarDeployment.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.sar.context.classloader;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public class ClassAInSarDeployment {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassBInSarDeployment.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassBInSarDeployment.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.sar.context.classloader;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public class ClassBInSarDeployment {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassCInSarDeployment.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassCInSarDeployment.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.sar.context.classloader;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public class ClassCInSarDeployment {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassDInSarDeployment.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/ClassDInSarDeployment.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.sar.context.classloader;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public class ClassDInSarDeployment {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/MBeanTCCLTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/MBeanTCCLTestCase.java
@@ -1,0 +1,106 @@
+package org.jboss.as.test.integration.sar.context.classloader;
+
+import java.io.IOException;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnectorFactory;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.sar.context.classloader.mbean.MBeanInAModuleService;
+import org.jboss.as.test.integration.sar.context.classloader.mbean.MBeanInAModuleServiceMBean;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the MBean instance lifecycle has the correct TCCL set. The TCCL is expected to be the classloader of the deployment through which the MBean was deployed.
+ *
+ * @author: Jaikiran Pai
+ * @see https://issues.jboss.org/browse/WFLY-822
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MBeanTCCLTestCase {
+
+    private static final Logger logger = Logger.getLogger(MBeanTCCLTestCase.class);
+
+    private static final String EAR_NAME = "tccl-mbean-test-app";
+    private static final String SAR_NAME = "tccl-mbean-test-sar";
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    /**
+     * .ear
+     * |
+     * |---- META-INF/jboss-deployment-structure.xml
+     * |
+     * |---- .sar
+     * |      |
+     * |      |--- META-INF/jboss-service.xml (deploys the MBean whose class resides in a separate JBoss module)
+     * |      |
+     * |      |--- ClassA, ClassB, ClassC, ClassD (all of which will be attempted to be loaded from the MBean class which resides in a different JBoss module than this deployment)
+     * |
+     * |
+     * |---- .jar (configured as a JBoss Module in jboss-deployment-structure.xml of the .ear)
+     * |      |
+     * |      |---- MBean class (which relies on TCCL to load the classes present in the .sar deployment)
+     *
+     * @return
+     */
+    @Deployment
+    public static Archive createDeployment() {
+        // create a .sar which will contain a jboss-service.xml. The actual MBean class will reside in a module which will be added as a dependency on the .sar
+        final JavaArchive sar = ShrinkWrap.create(JavaArchive.class, SAR_NAME + ".sar");
+        // add the jboss-service.xml to the META-INF of the .sar
+        sar.addAsManifestResource(MBeanInAModuleService.class.getPackage(), "tccl-test-service.xml", "jboss-service.xml");
+        // add some (dummy) classes to the .sar. These classes will then be attempted to be loaded from the MBean class (which resides in a module)
+        sar.addClasses(ClassAInSarDeployment.class, ClassBInSarDeployment.class, ClassCInSarDeployment.class, ClassDInSarDeployment.class);
+
+        // now create a plain .jar containing the MBean class. This jar will be configured as a JBoss Module, in the jboss-deployment-structure.xml of the .ear to which this
+        // .jar will be added
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jar-containing-mbean-class.jar");
+        jar.addClasses(MBeanInAModuleService.class, MBeanInAModuleServiceMBean.class);
+
+        // create the .ear with the .sar and the .jar and the jboss-deployment-structure.xml
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_NAME + ".ear");
+        ear.addAsModule(sar);
+        ear.addAsModule(jar);
+        ear.addAsManifestResource(MBeanTCCLTestCase.class.getPackage(), "jboss-deployment-structure.xml", "jboss-deployment-structure.xml");
+
+        logger.info("created deployment: " + ear.toString(true));
+        return ear;
+    }
+
+    /**
+     * Tests the MBean was deployed successfully and can be invoked. The fact that the MBean deployed successfully is a sign that the TCCL access from within the MBean code, worked fine
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testTCCLInMBeanInvocation() throws Exception {
+        final MBeanServerConnection mBeanServerConnection = this.getMBeanServerConnection();
+        final ObjectName mbeanObjectName = new ObjectName("wildfly:name=tccl-test-mbean");
+        final int num1 = 3;
+        final int num2 = 4;
+        // invoke the operation on MBean
+        final Integer sum = (Integer) mBeanServerConnection.invoke(mbeanObjectName, "add", new Object[]{num1, num2}, new String[]{Integer.TYPE.getName(), Integer.TYPE.getName()});
+        Assert.assertEquals("Unexpected return value from MBean: " + mbeanObjectName, num1 + num2, (int) sum);
+    }
+
+    private MBeanServerConnection getMBeanServerConnection() throws IOException {
+        return JMXConnectorFactory.connect(managementClient.getRemoteJMXURL()).getMBeanServerConnection();
+
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/jboss-deployment-structure.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <sub-deployment name="tccl-mbean-test-sar.sar">
+        <dependencies>
+            <!-- Add a dependency on the module that we have configured later on in this jboss-deployment-structure.xml -->
+            <module name="deployment.mbean.module"/>
+        </dependencies>
+    </sub-deployment>
+
+    <module name="deployment.mbean.module">
+        <resources>
+            <resource-root path="jar-containing-mbean-class.jar"/>
+        </resources>
+    </module>
+
+</jboss-deployment-structure>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/mbean/MBeanInAModuleService.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/mbean/MBeanInAModuleService.java
@@ -1,0 +1,53 @@
+package org.jboss.as.test.integration.sar.context.classloader.mbean;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A MBean class which resides in a JBoss Module. This MBean tests that the TCCL corresponds to the deployment classloader of the deployment through which this MBean was deployed
+ *
+ * @author: Jaikiran Pai
+ */
+public class MBeanInAModuleService implements MBeanInAModuleServiceMBean {
+
+    private static final Logger logger = Logger.getLogger(MBeanInAModuleService.class);
+
+    static {
+        logger.info("Static block of " + MBeanInAModuleService.class.getName() + " being loaded");
+        // test TCCL in static block
+        testClassLoadByTCCL("org.jboss.as.test.integration.sar.context.classloader.ClassAInSarDeployment");
+    }
+
+    public MBeanInAModuleService() {
+        logger.info("Constructing " + this);
+        // test TCCL in constructor
+        testClassLoadByTCCL("org.jboss.as.test.integration.sar.context.classloader.ClassBInSarDeployment");
+    }
+
+    @Override
+    public int add(int a, int b) {
+        return a + b;
+    }
+
+    public void start() {
+        logger.info("Starting " + this);
+        // test TCCL in lifecycle method
+        testClassLoadByTCCL("org.jboss.as.test.integration.sar.context.classloader.ClassCInSarDeployment");
+    }
+
+    public void stop() {
+        logger.info("Stopping " + this);
+        // test TCCL in lifecycle method
+        testClassLoadByTCCL("org.jboss.as.test.integration.sar.context.classloader.ClassDInSarDeployment");
+    }
+
+    private static void testClassLoadByTCCL(final String className) {
+        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        logger.info("Trying to load class " + className + " from TCCL " + tccl);
+        try {
+            tccl.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        logger.info("Successfully loaded class " + className + " from TCCL " + tccl);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/mbean/MBeanInAModuleServiceMBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/mbean/MBeanInAModuleServiceMBean.java
@@ -1,0 +1,9 @@
+package org.jboss.as.test.integration.sar.context.classloader.mbean;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public interface MBeanInAModuleServiceMBean {
+
+    int add(int a, int b);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/mbean/tccl-test-service.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/mbean/tccl-test-service.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server xmlns="urn:jboss:service:7.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="urn:jboss:service:7.0 jboss-service_7_0.xsd">
+
+    <mbean name="wildfly:name=tccl-test-mbean" code="org.jboss.as.test.integration.sar.context.classloader.mbean.MBeanInAModuleService">
+    </mbean>
+</server>


### PR DESCRIPTION
The commit here includes a fix and testcase for https://issues.jboss.org/browse/WFLY-822.

The issue reported in that JIRA was that the TCCL was set to an incorrect classloader during the lifecycle invocation(s) of the MBean instance. The fix ensures that the TCCL now corresponds to the classloader of the deployment, through which the MBean was deployed, thus treating it similar to EE components.
