### PR TITLE
[WFLY-245] Some operation additions for controlling backup status in Infinispan Cross-Site Replication

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanMessages.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/InfinispanMessages.java
@@ -206,4 +206,14 @@ public interface InfinispanMessages {
     @Message(id = 10386, value = "Unknown metric %s")
     String unknownMetric(String metricName);
 
+    /**
+     * Creates an exception indicating failure to invoke an operation.
+     *
+     * @param operation the operation name.
+     *
+     * @return an {@link OperationFailedException} for the error.
+     */
+    @Message(id = 10387, value = "Failed to invoke operation: %s")
+    OperationFailedException failedToInvokeOperation(@Cause Throwable cause, String operation);
+
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupSiteResource.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupSiteResource.java
@@ -108,14 +108,18 @@ public class BackupSiteResource extends SimpleResourceDefinition {
         // operations
     static final OperationDefinition BACKUP_BRING_SITE_ONLINE =
             new SimpleOperationDefinitionBuilder(ModelKeys.BRING_SITE_ONLINE, InfinispanExtension.getResourceDescriptionResolver("backup.ops"))
+                .setRuntimeOnly()
                 .build();
 
     static final OperationDefinition BACKUP_TAKE_SITE_OFFLINE =
             new SimpleOperationDefinitionBuilder(ModelKeys.TAKE_SITE_OFFLINE, InfinispanExtension.getResourceDescriptionResolver("backup.ops"))
+                .setRuntimeOnly()
                 .build();
 
     static final OperationDefinition BACKUP_SITE_STATUS =
             new SimpleOperationDefinitionBuilder(ModelKeys.SITE_STATUS, InfinispanExtension.getResourceDescriptionResolver("backup.ops"))
+                .setRuntimeOnly()
+                .setReadOnly()
                 .build();
 
 
@@ -167,7 +171,7 @@ public class BackupSiteResource extends SimpleResourceDefinition {
             final String site = address.getLastElement().getValue();
 
             final ServiceName cacheServiceName = CacheService.getServiceName(cacheContainerName, cacheName);
-            final ServiceController<?> controller = context.getServiceRegistry(false).getService(cacheServiceName);
+            final ServiceController<?> controller = context.getServiceRegistry(true).getService(cacheServiceName);
             Cache<?, ?> cache = (Cache<?, ?>) controller.getValue();
 
             ModelNode result = null;
@@ -203,7 +207,7 @@ public class BackupSiteResource extends SimpleResourceDefinition {
             final String site = address.getLastElement().getValue();
 
             final ServiceName cacheServiceName = CacheService.getServiceName(cacheContainerName, cacheName);
-            final ServiceController<?> controller = context.getServiceRegistry(false).getService(cacheServiceName);
+            final ServiceController<?> controller = context.getServiceRegistry(true).getService(cacheServiceName);
             Cache<?, ?> cache = (Cache<?, ?>) controller.getValue();
 
             ModelNode result = null;
@@ -239,7 +243,7 @@ public class BackupSiteResource extends SimpleResourceDefinition {
             final String site = address.getLastElement().getValue();
 
             final ServiceName cacheServiceName = CacheService.getServiceName(cacheContainerName, cacheName);
-            final ServiceController<?> controller = context.getServiceRegistry(false).getService(cacheServiceName);
+            final ServiceController<?> controller = context.getServiceRegistry(true).getService(cacheServiceName);
             Cache<?, ?> cache = (Cache<?, ?>) controller.getValue();
 
             ModelNode result = null;

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
@@ -159,12 +159,15 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition {
     static final AttributeDefinition[] CACHE_CONTAINER_METRICS = {CACHE_MANAGER_STATUS, CLUSTER_NAME, COORDINATOR_ADDRESS, IS_COORDINATOR, LOCAL_ADDRESS};
 
     private final ResolvePathHandler resolvePathHandler;
-    public CacheContainerResourceDefinition(final ResolvePathHandler resolvePathHandler) {
+    private final boolean runtimeRegistration;
+
+    public CacheContainerResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean runtimeRegistration) {
         super(CONTAINER_PATH,
                 InfinispanExtension.getResourceDescriptionResolver(ModelKeys.CACHE_CONTAINER),
                 CacheContainerAdd.INSTANCE,
                 CacheContainerRemove.INSTANCE);
         this.resolvePathHandler = resolvePathHandler;
+        this.runtimeRegistration = runtimeRegistration;
     }
 
     @Override
@@ -196,9 +199,17 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition {
 
         // child resources
         resourceRegistration.registerSubModel(new TransportResourceDefinition());
-        resourceRegistration.registerSubModel(new LocalCacheResourceDefinition(resolvePathHandler));
-        resourceRegistration.registerSubModel(new InvalidationCacheResourceDefinition(resolvePathHandler));
-        resourceRegistration.registerSubModel(new ReplicatedCacheResourceDefinition(resolvePathHandler));
-        resourceRegistration.registerSubModel(new DistributedCacheResourceDefinition(resolvePathHandler));
+        resourceRegistration.registerSubModel(new LocalCacheResourceDefinition(getResolvePathHandler(), isRuntimeRegistration()));
+        resourceRegistration.registerSubModel(new InvalidationCacheResourceDefinition(getResolvePathHandler(), isRuntimeRegistration()));
+        resourceRegistration.registerSubModel(new ReplicatedCacheResourceDefinition(getResolvePathHandler(), isRuntimeRegistration()));
+        resourceRegistration.registerSubModel(new DistributedCacheResourceDefinition(getResolvePathHandler(), isRuntimeRegistration()));
+    }
+
+    public boolean isRuntimeRegistration() {
+        return runtimeRegistration;
+    }
+
+    public ResolvePathHandler getResolvePathHandler() {
+        return resolvePathHandler;
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResourceDefinition.java
@@ -194,9 +194,12 @@ public class CacheResourceDefinition extends SimpleResourceDefinition {
 
 
     private final ResolvePathHandler resolvePathHandler;
-    public CacheResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, AbstractAddStepHandler addHandler, OperationStepHandler removeHandler, ResolvePathHandler resolvePathHandler) {
+    private final boolean runtimeRegistration;
+
+    public CacheResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, AbstractAddStepHandler addHandler, OperationStepHandler removeHandler, ResolvePathHandler resolvePathHandler, boolean runtimeRegistration) {
         super(pathElement, descriptionResolver, addHandler, removeHandler);
         this.resolvePathHandler = resolvePathHandler;
+        this.runtimeRegistration = runtimeRegistration;
     }
 
     @Override
@@ -229,10 +232,18 @@ public class CacheResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new EvictionResourceDefinition());
         resourceRegistration.registerSubModel(new ExpirationResourceDefinition());
         resourceRegistration.registerSubModel(new StoreResourceDefinition());
-        resourceRegistration.registerSubModel(new FileStoreResourceDefinition(resolvePathHandler));
+        resourceRegistration.registerSubModel(new FileStoreResourceDefinition(getResolvePathHandler()));
         resourceRegistration.registerSubModel(new StringKeyedJDBCStoreResourceDefinition());
         resourceRegistration.registerSubModel(new BinaryKeyedJDBCStoreResourceDefinition());
         resourceRegistration.registerSubModel(new MixedKeyedJDBCStoreResourceDefinition());
         resourceRegistration.registerSubModel(new RemoteStoreResourceDefinition());
+    }
+
+    public boolean isRuntimeRegistration() {
+        return runtimeRegistration;
+    }
+
+    public ResolvePathHandler getResolvePathHandler() {
+        return resolvePathHandler;
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
@@ -110,8 +110,8 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
 
     static final AttributeDefinition[] CLUSTERED_CACHE_METRICS = {AVERAGE_REPLICATION_TIME, REPLICATION_COUNT, REPLICATION_FAILURES, SUCCESS_RATIO};
 
-    public ClusteredCacheResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, AbstractAddStepHandler addHandler, OperationStepHandler removeHandler, ResolvePathHandler resolvePathHandler) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler, resolvePathHandler);
+    public ClusteredCacheResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, AbstractAddStepHandler addHandler, OperationStepHandler removeHandler, ResolvePathHandler resolvePathHandler, boolean runtimeRegistration) {
+        super(pathElement, descriptionResolver, addHandler, removeHandler, resolvePathHandler, runtimeRegistration);
     }
 
     @Override

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
@@ -96,11 +96,11 @@ public class DistributedCacheResourceDefinition extends SharedCacheResourceDefin
 
     static final AttributeDefinition[] DISTRIBUTED_CACHE_ATTRIBUTES = {OWNERS, SEGMENTS, L1_LIFESPAN};
 
-    public DistributedCacheResourceDefinition(final ResolvePathHandler resolvePathHandler) {
+    public DistributedCacheResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean runtimeRegistration) {
         super(DISTRIBUTED_CACHE_PATH,
                 InfinispanExtension.getResourceDescriptionResolver(ModelKeys.DISTRIBUTED_CACHE),
                 DistributedCacheAdd.INSTANCE,
-                CacheRemove.INSTANCE, resolvePathHandler);
+                CacheRemove.INSTANCE, resolvePathHandler, runtimeRegistration);
     }
 
     @Override

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -78,7 +78,7 @@ public class InfinispanExtension implements Extension {
             resolvePathHandler = null;
         }
 
-        subsystem.registerSubsystemModel(new InfinispanSubsystemRootResourceDefinition(resolvePathHandler));
+        subsystem.registerSubsystemModel(new InfinispanSubsystemRootResourceDefinition(resolvePathHandler, context.isRuntimeOnlyRegistrationValid()));
         subsystem.registerXMLElementWriter(new InfinispanSubsystemXMLWriter());
         if (context.isRegisterTransformers()) {
             // TODO move transformation out of this utility class and into the ResourceDefinition impls

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemRootResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemRootResourceDefinition.java
@@ -39,12 +39,15 @@ import org.jboss.as.controller.services.path.ResolvePathHandler;
 public class InfinispanSubsystemRootResourceDefinition extends SimpleResourceDefinition {
 
     private final ResolvePathHandler resolvePathHandler;
-    public InfinispanSubsystemRootResourceDefinition(final ResolvePathHandler resolvePathHandler) {
+    private final boolean runtimeRegistration;
+
+    public InfinispanSubsystemRootResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean runtimeRegistration) {
         super(PathElement.pathElement(SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME),
                 InfinispanExtension.getResourceDescriptionResolver(),
                 InfinispanSubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
         this.resolvePathHandler = resolvePathHandler;
+        this.runtimeRegistration = runtimeRegistration;
     }
 
     @Override
@@ -61,8 +64,14 @@ public class InfinispanSubsystemRootResourceDefinition extends SimpleResourceDef
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerSubModel(new CacheContainerResourceDefinition(resolvePathHandler));
+        resourceRegistration.registerSubModel(new CacheContainerResourceDefinition(getResolvePathHandler(), isRuntimeRegistration()));
     }
 
+    public ResolvePathHandler getResolvePathHandler() {
+        return resolvePathHandler;
+    }
 
+    public boolean isRuntimeRegistration() {
+        return runtimeRegistration;
+    }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinition.java
@@ -36,10 +36,10 @@ public class InvalidationCacheResourceDefinition extends ClusteredCacheResourceD
 
     // attributes
 
-    public InvalidationCacheResourceDefinition(final ResolvePathHandler resolvePathHandler) {
+    public InvalidationCacheResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean runtimeRegistration) {
         super(INVALIDATION_CACHE_PATH,
                 InfinispanExtension.getResourceDescriptionResolver(ModelKeys.INVALIDATION_CACHE),
                 InvalidationCacheAdd.INSTANCE,
-                CacheRemove.INSTANCE, resolvePathHandler);
+                CacheRemove.INSTANCE, resolvePathHandler, runtimeRegistration);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheResourceDefinition.java
@@ -36,11 +36,11 @@ public class LocalCacheResourceDefinition extends CacheResourceDefinition {
 
     // attributes
 
-    public LocalCacheResourceDefinition(final ResolvePathHandler resolvePathHandler) {
+    public LocalCacheResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean runtimeRegistration) {
         super(LOCAL_CACHE_PATH,
                 InfinispanExtension.getResourceDescriptionResolver(ModelKeys.LOCAL_CACHE),
                 LocalCacheAdd.INSTANCE,
-                CacheRemove.INSTANCE, resolvePathHandler);
+                CacheRemove.INSTANCE, resolvePathHandler, runtimeRegistration);
     }
 
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ModelKeys.java
@@ -41,6 +41,7 @@ public class ModelKeys {
     static final String BATCHING = "batching";
     static final String BINARY_KEYED_TABLE = "binary-keyed-table";
     static final String BINARY_KEYED_TABLE_NAME = "BINARY_KEYED_TABLE";
+    static final String BRING_SITE_ONLINE = "bring-site-online";
     static final String BUCKET_TABLE = "bucket-table";
     static final String CACHE = "cache";
     // static final String CACHE_MODE = "cache-mode";
@@ -125,6 +126,7 @@ public class ModelKeys {
     static final String SHUTDOWN_TIMEOUT = "shutdown-timeout";
     static final String SINGLETON = "singleton";
     static final String SITE = "site";
+    static final String SITE_STATUS = "site-status";
     static final String SOCKET_TIMEOUT = "socket-timeout";
     static final String STACK = "stack";
     static final String START = "start";
@@ -137,6 +139,7 @@ public class ModelKeys {
     static final String STRIPING = "striping";
     static final String TAKE_BACKUP_OFFLINE_AFTER_FAILURES = "after-failures";
     static final String TAKE_BACKUP_OFFLINE_MIN_WAIT = "min-wait";
+    static final String TAKE_SITE_OFFLINE = "take-site-offline";
     static final String TCP_NO_DELAY = "tcp-no-delay";
     static final String THREAD_POOL_SIZE = "thread-pool-size";
     static final String TIMEOUT = "timeout";

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceDefinition.java
@@ -36,10 +36,10 @@ public class ReplicatedCacheResourceDefinition extends SharedCacheResourceDefini
 
     // attributes
 
-    public ReplicatedCacheResourceDefinition(final ResolvePathHandler resolvePathHandler) {
+    public ReplicatedCacheResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean runtimeRegistration) {
         super(REPLICATED_CACHE_PATH,
                 InfinispanExtension.getResourceDescriptionResolver(ModelKeys.REPLICATED_CACHE),
                 ReplicatedCacheAdd.INSTANCE,
-                CacheRemove.INSTANCE, resolvePathHandler);
+                CacheRemove.INSTANCE, resolvePathHandler, runtimeRegistration);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedCacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedCacheResourceDefinition.java
@@ -37,8 +37,8 @@ import org.jboss.as.controller.services.path.ResolvePathHandler;
  */
 public class SharedCacheResourceDefinition extends ClusteredCacheResourceDefinition {
 
-    public SharedCacheResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, AbstractAddStepHandler addHandler, OperationStepHandler removeHandler, ResolvePathHandler resolvePathHandler) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler, resolvePathHandler);
+    public SharedCacheResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, AbstractAddStepHandler addHandler, OperationStepHandler removeHandler, ResolvePathHandler resolvePathHandler, boolean runtimeRegistration) {
+        super(pathElement, descriptionResolver, addHandler, removeHandler, resolvePathHandler, runtimeRegistration);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class SharedCacheResourceDefinition extends ClusteredCacheResourceDefinit
         super.registerChildren(registration);
 
         registration.registerSubModel(new StateTransferResourceDefinition());
-        registration.registerSubModel(new BackupSiteResource());
+        registration.registerSubModel(new BackupSiteResource(isRuntimeRegistration()));
         registration.registerSubModel(new BackupForResourceDefinition());
     }
 }

--- a/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -296,3 +296,8 @@ infinispan.backup-for.add=Adds a backup designation for this cache.
 infinispan.backup-for.remove=Removes a backup designation for this cache.
 infinispan.backup-for.remote-cache=The name of the remote cache for which this cache acts as a backup.
 infinispan.backup-for.remote-site=The site of the remote cache for which this cache acts as a backup.
+
+# cross-site backup operations
+infinispan.backup.ops.site-status=Displays the current status of the backup site.
+infinispan.backup.ops.bring-site-online=Re-enables a previously disabled backup site.
+infinispan.backup.ops.take-site-offline=Disables backup to a remote site.

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -140,4 +140,65 @@
 
     </group>
 
+    <group qualifier="clustering-xsite-backupFor">
+
+        <container qualifier="container-0" mode="custom" managed="false" default="true">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clustering-xsite-LON-0</property>
+                <!-- AS7-2493 different jboss.node.name must be specified -->
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clustering-xsite-LON-0 -Djboss.node.name=LON-0</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-1" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clustering-xsite-LON-1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clustering-xsite-LON-1 -Djboss.node.name=LON-1 -Djboss.port.offset=100</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node1}</property>
+                <property name="managementPort">10090</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-2" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clustering-xsite-NYC-0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clustering-xsite-NYC-0 -Djboss.node.name=NYC-0 -Djboss.port.offset=200</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node2}</property>
+                <property name="managementPort">10190</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node2} 10199</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-3" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clustering-xsite-SFO-0-backupFor</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clustering-xsite-SFO-0-backupFor -Djboss.node.name=SFO-0-backupFor -Djboss.port.offset=300</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="managementAddress">${node3}</property>
+                <property name="managementPort">10290</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node3} 10299</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+    </group>
+
 </arquillian>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/xsite/web-backupfor.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/xsite/web-backupfor.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2012, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+    <!-- No need for this app to be distributable and trigger the creation of a session cache -->
+    <servlet>
+        <servlet-name>CacheAccessServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.clustering.xsite.CacheAccessServlet</servlet-class>
+        <init-param>
+            <param-name>jndi-name</param-name>
+            <param-value>java:jboss/infinispan/cache/web/LONrepl</param-value>
+        </init-param>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>CacheAccessServlet</servlet-name>
+        <url-pattern>/cache</url-pattern>
+    </servlet-mapping>
+
+    <resource-ref>
+        <res-ref-name>TheTargetCache</res-ref-name>
+        <res-type>org.infinispan.Cache</res-type>
+        <lookup-name>java:jboss/infinispan/cache/web/LONrepl</lookup-name>
+    </resource-ref>
+</web-app>

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -171,12 +171,26 @@
         <ts.config-as.add-xsite-remote-site name="wildfly-clustering-xsite-SFO-0" stack="udp"
                                       remote-site.site="NYC" remote-site.stack="tcp" remote-site.cluster="bridge"/>
 
-        <!-- create a named backup cache based on repl for LON:web:dist and mark as backup-for
-        <ts.config-as.copy-cache name="wildfly-clustering-xsite-SFO-0" container.name="web"
+        <!-- site SFO, node 3, mcast 2 + backupFor -->
+        <echo message="Building config clustering-xsite-SFO-0-backupFor"/>
+        <copy todir="target/wildfly-clustering-xsite-SFO-0-backupFor" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
+        </copy>
+        <ts.config-as.ip-with-multicast-longform name="wildfly-clustering-xsite-SFO-0-backupFor"
+                                                 managementIPAddress="${node3}" publicIPAddress="${node3}"
+                                                 udpMcastAddress="${mcast-sfo}" diagnosticsMcastAddress="${mcast-sfo}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-sfo}"/>
+        <ts.config-as.add-port-offset name="wildfly-clustering-xsite-SFO-0-backupFor" offset="300" nativePort="9999" httpPort="9990"/>
+        <!-- define relay at JGroups level -->
+        <ts.config-as.add-xsite-relay name="wildfly-clustering-xsite-SFO-0-backupFor" stack="udp" relay.site="SFO"
+                                      remote-site.site="LON" remote-site.stack="tcp" remote-site.cluster="bridge"/>
+        <ts.config-as.add-xsite-remote-site name="wildfly-clustering-xsite-SFO-0-backupFor" stack="udp"
+                                      remote-site.site="NYC" remote-site.stack="tcp" remote-site.cluster="bridge"/>
+
+        <!-- create a named backup cache based on repl for LON:web:dist and mark as backup-for -->
+        <ts.config-as.copy-cache name="wildfly-clustering-xsite-SFO-0-backupFor" container.name="web"
                                        cache-type="replicated-cache" cache.base="repl" cache.name="LONrepl"/>
-        <ts.config-as.add-xsite-backup-for name="wildfly-clustering-xsite-SFO-0" container="web"
+        <ts.config-as.add-xsite-backup-for name="wildfly-clustering-xsite-SFO-0-backupFor" container="web"
                                        cache-type="replicated-cache" cache="LONrepl" remote-site="LON" remote-cache="repl"/>
-        -->
 
     </target>
 


### PR DESCRIPTION
This PR adds:
- three operations to display and control the status of xsite backups at a site (status, take-offline, bring-online)
- adds a test case to check functionality of backup-for, which allows the default name of a target backup cache to be  remapped
