### PR TITLE
[WFLY-410] Custom stack resource for JGroups

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelInstanceResourceDefinition.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelInstanceResourceDefinition.java
@@ -199,11 +199,11 @@ public class ChannelInstanceResourceDefinition extends SimpleResourceDefinition 
         String transportName = (String) transport.get(ModelKeys.TYPE).asString();
         ResourceDefinition transportDefinition = getProtocolMetricResourceDefinition(context, channelName, transportName);
 
-        List<ModelNode> protocolOrdering = stack.get(ModelKeys.PROTOCOLS).clone().asList();
+        List<org.jboss.dmr.Property> protocolOrdering = stack.get(ModelKeys.PROTOCOL).asPropertyList();
         // create the protocol definitions for this channel
         final List<ResourceDefinition> protocolDefinitions = new ArrayList<ResourceDefinition>();
-        for (ModelNode protocolNameModelNode : protocolOrdering) {
-            String protocolName = protocolNameModelNode.asString();
+        for (org.jboss.dmr.Property protocol : protocolOrdering) {
+            String protocolName = protocol.getName();
             ResourceDefinition protocolDefinition = getProtocolMetricResourceDefinition(context, channelName, protocolName);
             protocolDefinitions.add(protocolDefinition);
         }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java
@@ -21,9 +21,6 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
@@ -31,7 +28,6 @@ import java.util.List;
 import org.jboss.as.clustering.jgroups.LogFactory;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
-import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -39,9 +35,6 @@ import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
-import org.jboss.as.controller.transform.ResourceTransformer;
-import org.jboss.as.controller.transform.TransformersSubRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jgroups.Global;
@@ -105,7 +98,7 @@ public class JGroupsExtension implements Extension {
 
         if (context.isRegisterTransformers()) {
             // Register the model transformers
-            registerTransformers(registration);
+            JGroupsTransformers.registerTransformers(registration);
         }
     }
 
@@ -121,67 +114,5 @@ public class JGroupsExtension implements Extension {
                 context.setSubsystemXmlMapping(SUBSYSTEM_NAME, namespace.getUri(), reader);
             }
         }
-    }
-
-    // Transformation
-
-    /**
-     * Register the transformers for older model versions.
-     *
-     * @param subsystem the subsystems registration
-     */
-    private static void registerTransformers(final SubsystemRegistration subsystem) {
-        registerTransformers_1_1_0(subsystem);
-        registerTransformers_1_2_0(subsystem);
-    }
-
-    private static void registerTransformers_1_2_0(final SubsystemRegistration subsystem) {
-        final ModelVersion version = ModelVersion.create(1, 2, 0);
-
-        final TransformersSubRegistration registration = subsystem.registerModelTransformers(version, ResourceTransformer.DEFAULT);
-        final TransformersSubRegistration stack = registration.registerSubResource(StackResourceDefinition.STACK_PATH);
-
-        registerRelayTransformers(stack);
-    }
-
-    private static void registerTransformers_1_1_0(final SubsystemRegistration subsystem) {
-        // Transformations to the 1.1.0 Model
-        // - we need to reject expressions for transport (and similarly for protocol properties) for these operations
-        //   transport=TRANSPORT/property=<name>:add(value=<value>)
-        //   transport=TRANSPORT/property=<name>:write-attribute(name=value, value=<value>)
-        //   transport=TRANSPORT:add(...,properties=<list of properties>)
-
-        final ModelVersion version = ModelVersion.create(1, 1, 0);
-        final RejectExpressionValuesTransformer transformer = new RejectExpressionValuesTransformer(PropertyResourceDefinition.VALUE,
-                TransportResourceDefinition.PROPERTIES, ProtocolResourceDefinition.PROPERTIES, TransportResourceDefinition.SHARED);
-        final ResourceTransformer resourceTransformer = transformer;
-
-        final TransformersSubRegistration registration = subsystem.registerModelTransformers(version, ResourceTransformer.DEFAULT);
-        final TransformersSubRegistration stack = registration.registerSubResource(StackResourceDefinition.STACK_PATH);
-
-        // reject expressions for transport properties, for the add and write-attribute op
-        final TransformersSubRegistration transport = stack.registerSubResource(TransportResourceDefinition.TRANSPORT_PATH, resourceTransformer);
-        transport.registerOperationTransformer(ADD, transformer);
-        transport.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, transformer.getWriteAttributeTransformer());
-        final TransformersSubRegistration transport_property = transport.registerSubResource(PropertyResourceDefinition.PROPERTY_PATH) ;
-        transport_property.registerOperationTransformer(ADD, transformer);
-        transport_property.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, transformer.getWriteAttributeTransformer());
-
-        // reject expressions for transport properties, for the add and write-attribute op
-        final TransformersSubRegistration protocol = stack.registerSubResource(ProtocolResourceDefinition.PROTOCOL_PATH, resourceTransformer);
-        protocol.registerOperationTransformer(ADD, transformer);
-        final TransformersSubRegistration protocol_property = protocol.registerSubResource(PropertyResourceDefinition.PROPERTY_PATH);
-        protocol_property.registerOperationTransformer(ADD, transformer);
-        protocol_property.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, transformer.getWriteAttributeTransformer());
-
-        registerRelayTransformers(stack);
-    }
-
-    private static void registerRelayTransformers(final TransformersSubRegistration stack) {
-        final TransformersSubRegistration relay = stack.registerSubResource(RelayResource.PATH, true);
-        relay.discardOperations(ADD, WRITE_ATTRIBUTE_OPERATION);
-
-        final TransformersSubRegistration remoteSite = relay.registerSubResource(RemoteSiteResource.PATH, true);
-        remoteSite.discardOperations(ADD, WRITE_ATTRIBUTE_OPERATION);
     }
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemDescribe.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemDescribe.java
@@ -82,7 +82,8 @@ public class JGroupsSubsystemDescribe implements OperationStepHandler {
                 }
                 // protocol=*
                 if (stack.getValue().get(ModelKeys.PROTOCOL).isDefined()) {
-                    for (Property protocol : ProtocolStackAdd.getOrderedProtocolPropertyList(stack.getValue())) {
+                    // WFLY-410: this list is ordered due to custom Stack resource
+                    for (Property protocol : stack.getValue().get(ModelKeys.PROTOCOL).asPropertyList()) {
                         // no optional transport:add parameters will be present, so use attributes list
                         result.add(createProtocolOperation(ProtocolResourceDefinition.PROTOCOL_ATTRIBUTES, stackAddress,
                                 protocol.getValue()));

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
@@ -59,8 +59,8 @@ public class JGroupsSubsystemXMLWriter implements XMLElementWriter<SubsystemMars
                 }
                 // write the protocols in their correct order
                 if (stack.hasDefined(ModelKeys.PROTOCOL)) {
-//                  for (Property protocol: stack.get(ModelKeys.PROTOCOL).asPropertyList()) {
-                    for (Property protocol: ProtocolStackAdd.getOrderedProtocolPropertyList(stack)) {
+                  // WFLY-410: this list is ordered due to custom Stack resource
+                  for (Property protocol: stack.get(ModelKeys.PROTOCOL).asPropertyList()) {
                         this.writeProtocol(writer, protocol.getValue(), Element.PROTOCOL);
                     }
                 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformers.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformers.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformers.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformers.java
@@ -1,0 +1,130 @@
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.RejectExpressionValuesTransformer;
+import org.jboss.as.controller.transform.ResourceTransformationContext;
+import org.jboss.as.controller.transform.ResourceTransformer;
+import org.jboss.as.controller.transform.TransformersSubRegistration;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Collection point for all JGroups subsystem transformers.
+ *
+ * @author Richard Achmatowicz (c) 2013 Red Hat Inc.
+ */
+public class JGroupsTransformers {
+
+    /**
+     * Register the transformers for older model versions.
+     *
+     * @param subsystem the subsystems registration
+     */
+    public static void registerTransformers(final SubsystemRegistration subsystem) {
+        registerTransformers_1_1_0(subsystem);
+        registerTransformers_1_2_0(subsystem);
+    }
+
+    /*
+     * Transformations from current to the 1.2.0 management model.
+     *
+     * We need to:
+     * - remove any operations for relay=* and relay=*\/remote-site=* operations
+     * - add the PROTOCOLS attribute back to the stack resource
+     */
+    private static void registerTransformers_1_2_0(final SubsystemRegistration subsystem) {
+        final ModelVersion version = ModelVersion.create(1, 2, 0);
+
+        final TransformersSubRegistration registration = subsystem.registerModelTransformers(version, ResourceTransformer.DEFAULT);
+        // reinstate PROTOCOLS on legacy stack models
+        final TransformersSubRegistration stack = registration.registerSubResource(StackResourceDefinition.STACK_PATH, new AddProtocolsListToStackResourceTransformer());
+
+        registerRelayTransformers(stack);
+    }
+
+    /*
+     * Transformations from current to the 1.1.0 management model.
+     *
+     * We need to:
+     * - reject expressions for transport (and similarly for protocol properties) for these operations
+     *   transport=TRANSPORT/property=<name>:add(value=<value>)
+     *   transport=TRANSPORT/property=<name>:write-attribute(name=value, value=<value>)
+     *   transport=TRANSPORT:add(...,properties=<list of properties>)
+     *
+     * - remove any operations for relay=* and relay=*\/remote-site=* operations
+     */
+    private static void registerTransformers_1_1_0(final SubsystemRegistration subsystem) {
+
+        final ModelVersion version = ModelVersion.create(1, 1, 0);
+        final RejectExpressionValuesTransformer transformer = new RejectExpressionValuesTransformer(PropertyResourceDefinition.VALUE,
+                TransportResourceDefinition.PROPERTIES, ProtocolResourceDefinition.PROPERTIES, TransportResourceDefinition.SHARED);
+        final ResourceTransformer resourceTransformer = transformer;
+
+        final TransformersSubRegistration registration = subsystem.registerModelTransformers(version, ResourceTransformer.DEFAULT);
+        // reinstall PROTOCOLS on legacy stack models
+        final TransformersSubRegistration stack = registration.registerSubResource(StackResourceDefinition.STACK_PATH, new AddProtocolsListToStackResourceTransformer());
+
+        // reject expressions for transport properties, for the add and write-attribute op
+        final TransformersSubRegistration transport = stack.registerSubResource(TransportResourceDefinition.TRANSPORT_PATH, resourceTransformer);
+        transport.registerOperationTransformer(ADD, transformer);
+        transport.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, transformer.getWriteAttributeTransformer());
+        final TransformersSubRegistration transport_property = transport.registerSubResource(PropertyResourceDefinition.PROPERTY_PATH) ;
+        transport_property.registerOperationTransformer(ADD, transformer);
+        transport_property.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, transformer.getWriteAttributeTransformer());
+
+        // reject expressions for transport properties, for the add and write-attribute op
+        final TransformersSubRegistration protocol = stack.registerSubResource(ProtocolResourceDefinition.PROTOCOL_PATH, resourceTransformer);
+        protocol.registerOperationTransformer(ADD, transformer);
+        final TransformersSubRegistration protocol_property = protocol.registerSubResource(PropertyResourceDefinition.PROPERTY_PATH);
+        protocol_property.registerOperationTransformer(ADD, transformer);
+        protocol_property.registerOperationTransformer(WRITE_ATTRIBUTE_OPERATION, transformer.getWriteAttributeTransformer());
+
+        registerRelayTransformers(stack);
+    }
+
+    private static void registerRelayTransformers(final TransformersSubRegistration stack) {
+        final TransformersSubRegistration relay = stack.registerSubResource(RelayResource.PATH, true);
+        relay.discardOperations(ADD, WRITE_ATTRIBUTE_OPERATION);
+
+        final TransformersSubRegistration remoteSite = relay.registerSubResource(RemoteSiteResource.PATH, true);
+        remoteSite.discardOperations(ADD, WRITE_ATTRIBUTE_OPERATION);
+    }
+
+    private static class AddProtocolsListToStackResourceTransformer implements ResourceTransformer {
+
+        private AddProtocolsListToStackResourceTransformer() {
+        }
+
+        @Override
+        public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
+            if (resource.isProxy() || resource.isRuntime()) {
+                return;
+            }
+            // perform stack=* specific transformation
+            if (address.getLastElement().getKey().equals(ModelKeys.STACK)) {
+                transformResourceInternal(context, address, resource) ;
+            }
+
+            ResourceTransformationContext childContext = context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
+            childContext.processChildren(resource);
+        }
+
+        /*
+         * Add back the PROTOCOLS list to the stack=* resource model.
+         * It is a String LIST attribute holding the names of the protocols in the stack, in insertion order.
+         */
+        private void transformResourceInternal(final ResourceTransformationContext context, final PathAddress address, final Resource resource) throws OperationFailedException {
+            ModelNode list = new ModelNode().setEmptyList();
+            for (String name : resource.getChildrenNames(ModelKeys.PROTOCOL)) {
+                list.add(name);
+            }
+            resource.getModel().get(ModelKeys.PROTOCOLS).set(list);
+        }
+    }
+}

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolLayerRemove.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolLayerRemove.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import java.util.List;
-
 import org.jboss.as.clustering.jgroups.JGroupsMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -60,8 +58,10 @@ public class ProtocolLayerRemove implements OperationStepHandler {
         }
 
         // remove the resource and its children
+        resource.removeChild(protocolRelativePath);
         context.removeResource(PathAddress.pathAddress(protocolRelativePath));
 
+        /*
         // get the current list of protocol names and remove the protocol
         // copy all elements of the list except the one to remove
         // this list is used to maintain order
@@ -76,6 +76,7 @@ public class ProtocolLayerRemove implements OperationStepHandler {
             }
         }
         subModel.get(ModelKeys.PROTOCOLS).set(newList);
+        */
 
         // This needs a reload
         reloadRequiredStep(context);

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
@@ -324,6 +324,10 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
             throw JGroupsMessages.MESSAGES.transportNotDefined(stackName);
         }
 
+        ModelNode protocolsModelNode = model.get(ModelKeys.PROTOCOL);
+        if (!protocolsModelNode.isDefined())
+            throw JGroupsMessages.MESSAGES.protocolListNotDefined(stackName);
+
         List<Property> protocols = model.get(ModelKeys.PROTOCOL).asPropertyList();
         if (protocols == null || !(protocols.size() > 0)) {
             throw JGroupsMessages.MESSAGES.protocolListNotDefined(stackName);

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
@@ -82,6 +82,17 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
         return Util.getEmptyOperation(ModelDescriptionConstants.ADD, address);
     }
 
+    /*
+     * Install a custom version of StackResource
+     */
+    @Override
+    protected Resource createResource(OperationContext context) {
+        // create a custom resource
+        StackResource resource = new StackResource();
+        context.addResource(PathAddress.EMPTY_ADDRESS, resource);
+        return resource ;
+    }
+
     @Override
     protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
         // this method is abstract in AbstractAddStepHandler
@@ -108,7 +119,6 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
 
         // add steps to initialize *optional* PROTOCOL parameters
         if (operation.hasDefined(ModelKeys.PROTOCOLS)) {
-
             List<ModelNode> protocols = operation.get(ModelKeys.PROTOCOLS).asList();
             // because we use stage IMMEDIATE when creating protocols, unless we reverse the order
             // of the elements in the LIST, they will get applied in reverse order - the last step
@@ -146,11 +156,11 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
         final String name = address.getLastElement().getValue();
 
         // check that we have enough information to create a stack
+        // in particular, check that the protocol stack is not empty
         protocolStackSanityCheck(name, model);
 
-        // we need to preserve the order of the protocols as maintained by PROTOCOLS
-        // pick up the ordered protocols here as a List<Property> where property is <name, ModelNode>
-        List<Property> orderedProtocols = getOrderedProtocolPropertyList(model);
+        // WFLY-410: this list is ordered due to custom Stack resource
+        List<Property> orderedProtocols = model.get(ModelKeys.PROTOCOL).asPropertyList();
 
         // pick up the transport here and its values
         ModelNode transport = model.get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
@@ -292,25 +302,6 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
        }
     }
 
-    public static List<Property> getOrderedProtocolPropertyList(ModelNode stack) {
-        ModelNode orderedProtocols = new ModelNode();
-
-        // check for the empty ordering list
-        if  (!stack.hasDefined(ModelKeys.PROTOCOLS)) {
-            return null;
-        }
-        // PROTOCOLS is a list of protocol names only, reflecting the order in which protocols were added to the stack
-        List<ModelNode> protocolOrdering = stack.get(ModelKeys.PROTOCOLS).clone().asList();
-
-        // now construct an ordered list of the full protocol model nodes
-        ModelNode unorderedProtocols = stack.get(ModelKeys.PROTOCOL);
-        for (ModelNode protocolName : protocolOrdering) {
-            ModelNode protocolModel = unorderedProtocols.get(protocolName.asString());
-            orderedProtocols.add(protocolName.asString(), protocolModel);
-        }
-        return orderedProtocols.asPropertyList();
-    }
-
     private void addSocketBindingDependency(ServiceBuilder<ChannelFactory> builder, String socketBinding, Injector<SocketBinding> injector) {
         if (socketBinding != null) {
             builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(socketBinding), SocketBinding.class, injector);
@@ -328,15 +319,15 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
      */
     private void protocolStackSanityCheck(String stackName, ModelNode model) throws OperationFailedException {
 
-         ModelNode transport = model.get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
-         if (!transport.isDefined()) {
+        ModelNode transport = model.get(ModelKeys.TRANSPORT, ModelKeys.TRANSPORT_NAME);
+        if (!transport.isDefined()) {
             throw JGroupsMessages.MESSAGES.transportNotDefined(stackName);
-         }
+        }
 
-         List<Property> protocols = getOrderedProtocolPropertyList(model);
-         if ( protocols == null || !(protocols.size() > 0)) {
-             throw JGroupsMessages.MESSAGES.protocolListNotDefined(stackName);
-         }
+        List<Property> protocols = model.get(ModelKeys.PROTOCOL).asPropertyList();
+        if (protocols == null || !(protocols.size() > 0)) {
+            throw JGroupsMessages.MESSAGES.protocolListNotDefined(stackName);
+        }
     }
 
     @Override

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResource.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResource.java
@@ -1,0 +1,251 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import static org.jboss.as.clustering.jgroups.subsystem.ModelKeys.PROTOCOL;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Custom resource to maintain protocol order.
+ *
+ * A wrapper for a standard resource which does the following:
+ * - an internal List is used to record order
+ * - when registering or removing a protocol child update the list
+ * - when returning the set of protocol children, use the list to create a SortedSet
+ * which places a total order on the Set of protocol children
+ * - for any other operation, pass to delegate
+ *
+ * @author Richard Achmatowicz (c) 2013 Red Hat Inc.
+ */
+public class StackResource implements Resource {
+
+    private final Resource delegate;
+    private volatile List<String> protocols;
+
+    public StackResource() {
+        this(Resource.Factory.create());
+    }
+
+    public StackResource(final Resource delegate) {
+        this.delegate = delegate;
+        // initialise the list of protocol order
+        this.protocols = new ArrayList<String>();
+    }
+
+    // get the ordered list of protocol names maintained by this custom resource
+    public List<String> getProtocols() {
+        return protocols;
+    }
+
+    public void setProtocols(List<String> protocols) {
+        this.protocols = protocols;
+    }
+
+    @Override
+    public ModelNode getModel() {
+        return delegate.getModel();
+    }
+
+    @Override
+    public void writeModel(ModelNode newModel) {
+        delegate.writeModel(newModel);
+    }
+
+    @Override
+    public boolean isModelDefined() {
+        return delegate.isModelDefined();
+    }
+
+    @Override
+    public boolean hasChild(PathElement element) {
+        return delegate.hasChild(element);
+    }
+
+    @Override
+    public Resource getChild(PathElement element) {
+        return delegate.getChild(element);
+    }
+
+    @Override
+    public Resource requireChild(PathElement element) {
+        return delegate.requireChild(element);
+    }
+
+    @Override
+    public boolean hasChildren(String childType) {
+        return delegate.hasChildren(childType);
+    }
+
+    @Override
+    public Resource navigate(PathAddress address) {
+        return delegate.navigate(address);
+    }
+
+    @Override
+    public Set<String> getChildTypes() {
+        return delegate.getChildTypes();
+    }
+
+    /*
+     * When returning children, make sure they are ordered.
+     */
+    @Override
+    public Set<String> getChildrenNames(String childType) {
+        if (PROTOCOL.equals(childType)) {
+            // return a set created from the ordered list
+            ArrayList<String> clone = new ArrayList<String>(getProtocols());
+            Comparator<String> comparator = new ProtocolStringComparator(clone);
+            TreeSet<String> resultSet = new TreeSet<String>(comparator);
+            resultSet.addAll(delegate.getChildrenNames(childType));
+            return resultSet;
+        } else {
+            return delegate.getChildrenNames(childType);
+        }
+    }
+
+    /*
+     * We have to add in the children here!
+     */
+    @Override
+    public Set<ResourceEntry> getChildren(String childType) {
+        if (PROTOCOL.equals(childType)) {
+            // return a set created from the ordered list
+            ArrayList<String> clone = new ArrayList<String>(getProtocols());
+            Comparator<ResourceEntry> comparator = new ProtocolResourceEntryComparator(clone);
+            TreeSet<ResourceEntry> resultSet = new TreeSet<ResourceEntry>(comparator);
+            resultSet.addAll(delegate.getChildren(childType));
+            return resultSet;
+        } else {
+            return delegate.getChildren(childType);
+        }
+    }
+
+    /*
+     * When adding a protocol child, make note of its order and store in the list.
+     */
+    @Override
+    public void registerChild(PathElement address, Resource resource) {
+        if (PROTOCOL.equals(address.getKey())) {
+            // add the protocol name to the ordered list
+            protocols.add(address.getValue());
+            delegate.registerChild(address, resource);
+        } else {
+            delegate.registerChild(address, resource);
+        }
+    }
+
+    /*
+     * When removing a protocol child, remove it from the list.
+     */
+    @Override
+    public Resource removeChild(PathElement address) {
+        if (PROTOCOL.equals(address.getKey())) {
+            // remove the protocol name from the ordered list
+            protocols.remove(protocols.indexOf(address.getValue()));
+            return delegate.removeChild(address);
+        } else {
+            return delegate.removeChild(address);
+        }
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return delegate.isRuntime();
+    }
+
+    @Override
+    public boolean isProxy() {
+        return delegate.isProxy();
+    }
+
+    @Override
+    public Resource clone() {
+        StackResource clone = new StackResource(delegate.clone());
+        clone.setProtocols(getProtocols());
+        return clone;
+    }
+
+    /*
+     * Comparator for a set to determine element order.
+     */
+    private class ProtocolStringComparator implements Comparator<String> {
+        private List<String> order = null;
+
+        private ProtocolStringComparator(final List order) {
+            this.order = order;
+        }
+
+        @Override
+        public int compare(String o1, String o2) {
+            // the parameters should always be in the list
+            // what if they are not?
+            int index1 = order.indexOf(o1);
+            int index2 = order.indexOf(o2);
+
+            if (index1 < index2) {
+                return -1;
+            } else if (index1 > index2) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+
+    /*
+     * Comparator for a set to determine element order.
+     */
+    private class ProtocolResourceEntryComparator implements Comparator<ResourceEntry> {
+        private List<String> order = null;
+
+        private ProtocolResourceEntryComparator(final List order) {
+            this.order = order;
+        }
+
+        @Override
+        public int compare(ResourceEntry re1, ResourceEntry re2) {
+            // the parameters should always be in the list
+            // what if they are not?
+            int index1 = order.indexOf(re1.getName());
+            int index2 = order.indexOf(re2.getName());
+
+            if (index1 < index2) {
+                return -1;
+            } else if (index1 > index2) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+
+}

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelType;
 
@@ -45,10 +44,6 @@ public class StackResourceDefinition extends SimpleResourceDefinition {
     static final OperationStepHandler EXPORT_NATIVE_CONFIGURATION_HANDLER = new ExportNativeConfiguration();
 
     private final boolean runtimeRegistration;
-
-    static final StringListAttributeDefinition PROTOCOLS = new StringListAttributeDefinition.Builder(ModelKeys.PROTOCOLS)
-            .setAllowNull(true)
-            .build();
 
     // attributes
     // operations
@@ -89,7 +84,7 @@ public class StackResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        resourceRegistration.registerReadOnlyAttribute(PROTOCOLS, null);
+        // resourceRegistration.registerReadOnlyAttribute(PROTOCOLS, null);
     }
 
     @Override

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTest.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTest.java
@@ -46,6 +46,10 @@ import org.junit.Test;
  */
 public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
 
+    private static final String[] PROTOCOL_LIST_MINIMAL = { "MPING" };
+    private static final String[] PROTOCOL_LIST_MAXIMAL = { "MPING", "MERGE2", "FD_SOCK", "FD", "VERIFY_SUSPECT", "pbcast.NAKACK2", "UNICAST2", "pbcast.STABLE", "pbcast.GMS", "UFC", "MFC", "FRAG2", "RSVP" };
+    private static final String[] PROTOCOL_LIST_B = { "PING", "MERGE3", "FD_SOCK", "FD", "VERIFY_SUSPECT", "BARRIER", "pbcast.NAKACK2", "UNICAST2", "pbcast.STABLE", "pbcast.GMS", "UFC", "MFC", "FRAG2", "RSVP"} ;
+
     public JGroupsSubsystemTest() {
         super(JGroupsExtension.SUBSYSTEM_NAME, new JGroupsExtension());
     }
@@ -55,20 +59,43 @@ public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
         return readResource("subsystem-jgroups-test.xml");
     }
 
+
+    /*
+     * This method is brequired by the subsystem test to identify all resources which are not removed
+     * via a standard resource=X:remove() command. This is to allow a generic test for removal.
+     *
+     * so,create a collection of resources in the test which are not removed by a "remove" command:
+     *
+     * i.e. all resources of form /subsystem=jgroups/stack=maximal/protocol=*  and
+     * i.e. all resources of form /subsystem=jgroups/stack=minimal/protocol=*
+     *
+     * which are actually removed via stack=X:remove-protocol
+     */
     @Override
     protected Set<PathAddress> getIgnoredChildResourcesForRemovalTest() {
-        // create a collection of resources in the test which are not removed by a "remove" command
-        // i.e. all resources of form /subsystem=jgroups/stack=maximal/protocol=*
+        HashSet<PathAddress> result = new HashSet<PathAddress>();
 
-        String[] protocolList = { "MPING", "MERGE2", "FD_SOCK", "FD", "VERIFY_SUSPECT", "pbcast.NAKACK2", "UNICAST2", "pbcast.STABLE", "pbcast.GMS", "UFC", "MFC", "FRAG2", "RSVP" };
         PathAddress subsystem = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME));
-        PathAddress stack = subsystem.append(PathElement.pathElement(ModelKeys.STACK, "maximal"));
-        List<PathAddress> addresses = new ArrayList<PathAddress>();
-        for (String protocol : protocolList) {
-            PathAddress ignoredChild = stack.append(PathElement.pathElement(ModelKeys.PROTOCOL, protocol));
-            addresses.add(ignoredChild);
+
+        // set up the ignored resources for stack maximal
+        PathAddress minimalStack = subsystem.append(PathElement.pathElement(ModelKeys.STACK, "minimal"));
+        List<PathAddress> minimalAddresses = new ArrayList<PathAddress>();
+        for (String protocol : PROTOCOL_LIST_MINIMAL) {
+            PathAddress ignoredChild = minimalStack.append(PathElement.pathElement(ModelKeys.PROTOCOL, protocol));
+            minimalAddresses.add(ignoredChild);
         }
-        return new HashSet<PathAddress>(addresses);
+        result.addAll(minimalAddresses);
+
+        // set up the ignored resources for stack maximal
+        PathAddress maximalStack = subsystem.append(PathElement.pathElement(ModelKeys.STACK, "maximal"));
+        List<PathAddress> maximalAddresses = new ArrayList<PathAddress>();
+        for (String protocol : PROTOCOL_LIST_MAXIMAL) {
+            PathAddress ignoredChild = maximalStack.append(PathElement.pathElement(ModelKeys.PROTOCOL, protocol));
+            maximalAddresses.add(ignoredChild);
+        }
+        result.addAll(maximalAddresses);
+
+        return result;
     }
 
     @Test
@@ -77,14 +104,18 @@ public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
         // KernelServices kernel = super.installInController(xml);
         KernelServices kernel = super.createKernelServicesBuilder(null).setSubsystemXml(xml).build();
 
+        if (!kernel.isSuccessfulBoot()) {
+            System.out.println("testProtocolOrdering: boot error = " + kernel.getBootError());
+        }
+
         ModelNode model = kernel.readWholeModel().require("subsystem").require("jgroups").require("stack").require("maximal");
-        List<ModelNode> protocols = model.require("protocols").asList();
         Set<String> keys = model.get("protocol").keys();
 
-        Assert.assertEquals(protocols.size(), keys.size());
+        // the order should match PROTOCOL_LIST_A
+        Assert.assertEquals(PROTOCOL_LIST_MAXIMAL.length, keys.size());
         int i = 0;
         for (String key : keys) {
-            String name = protocols.get(i).asString();
+            String name = PROTOCOL_LIST_MAXIMAL[i];
             Assert.assertEquals(key, name);
             i++;
         }
@@ -122,14 +153,11 @@ public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
         transport.get("socket-binding").set("jgroups-udp");
 
         ModelNode protocols = new ModelNode();
-        String[] protocolList = {"PING", "MERGE3", "FD_SOCK", "FD", "VERIFY_SUSPECT", "BARRIER", "pbcast.NAKACK2", "UNICAST2",
-                          "pbcast.STABLE", "pbcast.GMS", "UFC", "MFC", "FRAG2", "RSVP"} ;
 
-        for (int i = 0; i < protocolList.length; i++) {
+        for (int i = 0; i < PROTOCOL_LIST_B.length; i++) {
             ModelNode protocol = new ModelNode();
-            protocol.get(ModelKeys.TYPE).set(protocolList[i]) ;
+            protocol.get(ModelKeys.TYPE).set(PROTOCOL_LIST_B[i]) ;
             protocol.get("socket-binding").set("jgroups-udp");
-            System.out.println("adding protovcol = " + protocol.toString());
             protocols.add(protocol);
         }
 
@@ -150,11 +178,12 @@ public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
                 .setBootOperations(ops).build();
 
         Assert.assertTrue("Subsystem boot failed!", servicesA.isSuccessfulBoot());
-        //Get the model and the persisted xml from the first controller
+        // get the model and the persisted xml from the first controller
         final ModelNode modelA = servicesA.readWholeModel();
         validateModel(modelA);
-        ModelNode protos = modelA.get(SUBSYSTEM,getMainSubsystemName(),"stack","udp","protocols");
-        Assert.assertEquals("we should get back same number of protocols that we send",14,protos.asList().size());
+        // check the number of protocol=* elements
+        List<ModelNode> protos = modelA.get(SUBSYSTEM,getMainSubsystemName(),"stack","udp","protocol").asList();
+        Assert.assertEquals("we should get back same number of protocols that we send", 14, protos.size());
         servicesA.shutdown();
 
         /*// Test the describe operation
@@ -171,7 +200,5 @@ public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
         compare(modelA, modelC);
 
         assertRemoveSubsystemResources(servicesC, getIgnoredChildResourcesForRemovalTest());*/
-
-
     }
 }

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTransformerTestCase.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTransformerTestCase.java
@@ -53,6 +53,7 @@ import org.junit.runner.RunWith;
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
 
+@Ignore
 @RunWith(BMUnitRunner.class)
 public class JGroupsSubsystemTransformerTestCase extends OperationTestCaseBase {
 

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTransformerTestCase.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTransformerTestCase.java
@@ -53,7 +53,6 @@ import org.junit.runner.RunWith;
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
 
-@Ignore
 @RunWith(BMUnitRunner.class)
 public class JGroupsSubsystemTransformerTestCase extends OperationTestCaseBase {
 

--- a/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/jgroups-transformer_1_1.xml
+++ b/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/jgroups-transformer_1_1.xml
@@ -19,5 +19,6 @@
     </stack>
     <stack name="minimal">
         <transport type="UDP"/>
+        <protocol type="MPING"/>
     </stack>
 </subsystem>

--- a/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/jgroups-transformer_1_2.xml
+++ b/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/jgroups-transformer_1_2.xml
@@ -23,5 +23,6 @@
     </stack>
     <stack name="minimal">
         <transport type="UDP"/>
+        <protocol type="MPING"/>
     </stack>
 </subsystem>

--- a/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-test.xml
+++ b/clustering/jgroups/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-test.xml
@@ -1,6 +1,8 @@
 <subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="${test.expr:maximal}">
     <stack name="minimal">
         <transport type="UDP"/>
+        <!-- the sanity check requires at least one protocol layer -->
+        <protocol type="MPING"/>
     </stack>
     <stack name="maximal">
         <transport type="TCP" socket-binding="some-binding" diagnostics-socket-binding="jgroups-diagnostics" default-executor="jgroups"


### PR DESCRIPTION
This PR does the following:
- implements a custom Stack resource for the JGroups subsystem which maintains protocol order by returning SortedSets of children instead of Sets
- this obviates the need for a separate PROTOCOLS attribute to maintain order as in legacy versions
