### PR TITLE
Changed integration test xsl file matching to remove version-number links.

### DIFF
--- a/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
+++ b/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
@@ -1,20 +1,21 @@
 <xsl:stylesheet version="1.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:2.0">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="xml" indent="yes"/>
 
     <xsl:param name="realmName"/>
     <xsl:param name="secret"/>
+    
+    <xsl:variable name="jboss" select="'urn:jboss:domain:'"/>
 
     <xsl:variable name="newIdentityRealm">
-        <d:security-realm>
+        <security-realm>
             <xsl:attribute name="name"><xsl:value-of select="$realmName"/></xsl:attribute>
-            <d:server-identities>
-                <d:secret>
+            <server-identities>
+                <secret>
                     <xsl:attribute name="value"><xsl:value-of select="$secret"/></xsl:attribute>
-                </d:secret>
-            </d:server-identities>
-        </d:security-realm>
+                </secret>
+            </server-identities>
+        </security-realm>
     </xsl:variable>
 
     <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
@@ -25,9 +26,12 @@
     </xsl:template>
 
     <!-- Prevent duplicates -->
-    <xsl:template match="//d:management/d:security-realms/d:security-realm[@name=$realmName]"/>
+    <xsl:template match="//*[local-name()='management' and starts-with(namespace-uri(), $jboss)]
+   						  /*[local-name()='security-realms']
+   						  /*[local-name()='security-realm' and @name=$realmName]"/>
 
-    <xsl:template match="//d:management/d:security-realms">
+    <xsl:template match="//*[local-name()='management' and starts-with(namespace-uri(), $jboss)]
+   						  /*[local-name()='security-realms']">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*"/>
             <xsl:copy-of select="$newIdentityRealm"/>

--- a/testsuite/integration/src/test/xslt/addMessagingBackup.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingBackup.xsl
@@ -1,9 +1,12 @@
 <xsl:stylesheet version="1.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:messaging="urn:jboss:domain:messaging:1.4">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	
+    <xsl:variable name="messaging" select="'urn:jboss:domain:messaging:'"/>
+	
+	<xsl:output method="xml" indent="yes"/>
 
-<xsl:output method="xml" indent="yes"/>
-    <xsl:template match="//messaging:subsystem/messaging:hornetq-server">
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $messaging)]
+   						  /*[local-name()='hornetq-server']">
         <xsl:copy>
             <xsl:element name="backup">true</xsl:element>
             <xsl:apply-templates select="node()"/>

--- a/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
@@ -1,9 +1,12 @@
 <xsl:stylesheet version="1.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:messaging="urn:jboss:domain:messaging:1.4">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                
+    <xsl:variable name="messaging" select="'urn:jboss:domain:messaging:'"/>
 
-<xsl:output method="xml" indent="yes"/>
-    <xsl:template match="//messaging:subsystem/messaging:hornetq-server">
+	<xsl:output method="xml" indent="yes"/>
+    
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $messaging)]
+   						  /*[local-name()='hornetq-server']">
         <xsl:copy>
             <xsl:element name="failover-on-shutdown">true</xsl:element>
             <xsl:apply-templates select="node()"/>

--- a/testsuite/integration/src/test/xslt/addPortOffset.xsl
+++ b/testsuite/integration/src/test/xslt/addPortOffset.xsl
@@ -1,6 +1,5 @@
 <xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:2.0">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <!--
         An XSLT style sheet which will add a port offset to a standalone-ha.xml config.
@@ -19,25 +18,29 @@
         </server>
     -->
 
+    <xsl:variable name="jboss" select="'urn:jboss:domain:'"/>
+
     <!-- Template parameters and default values. -->
     <xsl:param name="portOffset" select="'100'"/>
     <xsl:param name="nativeInterfaceManagementPort" select="'9999'"/>
     <xsl:param name="httpInterfaceManagementPort" select="'9990'"/>
 
     <!-- Set the native management port. -->
-    <xsl:template match="//d:socket-binding-group/d:socket-binding[@name='management-native']/@port">
+    <xsl:template match="//*[local-name()='socket-binding-group' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='socket-binding' and @name='management-native']/@port">
         <xsl:attribute name="port">${jboss.management.native.port:<xsl:value-of select="$nativeInterfaceManagementPort"/>}</xsl:attribute>
     </xsl:template>
 
     <!-- Set the HTTP management port. -->
-    <xsl:template match="//d:socket-binding-group/d:socket-binding[@name='management-http']/@port">
+    <xsl:template match="//*[local-name()='socket-binding-group' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='socket-binding' and @name='management-http']/@port">
         <xsl:attribute name="port">
             <xsl:value-of select="$httpInterfaceManagementPort"/>
         </xsl:attribute>
     </xsl:template>
 
     <!-- Set the port offset. -->
-    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/@port-offset">
+    <xsl:template match="//*[local-name()='socket-binding-group' and @name='standard-sockets' and starts-with(namespace-uri(), $jboss)]/@port-offset">
         <xsl:attribute name="port-offset">
             <xsl:value-of select="$portOffset"/>
         </xsl:attribute>

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -1,7 +1,9 @@
 <xsl:stylesheet version="1.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:2.0"
-                xmlns:r="urn:jboss:domain:remoting:2.0">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+                
+    <xsl:variable name="jboss" select="'urn:jboss:domain:'"/>
+    <xsl:variable name="remoting" select="'urn:jboss:domain:remoting:'"/>
+                
     <xsl:output method="xml" indent="yes"/>
 
     <!--
@@ -18,7 +20,7 @@
     <xsl:param name="protocol" select="http-remoting"/>
 
     <xsl:variable name="newRemoteOutboundConnection">
-        <r:remote-outbound-connection>
+        <remote-outbound-connection>
             <xsl:attribute name="name"><xsl:value-of select="$connectionName"/></xsl:attribute>
             <xsl:attribute name="outbound-socket-binding-ref">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
             <xsl:attribute name="protocol"><xsl:value-of select="$protocol"/></xsl:attribute>
@@ -28,11 +30,11 @@
             <xsl:if test="$userName != 'NOT_DEFINED'">
                 <xsl:attribute name="username"><xsl:value-of select="$userName"/></xsl:attribute>
             </xsl:if>
-            <r:properties>
-                <r:property name="SASL_POLICY_NOANONYMOUS" value="false"/>
-                <r:property name="SSL_ENABLED" value="false"/>
-            </r:properties>
-        </r:remote-outbound-connection>
+            <properties>
+                <property name="SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="SSL_ENABLED" value="false"/>
+            </properties>
+        </remote-outbound-connection>
     </xsl:variable>
 
     <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
@@ -42,14 +44,16 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//r:subsystem">
+
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $remoting)]">
         <xsl:choose>
-            <xsl:when test="not(//r:subsystem/r:outbound-connections)">
+            <xsl:when test="not(//*[local-name()='subsystem' and starts-with(namespace-uri(), $remoting)]
+            					 /*[local-name()='outbound-connections'])">
                 <xsl:copy>
                     <xsl:apply-templates select="node()|@*"/>
-                    <r:outbound-connections>
+                    <outbound-connections>
                         <xsl:copy-of select="$newRemoteOutboundConnection"/>
-                    </r:outbound-connections>
+                    </outbound-connections>
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>
@@ -60,14 +64,15 @@
         </xsl:choose>
     </xsl:template>
 
-    <xsl:template match="//r:subsystem/r:outbound-connections">
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $remoting)]
+            			  /*[local-name()='outbound-connections']">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*"/>
             <xsl:copy-of select="$newRemoteOutboundConnection"/>
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']">
+    <xsl:template match="//*[local-name()='socket-binding-group' and starts-with(namespace-uri(), $jboss) and @name='standard-sockets']">
         <xsl:copy>
             <xsl:attribute name="name">
                 <xsl:value-of select="'standard-sockets'"/>
@@ -79,13 +84,13 @@
                 <xsl:value-of select="@port-offset"/>
             </xsl:attribute>
             <xsl:apply-templates select="node()"/>
-            <d:outbound-socket-binding>
+            <outbound-socket-binding>
                 <xsl:attribute name="name">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
-                <d:remote-destination>
+                <remote-destination>
                     <xsl:attribute name="host"><xsl:value-of select="$node"/></xsl:attribute>
                     <xsl:attribute name="port"><xsl:value-of select="$remotePort"/></xsl:attribute>
-                </d:remote-destination>
-            </d:outbound-socket-binding>
+                </remote-destination>
+            </outbound-socket-binding>
         </xsl:copy>
     </xsl:template>
 

--- a/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
+++ b/testsuite/integration/src/test/xslt/changeIPAddresses.xsl
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns="urn:jboss:domain:2.0"
-                xmlns:d="urn:jboss:domain:2.0"
-                xmlns:ws11="urn:jboss:domain:webservices:1.1"
-                xmlns:ws12="urn:jboss:domain:webservices:1.2"
-                xmlns:xts="urn:jboss:domain:xts:1.0"
->
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <!--
       An XSLT style sheet which will change IP unicast and multicast addresses for standalone.xml and standalone-ha.xml.
@@ -31,6 +25,10 @@
 	...
       </server>
     -->
+                
+    <xsl:variable name="jboss" select="'urn:jboss:domain:'"/>
+    <xsl:variable name="webservices" select="'urn:jboss:domain:webservices:'"/>
+    <xsl:variable name="xts" select="'urn:jboss:domain:xts:'"/>
 
     <!-- IP addresses  select="..." is default value. -->
     <xsl:param name="managementIPAddress" select="'127.0.0.1'"/>
@@ -43,7 +41,9 @@
 
 
     <!-- Change the management and public IP addresses. -->
-    <xsl:template match="//d:interfaces/d:interface[@name='management']/d:inet-address">
+    <xsl:template match="//*[local-name()='interfaces' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='interface' and @name='management']
+    				 	  /*[local-name()='inet-address']">
         <xsl:copy>
             <xsl:attribute name="value">
                 <xsl:value-of select="$managementIPAddress"/>
@@ -51,40 +51,44 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//d:interfaces/d:interface[@name='public']/d:inet-address">
+    <xsl:template match="//*[local-name()='interfaces' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='interface' and @name='public']
+    				 	  /*[local-name()='inet-address']">
         <xsl:copy><xsl:attribute name="value">${jboss.bind.address:<xsl:value-of select="$publicIPAddress"/>}</xsl:attribute></xsl:copy>
     </xsl:template>
-    <xsl:template match="//d:interfaces/d:interface[@name='unsecure']/d:inet-address">
+    <xsl:template match="//*[local-name()='interfaces' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='interface' and @name='unsecure']
+    				 	  /*[local-name()='inet-address']">
         <xsl:copy><xsl:attribute name="value">${jboss.bind.address.unsecure:<xsl:value-of select="$publicIPAddress"/>}</xsl:attribute></xsl:copy>
     </xsl:template>
 
     <!-- Change UDP multicast addresses. -->
-    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-udp']/@multicast-address">
+    <xsl:template match="//*[local-name()='socket-binding-group' and @name='standard-sockets' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='socket-binding' and @name='jgroups-udp']/@multicast-address">
         <xsl:attribute name="multicast-address">${jboss.default.multicast.address:<xsl:value-of select="$udpMcastAddress"/>}</xsl:attribute>
     </xsl:template>
 
     <!-- Change MPING multicast addresses. -->
-    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='jgroups-mping']/@multicast-address">
+    <xsl:template match="//*[local-name()='socket-binding-group' and @name='standard-sockets' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='socket-binding' and @name='jgroups-mping']/@multicast-address">
         <xsl:attribute name="multicast-address">${jboss.default.multicast.address:<xsl:value-of select="$mpingMcastAddress"/>}</xsl:attribute>
     </xsl:template>
 
     <!-- Change modcluster multicast addresses. -->
-    <xsl:template match="//d:socket-binding-group[@name='standard-sockets']/d:socket-binding[@name='modcluster']/@multicast-address">
+    <xsl:template match="//*[local-name()='socket-binding-group' and @name='standard-sockets' and starts-with(namespace-uri(), $jboss)]
+    				 	  /*[local-name()='socket-binding' and @name='modcluster']/@multicast-address">
         <xsl:attribute name="multicast-address">
             <xsl:value-of select="$modclusterMcastAddress"/>
         </xsl:attribute>
     </xsl:template>
 
     <!-- Change WSDL host. -->
-    <xsl:template match="//ws11:wsdl-host">
-        <xsl:copy>${jboss.bind.address:<xsl:value-of select="$publicIPAddress"/>}</xsl:copy>
-    </xsl:template>
-    <xsl:template match="//ws12:wsdl-host">
+    <xsl:template match="//*[local-name()='wsdl-host' and starts-with(namespace-uri(), $webservices)]">
         <xsl:copy>${jboss.bind.address:<xsl:value-of select="$publicIPAddress"/>}</xsl:copy>
     </xsl:template>
 
     <!-- Change XTS Coordinator -->
-    <xsl:template match="//xts:xts-environment/@url">
+    <xsl:template match="//*[local-name()='xts-environment' and starts-with(namespace-uri(), $xts)]/@url">
         <xsl:attribute name="url">
             <xsl:choose>
                 <xsl:when test="contains($publicIPAddress,':')">
@@ -98,7 +102,8 @@
     </xsl:template>
 
     <!-- Mail SMTP -->
-    <xsl:template match="//d:outbound-socket-binding[@name='mail-smtp']/d:remote-destination/@host">
+    <xsl:template match="//*[local-name()='outbound-socket-binding' and @name='mail-smtp' and starts-with(namespace-uri(), $jboss)]
+    					  /*[local-name()='remote-destination']/@host">
         <xsl:attribute name="host"><xsl:value-of select="$publicIPAddress"/></xsl:attribute>
     </xsl:template>
 

--- a/testsuite/integration/src/test/xslt/changeTransportStack.xsl
+++ b/testsuite/integration/src/test/xslt/changeTransportStack.xsl
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Author: Radoslav Husar, Version: March 2012 -->
 <xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:domain="urn:jboss:domain:2.0"
-                xmlns:jgroups="urn:jboss:domain:jgroups:1.1"
->
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <!--
         An XSLT that will change the default JGroups transport stack.
@@ -12,11 +9,13 @@
         <subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="tcp">
     -->
 
+    <xsl:variable name="jgroups" select="'urn:jboss:domain:jgroups:'"/>
+
     <!-- stack parameter -->
     <xsl:param name="defaultStack" select="'tcp'"/>
 
     <!-- only change default-stack attribute directly on jgroups subsystem -->
-    <xsl:template match="//jgroups:subsystem">
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $jgroups)]">
         <xsl:copy>
             <xsl:attribute name="default-stack">
                 <xsl:value-of select="$defaultStack"/>

--- a/testsuite/integration/src/test/xslt/enableJTS.xsl
+++ b/testsuite/integration/src/test/xslt/enableJTS.xsl
@@ -1,13 +1,15 @@
 <xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:t="urn:jboss:domain:transactions:1.3"
-                xmlns:j="urn:jboss:domain:jacorb:1.3">
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
     <!--
         An XSLT style sheet which will enable JTS,
         by adding the JTS attribute to the transactions subsystem,
         and turning on transaction propagation in the JacORB subsystem.
     -->
+    
+    <xsl:variable name="transactions" select="'urn:jboss:domain:transactions:'"/>
+    <xsl:variable name="jacorb" select="'urn:jboss:domain:jacorb:'"/>
+    
     <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
     <xsl:template match="node()|@*">
         <xsl:copy>
@@ -15,20 +17,22 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//j:subsystem/j:orb">
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $jacorb)]
+    					  /*[local-name()='orb']">
         <xsl:copy>
             <xsl:attribute name="socket-binding"><xsl:value-of select="@socket-binding"/></xsl:attribute>
             <xsl:attribute name="ssl-socket-binding"><xsl:value-of select="@ssl-socket-binding"/></xsl:attribute>
-            <j:initializers transactions="on" security="client"/>
+            <initializers transactions="on" security="client"/>
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="//t:subsystem">
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $transactions)]">
         <xsl:choose>
-            <xsl:when test="not(//t:subsystem/t:jts)">
+            <xsl:when test="not(//*[local-name()='subsystem' and starts-with(namespace-uri(), $transactions)]
+            				     /*[local-name()='jts'])">
                 <xsl:copy>
                     <xsl:apply-templates select="node()|@*"/>
-                    <t:jts/>
+                    <jts/>
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>

--- a/testsuite/integration/src/test/xslt/enableTrace.xsl
+++ b/testsuite/integration/src/test/xslt/enableTrace.xsl
@@ -1,9 +1,7 @@
 <xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:d="urn:jboss:domain:2.0"
-                xmlns:l="urn:jboss:domain:logging:1.2"
-                exclude-result-prefixes="l d"
-        >
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+	<xsl:variable name="nsInf" select="'urn:jboss:domain:logging:'"/>
 
     <!--
       An XSLT style sheet which will enable trace logging for the test suite.
@@ -15,16 +13,16 @@
         <xsl:param name="list" />
         <xsl:variable name="first" select="substring-before(concat($list,','), ',')" />
         <xsl:variable name="remaining" select="substring-after($list, ',')" />
-        <xsl:element name="logger" namespace="urn:jboss:domain:logging:1.2">
+        <logger>
             <xsl:attribute name="category" >
-                <xsl:value-of select="$first"></xsl:value-of>
+                <xsl:value-of select="$first"/>
             </xsl:attribute>
-            <xsl:element name="level" namespace="urn:jboss:domain:logging:1.2" >
+            <level >
                 <xsl:attribute name="name" >
                     <xsl:value-of select="'TRACE'"/>
                 </xsl:attribute>
-            </xsl:element>
-        </xsl:element>
+            </level>
+        </logger>
         <xsl:if test="string-length($remaining) > 0">
             <xsl:call-template name="output-loggers">
                 <xsl:with-param name="list" select="$remaining" />
@@ -33,7 +31,10 @@
     </xsl:template>
 
 
-    <xsl:template match="//l:subsystem/l:console-handler">
+    <!-- <xsl:template match="//l:subsystem/l:console-handler"> -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsInf)]
+   						/*[local-name()='console-handler' and starts-with(namespace-uri(), $nsInf)]/@name">
+   						       
         <xsl:choose>
             <xsl:when test="$trace='none'">
                 <xsl:copy>
@@ -41,18 +42,36 @@
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:copy>
-                    <xsl:attribute name="name">
-                        <xsl:value-of select="'CONSOLE'"/>
-                    </xsl:attribute>
-                    <level name="TRACE"/>
-                    <xsl:apply-templates select="//l:subsystem/l:console-handler/l:formatter"/>
-                </xsl:copy>
+  				<xsl:attribute name="name"> 
+        			<xsl:value-of select="'CONSOLE'"/>
+        		</xsl:attribute>                 
             </xsl:otherwise>
         </xsl:choose>
-    </xsl:template>
 
-    <xsl:template match="//l:subsystem/l:periodic-rotating-file-handler" use-when="$trace">
+     </xsl:template>
+     
+	<xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsInf)]
+   						/*[local-name()='console-handler' and starts-with(namespace-uri(), $nsInf)]
+   						/*[local-name()='level' and starts-with(namespace-uri(), $nsInf)]/@name">
+   						
+        <xsl:choose>
+            <xsl:when test="$trace='none'">
+                <xsl:copy>
+                    <xsl:apply-templates select="node()|@*"/>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+				<xsl:attribute name="name"> 
+        			<xsl:value-of select="'TRACE'" />
+        		</xsl:attribute>
+            </xsl:otherwise>
+        </xsl:choose>
+
+	</xsl:template>
+     
+    <!-- <xsl:template match="//l:subsystem/l:periodic-rotating-file-handler" use-when="$trace"> -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsInf)]
+   						/*[local-name()='periodic-rotating-file-handler' and starts-with(namespace-uri(), $nsInf)]" use-when="$trace">
         <xsl:choose>
             <xsl:when test="$trace='none'">
                 <xsl:copy>


### PR DESCRIPTION
Edited xsl files to follow existing matching pattern in changeCacheMode.xsl that eliminates version-numbers from the namespace match.

This was a problem that disabled enableTrace.xsl recently and this fix solves the problem going forward. 
