### PR TITLE
WFLY-1658 Fix handling of metadata on EJB  methods which accept arrays as parameters

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/MethodPermissionsMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/MethodPermissionsMergingProcessor.java
@@ -40,10 +40,10 @@ import org.jboss.as.ejb3.component.MethodIntf;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.security.EJBMethodSecurityAttribute;
 import org.jboss.as.ejb3.security.EjbJaccConfigurator;
+import org.jboss.as.ejb3.util.MethodInfoHelper;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
-import org.jboss.invocation.proxy.MethodIdentifier;
 import org.jboss.logging.Logger;
 import org.jboss.metadata.ejb.spec.AssemblyDescriptorMetaData;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
@@ -83,8 +83,7 @@ public class MethodPermissionsMergingProcessor extends AbstractMergingProcessor<
 
         for (Map.Entry<Method, List<Boolean>> entry : permitData.getMethodAnnotations().entrySet()) {
             final Method method = entry.getKey();
-            final MethodIdentifier identifier = MethodIdentifier.getIdentifierForMethod(method);
-            description.getAnnotationMethodPermissions().setAttribute(null, EJBMethodSecurityAttribute.permitAll(), method.getDeclaringClass().getName(), method.getName(), identifier.getParameterTypes());
+            description.getAnnotationMethodPermissions().setAttribute(null, EJBMethodSecurityAttribute.permitAll(), method.getDeclaringClass().getName(), method.getName(), MethodInfoHelper.getCanonicalParameterTypes(method));
         }
 
         final RuntimeAnnotationInformation<String[]> data = MethodAnnotationAggregator.runtimeAnnotationInformation(componentClass, applicationClasses, deploymentReflectionIndex, RolesAllowed.class);
@@ -95,8 +94,7 @@ public class MethodPermissionsMergingProcessor extends AbstractMergingProcessor<
 
         for (Map.Entry<Method, List<String[]>> entry : data.getMethodAnnotations().entrySet()) {
             final Method method = entry.getKey();
-            final MethodIdentifier identifier = MethodIdentifier.getIdentifierForMethod(method);
-            description.getAnnotationMethodPermissions().setAttribute(null, EJBMethodSecurityAttribute.rolesAllowed(new HashSet<String>(Arrays.<String>asList(entry.getValue().get(0)))), method.getDeclaringClass().getName(), method.getName(), identifier.getParameterTypes());
+            description.getAnnotationMethodPermissions().setAttribute(null, EJBMethodSecurityAttribute.rolesAllowed(new HashSet<String>(Arrays.<String>asList(entry.getValue().get(0)))), method.getDeclaringClass().getName(), method.getName(), MethodInfoHelper.getCanonicalParameterTypes(method));
         }
 
         final RuntimeAnnotationInformation<Boolean> denyData = MethodAnnotationAggregator.runtimeAnnotationInformation(componentClass, applicationClasses, deploymentReflectionIndex, DenyAll.class);
@@ -107,8 +105,7 @@ public class MethodPermissionsMergingProcessor extends AbstractMergingProcessor<
 
         for (Map.Entry<Method, List<Boolean>> entry : denyData.getMethodAnnotations().entrySet()) {
             final Method method = entry.getKey();
-            final MethodIdentifier identifier = MethodIdentifier.getIdentifierForMethod(method);
-            description.getAnnotationMethodPermissions().setAttribute(null, EJBMethodSecurityAttribute.denyAll(), method.getDeclaringClass().getName(), method.getName(), identifier.getParameterTypes());
+            description.getAnnotationMethodPermissions().setAttribute(null, EJBMethodSecurityAttribute.denyAll(), method.getDeclaringClass().getName(), method.getName(), MethodInfoHelper.getCanonicalParameterTypes(method));
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnotationAuthorizationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnotationAuthorizationTestCase.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -261,4 +262,21 @@ public class AnnotationAuthorizationTestCase {
         }
     }
 
+    /**
+     * Tests that a method which accepts an array as a parameter and is marked with @PermitAll is allowed to be invoked by clients.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPermitAllMethodWithArrayParams() throws Exception {
+        LoginContext lc = Util.getCLMLoginContext("user1", "password1");
+        lc.login();
+        try {
+            final String[] messages = new String[] {"foo", "bar"};
+            final String[] echoes = denyAllOverrideBean.permitAllEchoWithArrayParams(messages);
+            assertArrayEquals("Unexpected echoes returned by bean method", messages, echoes);
+        } finally {
+            lc.logout();
+        }
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/DenyAllOverrideBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/DenyAllOverrideBean.java
@@ -45,6 +45,11 @@ public class DenyAllOverrideBean {
         return message;
     }
 
+    @PermitAll
+    public String[] permitAllEchoWithArrayParams(final String[] messages) {
+        return messages;
+    }
+
     @RolesAllowed("Role1")
     public String role1Echo(final String message) {
         return message;


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-1658 where we weren't correctly handling methods which accept array parameters. The commit also includes a testcase to test this fix.

P.S: We'll need a TCK run against this change.
