### PR TITLE
Don't use a constant string for lock

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -101,7 +101,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
         });
     }
 
-    private final Object lock = "lock";
+    private final Object lock = new Object();
 
     private final CallbackHandler handler;
     private final SSLContext sslContext;


### PR DESCRIPTION
The commit here fixes the lock that was being used in the CLIModelControllerClient.
