### PR TITLE
WFLY-1560 fixing module names/slots in jca moduledeployment tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
@@ -22,12 +22,16 @@
 package org.jboss.as.test.integration.jca.moduledeployment;
 
 import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.net.URL;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
@@ -48,7 +52,9 @@ import org.xnio.IoUtils;
  *
  * @author <a href="vrastsel@redhat.com">Vladimir Rastseluev</a>
  */
-public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
+public abstract class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
+
+    private static final Pattern MODULE_SLOT_PATTERN = Pattern.compile("slot=\"main\"");
 
     protected File testModuleRoot;
     protected File slot;
@@ -93,7 +99,7 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
             throw new IllegalArgumentException(testModuleRoot
                     + " already exists");
         }
-        File file = new File(testModuleRoot, "main");
+        File file = new File(testModuleRoot, getSlot());
         if (!file.mkdirs()) {
             throw new IllegalArgumentException("Could not create " + file);
         }
@@ -102,7 +108,7 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
         if (url == null) {
             throw new IllegalStateException("Could not find module.xml");
         }
-        copyFile(new File(file, "module.xml"), url.openStream());
+        copyModuleXml(slot, url.openStream());
 
     }
 
@@ -116,6 +122,24 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
                 i = src.read();
             }
         } finally {
+            IoUtils.safeClose(out);
+        }
+    }
+
+    protected void copyModuleXml(File slot, InputStream src) throws IOException {
+        BufferedReader in = null;
+        PrintWriter out = null;
+        try {
+            in = new BufferedReader(new InputStreamReader(src));
+            out = new PrintWriter(new File(slot, "module.xml"));
+            String line;
+            while ((line = in.readLine()) != null) {
+                // replace slot name in the module xml file
+                line = MODULE_SLOT_PATTERN.matcher(line).replaceAll("slot=\"" + getSlot() + "\"");
+                out.println(line);
+            }
+        } finally {
+            IoUtils.safeClose(in);
             IoUtils.safeClose(out);
         }
     }
@@ -154,13 +178,13 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
 
     @Override
     protected void doSetup(ManagementClient managementClient) throws Exception {
-
         addModule(defaultPath);
-
     }
 
     protected void setConfiguration(String fileName) throws Exception {
         String xml = FileUtils.readFile(this.getClass(), fileName);
+        // replace slot name in the configuration
+        xml = MODULE_SLOT_PATTERN.matcher(xml).replaceAll("slot=\"" + getSlot() + "\"");
         List<ModelNode> operations = xmlToModelOperations(xml,
                 Namespace.CURRENT.getUriString(),
                 new ResourceAdapterSubsystemParser());
@@ -188,8 +212,8 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
                 javax.jms.MessageListener.class);
         rar.addAsManifestResource(this.getClass().getPackage(), raFile,
                 "ra.xml");
-        rar.as(ExplodedExporter.class).exportExploded(testModuleRoot, "main");
-        jar.as(ExplodedExporter.class).exportExploded(testModuleRoot, "main");
+        rar.as(ExplodedExporter.class).exportExploded(testModuleRoot, getSlot());
+        jar.as(ExplodedExporter.class).exportExploded(testModuleRoot, getSlot());
     }
 
     /**
@@ -205,7 +229,7 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
         jar.addPackage(MultipleConnectionFactory1.class.getPackage());
         rar.addAsManifestResource(
                 PureJarTestCase.class.getPackage(), raFile, "ra.xml");
-        rar.as(ExplodedExporter.class).exportExploded(testModuleRoot, "main");
+        rar.as(ExplodedExporter.class).exportExploded(testModuleRoot, getSlot());
 
         copyFile(new File(slot, "ra16out.jar"), jar.as(ZipExporter.class).exportAsInputStream());
     }
@@ -218,5 +242,12 @@ public class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmtServerSet
     public static ModelNode getAddress() {
         return address;
     }
+
+    /**
+     * This should be overridden to return a unique slot name for each test-case class / module.
+     * We need this since custom modules are not supported to be removing at runtime, see WFLY-1560.
+     * @return a name of the slot of the test module
+     */
+    protected abstract String getSlot();
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
@@ -60,7 +60,6 @@ public abstract class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmt
     protected File slot;
     public static ModelNode address;
     protected final String defaultPath = "org/jboss/ironjacamar/ra16out";
-    private boolean firstRemove = true;
 
     public void addModule(final String moduleName) throws Exception {
         addModule(moduleName, "module.xml");
@@ -68,18 +67,21 @@ public abstract class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmt
 
     public void addModule(final String moduleName, String moduleXml) throws Exception {
         testModuleRoot = new File(getModulePath(), moduleName);
-        if (firstRemove) {
-            removeModule(moduleName);
-            firstRemove = false;
-        }
+        removeModule(moduleName);
         createTestModule(moduleXml);
     }
 
     public void removeModule(final String moduleName) throws Exception {
+        removeModule(moduleName, false);
+    }
+
+    public void removeModule(final String moduleName, boolean deleteParent) throws Exception {
         testModuleRoot = new File(getModulePath(), moduleName);
         File file = testModuleRoot;
-        while (!getModulePath().equals(file.getParentFile()))
-            file = file.getParentFile();
+        if (deleteParent) {
+            while (!getModulePath().equals(file.getParentFile()))
+                file = file.getParentFile();
+        }
         deleteRecursively(file);
     }
 
@@ -173,7 +175,7 @@ public abstract class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmt
             throws Exception {
         takeSnapShot();
         remove(address);
-        removeModule(defaultPath);
+        removeModule(defaultPath, true);
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicFlatTestCase.java
@@ -71,7 +71,12 @@ public class BasicFlatTestCase extends AbstractModuleDeploymentTestCase {
 			setConfiguration("basic.xml");
 
 		}
-	}
+
+        @Override
+        protected String getSlot() {
+            return BasicFlatTestCase.class.getSimpleName().toLowerCase();
+        }
+    }
 
 	/**
 	 * Define the deployment

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/BasicJarTestCase.java
@@ -58,5 +58,10 @@ public class BasicJarTestCase extends BasicFlatTestCase {
 			setConfiguration("basic.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return BasicJarTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowFlatTestCase.java
@@ -87,6 +87,11 @@ public class InflowFlatTestCase extends AbstractModuleDeploymentTestCase {
 			setConfiguration("inflow.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return InflowFlatTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowJarTestCase.java
@@ -83,6 +83,11 @@ public class InflowJarTestCase extends AbstractModuleDeploymentTestCase {
 			setConfiguration("inflow.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return InflowJarTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationFlatTestCase.java
@@ -77,6 +77,10 @@ public class MultiActivationFlatTestCase extends
 
         }
 
+        @Override
+        protected String getSlot() {
+            return MultiActivationFlatTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiActivationJarTestCase.java
@@ -58,5 +58,10 @@ public class MultiActivationJarTestCase extends MultiActivationFlatTestCase {
 			setConfiguration("double.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return MultiActivationJarTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationFlatTestCase.java
@@ -73,6 +73,11 @@ public class MultiObjectActivationFlatTestCase extends
 			setConfiguration("multi.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return MultiObjectActivationFlatTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/MultiObjectActivationJarTestCase.java
@@ -58,5 +58,10 @@ public class MultiObjectActivationJarTestCase extends MultiObjectActivationFlatT
 			setConfiguration("multi.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return MultiObjectActivationJarTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationFlatTestCase.java
@@ -72,6 +72,11 @@ public class PartialObjectActivationFlatTestCase extends
 			setConfiguration("basic.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return PartialObjectActivationFlatTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PartialObjectActivationJarTestCase.java
@@ -58,5 +58,10 @@ public class PartialObjectActivationJarTestCase extends PartialObjectActivationF
 			setConfiguration("basic.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return PartialObjectActivationJarTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureFlatTestCase.java
@@ -71,6 +71,11 @@ public class PureFlatTestCase extends AbstractModuleDeploymentTestCase {
             setConfiguration("pure.xml");
 
         }
+
+        @Override
+        protected String getSlot() {
+            return PureFlatTestCase.class.getSimpleName().toLowerCase();
+        }
     }
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/PureJarTestCase.java
@@ -58,5 +58,10 @@ public class PureJarTestCase extends PureFlatTestCase {
 			setConfiguration("pure.xml");
 
 		}
+
+        @Override
+        protected String getSlot() {
+            return PureJarTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesFlatTestCase.java
@@ -81,6 +81,10 @@ public class TwoModulesFlatTestCase extends TwoRaFlatTestCase {
 			removeModule("org/jboss/ironjacamar/ra16out1");
 		}
 
+        @Override
+        protected String getSlot() {
+            return TwoModulesFlatTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesFlatTestCase.java
@@ -78,7 +78,7 @@ public class TwoModulesFlatTestCase extends TwoRaFlatTestCase {
 				String containerId) throws Exception {
 			super.tearDown(managementClient, containerId);
 			remove(address1);
-			removeModule("org/jboss/ironjacamar/ra16out1");
+			removeModule("org/jboss/ironjacamar/ra16out1", true);
 		}
 
         @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesJarTestCase.java
@@ -80,6 +80,10 @@ public class TwoModulesJarTestCase extends TwoModulesFlatTestCase {
             removeModule("org/jboss/ironjacamar/ra16out1");
         }
 
+        @Override
+        protected String getSlot() {
+            return TwoModulesJarTestCase.class.getSimpleName().toLowerCase();
+        }
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesJarTestCase.java
@@ -77,7 +77,7 @@ public class TwoModulesJarTestCase extends TwoModulesFlatTestCase {
                              String containerId) throws Exception {
             super.tearDown(managementClient, containerId);
             remove(address1);
-            removeModule("org/jboss/ironjacamar/ra16out1");
+            removeModule("org/jboss/ironjacamar/ra16out1", true);
         }
 
         @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
@@ -82,7 +82,9 @@ public class TwoModulesOfDifferentTypeTestCase extends TwoModulesFlatTestCase {
 
         @Override
         protected String getSlot() {
-            return TwoModulesOfDifferentTypeTestCase.class.getSimpleName().toLowerCase();
+            // change the "main" slot to something different, preferably to XXXYourNewTestCase.class.getSimpleName().toLowerCase(),
+            // if you are going to clone this test case
+            return "main";
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
@@ -80,6 +80,10 @@ public class TwoModulesOfDifferentTypeTestCase extends TwoModulesFlatTestCase {
             removeModule("org/jboss/ironjacamar/ra16out1");
         }
 
+        @Override
+        protected String getSlot() {
+            return TwoModulesOfDifferentTypeTestCase.class.getSimpleName().toLowerCase();
+        }
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoModulesOfDifferentTypeTestCase.java
@@ -77,7 +77,7 @@ public class TwoModulesOfDifferentTypeTestCase extends TwoModulesFlatTestCase {
                              String containerId) throws Exception {
             super.tearDown(managementClient, containerId);
             remove(address1);
-            removeModule("org/jboss/ironjacamar/ra16out1");
+            removeModule("org/jboss/ironjacamar/ra16out1", true);
         }
 
         @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaFlatTestCase.java
@@ -86,6 +86,10 @@ public class TwoRaFlatTestCase extends AbstractModuleDeploymentTestCase {
 			super.tearDown(managementClient, containerId);
 		}
 
+        @Override
+        protected String getSlot() {
+            return TwoRaFlatTestCase.class.getSimpleName().toLowerCase();
+        }
 	}
 
 	/**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/TwoRaJarTestCase.java
@@ -77,6 +77,10 @@ public class TwoRaJarTestCase extends TwoRaFlatTestCase {
             super.tearDown(managementClient, containerId);
         }
 
+        @Override
+        protected String getSlot() {
+            return TwoRaJarTestCase.class.getSimpleName().toLowerCase();
+        }
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module-jar.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out">
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out" slot="main">
 
     <resources>
     	<resource-root path="."/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out">
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out" slot="main">
 
     <resources>
     	<resource-root path="."/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1-jar.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out1">
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out1" slot="main">
    
     <resources>
     	<resource-root path="."/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module1.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out1">
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.ra16out1" slot="main">
 
     <resources>
     	<resource-root path="."/>


### PR DESCRIPTION
Fixing module names/slots to be unique across the jca moduledeployment tests as it is not supported to remove modules at runtime.

https://issues.jboss.org/browse/WFLY-1560
