### PR TITLE
WFLY-1499 Clustering tests intermittently fail mainly because they do not clean their deployments properly

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2012, Red Hat, Inc., and individual contributors
+ * Copyright 2013, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -36,16 +36,16 @@ public final class NodeUtil {
     private static final Logger log = Logger.getLogger(NodeUtil.class);
 
     public static void deploy(Deployer deployer, String... deployments) {
-        for (int i = 0; i < deployments.length; i++) {
-            log.info("Deploying deployment=" + deployments[i]);
-            deployer.deploy(deployments[i]);
+        for (String deployment : deployments) {
+            log.info("Deploying deployment=" + deployment);
+            deployer.deploy(deployment);
         }
     }
 
     public static void undeploy(Deployer deployer, String... deployments) {
-        for (int i = 0; i < deployments.length; i++) {
-            log.info("Undeploying deployment=" + deployments[i]);
-            deployer.undeploy(deployments[i]);
+        for (String deployment : deployments) {
+            log.info("Undeploying deployment=" + deployment);
+            deployer.undeploy(deployment);
         }
     }
 
@@ -62,10 +62,10 @@ public final class NodeUtil {
 
     public static void start(ContainerController controller, String[] containers) {
         // TODO do this in parallel.
-        for (int i = 0; i < containers.length; i++) {
+        for (String container : containers) {
             try {
-                log.info("Starting deployment=NONE, container=" + containers[i]);
-                controller.start(containers[i]);
+                log.info("Starting deployment=NONE, container=" + container);
+                controller.start(container);
             } catch (Throwable e) {
                 log.error("Failed to start containers", e);
             }
@@ -82,11 +82,11 @@ public final class NodeUtil {
     }
 
     public static void stop(ContainerController controller, String[] containers) {
-        for (int i = 0; i < containers.length; i++) {
+        for (String container : containers) {
             try {
-                log.info("Stopping container=" + containers[i]);
-                controller.stop(containers[i]);
-                log.info("Stopped container=" + containers[i]);
+                log.info("Stopping container=" + container);
+                controller.stop(container);
+                log.info("Stopped container=" + container);
             } catch (Throwable e) {
                 log.error("Failed to stop containers", e);
             }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerHome.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ViewChangeListenerHome.java
@@ -1,0 +1,34 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+import java.rmi.RemoteException;
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+
+/**
+ * @author Radoslav Husar
+ * @version Jul 2013
+ */
+public interface ViewChangeListenerHome extends EJBHome {
+    ViewChangeListener create() throws RemoteException, CreateException;
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ExtendedClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ExtendedClusterAbstractTestCase.java
@@ -21,11 +21,7 @@
  */
 package org.jboss.as.test.clustering.cluster;
 
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.ExtendedClusteringTestConstants;
-import org.jboss.as.test.clustering.NodeUtil;
-import org.junit.Test;
 
 /**
  * Base cluster test that ensures the custom containers are already running.
@@ -35,21 +31,16 @@ import org.junit.Test;
  */
 public abstract class ExtendedClusterAbstractTestCase extends ClusterAbstractTestCase implements ExtendedClusteringTestConstants {
 
-    /**
-     * Ensure the containers are running, otherwise start them.
-     */
-    @Test
-    @InSequence(-1)
-    @RunAsClient
-    public void testSetup() {
-        this.setUp();
+    @Override
+    public void beforeTestMethod() {
+        this.start(XSITE_CONTAINERS);
+        this.deploy(XSITE_DEPLOYMENTS);
     }
 
-    /**
-     * Override this method for different behavior of the test.
-     */
-    protected void setUp() {
-        NodeUtil.start(controller, XSITE_CONTAINERS);
+    @Override
+    public void afterTestMethod() {
+        this.start(XSITE_CONTAINERS);
+        this.undeploy(XSITE_DEPLOYMENTS);
     }
-
 }
+

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -8,7 +8,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
@@ -69,16 +68,7 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
         context.close();
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-
-        // Also deploy
-        deploy(DEPLOYMENTS);
-    }
-
     @Test
-    @InSequence(1)
     public void test() throws Exception {
 
         String cluster = "ejb";

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/StatefulTimeoutTestCase.java
@@ -44,8 +44,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
 /**
  * Tests that the stateful timeout annotation works
  *
@@ -83,22 +81,37 @@ public class StatefulTimeoutTestCase extends ClusterAbstractTestCase {
         return beanType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + beanType.getSimpleName() + "!" + beanType.getName()));
     }
 
-    /**
-     * Ensure the containers are running.
-     */
+    // TODO: Workaround for https://issues.jboss.org/browse/ARQ-351, remove after fixed.
+
     @Override
+    public void beforeTestMethod() {
+        // Do nothing.
+    }
+
+    @Override
+    public void afterTestMethod() {
+        // Do nothing.
+    }
+
     @Test
-    @InSequence(-1)
+    @InSequence(Integer.MIN_VALUE)
     @RunAsClient
-    public void testSetup() {
+    public void setup() {
         start(CONTAINERS);
         deploy(DEPLOYMENTS);
     }
 
     @Test
+    @InSequence(Integer.MAX_VALUE)
+    @RunAsClient
+    public void cleanup() {
+        start(CONTAINERS);
+        undeploy(DEPLOYMENTS);
+    }
+
+    @Test
     @OperateOnDeployment(DEPLOYMENT_1)
     public void testStatefulTimeout(@ArquillianResource InitialContext iniCtx) throws Exception {
-
         ClusteredCacheBean.preDestroy = false;
         ClusteredCacheBean.prePassivate = false;
         ClusteredCacheBean sfsb1 = lookup(iniCtx, ClusteredCacheBean.class);
@@ -120,7 +133,6 @@ public class StatefulTimeoutTestCase extends ClusterAbstractTestCase {
     @Test
     @OperateOnDeployment(DEPLOYMENT_1)
     public void testClusteredStatefulTimeout(@ArquillianResource InitialContext iniCtx) throws Exception {
-
         ClusteredBean.preDestroy = false;
         ClusteredBean.prePassivate = false;
         ClusteredBean sfsb1 = lookup(iniCtx, ClusteredBean.class);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/ClusteredBeanDeploymentTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/deployment/ClusteredBeanDeploymentTestCase.java
@@ -21,11 +21,14 @@
  */
 package org.jboss.as.test.clustering.cluster.ejb3.deployment;
 
-import org.jboss.arquillian.container.test.api.Deployment;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.shrinkwrap.api.Archive;
@@ -34,16 +37,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
-
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
-
-import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
-
-import org.jboss.as.test.clustering.NodeUtil;
 
 /**
  * The purpose of this testcase is to ensure that a EJB marked as clustered, either via annotation or deployment descriptor,
@@ -58,7 +51,7 @@ public class ClusteredBeanDeploymentTestCase extends ClusterAbstractTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false)
     @TargetsContainer(CONTAINER_1)
-    public static Archive createDDBasedDeployment() {
+    public static Archive<?> createDDBasedDeployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, DD_BASED_MODULE_NAME + ".jar");
         ejbJar.addClasses(DDBasedClusteredBean.class, ClusteredBean.class);
         ejbJar.addClasses(ClusterAbstractTestCase.class, ClusteringTestConstants.class);
@@ -66,10 +59,32 @@ public class ClusteredBeanDeploymentTestCase extends ClusterAbstractTestCase {
         return ejbJar;
     }
 
+    // TODO: Workaround for https://issues.jboss.org/browse/ARQ-351, remove after fixed.
+
     @Override
-    protected void setUp() {
-        super.setUp();
+    public void beforeTestMethod() {
+        // Do nothing.
+    }
+
+    @Override
+    public void afterTestMethod() {
+        // Do nothing.
+    }
+
+    @Test
+    @InSequence(Integer.MIN_VALUE)
+    @RunAsClient
+    public void setup() {
+        start(CONTAINER_1);
         deploy(DEPLOYMENT_1);
+    }
+
+    @Test
+    @InSequence(Integer.MAX_VALUE)
+    @RunAsClient
+    public void cleanup() {
+        start(CONTAINER_1);
+        undeploy(DEPLOYMENT_1);
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/descriptor/disable/DisableClusteredTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.clustering.cluster.ejb3.descriptor.disable;
 
 
 import java.util.Properties;
-
 import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -32,7 +31,6 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
@@ -103,22 +101,12 @@ public class DisableClusteredTestCase extends ClusterAbstractTestCase {
         directory.close();
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-        node1Running = true;
-        node2Running = true;
-    }
-
     /**
      * Validate the stateful bean is not clustered by having failover not work
      */
     @Test
-    @InSequence(1)
     public void testStatefulBean() throws Exception {
-        previousSelector = EJBClientContextSelector
-                .setup(PROPERTIES_FILENAME);
+        previousSelector = EJBClientContextSelector.setup(PROPERTIES_FILENAME);
         DisableClusteredRemote stateful = directory.lookupStateful("DisableClusteredAnnotationStateful", DisableClusteredRemote.class);
 
         String node1 = stateful.getNodeState();
@@ -145,10 +133,15 @@ public class DisableClusteredTestCase extends ClusterAbstractTestCase {
      * Test stateless bean by demonstrating no load balancing
      */
     @Test
-    @InSequence(2)
     public void testStatelessBean(
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2) throws Exception {
+
+        if (node1Running) {
+            stop(CONTAINER_2);
+        } else {
+            stop(CONTAINER_1);
+        }
 
         String hostName = node1Running ? client1.getRemoteEjbURL().getHost() : client2.getRemoteEjbURL().getHost();
         int port = node1Running ? client1.getRemoteEjbURL().getPort() : client2.getRemoteEjbURL().getPort();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/FailoverWithSecurityTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/security/FailoverWithSecurityTestCase.java
@@ -23,13 +23,9 @@
 package org.jboss.as.test.clustering.cluster.ejb3.security;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.NodeInfoServlet;
 import org.jboss.as.test.clustering.NodeNameGetter;
@@ -89,17 +85,8 @@ public class FailoverWithSecurityTestCase extends ClusterAbstractTestCase {
         context = new RemoteEJBDirectory(ARCHIVE_NAME);
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     @Test
-    @InSequence(1)
-    public void testDomainSecurityAnnotation(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) ManagementClient client1,
-                                             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) ManagementClient client2)
-            throws Exception {
+    public void testDomainSecurityAnnotation() throws Exception {
 
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup(PROPERTIES_FILE);
 
@@ -165,7 +152,6 @@ public class FailoverWithSecurityTestCase extends ClusterAbstractTestCase {
             }
         }
     }
-
 
     private void establishView(ViewChangeListener listener, String... members) throws InterruptedException {
         listener.establishView("ejb", members);

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/StatefulFailoverTestCase.java
@@ -39,7 +39,6 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.AbstractEJBDirectory;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
@@ -56,7 +55,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -96,14 +94,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         return war;
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     @Test
-    @InSequence(1)
     public void testRestart(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -175,7 +166,6 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     @Test
-    @InSequence(2)
     public void testRedeploy(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -195,7 +185,6 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
             assertEquals(20020202, this.queryCount(client, url1));
 
             start(CONTAINER_2);
-            //deploy(DEPLOYMENT_2);
 
             this.establishView(client, baseURL1, NODE_1, NODE_2);
 
@@ -241,12 +230,6 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         } finally {
             client.getConnectionManager().shutdown();
         }
-    }
-
-    @Test
-    @InSequence(3)
-    public void testCleanup() {
-        undeploy(DEPLOYMENTS);
     }
 
     private int queryCount(HttpClient client, String url) throws IOException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/LocalEJBClientFailoverTestCase.java
@@ -24,12 +24,9 @@ package org.jboss.as.test.clustering.cluster.ejb3.stateful.remote.failover;
 
 import javax.naming.NamingException;
 
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
@@ -73,12 +70,6 @@ public class LocalEJBClientFailoverTestCase extends ClusterAbstractTestCase {
     private static final String NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1 = "node-name-arq-deployment-container-1";
     private static final String NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2 = "node-name-arq-deployment-container-2";
 
-    @ArquillianResource
-    private ContainerController container;
-
-    @ArquillianResource
-    private Deployer deployer;
-
     private static EJBDirectory directory;
     private static EJBDirectory clientDirectory;
 
@@ -97,7 +88,6 @@ public class LocalEJBClientFailoverTestCase extends ClusterAbstractTestCase {
         return jar;
     }
 
-
     @Deployment(name = NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_1, testable = false, managed = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> createNodeNameApplicationForContainer1() {
@@ -106,7 +96,7 @@ public class LocalEJBClientFailoverTestCase extends ClusterAbstractTestCase {
 
     @Deployment(name = NODE_NAME_ARQ_DEPLOYMENT_CONTAINER_2, testable = false, managed = false)
     @TargetsContainer(CONTAINER_2)
-    public static Archive createNodeNameApplicationForContainer2() {
+    public static Archive<?> createNodeNameApplicationForContainer2() {
         return createNodeNameApplication();
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -62,7 +62,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("AS7-6604") // now WFLY-828
+@Ignore("https://issues.jboss.org/browse/WFLY-828")
 public class RemoteEJBClientStatefulBeanFailoverTestCase extends ClusterAbstractTestCase {
 
     private static final Logger logger = Logger.getLogger(RemoteEJBClientStatefulBeanFailoverTestCase.class);
@@ -107,14 +107,6 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends ClusterAbstract
     @AfterClass
     public static void destroy() throws NamingException {
         context.close();
-    }
-
-    @Override
-    protected void setUp() {
-        super.setUp();
-
-        // Also deploy
-        deploy(DEPLOYMENTS);
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/dd/RemoteEJBClientDDBasedSFSBFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/stateful/remote/failover/dd/RemoteEJBClientDDBasedSFSBFailoverTestCase.java
@@ -94,12 +94,6 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase extends ClusterAbstractT
         context.close();
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     /**
      * Starts 2 nodes with the clustered beans deployed on each node. Invokes a (deployment descriptor based) clustered SFSB a few times.
      * Then stops a node from among the cluster (the one which received the last invocation) and continues invoking
@@ -112,8 +106,6 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase extends ClusterAbstractT
     public void testRemoteClientFailoverOnShutdown() throws Exception {
 
         final ContextSelector<EJBClientContext> previousSelector = EJBClientContextSelector.setup("cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties");
-        boolean container1Stopped = false;
-        boolean container2Stopped = false;
         try {
             final RemoteCounter remoteCounter = context.lookupStateful(DDBasedClusteredSFSB.class, RemoteCounter.class);
             // invoke on the bean a few times
@@ -131,13 +123,9 @@ public class RemoteEJBClientDDBasedSFSBFailoverTestCase extends ClusterAbstractT
             final String previousInvocationNodeName = result.getNodeName();
             // the value is configured in arquillian.xml of the project
             if (previousInvocationNodeName.equals(NODE_1)) {
-                undeploy(DEPLOYMENT_1);
                 stop(CONTAINER_1);
-                container1Stopped = true;
             } else {
-                undeploy(DEPLOYMENT_2);
                 stop(CONTAINER_2);
-                container2Stopped = true;
             }
             // invoke again
             CounterResult resultAfterShuttingDownANode = remoteCounter.increment();

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ejb3/xpc/StatefulWithXPCFailoverTestCase.java
@@ -34,14 +34,12 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-//import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.AbstractEJBDirectory;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
@@ -110,12 +108,6 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         return war;
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     /**
      * Use the second level cache statistics to ensure that deleting an entity on a cluster node, will
      * remove the entity from the second level cache on other nodes.
@@ -131,7 +123,6 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
      * @throws URISyntaxException
      */
     @Test
-    @InSequence(1)
     public void testSecondLevelCache(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -161,7 +152,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
             assertExecuteUrl(client, xpc1_echo_url + "StartingTestSecondLevelCache");  // echo message to server.log
             assertExecuteUrl(client, xpc2_echo_url + "StartingTestSecondLevelCache"); // echo message to server.log
 
-            String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity in node1 in memory db");                           //
+            String employeeName = executeUrlWithAnswer(client, xpc1_create_url, "create entity in node1 in memory db");
             assertEquals(employeeName, "Tom Brady");
             log.info(new Date() + "about to read entity on node1 (from xpc queue)");
 
@@ -210,7 +201,6 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     @Test
-    @InSequence(2)
     public void testBasicXPC(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -273,14 +263,6 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         } finally {
             org.apache.http.client.utils.HttpClientUtils.closeQuietly(client);
         }
-    }
-
-    @Test
-    @InSequence(3)
-    public void testCleanup() {
-        // node-1 was last shutdown, lets bring it up and remove deployments
-        start(CONTAINER_1);
-        undeploy(DEPLOYMENTS);
     }
 
     private String executeUrlWithAnswer(HttpClient client, String url, String message) throws IOException, InterruptedException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -49,7 +49,6 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
 import org.jboss.as.test.clustering.ViewChangeListener;
@@ -97,12 +96,6 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         return war;
-    }
-
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
     }
 
     /**
@@ -216,7 +209,6 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
      * @throws URISyntaxException
      */
     @Test
-    @InSequence(1)
     public void testGracefulSimpleFailover(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -351,7 +343,6 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
      * @throws URISyntaxException
      */
     @Test
-    @InSequence(2)
     public void testGracefulUndeployFailover(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -468,12 +459,6 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         }
 
         // Assert.fail("Show me the logs please!");
-    }
-
-    @Test
-    @InSequence(3)
-    public void testUndeploy() {
-        undeploy(DEPLOYMENTS);
     }
 
     /**

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/service/ServiceProviderRegistryTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/service/ServiceProviderRegistryTestCase.java
@@ -4,14 +4,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
-
 import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.EJBDirectory;
 import org.jboss.as.test.clustering.RemoteEJBDirectory;
@@ -71,16 +69,7 @@ public class ServiceProviderRegistryTestCase extends ClusterAbstractTestCase {
         context.close();
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-
-        // Also deploy
-        deploy(DEPLOYMENTS);
-    }
-
     @Test
-    @InSequence(1)
     public void test() throws Exception {
 
         String cluster = "ejb";

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonTestCase.java
@@ -80,12 +80,6 @@ public class SingletonTestCase extends ClusterAbstractTestCase {
         return war;
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     @Test
     public void testSingletonService(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
@@ -275,11 +269,6 @@ public class SingletonTestCase extends ClusterAbstractTestCase {
             }
         } finally {
             HttpClientUtils.closeQuietly(client);
-
-            deployer.undeploy(DEPLOYMENT_1);
-            controller.stop(CONTAINER_1);
-            deployer.undeploy(DEPLOYMENT_2);
-            controller.stop(CONTAINER_2);
         }
     }
 

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -35,7 +35,6 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
@@ -54,12 +53,6 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTestCase {
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     /**
      * Test simple graceful shutdown failover:
      * <p/>
@@ -75,7 +68,6 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
      * @throws URISyntaxException
      */
     @Test
-    @InSequence(1)
     public void testGracefulSimpleFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -183,7 +175,6 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
      * @throws URISyntaxException
      */
     @Test
-    @InSequence(2)
     public void testGracefulUndeployFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
@@ -272,12 +263,6 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
         }
 
         // Assert.fail("Show me the logs please!");
-    }
-
-    @Test
-    @InSequence(3)
-    public void testCleanup() {
-        undeploy(DEPLOYMENTS);
     }
 
     private void establishView(HttpClient client, URL baseURL, String... members) throws URISyntaxException, IOException {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
@@ -63,13 +63,19 @@ public class NonHaWebSessionPersistenceTestCase extends ClusterAbstractTestCase 
     }
 
     @Override
-    public void testSetup() {
+    public void beforeTestMethod() {
         // TODO rethink how this can be done faster with one less stopping (eg. make this test last)
         stop(CONTAINER_1);
         stop(CONTAINER_2);
 
         start(CONTAINER_SINGLE);
         deploy(DEPLOYMENT_1);
+    }
+
+    @Override
+    public void afterTestMethod() {
+        undeploy(DEPLOYMENT_1);
+        stop(CONTAINER_SINGLE);
     }
 
     @Test
@@ -105,8 +111,5 @@ public class NonHaWebSessionPersistenceTestCase extends ClusterAbstractTestCase 
         } finally {
             client.getConnectionManager().shutdown();
         }
-
-        undeploy(DEPLOYMENT_1);
-        stop(CONTAINER_SINGLE);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.clustering.cluster.web.expiration;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
@@ -32,7 +31,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.web.ClusteredWebSimpleTestCase;
@@ -43,6 +41,7 @@ import org.junit.Test;
 
 /**
  * Validates get/set/remove/invalidate session operations, session expiration, and their corresponding events
+ *
  * @author Paul Ferraro
  */
 public abstract class SessionExpirationTestCase extends ClusterAbstractTestCase {
@@ -55,14 +54,7 @@ public abstract class SessionExpirationTestCase extends ClusterAbstractTestCase 
         return war;
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
     @Test
-    @InSequence(1)
     public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
                      @ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
                              throws IOException, URISyntaxException, InterruptedException {
@@ -405,11 +397,5 @@ public abstract class SessionExpirationTestCase extends ClusterAbstractTestCase 
         } finally {
             HttpClientUtils.closeQuietly(client);
         }
-    }
-
-    @Test
-    @InSequence(Integer.MAX_VALUE)
-    public void testCleanup() {
-        undeploy(DEPLOYMENTS);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Formatter;
 
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
@@ -55,8 +56,7 @@ public abstract class SessionPassivationTestCase extends ClusterAbstractTestCase
 
     @Test
     @InSequence(1)
-    public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-                     @ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
+    public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1)
                              throws IOException, URISyntaxException, InterruptedException {
         DefaultHttpClient client1 = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
         DefaultHttpClient client2 = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
@@ -168,29 +168,17 @@ public abstract class SessionPassivationTestCase extends ClusterAbstractTestCase
         }
     }
 
-    static private void checkResponseForHeader(HttpResponse response, String headerName) {
-        Assert.assertTrue("response doesn't contain header '"+headerName+"', all response headers=" +
-                showHeaders(response.getAllHeaders()),response.containsHeader(headerName));
+    private static void checkResponseForHeader(HttpResponse response, String headerName) {
+        Assert.assertTrue("response doesn't contain header '" + headerName + "', all response headers=" +
+                showHeaders(response.getAllHeaders()), response.containsHeader(headerName));
     }
 
-    static private String showHeaders(final org.apache.http.Header[] headers) {
+    private static String showHeaders(final org.apache.http.Header[] headers) {
         StringBuilder stringBuilder = new StringBuilder();
         Formatter result = new Formatter(stringBuilder);
-        for (int looper = 0; looper < headers.length;looper++) {
-            result.format("{name=%s, value=%s}, ", headers[looper].getName(), headers[looper].getValue());
+        for (Header header : headers) {
+            result.format("{name=%s, value=%s}, ", header.getName(), header.getValue());
         }
         return result.toString();
-    }
-
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(DEPLOYMENTS);
-    }
-
-    @Test
-    @InSequence(Integer.MAX_VALUE)
-    public void testCleanup() {
-        undeploy(DEPLOYMENTS);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClientStatefulFaliloverTestBase {
+public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClientStatefulFailoverTestBase {
 
     @ArquillianResource
     private ContainerController container;

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -22,19 +22,11 @@
 
 package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
 
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.CONTAINER_2;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_1;
-import static org.jboss.as.test.clustering.ClusteringTestConstants.DEPLOYMENT_2;
-
-import org.jboss.arquillian.container.test.api.ContainerController;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.ViewChangeListener;
 import org.jboss.as.test.clustering.ViewChangeListenerBean;
@@ -50,25 +42,21 @@ import org.junit.runner.RunWith;
  * other node(s) in cases like a node going down.
  * This test is taken from test of ejb3 beans.
  *
- * @author Jaikiran Pai, Radoslav Husar, Ondrej Chaloupka
+ * @author Jaikiran Pai
+ * @author Radoslav Husar
+ * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClientStatefulFailoverTestBase {
 
-    @ArquillianResource
-    private ContainerController container;
-
-    @ArquillianResource
-    private Deployer deployer;
-    
-    @Deployment(name = DEPLOYMENT_1_SINGLE, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> createDeploymentForContainer1Singleton() {
         return createDeploymentSingleton();
     }
 
-    @Deployment(name = DEPLOYMENT_2_SINGLE, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> createDeploymentForContainer2Singleton() {
         return createDeploymentSingleton();
@@ -90,9 +78,8 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClient
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addClasses(CounterBaseBean.class, CounterBean.class, CounterRemote.class, CounterRemoteHome.class, CounterResult.class);
         jar.addClass(NodeNameGetter.class);
-        jar.addAsManifestResource(new StringAsset("Dependencies: deployment." + ARCHIVE_NAME_SINGLE + ".jar\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: deployment." + ARCHIVE_NAME_SINGLE + ".jar, org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"), "MANIFEST.MF");
         jar.addClasses(ViewChangeListener.class, ViewChangeListenerBean.class);
-        jar.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         return jar;
     }
     
@@ -100,13 +87,13 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClient
     @InSequence(1)
     @Test
     public void testFailoverFromRemoteClientWhenOneNodeGoesDown() throws Exception {
-        failoverFromRemoteClient(container, deployer, false);
+        failoverFromRemoteClient(false);
     }
 
     @Override
     @InSequence(2)
     @Test
     public void testFailoverFromRemoteClientWhenOneNodeUndeploys() throws Exception {
-        failoverFromRemoteClient(container, deployer, true);
+        failoverFromRemoteClient(true);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -29,8 +29,8 @@ import org.junit.BeforeClass;
 /**
  * @author Ondrej Chaloupka
  */
-public abstract class RemoteEJBClientStatefulFaliloverTestBase {
-    private static final Logger log = Logger.getLogger(RemoteEJBClientStatefulFaliloverTestBase.class);
+public abstract class RemoteEJBClientStatefulFailoverTestBase {
+    private static final Logger log = Logger.getLogger(RemoteEJBClientStatefulFailoverTestBase.class);
 
     protected static final String PROPERTIES_FILE = "cluster/ejb3/stateful/failover/sfsb-failover-jboss-ejb-client.properties";
     protected static final String ARCHIVE_NAME = "ejb2-failover-test";

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -37,7 +37,7 @@ import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.Count
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterRemote;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterRemoteHome;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterResult;
-import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.RemoteEJBClientStatefulFaliloverTestBase;
+import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.RemoteEJBClientStatefulFailoverTestBase;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBClientStatefulFaliloverTestBase {
+public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBClientStatefulFailoverTestBase {
     private static final Logger log = Logger.getLogger(RemoteEJB2ClientStatefulBeanFailoverDDTestCase.class);
 
     @ArquillianResource

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/ejb-jar.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/ejb-jar.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' ?>
-<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" 
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN"
                          "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
 <!--
   ~ JBoss, Home of Professional Open Source.
@@ -31,6 +31,14 @@
          	<ejb-class>org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.dd.CounterBeanDD</ejb-class>
          	<session-type>Stateful</session-type>
          	<transaction-type>Container</transaction-type>
-         </session>
+        </session>
+        <session>
+            <ejb-name>ViewChangeListenerBean</ejb-name>
+            <home>org.jboss.as.test.clustering.ViewChangeListenerHome</home>
+            <remote>org.jboss.as.test.clustering.ViewChangeListener</remote>
+            <ejb-class>org.jboss.as.test.clustering.ViewChangeListenerBean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Bean</transaction-type>
+        </session>
 	</enterprise-beans>
 </ejb-jar>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/jboss-ejb3.xml
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/jboss-ejb3.xml
@@ -29,5 +29,11 @@
             <c:clustered>true</c:clustered>
         </c:clustering>
     </jee:assembly-descriptor>
+    <jee:assembly-descriptor>
+        <c:clustering>
+            <jee:ejb-name>ViewChangeListenerBean</jee:ejb-name>
+            <c:clustered>true</c:clustered>
+        </c:clustering>
+    </jee:assembly-descriptor>
 	
 </jboss>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/xsite/XSiteBackupForTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/xsite/XSiteBackupForTestCase.java
@@ -116,13 +116,6 @@ public class XSiteBackupForTestCase extends ExtendedClusterAbstractTestCase {
         return war;
     }
 
-
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(XSITE_DEPLOYMENTS);
-    }
-
     /*
      * Tests that puts get relayed to their backup sites, even when using backup-for to rename
      * the backup cache name.

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
@@ -104,12 +104,6 @@ public class XSiteSimpleTestCase extends ExtendedClusterAbstractTestCase {
         return war;
     }
 
-    @Override
-    protected void setUp() {
-        super.setUp();
-        deploy(XSITE_DEPLOYMENTS);
-    }
-
     /*
      * Tests that puts get relayed to their backup sites
      *


### PR DESCRIPTION
- introduce default framework contract -- each test starts with deployed class deployments which are automatically cleaned -- to simplify lots of tests and fix multiple cleanup problems
- fix few @Ignored test

https://issues.jboss.org/browse/WFLY-1499
