### PR TITLE
[WFLY-1337] Support JMS destination definition

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -49,6 +49,8 @@
         <module name="org.jboss.as.server"/>
         <!-- web-common is required only if servlet-connector are used -->
         <module name="org.jboss.as.web-common" optional="true"/>
+        <module name="org.jboss.jandex"/>
+        <module name="org.jboss.metadata"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -107,6 +107,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.spec.javax.jms</groupId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-connector</artifactId>
         </dependency>

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemAdd.java
@@ -28,6 +28,8 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.messaging.deployment.MessagingJMSDefinitionAnnotationParser;
+import org.jboss.as.messaging.deployment.MessagingJMSDefinitionDeploymentProcessor;
 import org.jboss.as.messaging.deployment.MessagingJndiBindingProcessor;
 import org.jboss.as.messaging.deployment.MessagingXmlInstallDeploymentUnitProcessor;
 import org.jboss.as.messaging.deployment.MessagingXmlParsingDeploymentUnitProcessor;
@@ -60,6 +62,8 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
             @Override
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_MESSAGING_XML_RESOURCES, new MessagingXmlParsingDeploymentUnitProcessor());
+                processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_EE_ANNOTATIONS, new MessagingJMSDefinitionAnnotationParser());
+                processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_REF, new MessagingJMSDefinitionDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_MESSAGING_XML_RESOURCES, new MessagingXmlInstallDeploymentUnitProcessor());
                 processorTarget.addDeploymentProcessor(MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_JMS_BINDINGS, new MessagingJndiBindingProcessor());
             }

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/DirectJMSDestinationInjectionSource.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/DirectJMSDestinationInjectionSource.java
@@ -1,0 +1,237 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import static org.jboss.as.messaging.CommonAttributes.DEFAULT;
+import static org.jboss.as.messaging.CommonAttributes.DURABLE;
+import static org.jboss.as.messaging.CommonAttributes.ENTRIES;
+import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.JMS_QUEUE;
+import static org.jboss.as.messaging.CommonAttributes.JMS_TOPIC;
+import static org.jboss.as.messaging.CommonAttributes.NAME;
+import static org.jboss.as.messaging.CommonAttributes.SELECTOR;
+import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jms.Destination;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.ee.component.InjectionSource;
+import org.jboss.as.messaging.MessagingExtension;
+import org.jboss.as.messaging.MessagingServices;
+import org.jboss.as.messaging.jms.JMSQueueConfigurationRuntimeHandler;
+import org.jboss.as.messaging.jms.JMSQueueService;
+import org.jboss.as.messaging.jms.JMSTopicConfigurationRuntimeHandler;
+import org.jboss.as.messaging.jms.JMSTopicService;
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ManagedReferenceFactory;
+import org.jboss.as.naming.ServiceBasedNamingStore;
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.naming.service.BinderService;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * A binding description for JMS Destination definitions.
+ * <p/>
+ * The referenced JMS definition must be directly visible to the
+ * component declaring the annotation.
+
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class DirectJMSDestinationInjectionSource extends InjectionSource {
+
+    /**
+     * The JNDI name
+     */
+    private final String name;
+    private final String interfaceName;
+
+    // optional attributes
+    private String description;
+    private String className;
+    private String resourceAdapter;
+    private String destinationName;
+
+    private Map<String, String> properties = new HashMap<String, String>();
+
+    public DirectJMSDestinationInjectionSource(final String name, String interfaceName) {
+        this.name = name;
+        this.interfaceName = interfaceName;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setClassName(String className) {
+        this.className = className;
+    }
+
+    public void setResourceAdapter(String resourceAdapter) {
+        this.resourceAdapter = resourceAdapter;
+    }
+
+    public void addProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
+    public void setDestinationName(String destinationName) {
+        this.destinationName = destinationName;
+    }
+
+    private String uniqueName(InjectionSource.ResolutionContext context, final String jndiName) {
+        StringBuilder uniqueName = new StringBuilder();
+        uniqueName.append(context.getApplicationName() + "_");
+        uniqueName.append(context.getModuleName() + "_");
+        if (context.getComponentName() != null) {
+            uniqueName.append(context.getComponentName() + "_");
+        }
+        uniqueName.append(jndiName);
+        return uniqueName.toString();
+    }
+
+    public void getResourceValue(final InjectionSource.ResolutionContext context, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final String uniqueName = destinationName != null ? destinationName : uniqueName(context, name);
+
+        try {
+            ServiceName hqServiceName = MessagingServices.getHornetQServiceName(getHornetQServerName());
+
+            if (interfaceName.equals(Queue.class.getName())) {
+                startQueue(context, uniqueName, phaseContext.getServiceTarget(), hqServiceName, serviceBuilder, deploymentUnit, injector);
+            } else {
+                startTopic(context, uniqueName, phaseContext.getServiceTarget(), hqServiceName, serviceBuilder, deploymentUnit, injector);
+            }
+        } catch (Exception e) {
+            throw new DeploymentUnitProcessingException(e);
+        }
+    }
+
+    /**
+     * To workaround HornetQ's BindingRegistry limitation in {@link org.jboss.as.messaging.jms.AS7BindingRegistry}
+     * that does not allow to build a BindingInfo with the ResolutionContext info, the JMS queue is created *without* any
+     * JNDI bindings and handle the JNDI bindings directly by getting the service's JMS queue.
+    */
+    private void startQueue(final ResolutionContext context,
+                            final String queueName,
+                            final ServiceTarget serviceTarget,
+                            final ServiceName hqServiceName,
+                            final ServiceBuilder<?> serviceBuilder,
+                            final DeploymentUnit deploymentUnit,
+                            final Injector<ManagedReferenceFactory>  injector) {
+
+        final String selector = properties.containsKey(SELECTOR.getName()) ? properties.get(SELECTOR.getName()) : null;
+        final boolean durable = properties.containsKey(DURABLE.getName()) ? Boolean.valueOf(properties.get(DURABLE.getName())) : DURABLE.getDefaultValue().asBoolean();
+
+        ModelNode destination = new ModelNode();
+        destination.get(NAME).set(queueName);
+        destination.get(DURABLE.getName()).set(durable);
+        if (selector != null) {
+            destination.get(SELECTOR.getName()).set(selector);
+        }
+        destination.get(ENTRIES).add(name);
+
+        Service<Queue> queueService = JMSQueueService.installService(null, null, queueName, serviceTarget, hqServiceName, selector, durable, new String[0]);
+        bindDestination(context, serviceTarget, serviceBuilder, injector, queueService);
+
+        //create the management registration
+        final PathElement serverElement = PathElement.pathElement(HORNETQ_SERVER, getHornetQServerName());
+        final PathElement dest = PathElement.pathElement(JMS_QUEUE, destinationName);
+        deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+        PathAddress registration = PathAddress.pathAddress(serverElement, dest);
+        MessagingXmlInstallDeploymentUnitProcessor.createDeploymentSubModel(registration, deploymentUnit);
+        JMSQueueConfigurationRuntimeHandler.INSTANCE.registerDestination(getHornetQServerName(), queueName, destination);
+    }
+
+    private void startTopic(ResolutionContext context, String topicName, ServiceTarget serviceTarget, ServiceName hqServiceName, ServiceBuilder<?> serviceBuilder, DeploymentUnit deploymentUnit, Injector<ManagedReferenceFactory> injector) {
+        ModelNode destination = new ModelNode();
+        destination.get(NAME).set(topicName);
+        destination.get(ENTRIES).add(name);
+
+        Service<Topic> topicService = JMSTopicService.installService(null, null, topicName, hqServiceName, serviceTarget, new String[0]);
+        bindDestination(context, serviceTarget, serviceBuilder, injector, topicService);
+
+        //create the management registration
+        final PathElement serverElement = PathElement.pathElement(HORNETQ_SERVER, getHornetQServerName());
+        final PathElement dest = PathElement.pathElement(JMS_TOPIC, destinationName);
+        deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+        PathAddress registration = PathAddress.pathAddress(serverElement, dest);
+        MessagingXmlInstallDeploymentUnitProcessor.createDeploymentSubModel(registration, deploymentUnit);
+        JMSTopicConfigurationRuntimeHandler.INSTANCE.registerDestination(getHornetQServerName(), topicName, destination);
+    }
+
+    private <D extends Destination> void bindDestination(ResolutionContext context, ServiceTarget serviceTarget, ServiceBuilder<?> serviceBuilder, Injector<ManagedReferenceFactory> injector, Service<D> destinationService) {
+        final ContextListAndJndiViewManagedReferenceFactory referenceFactoryService = new MessagingJMSDestinationManagedReferenceFactory(destinationService);
+        final ContextNames.BindInfo bindInfo = ContextNames.bindInfoForEnvEntry(context.getApplicationName(), context.getModuleName(), context.getComponentName(), !context.isCompUsesModule(), name);
+
+        final BinderService binderService = new BinderService(bindInfo.getBindName(), this);
+        final ServiceBuilder<?> binderBuilder = serviceTarget
+                .addService(bindInfo.getBinderServiceName(), binderService)
+                .addInjection(binderService.getManagedObjectInjector(), referenceFactoryService)
+                .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
+                .addListener(new AbstractServiceListener<Object>() {
+                    public void transition(final ServiceController<? extends Object> controller, final ServiceController.Transition transition) {
+                        switch (transition) {
+                            case STARTING_to_UP: {
+                                ROOT_LOGGER.boundJndiName(name);
+                                break;
+                            }
+                            case START_REQUESTED_to_DOWN: {
+                                ROOT_LOGGER.unboundJndiName(name);
+                                break;
+                            }
+                            case REMOVING_to_REMOVED: {
+                                ROOT_LOGGER.debugf("Removed messaging object [%s]", name);
+                                break;
+                            }
+                        }
+                    }
+                });
+        binderBuilder.setInitialMode(ServiceController.Mode.ACTIVE).install();
+
+        serviceBuilder.addDependency(bindInfo.getBinderServiceName(), ManagedReferenceFactory.class, injector);
+    }
+
+    /**
+     * The JMS destination can specify another hornetq-server to deploy its destinations
+     * by passing a property hornetq-server=&lt;name of the server>. Otherwise, "default" is used by default.
+     */
+    private String getHornetQServerName() {
+        return properties.containsKey(HORNETQ_SERVER) ? properties.get(HORNETQ_SERVER) : DEFAULT;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJMSDefinitionAnnotationParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJMSDefinitionAnnotationParser.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import static org.jboss.as.ee.EeMessages.MESSAGES;
+import static org.jboss.as.messaging.CommonAttributes.NAME;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.JMSDestinationDefinitions;
+
+import org.jboss.as.ee.component.Attachments;
+import org.jboss.as.ee.component.BindingConfiguration;
+import org.jboss.as.ee.component.EEApplicationClasses;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.annotation.CompositeIndex;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+
+/**
+ * Process {@link JMSDestinationDefinition}(s) annotations.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class MessagingJMSDefinitionAnnotationParser implements DeploymentUnitProcessor {
+
+    private static final DotName JMS_DESTINATION_DEFINITION = DotName.createSimple(JMSDestinationDefinition.class.getName());
+    private static final DotName JMS_DESTINATION_DEFINITIONS = DotName.createSimple(JMSDestinationDefinitions.class.getName());
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+        final CompositeIndex index = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.COMPOSITE_ANNOTATION_INDEX);
+        final EEApplicationClasses applicationClasses = deploymentUnit.getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
+
+        // @JMSDestinationDefinitions
+        for (AnnotationInstance annotation : index.getAnnotations(JMS_DESTINATION_DEFINITIONS)) {
+            final AnnotationTarget target = annotation.target();
+            if (!(target instanceof ClassInfo)) {
+                throw MESSAGES.classOnlyAnnotation(JMS_DESTINATION_DEFINITIONS.toString(), target);
+            }
+            List<AnnotationInstance> destinationDefinitions = getNestedDefinitionAnnotations(annotation);
+            for (AnnotationInstance definition : destinationDefinitions) {
+                processJMSDestinationDefinition(eeModuleDescription, definition, (ClassInfo) target, applicationClasses);
+            }
+        }
+
+        // @JMSDestinationDefinition
+        for (AnnotationInstance definition : index.getAnnotations(JMS_DESTINATION_DEFINITION)) {
+            final AnnotationTarget target = definition.target();
+            if (!(target instanceof ClassInfo)) {
+                throw MESSAGES.classOnlyAnnotation(JMS_DESTINATION_DEFINITION.toString(), target);
+            }
+            processJMSDestinationDefinition(eeModuleDescription, definition, (ClassInfo) target, applicationClasses);
+        }
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+    private void processJMSDestinationDefinition(EEModuleDescription eeModuleDescription, AnnotationInstance destinationDefinition, ClassInfo target, EEApplicationClasses applicationClasses) {
+        final AnnotationValue nameValue = destinationDefinition.value(NAME);
+        if (nameValue == null || nameValue.asString().isEmpty()) {
+            throw MESSAGES.annotationAttributeMissing(JMS_DESTINATION_DEFINITION.toString(), NAME);
+        }
+
+        final AnnotationValue interfaceNameValue = destinationDefinition.value("interfaceName");
+        if (interfaceNameValue == null || interfaceNameValue.asString().isEmpty()) {
+            throw MESSAGES.annotationAttributeMissing(JMS_DESTINATION_DEFINITION.toString(), "interfaceName");
+        }
+
+        DirectJMSDestinationInjectionSource source = new DirectJMSDestinationInjectionSource(nameValue.asString(), interfaceNameValue.asString());
+        source.setDestinationName(asString(destinationDefinition, "destinationName"));
+        for (String fullProp : asArray(destinationDefinition, "properties")) {
+            String[] prop = fullProp.split("=", 2);
+            source.addProperty(prop[0], prop[1]);
+        }
+
+        final BindingConfiguration config = new BindingConfiguration(nameValue.asString(), source);
+        eeModuleDescription.getBindingConfigurations().add(config);
+    }
+
+    /**
+     * Returns the nested {@link JMSDestinationDefinition} annotations out
+     * of the outer {@link JMSDestinationDefinitions} annotation
+     *
+     * @param definitions The outer {@link JMSDestinationDefinitions} annotation
+     */
+    private static List<AnnotationInstance> getNestedDefinitionAnnotations(AnnotationInstance definitions) {
+        if (definitions == null) {
+            return Collections.emptyList();
+        }
+        AnnotationInstance[] nested = definitions.value().asNestedArray();
+        return Arrays.asList(nested);
+    }
+
+    private static String asString(final AnnotationInstance annotation, String property) {
+        return asString(annotation, property, "");
+    }
+
+    private static String asString(final AnnotationInstance annotation, String property, String defaultValue) {
+        AnnotationValue value = annotation.value(property);
+        return value == null ? defaultValue : value.asString().isEmpty() ? defaultValue : value.asString();
+    }
+
+    private static String[] asArray(final AnnotationInstance annotation, String property) {
+        AnnotationValue value = annotation.value(property);
+        return value == null ? new String[0] : value.asStringArray();
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJMSDefinitionDeploymentProcessor.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJMSDefinitionDeploymentProcessor.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.ee.component.BindingConfiguration;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.DeploymentDescriptorEnvironment;
+import org.jboss.as.ee.component.EEApplicationClasses;
+import org.jboss.as.ee.component.ResourceInjectionTarget;
+import org.jboss.as.ee.component.deployers.AbstractDeploymentDescriptorBindingsProcessor;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
+import org.jboss.metadata.javaee.spec.JMSDestinationMetaData;
+import org.jboss.metadata.javaee.spec.JMSDestinationsMetaData;
+import org.jboss.metadata.javaee.spec.PropertiesMetaData;
+import org.jboss.metadata.javaee.spec.PropertyMetaData;
+import org.jboss.metadata.javaee.spec.RemoteEnvironment;
+
+/**
+ * Process jms-destination from deployment descriptor.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class MessagingJMSDefinitionDeploymentProcessor extends AbstractDeploymentDescriptorBindingsProcessor {
+
+    @Override
+    protected List<BindingConfiguration> processDescriptorEntries(DeploymentUnit deploymentUnit, DeploymentDescriptorEnvironment environment, ResourceInjectionTarget resourceInjectionTarget, ComponentDescription componentDescription, ClassLoader classLoader, DeploymentReflectionIndex deploymentReflectionIndex, EEApplicationClasses applicationClasses) throws DeploymentUnitProcessingException {
+        if (environment == null) {
+            return Collections.emptyList();
+        }
+
+        RemoteEnvironment remoteEnvironment = environment.getEnvironment();
+        List<BindingConfiguration> bindingConfigurations = new ArrayList<BindingConfiguration>();
+
+        JMSDestinationsMetaData destinationsMetadata = remoteEnvironment.getJmsDestinations();
+        if (destinationsMetadata != null) {
+            for (JMSDestinationMetaData metadata : destinationsMetadata) {
+                BindingConfiguration bindingConfiguration = processJMSDestinationDefinition(metadata);
+                bindingConfigurations.add(bindingConfiguration);
+            }
+        }
+
+        return bindingConfigurations;
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+    private BindingConfiguration processJMSDestinationDefinition(JMSDestinationMetaData metadata) {
+        String name = metadata.getName();
+        String interfaceName = metadata.getInterfaceName();
+        DirectJMSDestinationInjectionSource source = new DirectJMSDestinationInjectionSource(name, interfaceName);
+        source.setDestinationName(metadata.getDestinationName());
+        source.setResourceAdapter(metadata.getResourceAdapter());
+        source.setClassName(metadata.getClassName());
+        PropertiesMetaData properties = metadata.getProperties();
+        if (properties != null) {
+            for (PropertyMetaData property : properties) {
+                source.addProperty(property.getKey(), property.getValue());
+            }
+        }
+
+        return new BindingConfiguration(name, source);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJMSDestinationManagedReferenceFactory.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingJMSDestinationManagedReferenceFactory.java
@@ -1,0 +1,62 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2013, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import javax.jms.Destination;
+
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
+import org.jboss.as.naming.ManagedReference;
+import org.jboss.as.naming.ValueManagedReference;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.value.ImmediateValue;
+
+/**
+* @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
+*/
+class MessagingJMSDestinationManagedReferenceFactory<D extends Destination> implements ContextListAndJndiViewManagedReferenceFactory {
+
+    private final Service<D> service;
+
+    public MessagingJMSDestinationManagedReferenceFactory(Service<D> service) {
+        this.service = service;
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        return String.valueOf(getReference().getInstance());
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        final Object value = getReference().getInstance();
+        return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+    }
+
+    @Override
+    public ManagedReference getReference() {
+        return new ValueManagedReference(new ImmediateValue<Object>(service.getValue()));
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
@@ -22,34 +22,45 @@
 
 package org.jboss.as.messaging.jms;
 
+import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+import static org.jboss.as.server.Services.addServerExecutorDependency;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import javax.jms.Queue;
+
+import org.hornetq.jms.client.HornetQQueue;
 import org.hornetq.jms.server.JMSServerManager;
-import org.jboss.msc.inject.Injector;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-
-import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
-import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
-
-import java.util.concurrent.ExecutorService;
 
 /**
  * Service responsible for creating and destroying a {@code javax.jms.Queue}.
  *
  * @author Emanuel Muckenhuber
  */
-public class JMSQueueService implements Service<Void> {
+public class JMSQueueService implements Service<Queue> {
 
     private final InjectedValue<JMSServerManager> jmsServer = new InjectedValue<JMSServerManager>();
     private final InjectedValue<ExecutorService> executorInjector = new InjectedValue<ExecutorService>();
-
 
     private final String queueName;
     private final String selectorString;
     private final boolean durable;
     private final String[] jndi;
+
+    private Queue queue;
 
     public JMSQueueService(final String queueName, String selectorString, boolean durable, String[] jndi) {
         this.queueName = queueName;
@@ -58,7 +69,7 @@ public class JMSQueueService implements Service<Void> {
         this.jndi = jndi;
     }
 
-    /** {@inheritDoc} */
+    @Override
     public synchronized void start(final StartContext context) throws StartException {
         context.asynchronous();
 
@@ -68,6 +79,7 @@ public class JMSQueueService implements Service<Void> {
             public void run() {
                 try {
                     jmsManager.createQueue(false, queueName, selectorString, durable, jndi);
+                    queue = new HornetQQueue(queueName);
                     context.complete();
                 } catch (Throwable e) {
                     context.failed(MESSAGES.failedToCreate(e, "queue"));
@@ -76,7 +88,7 @@ public class JMSQueueService implements Service<Void> {
         });
     }
 
-    /** {@inheritDoc} */
+    @Override
     public synchronized void stop(final StopContext context) {
         // JMS Server Manager uses locking which waits on service completion, use async to prevent starvation
         context.asynchronous();
@@ -87,26 +99,38 @@ public class JMSQueueService implements Service<Void> {
             public void run() {
                 try {
                     jmsManager.removeQueueFromJNDI(queueName);
+                    queue = null;
                 } catch (Throwable e) {
                     MESSAGING_LOGGER.failedToDestroy(e, "queue", queueName);
                 }
                 context.complete();
             }
         });
-
     }
 
-    /** {@inheritDoc} */
-    public Void getValue() throws IllegalStateException {
-        return null;
+    @Override
+    public Queue getValue() throws IllegalStateException, IllegalArgumentException {
+        return queue;
     }
 
-    public InjectedValue<JMSServerManager> getJmsServer() {
-        return jmsServer;
-    }
+    public static Service<Queue> installService(final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final String name, final ServiceTarget serviceTarget, final ServiceName hqServiceName, final String selector, final boolean durable, final String[] jndiBindings) {
+        final JMSQueueService service = new JMSQueueService(name, selector, durable, jndiBindings);
 
-    public Injector<ExecutorService> getExecutorInjector() {
-        return executorInjector;
-    }
+        final ServiceName serviceName = JMSServices.getJmsQueueBaseServiceName(hqServiceName).append(name);
+        final ServiceBuilder<Queue> serviceBuilder = serviceTarget.addService(serviceName, service)
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
+                .addDependency(JMSServices.getJmsManagerBaseServiceName(hqServiceName), JMSServerManager.class, service.jmsServer)
+                .setInitialMode(ServiceController.Mode.PASSIVE);
+        addServerExecutorDependency(serviceBuilder, service.executorInjector, false);
+        if (verificationHandler != null) {
+            serviceBuilder.addListener(verificationHandler);
+        }
 
+        final ServiceController<Queue> controller = serviceBuilder.install();
+        if (newControllers != null) {
+            newControllers.add(controller);
+        }
+
+        return service;
+    }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAdd.java
@@ -26,7 +26,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 
 import java.util.List;
 
-import org.hornetq.jms.server.JMSServerManager;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -34,12 +33,9 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.messaging.CommonAttributes;
-import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 
@@ -66,25 +62,13 @@ public class JMSTopicAdd extends AbstractAddStepHandler {
 
         final ModelNode entries = CommonAttributes.DESTINATION_ENTRIES.resolveModelAttribute(context, model);
         final String[] jndiBindings = JMSServices.getJndiBindings(entries);
-        installServices(verificationHandler, newControllers, name, hqServiceName, serviceTarget, jndiBindings);
+        JMSTopicService.installService(verificationHandler, newControllers, name, hqServiceName, serviceTarget, jndiBindings);
     }
 
+    /**
+     * @deprecated use {@link JMSTopicService#installService(org.jboss.as.controller.ServiceVerificationHandler, java.util.List, String, org.jboss.msc.service.ServiceName, org.jboss.msc.service.ServiceTarget, String[])} instead.
+     */
     public void installServices(final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers, final String name, final ServiceName hqServiceName, final ServiceTarget serviceTarget, final String[] jndiBindings) {
-        final JMSTopicService service = new JMSTopicService(name, jndiBindings);
-        final ServiceName serviceName = JMSServices.getJmsTopicBaseServiceName(hqServiceName).append(name);
-
-        final ServiceBuilder<Void> serviceBuilder = serviceTarget.addService(serviceName, service)
-                .addDependency(HornetQActivationService.getHornetQActivationServiceName(hqServiceName))
-                .addDependency(JMSServices.getJmsManagerBaseServiceName(hqServiceName), JMSServerManager.class, service.getJmsServer())
-                .setInitialMode(Mode.PASSIVE);
-        org.jboss.as.server.Services.addServerExecutorDependency(serviceBuilder, service.getExecutorInjector(), false);
-        if(verificationHandler != null) {
-            serviceBuilder.addListener(verificationHandler);
-        }
-
-        final ServiceController<Void> controller = serviceBuilder.install();
-        if(newControllers != null) {
-            newControllers.add(controller);
-        }
+        JMSTopicService.installService(verificationHandler, newControllers, name, hqServiceName, serviceTarget, jndiBindings);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/JMSResourceDefinitionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/JMSResourceDefinitionsTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.definitions;
+
+import static org.jboss.shrinkwrap.api.ArchivePaths.create;
+
+import javax.ejb.EJB;
+import javax.jms.JMSException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+public class JMSResourceDefinitionsTestCase {
+
+    @EJB
+    private MessagingBean bean;
+
+    @Deployment
+    public static JavaArchive createArchive() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "JMSResourceDefinitionsTestCase.jar")
+                .addPackage(MessagingDefiner.class.getPackage())
+                .addAsManifestResource(
+                        MessagingDefiner.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml")
+                .addAsManifestResource(
+                        EmptyAsset.INSTANCE,
+                        create("beans.xml"));
+        System.out.println("archive = " + archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    public void testInjectedDefinitions() throws JMSException {
+        bean.checkInjectedResources();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/JMSResourceManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/JMSResourceManagementTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.definitions;
+
+import static org.jboss.as.controller.operations.common.Util.getEmptyOperation;
+import static org.jboss.shrinkwrap.api.ArchivePaths.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@RunAsClient
+@RunWith(Arquillian.class)
+public class JMSResourceManagementTestCase {
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Deployment
+    public static JavaArchive createArchive() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "JMSResourceDefinitionsTestCase.jar")
+                .addPackage(MessagingDefiner.class.getPackage())
+                .addAsManifestResource(
+                        MessagingDefiner.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml")
+                .addAsManifestResource(
+                        EmptyAsset.INSTANCE,
+                        create("beans.xml"));
+
+        System.out.println("archive = " + archive.toString(true));
+        return archive;
+    }
+
+    @Test
+    public void testManagementOfInjectedResource() throws Exception {
+        ModelNode readResourceWithRuntime = getOperation("jms-queue", "injectedQueue1", "read-resource");
+        readResourceWithRuntime.get("include-runtime").set(true);
+        ModelNode result = execute(readResourceWithRuntime, true);
+        assertEquals(true, result.get("durable").asBoolean());
+        assertFalse(result.hasDefined("selector"));
+
+        // injectedQueue3 has been declared in the annotation with selector => color = 'red'
+        // and durable = false
+        readResourceWithRuntime = getOperation("jms-queue", "injectedQueue2", "read-resource");
+        readResourceWithRuntime.get("include-runtime").set(true);
+        result = execute(readResourceWithRuntime, true);
+        assertEquals(false, result.get("durable").asBoolean());
+        assertEquals("color = 'red'", result.get("selector").asString());
+
+        // injectedQueue3 has been declared in the ejb-jar.xml with selector => color = 'blue'
+        // and durable => false
+        readResourceWithRuntime = getOperation("jms-queue", "injectedQueue3", "read-resource");
+        readResourceWithRuntime.get("include-runtime").set(true);
+        result = execute(readResourceWithRuntime, true);
+        assertEquals(false, result.get("durable").asBoolean());
+        assertEquals("color = 'blue'", result.get("selector").asString());
+
+        // injectedTopic1 has been declared in the annotation
+        readResourceWithRuntime = getOperation("jms-topic", "injectedTopic1", "read-resource");
+        readResourceWithRuntime.get("include-runtime").set(true);
+        execute(readResourceWithRuntime, true);
+
+        // injectedTopic2 has been declared in the ejb-jar.xml
+        readResourceWithRuntime = getOperation("jms-topic", "injectedTopic2", "read-resource");
+        readResourceWithRuntime.get("include-runtime").set(true);
+        execute(readResourceWithRuntime, true);
+    }
+
+    private ModelNode getOperation(String resourceType, String resourceName, String operationName) {
+        final ModelNode address = new ModelNode();
+        address.add("deployment", "JMSResourceDefinitionsTestCase.jar");
+        address.add("subsystem", "messaging");
+        address.add("hornetq-server", "default");
+        address.add(resourceType, resourceName);
+        return getEmptyOperation(operationName, address);
+    }
+
+    private ModelNode execute(final ModelNode op, final boolean expectSuccess) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        final String outcome = response.get("outcome").asString();
+        if (expectSuccess) {
+            if (!"success".equals(outcome)) {
+                System.out.println(response);
+            }
+            assertEquals("success", outcome);
+            return response.get("result");
+        } else {
+            if ("success".equals(outcome)) {
+                System.out.println(response);
+            }
+            assertEquals("failed", outcome);
+            return response.get("failure-description");
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.definitions;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.jms.Queue;
+import javax.jms.Topic;
+
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@Stateless
+public class MessagingBean {
+
+    // Use a @JMSDestinationDefinition inside a @JMSDestinationDefinitions
+    @Resource(lookup = "java:module/env/injectedQueue1")
+    private Queue queue1;
+
+    // Use a @JMSDestinationDefinition
+    @Resource(lookup = "java:global/injectedQueue2")
+    private Queue queue2;
+
+    // Use a jms-destination from the deployment descriptor
+    @Resource(lookup = "java:app/injectedQueue3")
+    private Queue queue3;
+
+    // Use a @JMSDestinationDefinition inside a @JMSDestinationDefinitions
+    @Resource(lookup = "java:module/env/injectedTopic1")
+    private Topic topic1;
+
+    // Use a jms-destination from the deployment descriptor
+    @Resource(lookup = "java:app/injectedTopic2")
+    private Topic topic2;
+
+    public void checkInjectedResources() {
+        assertNotNull(queue1);
+        assertNotNull(queue2);
+        assertNotNull(queue3);
+        assertNotNull(topic1);
+        assertNotNull(topic2);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingDefiner.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingDefiner.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.definitions;
+
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.JMSDestinationDefinitions;
+
+@JMSDestinationDefinitions(
+        value =  {
+                @JMSDestinationDefinition(
+                        name="java:module/env/injectedQueue1",
+                        interfaceName="javax.jms.Queue",
+                        destinationName="injectedQueue1"
+                ),
+                @JMSDestinationDefinition(
+                        name="java:module/env/injectedTopic1",
+                        interfaceName="javax.jms.Topic",
+                        destinationName="injectedTopic1"
+                )
+        }
+)
+@JMSDestinationDefinition(
+        name="java:global/injectedQueue2",
+        interfaceName="javax.jms.Queue",
+        destinationName="injectedQueue2",
+        properties = {
+                "durable=false",
+                "selector=color = 'red'"
+        }
+)
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class MessagingDefiner {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/ejb-jar.xml
@@ -1,0 +1,53 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd"
+         version="3.2">
+    <enterprise-beans>
+        <session>
+            <ejb-name>MessagingBean</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.messaging.jms.definitions.MessagingBean</ejb-class>
+            <jms-destination>
+                <description></description>
+                <name>java:app/injectedQueue3</name>
+                <interface-name>javax.jms.Queue</interface-name>
+                <destination-name>injectedQueue3</destination-name>
+                <property>
+                    <name>durable</name>
+                    <value>false</value>
+                </property>
+                <property>
+                    <name>selector</name>
+                    <value>color = 'blue'</value>
+                </property>
+            </jms-destination>
+            <jms-destination>
+                <description></description>
+                <name>java:app/injectedTopic2</name>
+                <interface-name>javax.jms.Topic</interface-name>
+                <destination-name>injectedTopic2</destination-name>
+            </jms-destination>
+        </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
- process @JMSDestinationDefinition(s) annotation + <jms-destination>'s
  deployment descriptor
- refactor JMSQueueService to implement Service<Queue> and use the
  service's value to bind the Queue with the correct binding info when
  processing the definitions
- same refactoring for JMSTopicService

---

The jms connection factory definition will be addressed in a separate PR as it likely involves some changes to the connector subsystem
