### PR TITLE
Build fails if local repo path contains spaces

### DIFF
--- a/clustering/infinispan/pom.xml
+++ b/clustering/infinispan/pom.xml
@@ -128,7 +128,7 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>false</parallel>
-                    <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+                    <argLine>-javaagent:"${org.jboss.byteman:byteman:jar}"=port:9091,boot:"${org.jboss.byteman:byteman:jar}"</argLine>
                     <systemPropertyVariables>
                         <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
                         <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>

--- a/clustering/jgroups/pom.xml
+++ b/clustering/jgroups/pom.xml
@@ -103,7 +103,7 @@
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <parallel>false</parallel>
-                    <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+                    <argLine>-javaagent:"${org.jboss.byteman:byteman:jar}"=port:9091,boot:"${org.jboss.byteman:byteman:jar}"</argLine>
                     <systemPropertyVariables>
                         <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
                         <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -57,8 +57,8 @@
                 <configuration>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <!-- the log manager needs to be setup before the agent -->
-                    <argLine>-Xbootclasspath/a:${org.jboss.logmanager:jboss-logmanager:jar}
-                        -javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+                    <argLine>-Xbootclasspath/a:"${org.jboss.logmanager:jboss-logmanager:jar}"
+                        -javaagent:"${org.jboss.byteman:byteman:jar}"=port:9091,boot:"${org.jboss.byteman:byteman:jar}"</argLine>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.server.log.dir>${project.build.directory}${file.separator}logs</jboss.server.log.dir>


### PR DESCRIPTION
The build fails, if the local repository path contains spaces and the command arguments are not escaped or quoted.
