### PR TITLE
[WFLY-1669] Change the default https port for the http management interfaces to 9993

### DIFF
--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -61,7 +61,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
 
         <?SOCKET-BINDINGS?>
 

--- a/config-assembly/src/test/resources/org/jboss/as/config/assembly/standalone-template.xml
+++ b/config-assembly/src/test/resources/org/jboss/as/config/assembly/standalone-template.xml
@@ -41,7 +41,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <?SOCKET-BINDINGS?>
     </socket-binding-group>
 </server>

--- a/core-model-test/src/test/resources/org/jboss/as/core/model/test/socketbinding/standalone.xml
+++ b/core-model-test/src/test/resources/org/jboss/as/core/model/test/socketbinding/standalone.xml
@@ -27,7 +27,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/shipped/standalone.xml
@@ -43,7 +43,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/socketbindinggroups/standalone.xml
@@ -7,7 +7,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
            <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
            <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-           <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+           <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
            <socket-binding name="ajp" port="8009"/>
            <socket-binding name="http" port="8080"/>
            <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-full-ha.xml
@@ -478,7 +478,7 @@
         <socket-binding name="jgroups-udp-fd" port="54200"/>
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="messaging" port="5445"/>
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-full.xml
@@ -378,7 +378,7 @@
         <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="messaging" port="5445"/>
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="remoting" port="4447"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-ha.xml
@@ -354,7 +354,7 @@
         <socket-binding name="jgroups-udp-fd" port="54200"/>
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0-xts.xml
@@ -386,7 +386,7 @@
         <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="messaging" port="5445"/>
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="remoting" port="4447"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-0.xml
@@ -276,7 +276,7 @@
         <socket-binding name="https" port="8443"/>
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-full-ha.xml
@@ -470,7 +470,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-full.xml
@@ -367,7 +367,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-ha.xml
@@ -353,7 +353,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-hornetq-colocated.xml
@@ -424,7 +424,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-jts.xml
@@ -275,7 +275,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1-xts.xml
@@ -371,7 +371,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-1.xml
@@ -274,7 +274,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-full-ha.xml
@@ -470,7 +470,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-full.xml
@@ -367,7 +367,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-ha.xml
@@ -353,7 +353,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-hornetq-colocated.xml
@@ -424,7 +424,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-jts.xml
@@ -275,7 +275,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2-xts.xml
@@ -371,7 +371,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-2.xml
@@ -281,7 +281,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full-ha.xml
@@ -467,7 +467,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full.xml
@@ -363,7 +363,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-ha.xml
@@ -362,7 +362,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-hornetq-colocated.xml
@@ -430,7 +430,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-jts.xml
@@ -288,7 +288,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-xts.xml
@@ -367,7 +367,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3.xml
@@ -281,7 +281,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -178,7 +178,7 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     private static String fixExpressions(String line) {
         String result = line.replace("${jboss.management.native.port:9999}", "9999");
         result = result.replace("${jboss.management.http.port:9990}", "9990");
-        result = result.replace("${jboss.management.https.port:9443}", "9443");
+        result = result.replace("${jboss.management.https.port:9993}", "9993");
         result = result.replace("${jboss.domain.master.port:9999}", "9999");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");
         result = result.replace("${jboss.socket.binding.port-offset:0}", "0");


### PR DESCRIPTION
This is to eliminate offset problems against 8443 which is the long established default for the web container.
