### PR TITLE
WFLY-1679: Update to HAL Release Stream 2.3.0.Final

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -812,7 +812,7 @@
         </module-def>
 
         <module-def name="org.jboss.as.console">
-            <maven-resource-with-classifier group="org.jboss.as" artifact="jboss-as-console" classifier="resources"/>
+            <maven-resource-with-classifier group="org.jboss.hal" artifact="release-stream" classifier="resources"/>
         </module-def>
 
         <module-def name="org.jboss.as.cli">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -945,8 +945,8 @@
                 </dependency>
 
                 <dependency>
-                    <groupId>org.jboss.as</groupId>
-                    <artifactId>jboss-as-console</artifactId>
+                    <groupId>org.jboss.hal</groupId>
+                    <artifactId>release-stream</artifactId>
                     <classifier>resources</classifier>
                 </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
         <version.org.jboss.ejb-client>2.0.0.Beta3</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.1.0</version.org.jboss.ejb3.ext-api>
-        <version.org.jboss.hal.release-stream>1.6.3.1.Final</version.org.jboss.hal.release-stream>
+        <version.org.jboss.hal.release-stream>2.3.0.Final</version.org.jboss.hal.release-stream>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.0.Beta2</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.0.17.Final</version.org.jboss.ironjacamar>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
             In cases where multiple artifacts use the same groupId but have different
             versions, add the artifactId or other qualifier to the property name.
-            For example: <version.org.jboss.as.console>
+            For example: <version.org.jboss.hal.release-stream>
          -->
 
         <version.ant.junit>1.8.3</version.ant.junit>
@@ -157,7 +157,6 @@
         <version.org.jboss.aesh>0.33.3</version.org.jboss.aesh>
         <version.org.jboss.arquillian.core>1.0.3.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.osgi>2.0.0.CR3</version.org.jboss.arquillian.osgi>
-        <version.org.jboss.as.console>1.6.1.Final</version.org.jboss.as.console>
         <version.org.jboss.as.jbossweb-native>2.0.10.Final</version.org.jboss.as.jbossweb-native>
         <version.org.jboss.byteman>2.0.1</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.0.4.Final</version.org.jboss.classfilewriter>
@@ -166,6 +165,7 @@
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
         <version.org.jboss.ejb-client>2.0.0.Beta3</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.1.0</version.org.jboss.ejb3.ext-api>
+        <version.org.jboss.hal.release-stream>1.6.3.1.Final</version.org.jboss.hal.release-stream>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.0.Beta2</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.0.17.Final</version.org.jboss.ironjacamar>
@@ -4577,9 +4577,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.as</groupId>
-                <artifactId>jboss-as-console</artifactId>
-                <version>${version.org.jboss.as.console}</version>
+                <groupId>org.jboss.hal</groupId>
+                <artifactId>release-stream</artifactId>
+                <version>${version.org.jboss.hal.release-stream}</version>
                 <classifier>resources</classifier>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
Update from core console `org.jboss.as:jboss-as-console:1.6.1.Final` to HAL release stream `org.jboss.hal:release-stream:1.6.3.1.Final`
