### PR TITLE
WFLY-1672 Remove forgotten module directories created by tests.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/globalmodules/GlobalModulesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/globalmodules/GlobalModulesTestCase.java
@@ -78,7 +78,6 @@ public class GlobalModulesTestCase {
             module.get("annotations").set(true);
             value.add(module);
 
-
             final ModelNode op = new ModelNode();
             op.get(OP_ADDR).set(SUBSYSTEM, "ee");
             op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
@@ -86,9 +85,11 @@ public class GlobalModulesTestCase {
             op.get(VALUE).set(value);
             managementClient.getControllerClient().execute(op);
 
-
             File testModuleRoot = new File(getModulePath(), "org/jboss/test/globalModule");
-            deleteRecursively(testModuleRoot);
+            File file = testModuleRoot;
+            while (!getModulePath().equals(file.getParentFile()))
+                file = file.getParentFile();
+            deleteRecursively(file);
             createTestModule(testModuleRoot);
         }
 
@@ -100,9 +101,11 @@ public class GlobalModulesTestCase {
             op.get(NAME).set("global-modules");
             managementClient.getControllerClient().execute(op);
 
-
             File testModuleRoot = new File(getModulePath(), "org/jboss/test/globalModule");
-            deleteRecursively(testModuleRoot);
+            File file = testModuleRoot;
+            while (!getModulePath().equals(file.getParentFile()))
+                file = file.getParentFile();
+            deleteRecursively(file);
         }
 
         private static void deleteRecursively(File file) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
@@ -54,20 +54,27 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
     protected File slot;
     public static ModelNode address;
     protected final String defaultPath = "org/jboss/ironjacamar/ra16out";
+    private boolean firstRemove = true;
 
     public void addModule(final String moduleName) throws Exception {
         addModule(moduleName, "module.xml");
     }
 
-    public void addModule(final String moduleName, String moduleXml)
-            throws Exception {
-        removeModule(moduleName);
+    public void addModule(final String moduleName, String moduleXml) throws Exception {
+        testModuleRoot = new File(getModulePath(), moduleName);
+        if (firstRemove) {
+            removeModule(moduleName);
+            firstRemove = false;
+        }
         createTestModule(moduleXml);
     }
 
     public void removeModule(final String moduleName) throws Exception {
         testModuleRoot = new File(getModulePath(), moduleName);
-        deleteRecursively(testModuleRoot);
+        File file = testModuleRoot;
+        while (!getModulePath().equals(file.getParentFile()))
+            file = file.getParentFile();
+        deleteRecursively(file);
     }
 
     private void deleteRecursively(File file) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/multideployment/WeldModuleDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/multideployment/WeldModuleDeploymentTestCase.java
@@ -69,14 +69,20 @@ public class WeldModuleDeploymentTestCase {
 
     public static void doSetup() throws Exception {
         File testModuleRoot = new File(getModulePath(), "org/jboss/test/weldModule");
-        deleteRecursively(testModuleRoot);
+        File file = testModuleRoot;
+        while (!getModulePath().equals(file.getParentFile()))
+            file = file.getParentFile();
+        deleteRecursively(file);
         createTestModule(testModuleRoot);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
         File testModuleRoot = new File(getModulePath(), "org/jboss/test/weldModule");
-        deleteRecursively(testModuleRoot);
+        File file = testModuleRoot;
+        while (!getModulePath().equals(file.getParentFile()))
+            file = file.getParentFile();
+        deleteRecursively(file);
     }
 
     private static void deleteRecursively(File file) {


### PR DESCRIPTION
WFLY issue : https://issues.jboss.org/browse/WFLY-1672

Three module related tests use method deleteRecursively() which does not delete module directories properly when module path is multi-layer, part of module directory remain in JBOSS_HOME/modules after test completion.

Example: JBOSS_HOME/modules/org/jboss/test is left behind instead of deleting whole org/jboss/test/weldModule
