### PR TITLE
Upgrade remote naming to 1.0.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <version.org.jboss.osgi.repository>3.0.0.Final</version.org.jboss.osgi.repository>
         <version.org.jboss.osgi.spi>4.0.0.Final</version.org.jboss.osgi.spi>
         <version.org.jboss.osgi.vfs>2.0.0.Final</version.org.jboss.osgi.vfs>
-        <version.org.jboss.remote-naming>1.0.6.Final</version.org.jboss.remote-naming>
+        <version.org.jboss.remote-naming>1.0.7.Final</version.org.jboss.remote-naming>
         <version.org.jboss.remoting>4.0.0.Beta1</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.0.Beta1</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.resteasy>3.0.1.Final</version.org.jboss.resteasy>


### PR DESCRIPTION
The commit here upgrade remote-naming to 1.0.7.Final and brings in an important fix related to the way remoting connections were cached during JNDI lookups. A similar fix for EJB client project will require a upgrade of that project, for which a separate PR will be issued (since it currently clashes with another PR, that's in the merge queue).
